### PR TITLE
Make benchmark corpus setup reproducible

### DIFF
--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -20,7 +20,7 @@ jobs:
   verify:
     name: nightly pinned-corpus verify
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
@@ -52,7 +52,7 @@ jobs:
             --logs-dir target/corpus-verify-logs
 
       - name: upload per-repo verify logs on failure
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: corpus-verify-logs

--- a/bench/README.md
+++ b/bench/README.md
@@ -9,12 +9,14 @@ comparable over time. There are two layers, both over the same corpus split.
   gate). The checkouts themselves are NOT committed; point `--repos` at a directory whose
   immediate subdirectories are the repo ids (e.g. `bench/repos`, populated by
   `setup_repos.sh`).
-- `setup_repos.sh` removes any `bench/repos` entry outside the pinned corpus list, clones
-  the pinned commits, then **prunes generated/vendored files**
+- `setup_repos.sh` removes any `bench/repos` entry outside the pinned corpus list, resets
+  existing pinned clones to their exact commits, clones missing/drifted repos, then
+  **prunes generated/vendored files**
   (npm/vendored deps, build output, committed Javadoc/minified bundles, `@generated`
   source) — not code a developer refactors, and they skew clone measurements toward
-  boilerplate. Test fixtures (e.g. `prettier/tests/format`) are intentionally kept (test
-  data is a separate category from generated/vendor).
+  boilerplate. Local filesystem metadata such as `.DS_Store` is discarded before the
+  digest is computed. Test fixtures (e.g. `prettier/tests/format`) are intentionally
+  kept (test data is a separate category from generated/vendor).
 - `labels/prune_manifest.json` records the file-level prune audit: removed generated
   sources, protected label files that were deliberately kept, and the post-prune corpus
   digest. The checked-in manifest is the frozen pinned-corpus audit artifact; reconstructing

--- a/bench/corpus_prune/cli.py
+++ b/bench/corpus_prune/cli.py
@@ -91,6 +91,9 @@ def run_self_test() -> None:
         assert (src / "protected.py").exists()
         check_manifest(root, repos, labels_path, manifest_path)
 
+        (repos / ".DS_Store").write_text("metadata\n")
+        check_manifest(root, repos, labels_path, manifest_path)
+
         _, removed_count, verified_only = apply_prune(root, repos, labels_path, manifest_path)
         assert removed_count == 0, removed_count
         assert verified_only

--- a/bench/corpus_prune/core.py
+++ b/bench/corpus_prune/core.py
@@ -379,6 +379,8 @@ def iter_all_files(root: Path) -> Iterable[Path]:
         except OSError:
             continue
         for entry in entries:
+            if entry.name == ".DS_Store":
+                continue
             if entry.is_symlink():
                 yield entry
             elif entry.is_dir():

--- a/bench/labels/prune_manifest.json
+++ b/bench/labels/prune_manifest.json
@@ -2,9 +2,9 @@
   "banner_zone_bytes": 8192,
   "corpus_digest_after_prune": {
     "algorithm": "sha256(repo_path NUL kind NUL size NUL file_or_symlink_sha256 LF)",
-    "bytes": 1511232850,
-    "files": 119532,
-    "hex": "3f03380de5cf665ca31e8675a375d8ca8a8f8b2fe5db99f306c0948dd029b564"
+    "bytes": 1509667485,
+    "files": 119387,
+    "hex": "7247d64112bc20749de43d91fb86c6f288ae09271a08d67b68aa252d5abb5804"
   },
   "generated_by": "bench/prune_corpus.py",
   "labels": "bench/labels/refactoring_families.v5.json",
@@ -2218,6 +2218,15 @@
       "size": 96752
     },
     {
+      "detail": "matched banner text: DO NOT EDIT! /// The rule list containing all available rules built into SwiftLint. public let builtInRules: [any Rule.T",
+      "path": "bench/repos/swiftlint/Source/swiftlint-dev/Rules+Register.swift",
+      "reason": "generated-banner",
+      "repo": "swiftlint",
+      "repo_path": "swiftlint/Source/swiftlint-dev/Rules+Register.swift",
+      "sha256": "aef328e5698c3c7b9f662bd99d4e83ded260c75e2d37feb88132a1def8c1f43c",
+      "size": 10274
+    },
+    {
       "detail": "matched banner text: DO NOT EDIT BY HAND *** # # Generated",
       "path": "bench/repos/sympy/sympy/parsing/autolev/_antlr/__init__.py",
       "reason": "generated-banner",
@@ -2312,6 +2321,6 @@
   ],
   "totals": {
     "protected_skipped": 25,
-    "removed": 218
+    "removed": 219
   }
 }

--- a/bench/setup_repos.sh
+++ b/bench/setup_repos.sh
@@ -4,7 +4,8 @@
 # commits, so the corpus MUST be pinned — never point the detector at a working copy
 # that can drift (that silently invalidates every measurement).
 #
-# bench/repos is gitignored (111M). Run this once on a fresh checkout.
+# bench/repos is gitignored (111M). This script is rerunnable: existing pinned
+# clones are reset to the exact commit before pruning is applied again.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 if [ ! -f bench/prune_corpus.py ]; then
@@ -22,7 +23,12 @@ PY
   dst="bench/repos/$id"
   if [ -d "$dst/.git" ]; then
     have=$(git -C "$dst" rev-parse HEAD 2>/dev/null || echo none)
-    [ "${have:0:12}" = "${commit:0:12}" ] && { echo "ok   $id @ ${commit:0:12}"; continue; }
+    if [ "${have:0:12}" = "${commit:0:12}" ]; then
+      echo "reset $id @ ${commit:0:12}"
+      git -C "$dst" reset --hard --quiet "$commit"
+      git -C "$dst" clean -ffdx --quiet
+      continue
+    fi
   fi
   echo "clone $id @ ${commit:0:12}"
   rm -rf "$dst"
@@ -44,6 +50,9 @@ prune_corpus_dirs() {
   # minified / bundled files
   find bench/repos -type f \( -name '*.min.js' -o -name '*.min.css' -o -name '*.bundle.js' \) \
     -delete 2>/dev/null || true
+  # local filesystem metadata is not part of the pinned corpus and can otherwise
+  # perturb the post-prune digest on macOS workstations.
+  find bench/repos -type f -name '.DS_Store' -delete 2>/dev/null || true
 }
 prune_corpus_dirs
 # File-level generated/vendored prune. A Python pass (bench/prune_corpus.py) replaces the


### PR DESCRIPTION
## Summary
- reset existing pinned benchmark repos before pruning so reruns restore previously removed tracked files
- exclude `.DS_Store` from corpus pruning/digest accounting and document the behavior
- refresh the prune manifest to the fresh-corpus result: 219 removals, digest `7247d64112bc...`
- give the manual corpus-verify workflow enough time and upload logs on cancellation

## Why
A manual `corpus verify` run on main reconstructed a fresh corpus and produced 219 removals, while an already-pruned local corpus verified 218 removals. The setup script skipped repos that were already at the pinned commit, so tracked files removed by an earlier prune were never restored before the next prune.

## Verification
- `./bench/setup_repos.sh`
- `python3 -m py_compile bench/prune_corpus.py bench/corpus_prune/__init__.py bench/corpus_prune/cli.py bench/corpus_prune/core.py`
- `python3 bench/prune_corpus.py --self-test`
- `python3 bench/prune_corpus.py --apply`
- `python3 bench/prune_corpus.py --check-manifest`
- `./scripts/check-ci-local.sh --fast`