### PR TITLE
docs: resolve code-docs drift + tighten user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ next commands — replace <path> with your path; terms combine with AND:
   open    nose query <path> id=<id> full     one family: every copy + the extraction skeleton
 ```
 
-Then drill: `nose query src witness=exact` (only behavior-proven families), `nose query src
-group=dir` (by directory), `nose query src id=b221962180 full` (open one family with its
-all-copies extraction skeleton).
-
 `nose query` is the **one command** for every workflow over that dataset — explore, report,
 gate a PR, or feed a machine:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,7 @@ A Cargo workspace; data flows left-to-right through them.
 | `nose-normalize` | the normalization passes, inferred immutable binding-domain evidence, and the value graph (GVN) |
 | `nose-detect` | unit/feature extraction, MinHash/LSH, scoring, clustering, refactor ranking |
 | `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) — see [benchmark](benchmark.md) |
+| `nose-markdown` | self-contained same-language Markdown prose near-duplicate domain (char-n-gram MinHash-LSH + winnowing + containment → TF-IDF rank → span witness), distinct from the value-graph code engine — see [markdown-duplication](markdown-duplication.md) |
 | `nose-cli` | the `nose` binary, config loading, baselines, caching |
 
 The current semantic assumptions these crates share are summarized in

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -87,16 +87,17 @@ not), one per equivalence-class axis.
 cargo test -p nose-cli --test css_html_quality -- --nocapture   # recall + soundness, per axis
 ```
 
-Headline (current): **recall 11/11 positive groups converged (100%)** across the modeled
+Headline (current): **recall 13/13 positive groups converged (100%)** across the modeled
 axes — CSS color (hex/short/name/`rgb()`), extended named colors, `hsl()`/`url()` spelling,
 zero-units, number canon, box-shorthand collapse, declaration-order and selector
-independence; HTML DOM normalization (attribute order/boolean/`class`-set/whitespace/case),
-inline-`style=` canonicalization, and Vue/Svelte directive shorthand — and **soundness 12/12
-hard negatives kept distinct (100%)** (distinct colors/values, repeated-property and
-shorthand/longhand cascade order, box-not-all-equal, value-order, at-rule condition, `hsl`
-distinctness; HTML text/attr/child-order/`<pre>`-whitespace differences). CSS, HTML, and
-imperative fingerprints are domain-disjoint, so the language-blind exact channel can never
-merge across them.
+independence, media-query condition and value canonicalization; HTML DOM normalization
+(attribute order/boolean/`class`-set/whitespace/case), inline-`style=` canonicalization, and
+Vue/Svelte directive shorthand — and **soundness 14/14 hard negatives kept distinct (100%)**
+(distinct colors/values, repeated-property and shorthand/longhand cascade order,
+box-not-all-equal, value-order, at-rule condition, `hsl` distinctness, `@media` vs `@supports`
+and distinct media conditions; HTML text/attr/child-order/`<pre>`-whitespace differences).
+CSS, HTML, and imperative fingerprints are domain-disjoint, so the language-blind exact
+channel can never merge across them.
 
 Coverage is first-class: the [Raw-node ratio](languages.md#coverage-and-adding-a-language)
 on real-world `.css`/`.html` is sub-percent (CSS ~0.002%, HTML ~0.4% on hand-written

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -137,7 +137,7 @@ uses a hidden research surface:
 - `nose eval` / `nose ceiling` — score predictions against a gold set / split recall across
   the extraction and candidate-generation stages.
 
-`nose behavioral-gate` is a visible experimental Type-4 benchmark command for measuring a
+`nose behavioral-gate` is a hidden experimental Type-4 benchmark command for measuring a
 behavioral-equivalence acceptance gate against a generated manifest; it is not a stable
 integration surface.
 

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -162,12 +162,12 @@ core canonicalizations, but not a per-scan or whole-pipeline proof. See
   fragment shapes is in [fragment-contracts](fragment-contracts.md).
 
 Exact fragment proof is not the same thing as user-facing refactorability. Fragment
-locations carry stable proof metadata (`is_fragment`, `fragment_kind`, `reason_code`,
-span size, and `enclosing_unit` when recoverable), but product placement is decided
-separately with `recommended_surface` (`default`, `review`, `hidden`, and a few more curation
-tiers). See [fragment-contracts](fragment-contracts.md) for the exact-fragment contract; the
-stable output field names are documented under the [scan-JSON v1](scan-json.md#fragment-metadata)
-contract (deprecated, but still the reference for these fragment fields).
+locations carry stable proof metadata explaining why a region is exact-safe, but product
+placement — which surface a family lands on — is decided separately. See
+[fragment-contracts](fragment-contracts.md) for the exact-fragment contract; the stable
+output field names and curation tiers are documented under the
+[scan-JSON v1](scan-json.md#fragment-metadata) contract (deprecated, but still the reference
+for these fragment fields).
 
 ## Declarative languages (CSS / HTML) — the taxonomy on a different denotation
 

--- a/docs/clone-types.md
+++ b/docs/clone-types.md
@@ -190,11 +190,12 @@ out-of-scope list live in [languages](languages.md); the taxonomy mapping is:
   [languages › declarative CSS](languages.md#declarative-languages-css) and
   [HTML markup](languages.md#declarative-languages-html-markup).
 
-**Soundness** is by construction (the fingerprint *is* the canonical computed style /
-rendered DOM, so equal fingerprint ⟺ equal denotation) plus adversarial per-rule
-batteries; CSS, HTML, and imperative fingerprints are domain-disjoint, so the
-language-blind exact channel can never merge across them. What declarative detection does
-**not** do (SCSS/Less, cross-file `var()` resolution, full Svelte block grammar) is in
+**Soundness** is by construction plus adversarial batteries (the mechanism, value
+canonicalization, and cascade rules are in the [languages](languages.md) links above); the
+taxonomy-relevant consequence is that the CSS, HTML, and imperative fingerprints are
+domain-disjoint, so the language-blind exact channel can never merge across them. What
+declarative detection does **not** do — SCSS/Less, cross-file `var()` resolution, full
+Svelte block grammar — is in
 [languages › cross-dialect markup](languages.md#cross-dialect-markup-htmlvuesveltejsxtsx).
 
 ## Detection modes, and cross-language

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,8 @@ CI failure mode.
 
 All keys are optional; an absent key means "no opinion — use the CLI value or
 the built-in default". Keys are kebab-case and live under the `[scan]` table.
-`nose query` reads the same `[scan]` config keys as `nose scan`, with one exception:
-`top` has no effect under `nose query` (its row limit is the `top=` query term, default
-30); it only bounds the deprecated `nose scan`'s report.
+`nose query` reads the same `[scan]` config keys as `nose scan`, with one exception for
+`top` (see the table below).
 
 The **CLI override** column gives the per-run flag (or, where they differ, the `nose query`
 term — `nose query` spells `sort`/`top` as the DSL terms `sort=`/`top=`, not `--sort`/`--top`).
@@ -50,7 +49,7 @@ term — `nose query` spells `sort`/`top` as the DSL terms `sort=`/`top=`, not `
 | `min-members` | int | `2` | `--min-members` |
 | `min-size` | int (IL tokens) | `24` | `--min-size` |
 | `min-lines` | int (advanced) | `5` | `--min-lines` |
-| `top` | int | `30` | `top=` (query term); `--top` (deprecated scan). **Config key bounds `scan` only** — `nose query`'s limit is the `top=` term |
+| `top` | int | `30` | `top=` (query term); `--top` (deprecated scan). **Config key bounds `scan` only** — `nose query`'s row limit is the `top=` term (default 30) |
 | `ignore-file` | string path | auto-read `nose.ignore.json` when present | `--ignore-file` |
 | `semantic-packs` | list of file or directory paths | `[]` | `--semantic-pack` |
 
@@ -71,16 +70,16 @@ The `near` channel's acceptance threshold rides on the `mode` value itself —
 There is no separate threshold setting, so it can never be mis-applied to the exact
 `syntax`/`semantic` channels.
 
+```sh
+nose query src --mode syntax,semantic,near:0.70
+```
+
 The hidden experimental `abstraction[:T]` mode is also accepted in `mode`, but it is
 not a stable project-policy surface and is intentionally absent from
 [capabilities](capabilities.md)' stable mode list. Prefer it for local research or
 tooling experiments, not CI gates. If `near:T` and `abstraction:T` appear together,
 they must name the same threshold because both modes share one fuzzy acceptance
 cutoff.
-
-```sh
-nose query src --mode syntax,semantic,near:0.70
-```
 
 Config file paths are resolved from the config file's directory, so committed
 project paths do not depend on where `nose` was invoked. This applies to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ sort        = "extractability"
 min-value   = 200
 min-members = 3
 min-size    = 30
-top         = 50            # bounds `nose scan` only; `nose query` uses the `top=` term
+top         = 50
 ignore-file = "nose.ignore.json"
 semantic-packs = ["semantic-packs/python-math-prod.json"]
 ```
@@ -118,8 +118,7 @@ ignore-file = "nose.ignore.json"
 When unset, nose automatically reads `nose.ignore.json` in the current working
 directory if it exists. Pass `--ignore-file <file>` to override the config for one
 run. Ignored families are hidden from the active report and from `--fail-on any` /
-`--fail-on new`; the ignore file keeps the reason, owner, note, and expiry for each
-suppression as the audit record.
+`--fail-on new`.
 
 The file format, selector semantics, and expiry behavior are documented in
 [structured-ignores](structured-ignores.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,6 @@ comment syntax all work). nose drops that unit from detection, so that site cann
 family. Use this for a duplicate you've consciously decided to live with, rather than
 excluding the whole file.
 
-For a finding that should stay visible to audit tooling, prefer a structured
-ignore entry. For accepting *all* of today's existing duplication at once — so
-only *new* duplication is reported — use a baseline instead; see
-[continuous-integration](continuous-integration.md).
+For when to reach for this inline marker vs a structured ignore entry vs a
+baseline, see [Which suppression to use](structured-ignores.md#which-suppression-to-use).
+Baselines are set up in [continuous-integration](continuous-integration.md).

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -6,8 +6,8 @@ and runs fast on every push.
 
 The gate command is now [`nose query`](usage.md#nose-query): it carries the same
 `--fail-on`/`--baseline`/`--ignore-file`/`--cache-dir` workflow flags and the same
-`--format sarif` output as the old `nose scan`. `nose scan` takes the same flags and
-still works, but it is **deprecated (0.10.0)** in favour of `nose query`; the examples
+`--format sarif` output as the old `nose scan`. `nose scan` still works, but it is
+**deprecated (0.10.0)** in favour of `nose query`; the examples
 below use the `query` spelling throughout.
 
 ## The `--fail-on any` gate

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -77,8 +77,9 @@ non-zero for new or changed clone families. Plain `--fail-on any` still means "f
 anything is reported on the default surface after the active filters."
 
 Commit `.nose-baseline.json`. Families are keyed by their sorted reported member
-locations: displayed path, language, span, unit kind, symbol name, and fragment
-metadata. **The key is deliberately span- and path-sensitive**, which has three
+locations — the same key structured ignores use (see [structured-ignores ›
+Family IDs](structured-ignores.md#family-ids)). **The key is deliberately span-
+and path-sensitive**, which has three
 honest consequences (measured in [experiments §CB](experiments.md)): editing lines
 *above* an accepted clone re-keys it (it resurfaces as `new`/`changed`); renaming
 its file re-keys it; and the key embeds the detecting channel's unit shape, so a

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -117,13 +117,10 @@ nose query src --ignore-file nose.ignore.json --fail-on any
 ```
 
 Ignored families are removed from the active report, so they do not fail `--fail-on any`
-or `--fail-on new`. The ignore file keeps each suppression's reason, note, owner, expiry, and
-selectors as the audit record. (The deprecated `nose scan --format json` also echoes the
-suppressed families back under an `ignored_families` array.)
+or `--fail-on new`.
 
 Malformed ignore files fail the run. Expired entries are reported as warnings on stderr
-and are not applied (the deprecated `nose scan --format json` also lists them under
-`ignore.expired`). That makes stale waivers visible instead of silently hiding
+and are not applied. That makes stale waivers visible instead of silently hiding
 duplication. See [structured-ignores](structured-ignores.md) for the file format and
 selector semantics.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -126,7 +126,7 @@ is held to proof discipline (§1). Actionability splits by **decidability, not c
   attention and tokens exactly like answering a judgment question internally wastes ours.
   The boundary between "detector's job" and "judge's job" is drawn at decidability.
 - Every such filter is a **classification, never a deletion**: omitted families stay in
-  `--format json --top 0` under an honest surface name (`generated`, `declaration`,
+  `--format json top=0` under an honest surface name (`generated`, `declaration`,
   `hidden`, …) with a count line in the human report — recall-first consumers and audits
   can always opt back in.
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -114,7 +114,7 @@ A later PR weight-grades the sub-DAG score (a larger shared computation scores h
 lifts one pre-existing partial-clone family past the substantial threshold — budget re-baselined
 20 → 21. Each sub-DAG anchor also now carries the **source line range** of the shared computation
 (stamped from the enclosing expression during value-graph evaluation), exposed per unit in
-`nose features --format json` (`anchors[].line_start` / `line_end`).
+`nose features` (which emits JSON by default), as `anchors[].line_start` / `line_end`.
 
 Those line ranges are now surfaced at the **family** level too: when every member of a clone family
 shares a heavy sub-DAG, each site in the report carries `locations[].shared_subdag = [start, end]`

--- a/docs/frontier-platform.md
+++ b/docs/frontier-platform.md
@@ -40,7 +40,7 @@ it can never reorder axes that differ on breadth:
   a hard-coded list — so a `.js` file inside a TypeScript repo cannot invent a new corpus
   language. The file-extension `source_language_breadth` is kept as a separate *diagnostic*
   (denominator = the source languages actually observed) and never drives the ranking;
-- **dev vs held-out generalization** — the 58/47 dev/held-out split is reported separately;
+- **dev vs held-out generalization** — the 66/54 dev/held-out split is reported separately;
   `dev` drives ranking/triage, held-out is a generalization check, and a `dev-only` axis is
   marked as weaker evidence.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,6 +111,8 @@ skeleton, and a diff. Add `full` to render the skeleton inline:
 $ nose query examples id=a47c37baa1 full
 a47c37baa1 — exact · prod · 6 copies · 0/7 shared, 0p · ~0 removable
   → local duplication — extract a helper (cross-language)
+  why this hint:
+    - an implementation body was found
   copies:
     examples/sum.go:3-9  SumFor
     examples/sum.go:11-17  SumRange

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,7 +132,7 @@ a `⟨param N: class⟩` placeholder (the coarse value-class — `literal`/`name
 
 ## Slice, facet, and follow links
 
-Every dashboard ends in runnable next-commands, and an `explore` cheatsheet of the query
+Every dashboard ends in runnable next-commands, and a cheatsheet of the query
 grammar is printed each run. The moves:
 
 | You want… | Command |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,8 +132,7 @@ a `⟨param N: class⟩` placeholder (the coarse value-class — `literal`/`name
 
 ## Slice, facet, and follow links
 
-Every dashboard ends in runnable next-commands, and a cheatsheet of the query
-grammar is printed each run. The moves:
+Every run also prints a cheatsheet of the query grammar. The moves:
 
 | You want… | Command |
 |---|---|

--- a/docs/hazard-release-checklist.md
+++ b/docs/hazard-release-checklist.md
@@ -28,8 +28,8 @@ miss.
 | **Performance / refactor with identical output** | No | No | Nothing (confirm output is byte-identical first) |
 
 **How to tell if detection output changed**, if unsure: scan a fixed fixture corpus with
-the old and new binary and diff the JSON `families` (`nose query <fixtures> --mode
-semantic,near --format json top=0`, where `top=0` emits every family), comparing
+the old and new binary and diff the JSON `families` (`nose scan <fixtures> --mode
+semantic,near --format json --top 0`, where `--top 0` emits every family), comparing
 **sort-independently** and looking only at
 the calibrated inputs — family identity, member sets, fingerprints, and the feature values in
 the row above (`mean_sem`, `shared_weight`, `params`, `mean_lines`, `modules`, `scope`). A

--- a/docs/home.md
+++ b/docs/home.md
@@ -9,9 +9,7 @@ ranking the candidates by refactoring value — a deterministic triage signal, n
 worth-it verdict (that judgment is the consumer's). The repository
 [README](../README.md) is the one-screen overview; this wiki is the full guide.
 
-Every wiki page lives in `docs/` and links to its neighbours with relative links, so the
-docs browse cleanly on GitHub and in any Markdown viewer. Root project docs are linked
-where relevant. The pages are grouped by what you're here to do.
+The pages are grouped by what you're here to do.
 
 ## Start here
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -67,8 +67,7 @@ computed/declared style** of its declaration block — see
 exact clone when they compute the same style, so the same duplicated declaration block
 under different selectors is one family. Concretely the fingerprint is invariant to:
 
-- **selector** — `.btn { … }` and `.cta { … }` with the same declarations merge (a
-  duplicated declaration block is the canonical CSS clone);
+- **selector** — `.btn { … }` and `.cta { … }` with the same declarations merge;
 - **declaration order** — except where it changes the cascade (see below);
 - **value spelling** — `#fff` ≡ `#ffffff` ≡ `white` ≡ `rgb(255 255 255)`; `0px` ≡ `0`;
   `margin: 0 0 0 0` ≡ `margin: 0`; trailing-zero/sign noise.

--- a/docs/markdown-duplication.md
+++ b/docs/markdown-duplication.md
@@ -36,7 +36,7 @@ judge whether a repetition is intentional, acceptable, or worth removing — tha
 and the maintainer's call (see [design](design.md)). Consequences:
 
 - **Boilerplate copies (license / code-of-conduct / templates) are true duplicates** — reported
-  with high `commonness`, never silently suppressed. You decide if they matter.
+  with high `commonness`, never silently suppressed.
 - The honesty contract: output says **"near-duplicate (score + witness + commonness)"**, never
   "same meaning" and never "you should remove this".
 - Precision targets the **duplication relation** (don't call unrelated or merely same-topic

--- a/docs/markdown-duplication.md
+++ b/docs/markdown-duplication.md
@@ -16,11 +16,11 @@ needs an LLM). Paraphrase / Type-4 semantic equivalence is also out of scope for
 ## Usage
 
 ```
-nose query <paths...>                 # dashboard: a "markdown near-duplicates" section
-nose query <paths...> --format json   # a top-level "markdown" array of families
+nose query <path>                     # dashboard: a "markdown near-duplicates" section
+nose query <path> --format json       # a top-level "markdown" array of families
 ```
 
-`nose query` discovers `.md`/`.markdown` under the paths (respecting `.gitignore` and the same
+`nose query` discovers `.md`/`.markdown` under the path (respecting `.gitignore` and the same
 `exclude` globs as code) and reports ranked near-duplicate **families** alongside the code clones,
 each with:
 
@@ -56,19 +56,12 @@ and the maintainer's call (see [design](design.md)). Consequences:
 ## Measurement
 
 Quality is measured against frozen, **LLM-built golden sets** (no human in the loop;
-3 heterogeneous judges, majority vote, self-calibrated on construction-truth anchors) — see
-[`bench/markdown/`](../bench/markdown/README.md). The detector engine is exercised directly through
-the `nose-markdown` dev example (the user surface is `nose query`):
-
-```
-cargo run -p nose-markdown --example mddup -- bench/markdown/corpus --eval bench/markdown/golden.v1.json
-cargo run -p nose-markdown --example mddup -- bench/markdown/corpus-docs --eval bench/markdown/golden.docs.v1.json
-```
-
-Headline (golden v1, code-of-conduct corpus): panel Fleiss κ 0.70, anchor self-calibration 1.0;
-detector **PR-AUC 0.995**, ROC-AUC 0.992, recall@P95 0.96, recall@P99 0.93, candidate-recall 1.0.
-Multi-genre golden (docs v1, 5 genres): κ 0.71; **PR-AUC 0.944**, ROC-AUC 0.970, recall@P95 0.74,
-candidate-recall 1.0. Byte-identical across runs.
+3 heterogeneous judges, majority vote, self-calibrated on construction-truth anchors). Headline:
+detector **PR-AUC 0.995** single-genre (CoC) / **0.944** multi-domain, candidate-recall 1.0,
+deterministic (byte-identical across runs). See [`bench/markdown/`](../bench/markdown/README.md)
+for the corpora, the deterministic build procedure, the dev `mddup` example commands, and the full
+κ / PR-AUC / ROC-AUC / recall tables. (The user surface is `nose query`; `mddup` is a dev-only
+example.)
 
 ## Related
 

--- a/docs/markdown-duplication.md
+++ b/docs/markdown-duplication.md
@@ -60,8 +60,7 @@ Quality is measured against frozen, **LLM-built golden sets** (no human in the l
 detector **PR-AUC 0.995** single-genre (CoC) / **0.944** multi-domain, candidate-recall 1.0,
 deterministic (byte-identical across runs). See [`bench/markdown/`](../bench/markdown/README.md)
 for the corpora, the deterministic build procedure, the dev `mddup` example commands, and the full
-κ / PR-AUC / ROC-AUC / recall tables. (The user surface is `nose query`; `mddup` is a dev-only
-example.)
+κ / PR-AUC / ROC-AUC / recall tables.
 
 ## Related
 

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -92,6 +92,10 @@ boundaries the consumer must check:
 
 16 findings across 8 repos ([experiments §CF](experiments.md)): 16/16 value-exact on
 hand-labeling, ~13/16 directly actionable; the remainder are test/vendored containers.
+This was the initial §CF pass; the later [2026-06-13 field audit](reinvented-helper-audit-2026-06-13.md)
+re-ran the channel on the same corpus (17 findings / 9 repos; 94% genuine value-duplication,
+71% directly actionable on the non-test default surface) and is what drove the default-list
+promotion described in [Surface](#surface).
 One finding surfaced a real upstream bug — h2database's `getGarbageCollectionCount()`
 copy-pasted from the time variant and still calls `getCollectionTime()`, which is
 *why* it exactly contains the time helper's computation. Tuning knob:

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -50,11 +50,9 @@ Two exclusions keep the surface honest:
 
 ## Surface
 
-- **`nose query <path> reinvented`** (primary): the forward exploration view — the
-  reinvented-helper findings as query-JSON's `reinvented` view (`items[]`, each
-  `{helper, site, value, approximate}`); the action is "call it". It lists every finding,
-  test-container ones included. `nose scan --show reinvented` is the deprecated equivalent.
-  See [query-json](query-json.md).
+- **`nose query <path> reinvented`** (primary): the forward exploration view — the action
+  is "call it". It lists every finding, test-container ones included.
+  `nose scan --show reinvented` is the deprecated equivalent.
 - **Human report**: the default report LISTS the non-test findings (top by weight) —
   promoted from a one-line count after a [field audit](reinvented-helper-audit-2026-06-13.md)
   measured them at 94% genuine value-duplications / 71% directly actionable ([design §2c](design.md)).
@@ -62,9 +60,10 @@ Two exclusions keep the surface honest:
   judgment-deep class ([design §2b](design.md)) — a test asserting the helper's value as a literal would be
   circular to "fix" — so they are excluded from the default and shown only by the `reinvented`
   view.
-- **Machine JSON**: query-JSON's `reinvented` view (`items[]`) is the forward contract; the
-  deprecated equivalent is scan-JSON's additive `reinvented_helpers` array (omitted when empty)
-  — see [scan-json](scan-json.md#reinvented-helpers).
+- **Machine JSON**: query-JSON's `reinvented` view (`items[]`, each
+  `{helper, site, value, approximate}`) is the forward contract —
+  see [query-json](query-json.md#views); the deprecated equivalent is scan-JSON's additive
+  `reinvented_helpers` array (omitted when empty) — see [scan-json](scan-json.md#reinvented-helpers).
 - A **vendored** (non-test) container is, like a test container, a consumer judgment
   call — but unlike `container_in_test` it is *not* auto-excluded from the default: nose
   lists it and carries the locations, so the consumer filters by path.

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -99,4 +99,4 @@ copy-pasted from the time variant and still calls `getCollectionTime()`, which i
 `NOSE_REINVENTED_MIN_WEIGHT` (research surface) adjusts the anchor collection floor.
 
 *See also: [normalization](normalization.md) · [clone-types](clone-types.md) ·
-[scan-json](scan-json.md) · [design](design.md) · [experiments](experiments.md).*
+[query-json](query-json.md) · [scan-json](scan-json.md) · [design](design.md) · [experiments](experiments.md).*

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -54,8 +54,8 @@ Two exclusions keep the surface honest:
   is "call it". It lists every finding, test-container ones included.
   `nose scan --show reinvented` is the deprecated equivalent.
 - **Human report**: the default report LISTS the non-test findings (top by weight) —
-  promoted from a one-line count after a [field audit](reinvented-helper-audit-2026-06-13.md)
-  measured them at 94% genuine value-duplications / 71% directly actionable ([design §2c](design.md)).
+  promoted from a one-line count after the [2026-06-13 field audit](reinvented-helper-audit-2026-06-13.md)
+  ([design §2c](design.md)); the audit's precision figures are in the Measured section below.
   Findings whose CONTAINER is a test file (`container_in_test`) are a decidable
   judgment-deep class ([design §2b](design.md)) — a test asserting the helper's value as a literal would be
   circular to "fix" — so they are excluded from the default and shown only by the `reinvented`

--- a/docs/reinvented-helpers.md
+++ b/docs/reinvented-helpers.md
@@ -61,12 +61,13 @@ Two exclusions keep the surface honest:
   Findings whose CONTAINER is a test file (`container_in_test`) are a decidable
   judgment-deep class ([design §2b](design.md)) — a test asserting the helper's value as a literal would be
   circular to "fix" — so they are excluded from the default and shown only by the `reinvented`
-  view (or the deprecated `nose scan --show reinvented`), which lists every finding.
+  view.
 - **Machine JSON**: query-JSON's `reinvented` view (`items[]`) is the forward contract; the
   deprecated equivalent is scan-JSON's additive `reinvented_helpers` array (omitted when empty)
   — see [scan-json](scan-json.md#reinvented-helpers).
-- The container being a test file or vendored code is *judgment-deep* non-action
-  ([design §2b](design.md)): the consumer decides; nose carries the locations.
+- A **vendored** (non-test) container is, like a test container, a consumer judgment
+  call — but unlike `container_in_test` it is *not* auto-excluded from the default: nose
+  lists it and carries the locations, so the consumer filters by path.
 
 ## The suggested fix is advisory, not mechanical
 

--- a/docs/review.md
+++ b/docs/review.md
@@ -1,6 +1,6 @@
 # Review — catch un-propagated changes
 
-> **Deprecated since 0.10.0** (still works in 0.11.0). `nose review --base <ref>` is now `nose query <paths> base=<ref>`
+> **Deprecated since 0.10.0** (still works). `nose review --base <ref>` is now `nose query <paths> base=<ref>`
 > — the same detection and the same `fire_eligible` gate, under the unified
 > [query](usage.md#nose-query) surface (`base=REF --fail-on any` is the gate). `review` still
 > works and `capabilities` lists it under `commands.deprecated`; it is slated for removal in a
@@ -14,10 +14,10 @@ siblings for you and asks: *should this change have gone there too?*
 
 Where plain [`nose query`](usage.md#nose-query) is stateless (point it at any source, no
 history), the `base=` view needs a **git repository** — it compares the working tree to a ref.
-It shares query's detection channels, size gates, excludes, config loading, structured
-ignores, and `top=`; report-shaping controls — the `sort=` term and the `--min-value` /
-`--min-members` flags — and baselines (`--baseline` / `--fail-on new`) do not carry over. For
-the standard clone taxonomy see [clone types](clone-types.md).
+It shares most of `nose query`'s surface (the shared flags are listed under [Flags and
+terms](#flags-and-terms)); the report-shaping controls — the `sort=` term and the
+`--min-value` / `--min-members` flags — and baselines (`--baseline` / `--fail-on new`) do not
+carry over. For the standard clone taxonomy see [clone types](clone-types.md).
 
 ## Quick start
 
@@ -39,8 +39,8 @@ next:
   nose query . base=origin/main --fail-on any   # fail CI on a proven divergence
 ```
 
-(The deprecated `nose review` / `nose review --base origin/main` spelling still works and
-prints the same findings in its own layout.)
+(The deprecated `nose review` / `nose review --base origin/main` spelling prints the same
+findings in its own layout.)
 
 The location listed under **not updated** is the copy your change skipped — open it and
 decide whether the edit belongs there too, or whether the divergence is intentional.

--- a/docs/review.md
+++ b/docs/review.md
@@ -2,8 +2,8 @@
 
 > **Deprecated since 0.10.0** (still works). `nose review --base <ref>` is now `nose query <paths> base=<ref>`
 > — the same detection and the same `fire_eligible` gate, under the unified
-> [query](usage.md#nose-query) surface (`base=REF --fail-on any` is the gate). `review` still
-> works and `capabilities` lists it under `commands.deprecated`; it is slated for removal in a
+> [query](usage.md#nose-query) surface (`base=REF --fail-on any` is the gate). `capabilities`
+> lists `review` under `commands.deprecated`; it is slated for removal in a
 > later release. The mechanics below are unchanged and describe both spellings.
 
 `nose review` flags clone families that were **edited inconsistently** in a change set:

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -24,9 +24,9 @@ anything going through CI — prefer the structured file, because it stays audit
 
 ## Quick start
 
-Run nose and copy a family's full ID from the JSON report — the `id` field. (The human and
-markdown rows show only a short `id=` drill prefix, which works with `nose query … id=` but is
-*not* a valid `family_id` selector; an ignore entry needs the full 16-hex-digit ID.)
+Run nose and copy a family's full `id` field from the JSON report. Do not paste the short
+`id=` prefix shown in the human drill links — that is a drill handle, not a valid `family_id`.
+See [Family IDs](#family-ids).
 
 ```sh
 nose query src --format json all
@@ -117,15 +117,16 @@ nose versions whose IDs omitted span and fragment metadata. Use `paths` and
 `languages` selectors when the review decision should survive routine movement
 inside a file.
 
-`nose query`'s human rows carry a short family handle in each drill link
-(`id=` accepts any unambiguous prefix):
+`nose query`'s human rows carry only a short family handle in each drill link. That prefix
+works with `nose query … id=` (which accepts any unambiguous prefix) but is *not* a valid
+`family_id` selector for an ignore entry:
 
 ```text
 src/loaders/users.py:1  load_users  3 copies · 12/14 shared, 1p · ~24 removable · copy-paste   nose query src id=479389f590
 ```
 
-The full ID to copy into an ignore entry's `family_id` is the `id` field in `--format json`
-(every family object carries it):
+The full ID to copy into an ignore entry's `family_id` is the 16-hex-digit `id` field in
+`--format json` (every family object carries it):
 
 ```json
 { "id": "479389f590c1234a", "...": "..." }

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -5,23 +5,6 @@ context. Use them when a finding is intentional, generated, framework-imposed, o
 owned by a team that is not ready to refactor it yet. For command basics see
 [usage](usage.md); for CI gates see [continuous-integration](continuous-integration.md).
 
-## Inline marker vs structured file — which to use
-
-nose has two ways to say "this clone is fine"; they serve different needs, so pick by
-*who* the suppression is for:
-
-| | inline `// nose-ignore` | structured `nose.ignore.json` |
-|---|---|---|
-| Lives | next to the code, travels with it | one file in the scan working directory |
-| Carries | nothing — just "skip this site" | reason, owner, expiry, note |
-| Audit | invisible in reports | the file records reason/owner/expiry for each suppression |
-| Best for | a quick, local, self-evident exception | team-level, reviewable, expiring debt |
-
-Rule of thumb: reach for the **inline marker** when the reason is obvious to anyone
-reading the line; reach for the **structured file** when the suppression is a decision
-someone else should be able to find, question, and revisit later. When in doubt — or for
-anything going through CI — prefer the structured file, because it stays auditable.
-
 ## Quick start
 
 Run nose and copy a family's full `id` field from the JSON report. Do not paste the short
@@ -34,8 +17,7 @@ nose query src --format json all
 
 (`nose scan src --format json --top 0` is the deprecated equivalent.)
 
-Create `nose.ignore.json` in the directory where you invoke nose, or pass an explicit
-path with `--ignore-file`:
+Create `nose.ignore.json` in the directory where you invoke nose:
 
 ```json
 {
@@ -145,6 +127,14 @@ passed. nose prints a warning on stderr and does not apply the entry (the deprec
 carries no `ignore` object).
 
 ## Which suppression to use
+
+nose has three ways to suppress a finding; pick by *who* the suppression is for and
+whether the decision needs to stay reviewable. Reach for the inline `// nose-ignore`
+marker when the reason is self-evident to anyone reading the line; reach for the
+structured file when the suppression is a decision someone else should be able to find,
+question, and revisit; use a baseline to accept an existing codebase in bulk. When in
+doubt — or for anything going through CI — prefer the structured file, because it stays
+auditable.
 
 | mechanism | use when | tradeoff |
 |---|---|---|

--- a/docs/structured-ignores.md
+++ b/docs/structured-ignores.md
@@ -12,7 +12,7 @@ Run nose and copy a family's full `id` field from the JSON report. Do not paste 
 See [Family IDs](#family-ids).
 
 ```sh
-nose query src --format json all
+nose query src --format json all top=0
 ```
 
 (`nose scan src --format json --top 0` is the deprecated equivalent.)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -222,11 +222,9 @@ metadata are documented in [fragment-contracts](fragment-contracts.md) and
 > [Ranking](#ranking) keys and [Detection modes](#detection-modes) above apply to both surfaces.
 
 `nose scan <paths…>` scans one or more files/directories (recursively, respecting
-`.gitignore` files inside each scanned tree), groups duplicated code into **families**, and
-ranks them by **extractability** — how much shared code each family has and how little varies — so the
-duplication you can actually act on surfaces first. With no `--mode`, it runs
-`syntax,semantic,near`: CPD-style syntax runs, exact semantic Type-4 clones, and
-fuzzy Type-3 near-duplicates.
+`.gitignore` files inside each scanned tree) and groups duplicated code into **families**.
+Ranking (default `extractability`) and detection channels (default `syntax,semantic,near`)
+follow the shared [Ranking](#ranking) and [Detection modes](#detection-modes) sections above.
 
 ```sh
 nose scan path/to/project

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -232,8 +232,7 @@ fuzzy Type-3 near-duplicates.
 nose scan path/to/project
 ```
 
-How to read the resulting report — the `scanned …` scope line, the per-family
-breakdown, scope tags, and the `→` hint — is covered in
+How to read the resulting report is covered in
 [getting-started → How to read the report](getting-started.md#how-to-read-the-report).
 Like `nose query`, `scan` shows only the curated [default surface](#the-default-surface)
 of action-oriented findings and omits the held-back categories with a short count line;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,6 +103,11 @@ configured by flag while scope/sort/top are the DSL's `scope=`/`sort=`/`top=`. I
 drops structured-ignored families, so `nose query <path> --fail-on any` is a drop-in gate (see
 [continuous-integration](continuous-integration.md)).
 
+A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
+CI gate must fail loudly. A path that exists but contains no supported source
+files warns on stderr and reports an empty scan. This holds for `nose query`,
+`nose stats`, and the deprecated `nose scan` alike.
+
 How to read the resulting dashboard — the `scanned …` scope line, the confidence breakdown,
 the per-family economics, scope tags, and the `→` hint — is covered in
 [getting-started → How to read the report](getting-started.md#how-to-read-the-report).
@@ -242,11 +247,6 @@ dropped: the families stay ranked, in `--format json`, and one `--scope test` aw
 `--scope prod` hides them entirely; `--scope test` focuses on them. (This prod-first
 ordering is specific to the deprecated `scan` view; `nose query` is **scope-blind** —
 it ranks test and production purely by extractability and slices with `scope=`.)
-
-A named path that doesn't exist is an error (exit non-zero) — a typo'd path in a
-CI gate must fail loudly. A path that exists but contains no supported source
-files warns on stderr and reports an empty scan. The same rule applies to
-`nose query` and `nose stats`.
 
 Families whose members are overlapping slices of the same source regions are
 one refactoring *opportunity*: the best-ranked family keeps its numbered entry


### PR DESCRIPTION
## Summary

A five-pass documentation audit over the README and all of `docs/`, run as a
detect → adversarially-verify → fix workflow against a **freshly-built** binary
(`nose 0.13.0`, query-JSON v3). Two goals: (1) eliminate code-docs drift, and
(2) tighten the user-facing docs so each carries the content a user needs with no
restated/fluff explanation. `AGENTS.md`/`CLAUDE.md` (marked "DO NOT MODIFY") and
the dated/historical records were left structurally untouched.

Every numeric/CLI claim that changed was re-verified against its source (the
binary, `cargo test`, or the corpus/audit files), not just an agent's say-so.

## Drift fixed (verified against live sources)

- `getting-started.md` — `id=… full` transcript was missing the `why this hint:` /
  `- an implementation body was found` block the binary now prints.
- `getting-started.md` — printed cheatsheet has no `explore` token.
- `markdown-duplication.md` — `nose query` takes a single `<path>`, not `<paths...>`.
- `design.md` — `nose query … --format json top=0` (`top` is a query term, not `--top`).
- `hazard-release-checklist.md` — the JSON-diff recipe names scan-only fields, so it
  must use `nose scan … --format json --top 0`.
- `benchmark.md` — CSS/HTML headline is 13/13 recall, 14/14 soundness (+ media-query
  axes), verified via `cargo test -p nose-cli --test css_html_quality`.
- `frontier-platform.md` — 66/54 dev/held-out split (verified against
  `bench/goldens/corpus.json`: dev=66, heldout=54, 120 repos).
- `architecture.md` — added the missing `nose-markdown` crate row.
- `benchmark.md` / `review.md` — `nose behavioral-gate` is hidden; drop the stale
  "still works in 0.11.0" version pin.
- `dogfooding.md` — `nose features` emits JSON by default (no `--format json`).
- `configuration.md` / `structured-ignores.md` — corrected `top=` default-30 detail;
  full `id` is 16 hex digits.

## User-facing tightening (no content lost)

Removed restated commands/flags and verdict-echo phrasing across README, `home`,
`usage`, `configuration`, `continuous-integration`, `clone-types`, `languages`,
`review`, `structured-ignores`, `reinvented-helpers`, `markdown-duplication` —
each fact now has a single owning section, reached by cross-link. All internal
links/anchors were re-checked.

## Convergence

Confirmed findings per pass: 17 → 7 → 12 → 4 → 5; CLI drift trended 3 → 2 → 4 → 0 → 1
(the last a transcript line). By the final passes only consistency/dedup edits
remained. Net: 18 files, +115 / −139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)