### PR TITLE
Add executable semantic-pack conformance gates

### DIFF
--- a/crates/nose-cli/src/semantic_pack.rs
+++ b/crates/nose-cli/src/semantic_pack.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
-pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
 pub(crate) enum CheckFormat {
@@ -14,6 +14,7 @@ struct CheckJsonReport {
     schema_version: u32,
     status: &'static str,
     totals: CheckJsonTotals,
+    executable_conformance: CheckJsonExecutableConformance,
     influence_preflight: CheckJsonInfluencePreflight,
     manifests: Vec<CheckJsonManifest>,
 }
@@ -24,6 +25,9 @@ struct CheckJsonTotals {
     positive_fixtures: usize,
     hard_negatives: usize,
     fixture_issues: usize,
+    executable_conformance_rows: usize,
+    passed_executable_conformance_rows: usize,
+    executable_conformance_issues: usize,
     influence_rows: usize,
     blocked_influence_rows: usize,
 }
@@ -69,6 +73,29 @@ struct CheckJsonFixture {
 }
 
 #[derive(serde::Serialize)]
+struct CheckJsonExecutableConformance {
+    status: &'static str,
+    rows: Vec<CheckJsonExecutableConformanceRow>,
+}
+
+#[derive(serde::Serialize)]
+struct CheckJsonExecutableConformanceRow {
+    gate_id: String,
+    kind: &'static str,
+    row_id: String,
+    row_hash: String,
+    pack_id: String,
+    pack_hash: String,
+    manifest_path: String,
+    channel: &'static str,
+    oracle: &'static str,
+    passed: bool,
+    positive_fixtures: Vec<String>,
+    hard_negatives: Vec<String>,
+    issues: Vec<&'static str>,
+}
+
+#[derive(serde::Serialize)]
 struct CheckJsonInfluencePreflight {
     status: &'static str,
     rows: Vec<CheckJsonInfluenceRow>,
@@ -100,9 +127,13 @@ impl CheckJsonReport {
                 positive_fixtures: report.positive_fixture_count(),
                 hard_negatives: report.hard_negative_count(),
                 fixture_issues: report.fixture_issue_count(),
+                executable_conformance_rows: report.executable_conformance_count(),
+                passed_executable_conformance_rows: report.passed_executable_conformance_count(),
+                executable_conformance_issues: report.executable_conformance_issue_count(),
                 influence_rows: influence_preflight.rows.len(),
                 blocked_influence_rows: influence_preflight.blocked_count(),
             },
+            executable_conformance: CheckJsonExecutableConformance::new(report),
             influence_preflight: CheckJsonInfluencePreflight::new(influence_preflight),
             manifests: report
                 .manifests
@@ -151,6 +182,39 @@ impl CheckJsonReport {
     }
 }
 
+impl CheckJsonExecutableConformance {
+    fn new(report: &nose_semantics::SemanticPackConformanceReport) -> Self {
+        let rows = report
+            .manifests
+            .iter()
+            .flat_map(|manifest| &manifest.executable)
+            .map(|gate| CheckJsonExecutableConformanceRow {
+                gate_id: gate.gate_id.clone(),
+                kind: gate.kind.as_str(),
+                row_id: gate.row_id.clone(),
+                row_hash: format!("{:016x}", gate.row_hash),
+                pack_id: gate.pack_id.clone(),
+                pack_hash: format!("{:016x}", gate.pack_hash),
+                manifest_path: gate.manifest_path.display().to_string(),
+                channel: gate.channel.as_str(),
+                oracle: gate.oracle.as_str(),
+                passed: gate.passed(),
+                positive_fixtures: gate.positive_fixtures.clone(),
+                hard_negatives: gate.hard_negatives.clone(),
+                issues: gate.issues.iter().map(|issue| issue.as_str()).collect(),
+            })
+            .collect::<Vec<_>>();
+        let status = if rows.is_empty() {
+            "unavailable"
+        } else if report.executable_conformance_issue_count() == 0 {
+            "ok"
+        } else {
+            "failed"
+        };
+        Self { status, rows }
+    }
+}
+
 impl CheckJsonInfluencePreflight {
     fn new(report: &nose_semantics::ExternalInfluencePreflightReport) -> Self {
         Self {
@@ -183,8 +247,8 @@ pub(crate) fn cmd_check(paths: Vec<PathBuf>, format: CheckFormat) -> Result<()> 
     match format {
         CheckFormat::Human => print_human(&report),
         CheckFormat::Json => {
-            let influence_preflight =
-                nose_semantics::SemanticPackSet::new_local(&paths)?.external_influence_preflight();
+            let influence_preflight = nose_semantics::SemanticPackSet::new_local(&paths)?
+                .external_influence_preflight_with_conformance(&report);
             println!(
                 "{}",
                 serde_json::to_string_pretty(&CheckJsonReport::new(&report, &influence_preflight))?
@@ -193,8 +257,9 @@ pub(crate) fn cmd_check(paths: Vec<PathBuf>, format: CheckFormat) -> Result<()> 
     }
     if !report.passed() {
         anyhow::bail!(
-            "semantic pack conformance failed: {} fixture issue(s)",
-            report.fixture_issue_count()
+            "semantic pack conformance failed: {} fixture issue(s), {} executable gate issue(s)",
+            report.fixture_issue_count(),
+            report.executable_conformance_issue_count()
         );
     }
     Ok(())
@@ -219,6 +284,12 @@ fn print_human(report: &nose_semantics::SemanticPackConformanceReport) {
         } else {
             "failed"
         }
+    );
+    println!(
+        "executable gates: {} passed / {} declared; issues: {}",
+        report.passed_executable_conformance_count(),
+        report.executable_conformance_count(),
+        report.executable_conformance_issue_count()
     );
     for manifest in &report.manifests {
         println!(
@@ -252,6 +323,24 @@ fn print_human(report: &nose_semantics::SemanticPackConformanceReport) {
                 fixture.id,
                 issue_text,
                 path_text
+            );
+        }
+        for gate in &manifest.executable {
+            let issue_text = if gate.issues.is_empty() {
+                "ok".to_string()
+            } else {
+                gate.issues
+                    .iter()
+                    .map(|issue| issue.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            println!(
+                "    executable {} {}: {} ({})",
+                gate.kind.as_str(),
+                gate.row_id,
+                issue_text,
+                gate.oracle.as_str()
             );
         }
     }

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -49,7 +49,7 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
         json["schemas"]["semantic_packs"][0],
         "nose.semantic-pack.v0"
     );
-    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 1);
+    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 2);
 }
 
 #[test]

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -120,6 +120,30 @@ fn semantic_pack_manifest_with_value_law(id: &str) -> String {
     )
 }
 
+fn semantic_pack_manifest_with_executable_gates(id: &str) -> String {
+    semantic_pack_manifest(id).replace(
+        r#""known_unsupported": []"#,
+        r#""known_unsupported": [],
+    "executable": [{
+      "id": "python.library-api.example.gate",
+      "row_ref": "python.library-api.example",
+      "oracle": "fixture-expectations",
+      "positive_fixtures": ["positive"],
+      "hard_negatives": ["negative"],
+      "expected_positive": "exact-contract-open",
+      "expected_hard_negative": "exact-contract-closed"
+    }, {
+      "id": "python.example.contract.gate",
+      "row_ref": "python.example.contract",
+      "oracle": "fixture-expectations",
+      "positive_fixtures": ["positive"],
+      "hard_negatives": ["negative"],
+      "expected_positive": "exact-contract-open",
+      "expected_hard_negative": "exact-contract-closed"
+    }]"#,
+    )
+}
+
 fn semantic_pack_by_id<'a>(json: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
     json["semantic_packs"]
         .as_array()

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
@@ -40,6 +40,49 @@ fn query_json_reports_cli_semantic_pack_metadata_without_changing_families() {
 }
 
 #[test]
+fn query_json_keeps_executable_gated_pack_metadata_only() {
+    let dir = make_project("semantic_pack_cli_executable_metadata");
+    let pack = dir.join("pack.json");
+    fs::write(
+        &pack,
+        semantic_pack_manifest_with_executable_gates("com.example.gated-cli-pack"),
+    )
+    .unwrap();
+
+    let without_pack = query_json(&run(&[
+        "query",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+    ]));
+    let with_pack = query_json(&run(&[
+        "query",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--semantic-pack",
+        pack.to_str().unwrap(),
+        "--format",
+        "json",
+    ]));
+
+    assert_eq!(
+        query_families(&with_pack),
+        query_families(&without_pack),
+        "executable-gated external packs must remain metadata-only in query results"
+    );
+    let reported = semantic_pack_by_id(&with_pack, "com.example.gated-cli-pack");
+    assert_example_external_pack(reported, "com.example.gated-cli-pack");
+    assert_eq!(
+        reported["path"].as_str(),
+        Some(pack.canonicalize().unwrap().to_str().unwrap())
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn external_value_law_pack_does_not_add_semantic_law_provenance() {
     let dir = make_project("semantic_pack_external_law_metadata");
     fs::write(
@@ -186,14 +229,18 @@ fn semantic_pack_check_json_reports_conformance_success() {
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["manifests"], 1);
     assert_eq!(json["totals"]["positive_fixtures"], 1);
     assert_eq!(json["totals"]["hard_negatives"], 1);
     assert_eq!(json["totals"]["fixture_issues"], 0);
+    assert_eq!(json["totals"]["executable_conformance_rows"], 0);
+    assert_eq!(json["totals"]["passed_executable_conformance_rows"], 0);
+    assert_eq!(json["totals"]["executable_conformance_issues"], 0);
     assert_eq!(json["totals"]["influence_rows"], 2);
     assert_eq!(json["totals"]["blocked_influence_rows"], 2);
+    assert_eq!(json["executable_conformance"]["status"], "unavailable");
     assert_eq!(json["influence_preflight"]["status"], "blocked");
     let influence_rows = json["influence_preflight"]["rows"].as_array().unwrap();
     assert_eq!(influence_rows.len(), 2);
@@ -243,6 +290,81 @@ fn semantic_pack_check_json_reports_conformance_success() {
             .len(),
         0
     );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn semantic_pack_check_json_reports_passed_executable_gates_without_opening_influence() {
+    let dir = make_project("semantic_pack_check_executable_ok");
+    let fixture_dir = dir.join("fixtures");
+    fs::create_dir_all(&fixture_dir).unwrap();
+    fs::write(
+        fixture_dir.join("positive.py"),
+        "def positive(xs):\n    return sum(xs)\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture_dir.join("negative.py"),
+        "def negative(xs):\n    return list(xs)\n",
+    )
+    .unwrap();
+    let pack = dir.join("pack.json");
+    fs::write(
+        &pack,
+        semantic_pack_manifest_with_executable_gates("com.example.semantic-pack"),
+    )
+    .unwrap();
+
+    let out = Command::new(bin())
+        .args([
+            "semantic-pack",
+            "check",
+            pack.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("semantic pack check");
+
+    assert!(
+        out.status.success(),
+        "semantic-pack check should pass: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
+    assert_eq!(json["schema_version"], 2);
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["totals"]["executable_conformance_rows"], 2);
+    assert_eq!(json["totals"]["passed_executable_conformance_rows"], 2);
+    assert_eq!(json["totals"]["executable_conformance_issues"], 0);
+    assert_eq!(json["executable_conformance"]["status"], "ok");
+    let gates = json["executable_conformance"]["rows"].as_array().unwrap();
+    assert_eq!(gates.len(), 2);
+    assert!(gates.iter().all(|gate| {
+        gate["passed"] == true
+            && gate["oracle"] == "fixture-expectations"
+            && gate["issues"].as_array().unwrap().is_empty()
+    }));
+
+    let influence_rows = json["influence_preflight"]["rows"].as_array().unwrap();
+    assert_eq!(influence_rows.len(), 2);
+    for row in influence_rows {
+        assert_eq!(row["passed"], false);
+        let blockers = row["blockers"].as_array().unwrap();
+        assert!(blockers
+            .iter()
+            .any(|blocker| blocker == "data-only-registration"));
+        assert!(blockers
+            .iter()
+            .any(|blocker| blocker == "dependency-backed-evidence-unavailable"));
+        assert!(blockers
+            .iter()
+            .any(|blocker| blocker == "explicit-influence-trust-gate-missing"));
+        assert!(!blockers
+            .iter()
+            .any(|blocker| blocker == "executable-conformance-unavailable"));
+    }
     let _ = fs::remove_dir_all(&dir);
 }
 

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -93,10 +93,11 @@ pub use compiled::{
     value_graph_law_pack, BuiltinLanguageBinding, BuiltinPackDescriptor,
 };
 pub use conformance::{
-    SemanticPackConformanceManifest, SemanticPackConformanceReport, SemanticPackFixtureCheck,
-    SemanticPackFixtureIssue, SemanticPackFixtureKind,
+    SemanticPackConformanceManifest, SemanticPackConformanceReport,
+    SemanticPackExecutableConformanceCheck, SemanticPackExecutableConformanceIssue,
+    SemanticPackExecutableOracle, SemanticPackFixtureCheck, SemanticPackFixtureIssue,
+    SemanticPackFixtureKind,
 };
-use external::ExternalRowCoordinate;
 pub use external::{
     ExternalContractRow, ExternalEvidenceProducerRow, ExternalInfluenceBlocker,
     ExternalInfluencePreflightReport, ExternalRowConflict, ExternalRowConflictReport,
@@ -110,7 +111,6 @@ pub use loading::{
 use manifest::*;
 
 use compiled::compiled_builtin_packs;
-use std::collections::{HashMap, HashSet};
 use validation::validate_manifest;
 pub const SEMANTIC_PACK_API_VERSION: &str = "nose.semantic-pack.v0";
 
@@ -439,142 +439,6 @@ impl SemanticPackSet {
 
     pub fn external_value_law_rows(&self) -> &[ExternalValueLawRow] {
         &self.external_value_law_rows
-    }
-
-    pub fn external_row_conflicts(&self) -> ExternalRowConflictReport {
-        let mut conflicts = Vec::new();
-        let coordinates = self.external_row_coordinates();
-        for coordinate in &coordinates {
-            for builtin in builtin_pack_descriptors() {
-                if builtin_descriptor_contains_row_id(*builtin, coordinate.kind, &coordinate.row_id)
-                {
-                    conflicts.push(ExternalRowConflict {
-                        kind: coordinate.kind,
-                        row_id: coordinate.row_id.clone(),
-                        row_hash: coordinate.row_hash,
-                        external_pack_id: coordinate.pack_id.clone(),
-                        external_pack_hash: coordinate.pack_hash,
-                        external_manifest_path: coordinate.manifest_path.clone(),
-                        conflicting_pack_id: builtin.id.to_string(),
-                        conflicting_pack_hash: semantic_pack_hash(builtin.id),
-                        conflicting_source: SemanticPackSource::CompiledBuiltin,
-                        conflicting_manifest_path: None,
-                    });
-                }
-            }
-        }
-
-        let mut seen: HashMap<(ExternalRowKind, String), ExternalRowCoordinate> = HashMap::new();
-        for coordinate in coordinates {
-            let key = (coordinate.kind, coordinate.row_id.clone());
-            if let Some(first) = seen.get(&key) {
-                conflicts.push(ExternalRowConflict {
-                    kind: coordinate.kind,
-                    row_id: coordinate.row_id.clone(),
-                    row_hash: coordinate.row_hash,
-                    external_pack_id: coordinate.pack_id.clone(),
-                    external_pack_hash: coordinate.pack_hash,
-                    external_manifest_path: coordinate.manifest_path.clone(),
-                    conflicting_pack_id: first.pack_id.clone(),
-                    conflicting_pack_hash: first.pack_hash,
-                    conflicting_source: SemanticPackSource::LocalManifest,
-                    conflicting_manifest_path: Some(first.manifest_path.clone()),
-                });
-            } else {
-                seen.insert(key, coordinate);
-            }
-        }
-        ExternalRowConflictReport { conflicts }
-    }
-
-    pub fn external_influence_preflight(&self) -> ExternalInfluencePreflightReport {
-        let coordinates = self.external_row_coordinates();
-        let mut conflicting_rows = HashSet::new();
-        for conflict in self.external_row_conflicts().conflicts {
-            conflicting_rows.insert((
-                conflict.kind,
-                conflict.row_hash,
-                conflict.external_pack_hash,
-            ));
-            if conflict.conflicting_source == SemanticPackSource::LocalManifest {
-                conflicting_rows.insert((
-                    conflict.kind,
-                    conflict.row_hash,
-                    conflict.conflicting_pack_hash,
-                ));
-            }
-        }
-        let rows = coordinates
-            .into_iter()
-            .map(|coordinate| {
-                let mut blockers = vec![
-                    ExternalInfluenceBlocker::DataOnlyRegistration,
-                    ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable,
-                    ExternalInfluenceBlocker::ExplicitInfluenceTrustGateMissing,
-                ];
-                if coordinate.channel.exact_capable() {
-                    blockers.push(ExternalInfluenceBlocker::ExecutableConformanceUnavailable);
-                }
-                if conflicting_rows.contains(&(
-                    coordinate.kind,
-                    coordinate.row_hash,
-                    coordinate.pack_hash,
-                )) {
-                    blockers.push(ExternalInfluenceBlocker::RowConflict);
-                }
-                ExternalRowInfluencePreflight {
-                    kind: coordinate.kind,
-                    row_id: coordinate.row_id,
-                    row_hash: coordinate.row_hash,
-                    pack_id: coordinate.pack_id,
-                    pack_hash: coordinate.pack_hash,
-                    manifest_path: coordinate.manifest_path,
-                    channel: coordinate.channel,
-                    blockers,
-                }
-            })
-            .collect();
-        ExternalInfluencePreflightReport { rows }
-    }
-
-    fn external_row_coordinates(&self) -> Vec<ExternalRowCoordinate> {
-        let mut rows = Vec::with_capacity(
-            self.external_evidence_producer_rows.len()
-                + self.external_contract_rows.len()
-                + self.external_value_law_rows.len(),
-        );
-        rows.extend(
-            self.external_evidence_producer_rows
-                .iter()
-                .map(ExternalRowCoordinate::from_producer),
-        );
-        rows.extend(
-            self.external_contract_rows
-                .iter()
-                .map(ExternalRowCoordinate::from_contract),
-        );
-        rows.extend(
-            self.external_value_law_rows
-                .iter()
-                .map(ExternalRowCoordinate::from_law),
-        );
-        rows
-    }
-}
-
-fn builtin_descriptor_contains_row_id(
-    descriptor: BuiltinPackDescriptor,
-    kind: ExternalRowKind,
-    row_id: &str,
-) -> bool {
-    match kind {
-        ExternalRowKind::EvidenceProducer => descriptor
-            .evidence_producer_ids
-            .iter()
-            .chain(descriptor.source_fact_producer_ids.iter())
-            .any(|id| *id == row_id),
-        ExternalRowKind::Contract => descriptor.contract_ids.contains(&row_id),
-        ExternalRowKind::ValueLaw => descriptor.value_law_ids().contains(&row_id),
     }
 }
 

--- a/crates/nose-semantics/src/packs/conformance.rs
+++ b/crates/nose-semantics/src/packs/conformance.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackExecutableOracle {
+    FixtureExpectations,
+}
+
+impl SemanticPackExecutableOracle {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackExecutableOracle::FixtureExpectations => "fixture-expectations",
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SemanticPackFixtureKind {
     Positive,
@@ -51,6 +65,49 @@ impl SemanticPackFixtureCheck {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackExecutableConformanceIssue {
+    UnknownFixture,
+    WrongFixtureKind,
+    MissingExpectation,
+    ExpectationMismatch,
+    FixtureIssue,
+}
+
+impl SemanticPackExecutableConformanceIssue {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SemanticPackExecutableConformanceIssue::UnknownFixture => "unknown-fixture",
+            SemanticPackExecutableConformanceIssue::WrongFixtureKind => "wrong-fixture-kind",
+            SemanticPackExecutableConformanceIssue::MissingExpectation => "missing-expectation",
+            SemanticPackExecutableConformanceIssue::ExpectationMismatch => "expectation-mismatch",
+            SemanticPackExecutableConformanceIssue::FixtureIssue => "fixture-issue",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackExecutableConformanceCheck {
+    pub gate_id: String,
+    pub kind: ExternalRowKind,
+    pub row_id: String,
+    pub row_hash: u64,
+    pub pack_id: String,
+    pub pack_hash: u64,
+    pub manifest_path: PathBuf,
+    pub channel: SemanticPackChannel,
+    pub oracle: SemanticPackExecutableOracle,
+    pub positive_fixtures: Vec<String>,
+    pub hard_negatives: Vec<String>,
+    pub issues: Vec<SemanticPackExecutableConformanceIssue>,
+}
+
+impl SemanticPackExecutableConformanceCheck {
+    pub fn passed(&self) -> bool {
+        self.issues.is_empty()
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SemanticPackConformanceManifest {
     pub pack: SemanticPackSummary,
@@ -58,11 +115,12 @@ pub struct SemanticPackConformanceManifest {
     pub conformance_command: Option<String>,
     pub proof_links: Vec<String>,
     pub fixtures: Vec<SemanticPackFixtureCheck>,
+    pub executable: Vec<SemanticPackExecutableConformanceCheck>,
 }
 
 impl SemanticPackConformanceManifest {
     pub fn passed(&self) -> bool {
-        self.fixture_issue_count() == 0
+        self.fixture_issue_count() == 0 && self.executable_conformance_issue_count() == 0
     }
 
     pub fn fixture_issue_count(&self) -> usize {
@@ -70,6 +128,10 @@ impl SemanticPackConformanceManifest {
             .iter()
             .map(|fixture| fixture.issues.len())
             .sum()
+    }
+
+    pub fn executable_conformance_issue_count(&self) -> usize {
+        self.executable.iter().map(|gate| gate.issues.len()).sum()
     }
 }
 
@@ -108,5 +170,54 @@ impl SemanticPackConformanceReport {
             .iter()
             .map(SemanticPackConformanceManifest::fixture_issue_count)
             .sum()
+    }
+
+    pub fn executable_conformance_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .map(|manifest| manifest.executable.len())
+            .sum()
+    }
+
+    pub fn passed_executable_conformance_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .flat_map(|manifest| &manifest.executable)
+            .filter(|gate| gate.passed())
+            .count()
+    }
+
+    pub fn executable_conformance_issue_count(&self) -> usize {
+        self.manifests
+            .iter()
+            .map(SemanticPackConformanceManifest::executable_conformance_issue_count)
+            .sum()
+    }
+
+    pub fn executable_conformance_passed_for(
+        &self,
+        kind: ExternalRowKind,
+        row_hash: u64,
+        pack_hash: u64,
+        manifest_path: &std::path::Path,
+    ) -> bool {
+        let mut has_gate = false;
+        for gate in self
+            .manifests
+            .iter()
+            .flat_map(|manifest| &manifest.executable)
+        {
+            if gate.kind == kind
+                && gate.row_hash == row_hash
+                && gate.pack_hash == pack_hash
+                && gate.manifest_path == manifest_path
+            {
+                has_gate = true;
+                if !gate.passed() {
+                    return false;
+                }
+            }
+        }
+        has_gate
     }
 }

--- a/crates/nose-semantics/src/packs/external.rs
+++ b/crates/nose-semantics/src/packs/external.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SemanticPackRequirementSummary {
@@ -306,5 +307,165 @@ impl ExternalRowCoordinate {
             manifest_path: row.manifest_path.clone(),
             channel: row.channel,
         }
+    }
+}
+
+impl SemanticPackSet {
+    pub fn external_row_conflicts(&self) -> ExternalRowConflictReport {
+        let mut conflicts = Vec::new();
+        let coordinates = self.external_row_coordinates();
+        for coordinate in &coordinates {
+            for builtin in builtin_pack_descriptors() {
+                if builtin_descriptor_contains_row_id(*builtin, coordinate.kind, &coordinate.row_id)
+                {
+                    conflicts.push(ExternalRowConflict {
+                        kind: coordinate.kind,
+                        row_id: coordinate.row_id.clone(),
+                        row_hash: coordinate.row_hash,
+                        external_pack_id: coordinate.pack_id.clone(),
+                        external_pack_hash: coordinate.pack_hash,
+                        external_manifest_path: coordinate.manifest_path.clone(),
+                        conflicting_pack_id: builtin.id.to_string(),
+                        conflicting_pack_hash: semantic_pack_hash(builtin.id),
+                        conflicting_source: SemanticPackSource::CompiledBuiltin,
+                        conflicting_manifest_path: None,
+                    });
+                }
+            }
+        }
+
+        let mut seen: HashMap<(ExternalRowKind, String), ExternalRowCoordinate> = HashMap::new();
+        for coordinate in coordinates {
+            let key = (coordinate.kind, coordinate.row_id.clone());
+            if let Some(first) = seen.get(&key) {
+                conflicts.push(ExternalRowConflict {
+                    kind: coordinate.kind,
+                    row_id: coordinate.row_id.clone(),
+                    row_hash: coordinate.row_hash,
+                    external_pack_id: coordinate.pack_id.clone(),
+                    external_pack_hash: coordinate.pack_hash,
+                    external_manifest_path: coordinate.manifest_path.clone(),
+                    conflicting_pack_id: first.pack_id.clone(),
+                    conflicting_pack_hash: first.pack_hash,
+                    conflicting_source: SemanticPackSource::LocalManifest,
+                    conflicting_manifest_path: Some(first.manifest_path.clone()),
+                });
+            } else {
+                seen.insert(key, coordinate);
+            }
+        }
+        ExternalRowConflictReport { conflicts }
+    }
+
+    pub fn external_influence_preflight(&self) -> ExternalInfluencePreflightReport {
+        self.external_influence_preflight_with(|_| false)
+    }
+
+    pub fn external_influence_preflight_with_conformance(
+        &self,
+        conformance: &SemanticPackConformanceReport,
+    ) -> ExternalInfluencePreflightReport {
+        self.external_influence_preflight_with(|coordinate| {
+            conformance.executable_conformance_passed_for(
+                coordinate.kind,
+                coordinate.row_hash,
+                coordinate.pack_hash,
+                &coordinate.manifest_path,
+            )
+        })
+    }
+
+    fn external_influence_preflight_with(
+        &self,
+        executable_conformance_passed: impl Fn(&ExternalRowCoordinate) -> bool,
+    ) -> ExternalInfluencePreflightReport {
+        let coordinates = self.external_row_coordinates();
+        let mut conflicting_rows = HashSet::new();
+        for conflict in self.external_row_conflicts().conflicts {
+            conflicting_rows.insert((
+                conflict.kind,
+                conflict.row_hash,
+                conflict.external_pack_hash,
+            ));
+            if conflict.conflicting_source == SemanticPackSource::LocalManifest {
+                conflicting_rows.insert((
+                    conflict.kind,
+                    conflict.row_hash,
+                    conflict.conflicting_pack_hash,
+                ));
+            }
+        }
+        let rows = coordinates
+            .into_iter()
+            .map(|coordinate| {
+                let mut blockers = vec![
+                    ExternalInfluenceBlocker::DataOnlyRegistration,
+                    ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable,
+                    ExternalInfluenceBlocker::ExplicitInfluenceTrustGateMissing,
+                ];
+                if coordinate.channel.exact_capable() && !executable_conformance_passed(&coordinate)
+                {
+                    blockers.push(ExternalInfluenceBlocker::ExecutableConformanceUnavailable);
+                }
+                if conflicting_rows.contains(&(
+                    coordinate.kind,
+                    coordinate.row_hash,
+                    coordinate.pack_hash,
+                )) {
+                    blockers.push(ExternalInfluenceBlocker::RowConflict);
+                }
+                ExternalRowInfluencePreflight {
+                    kind: coordinate.kind,
+                    row_id: coordinate.row_id,
+                    row_hash: coordinate.row_hash,
+                    pack_id: coordinate.pack_id,
+                    pack_hash: coordinate.pack_hash,
+                    manifest_path: coordinate.manifest_path,
+                    channel: coordinate.channel,
+                    blockers,
+                }
+            })
+            .collect();
+        ExternalInfluencePreflightReport { rows }
+    }
+
+    fn external_row_coordinates(&self) -> Vec<ExternalRowCoordinate> {
+        let mut rows = Vec::with_capacity(
+            self.external_evidence_producer_rows.len()
+                + self.external_contract_rows.len()
+                + self.external_value_law_rows.len(),
+        );
+        rows.extend(
+            self.external_evidence_producer_rows
+                .iter()
+                .map(ExternalRowCoordinate::from_producer),
+        );
+        rows.extend(
+            self.external_contract_rows
+                .iter()
+                .map(ExternalRowCoordinate::from_contract),
+        );
+        rows.extend(
+            self.external_value_law_rows
+                .iter()
+                .map(ExternalRowCoordinate::from_law),
+        );
+        rows
+    }
+}
+
+fn builtin_descriptor_contains_row_id(
+    descriptor: BuiltinPackDescriptor,
+    kind: ExternalRowKind,
+    row_id: &str,
+) -> bool {
+    match kind {
+        ExternalRowKind::EvidenceProducer => descriptor
+            .evidence_producer_ids
+            .iter()
+            .chain(descriptor.source_fact_producer_ids.iter())
+            .any(|id| *id == row_id),
+        ExternalRowKind::Contract => descriptor.contract_ids.contains(&row_id),
+        ExternalRowKind::ValueLaw => descriptor.value_law_ids().contains(&row_id),
     }
 }

--- a/crates/nose-semantics/src/packs/loading.rs
+++ b/crates/nose-semantics/src/packs/loading.rs
@@ -22,6 +22,7 @@ pub fn check_semantic_pack_conformance(
         let conformance_command = manifest.conformance.command.clone();
         let proof_links = manifest.conformance.proofs.clone();
         let fixtures = collect_fixture_checks(&path, &manifest);
+        let executable = collect_executable_conformance_checks(&path, &manifest, &fixtures);
         let pack =
             SemanticPackSummary::from_manifest(path.clone(), manifest).map_err(|message| {
                 SemanticPackLoadError::InvalidManifest {
@@ -52,6 +53,7 @@ pub fn check_semantic_pack_conformance(
             conformance_command,
             proof_links,
             fixtures,
+            executable,
         });
     }
     Ok(SemanticPackConformanceReport { manifests })
@@ -245,6 +247,121 @@ fn resolve_fixture_path(manifest_path: &Path, declared_path: &str) -> PathBuf {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join(path)
+}
+
+fn collect_executable_conformance_checks(
+    manifest_path: &Path,
+    manifest: &SemanticPackManifest,
+    fixtures: &[SemanticPackFixtureCheck],
+) -> Vec<SemanticPackExecutableConformanceCheck> {
+    manifest
+        .conformance
+        .executable
+        .iter()
+        .filter_map(|gate| {
+            executable_row(manifest, &gate.row_ref).map(|(kind, channel)| {
+                executable_conformance_check(manifest_path, manifest, gate, kind, channel, fixtures)
+            })
+        })
+        .collect()
+}
+
+fn executable_row(
+    manifest: &SemanticPackManifest,
+    row_ref: &str,
+) -> Option<(ExternalRowKind, SemanticPackChannel)> {
+    manifest
+        .declares
+        .evidence_producers
+        .iter()
+        .find(|producer| producer.id == row_ref)
+        .map(|producer| (ExternalRowKind::EvidenceProducer, producer.channel))
+        .or_else(|| {
+            manifest
+                .declares
+                .contracts
+                .iter()
+                .find(|contract| contract.id == row_ref)
+                .map(|contract| (ExternalRowKind::Contract, contract.channel))
+        })
+        .or_else(|| {
+            manifest
+                .declares
+                .value_laws
+                .iter()
+                .find(|law| law.id == row_ref)
+                .map(|law| (ExternalRowKind::ValueLaw, law.channel))
+        })
+}
+
+fn executable_conformance_check(
+    manifest_path: &Path,
+    manifest: &SemanticPackManifest,
+    gate: &ManifestExecutableConformanceGate,
+    kind: ExternalRowKind,
+    channel: SemanticPackChannel,
+    fixtures: &[SemanticPackFixtureCheck],
+) -> SemanticPackExecutableConformanceCheck {
+    let mut issues = Vec::new();
+    match gate.oracle {
+        SemanticPackExecutableOracle::FixtureExpectations => {
+            collect_fixture_expectation_issues(
+                fixtures,
+                &gate.positive_fixtures,
+                SemanticPackFixtureKind::Positive,
+                &gate.expected_positive,
+                &mut issues,
+            );
+            collect_fixture_expectation_issues(
+                fixtures,
+                &gate.hard_negatives,
+                SemanticPackFixtureKind::HardNegative,
+                &gate.expected_hard_negative,
+                &mut issues,
+            );
+        }
+    }
+    SemanticPackExecutableConformanceCheck {
+        gate_id: gate.id.clone(),
+        kind,
+        row_id: gate.row_ref.clone(),
+        row_hash: stable_symbol_hash(&gate.row_ref),
+        pack_id: manifest.pack.id.clone(),
+        pack_hash: semantic_pack_hash(&manifest.pack.id),
+        manifest_path: manifest_path.to_path_buf(),
+        channel,
+        oracle: gate.oracle,
+        positive_fixtures: gate.positive_fixtures.clone(),
+        hard_negatives: gate.hard_negatives.clone(),
+        issues,
+    }
+}
+
+fn collect_fixture_expectation_issues(
+    fixtures: &[SemanticPackFixtureCheck],
+    ids: &[String],
+    expected_kind: SemanticPackFixtureKind,
+    expected_label: &str,
+    issues: &mut Vec<SemanticPackExecutableConformanceIssue>,
+) {
+    for id in ids {
+        let Some(fixture) = fixtures.iter().find(|fixture| fixture.id == *id) else {
+            issues.push(SemanticPackExecutableConformanceIssue::UnknownFixture);
+            continue;
+        };
+        if fixture.kind != expected_kind {
+            issues.push(SemanticPackExecutableConformanceIssue::WrongFixtureKind);
+            continue;
+        }
+        if !fixture.passed() {
+            issues.push(SemanticPackExecutableConformanceIssue::FixtureIssue);
+        }
+        match fixture.expectation.as_deref() {
+            Some(actual) if actual == expected_label => {}
+            Some(_) => issues.push(SemanticPackExecutableConformanceIssue::ExpectationMismatch),
+            None => issues.push(SemanticPackExecutableConformanceIssue::MissingExpectation),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/nose-semantics/src/packs/manifest.rs
+++ b/crates/nose-semantics/src/packs/manifest.rs
@@ -173,6 +173,8 @@ pub(super) struct ManifestConformance {
     pub(super) command: Option<String>,
     #[serde(default)]
     pub(super) proofs: Vec<String>,
+    #[serde(default)]
+    pub(super) executable: Vec<ManifestExecutableConformanceGate>,
 }
 
 #[derive(Deserialize)]
@@ -184,4 +186,16 @@ pub(super) struct ManifestFixture {
     pub(super) path: Option<String>,
     #[serde(default)]
     pub(super) expectation: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestExecutableConformanceGate {
+    pub(super) id: String,
+    pub(super) row_ref: String,
+    pub(super) oracle: SemanticPackExecutableOracle,
+    pub(super) positive_fixtures: Vec<String>,
+    pub(super) hard_negatives: Vec<String>,
+    pub(super) expected_positive: String,
+    pub(super) expected_hard_negative: String,
 }

--- a/crates/nose-semantics/src/packs/tests.rs
+++ b/crates/nose-semantics/src/packs/tests.rs
@@ -142,6 +142,46 @@ fn manifest_with_value_law(id: &str) -> String {
     )
 }
 
+fn manifest_with_executable_gates(id: &str) -> String {
+    manifest(id).replace(
+        r#""known_unsupported": []"#,
+        r#""known_unsupported": [],
+    "executable": [{
+      "id": "python.library-api.example.gate",
+      "row_ref": "python.library-api.example",
+      "oracle": "fixture-expectations",
+      "positive_fixtures": ["positive"],
+      "hard_negatives": ["negative"],
+      "expected_positive": "exact-contract-open",
+      "expected_hard_negative": "exact-contract-closed"
+    }, {
+      "id": "python.example.contract.gate",
+      "row_ref": "python.example.contract",
+      "oracle": "fixture-expectations",
+      "positive_fixtures": ["positive"],
+      "hard_negatives": ["negative"],
+      "expected_positive": "exact-contract-open",
+      "expected_hard_negative": "exact-contract-closed"
+    }]"#,
+    )
+}
+
+fn manifest_with_value_law_executable_gate(id: &str) -> String {
+    manifest_with_value_law(id).replace(
+        r#""known_unsupported": []"#,
+        r#""known_unsupported": [],
+    "executable": [{
+      "id": "python.example.numeric-law.gate",
+      "row_ref": "python.example.numeric-law",
+      "oracle": "fixture-expectations",
+      "positive_fixtures": ["positive"],
+      "hard_negatives": ["negative"],
+      "expected_positive": "exact-contract-open",
+      "expected_hard_negative": "exact-contract-closed"
+    }]"#,
+    )
+}
+
 #[test]
 fn builtin_pack_descriptor_registry_names_current_compiled_packs() {
     let descriptors = builtin_pack_descriptors();
@@ -210,3 +250,4 @@ mod descriptor_enumeration;
 mod manifest_cases_0;
 mod manifest_cases_1;
 mod manifest_cases_2;
+mod manifest_cases_3;

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_3.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_3.rs
@@ -1,0 +1,140 @@
+use super::*;
+
+#[test]
+fn passed_executable_gates_clear_only_executable_preflight_blocker() {
+    let dir = unique_dir("external_preflight_executable");
+    let fixture_dir = dir.join("fixtures");
+    fs::create_dir_all(&fixture_dir).unwrap();
+    fs::write(
+        fixture_dir.join("positive.py"),
+        "def positive(xs):\n    return sum(xs)\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture_dir.join("negative.py"),
+        "def negative(xs):\n    return list(xs)\n",
+    )
+    .unwrap();
+    let path = dir.join("pack.json");
+    fs::write(&path, manifest_with_executable_gates("com.example.gated")).unwrap();
+
+    let conformance = check_semantic_pack_conformance(std::slice::from_ref(&path))
+        .expect("manifest with executable gates loads");
+    assert!(conformance.passed());
+    assert_eq!(conformance.executable_conformance_count(), 2);
+    assert_eq!(conformance.passed_executable_conformance_count(), 2);
+    assert_eq!(conformance.executable_conformance_issue_count(), 0);
+
+    let set = SemanticPackSet::new_local(std::slice::from_ref(&path)).expect("pack loads");
+    let plain = set.external_influence_preflight();
+    assert!(plain.rows.iter().all(|row| row
+        .blockers
+        .contains(&ExternalInfluenceBlocker::ExecutableConformanceUnavailable)));
+
+    let report = set.external_influence_preflight_with_conformance(&conformance);
+    assert_eq!(report.rows.len(), 2);
+    assert_eq!(report.blocked_count(), 2);
+    for row in &report.rows {
+        assert_eq!(row.pack_id, "com.example.gated");
+        assert!(row
+            .blockers
+            .contains(&ExternalInfluenceBlocker::DataOnlyRegistration));
+        assert!(row
+            .blockers
+            .contains(&ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable));
+        assert!(row
+            .blockers
+            .contains(&ExternalInfluenceBlocker::ExplicitInfluenceTrustGateMissing));
+        assert!(!row
+            .blockers
+            .contains(&ExternalInfluenceBlocker::ExecutableConformanceUnavailable));
+        assert!(!row
+            .blockers
+            .contains(&ExternalInfluenceBlocker::RowConflict));
+        assert!(!row.passed());
+    }
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn executable_gates_support_value_law_rows() {
+    let dir = unique_dir("external_preflight_executable_law");
+    let fixture_dir = dir.join("fixtures");
+    fs::create_dir_all(&fixture_dir).unwrap();
+    fs::write(
+        fixture_dir.join("positive.py"),
+        "def positive(x):\n    return x + 0\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture_dir.join("negative.py"),
+        "def negative(x):\n    return x + 1\n",
+    )
+    .unwrap();
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest_with_value_law_executable_gate("com.example.gated-laws"),
+    )
+    .unwrap();
+
+    let conformance =
+        check_semantic_pack_conformance(std::slice::from_ref(&path)).expect("value-law gate loads");
+    assert!(conformance.passed());
+    assert_eq!(conformance.executable_conformance_count(), 1);
+    let gate = &conformance.manifests[0].executable[0];
+    assert_eq!(gate.kind, ExternalRowKind::ValueLaw);
+    assert_eq!(gate.row_id, "python.example.numeric-law");
+
+    let set = SemanticPackSet::new_local(std::slice::from_ref(&path)).expect("pack loads");
+    let report = set.external_influence_preflight_with_conformance(&conformance);
+    let law = report
+        .rows
+        .iter()
+        .find(|row| row.kind == ExternalRowKind::ValueLaw)
+        .expect("value-law preflight row");
+    assert!(!law
+        .blockers
+        .contains(&ExternalInfluenceBlocker::ExecutableConformanceUnavailable));
+    assert!(law
+        .blockers
+        .contains(&ExternalInfluenceBlocker::DataOnlyRegistration));
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn executable_conformance_fails_on_hard_negative_oracle_mismatch() {
+    let dir = unique_dir("conformance_executable_mismatch");
+    let fixture_dir = dir.join("fixtures");
+    fs::create_dir_all(&fixture_dir).unwrap();
+    fs::write(
+        fixture_dir.join("positive.py"),
+        "def positive(xs):\n    return sum(xs)\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture_dir.join("negative.py"),
+        "def negative(xs):\n    return list(xs)\n",
+    )
+    .unwrap();
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest_with_executable_gates("com.example.pack").replace(
+            r#""expected_hard_negative": "exact-contract-closed""#,
+            r#""expected_hard_negative": "exact-contract-open""#,
+        ),
+    )
+    .unwrap();
+
+    let report = check_semantic_pack_conformance(&[path]).expect("manifest is structurally valid");
+
+    assert!(!report.passed());
+    assert_eq!(report.fixture_issue_count(), 0);
+    assert_eq!(report.executable_conformance_count(), 2);
+    assert_eq!(report.executable_conformance_issue_count(), 2);
+    assert!(report.manifests[0].executable.iter().all(|gate| gate
+        .issues
+        .contains(&SemanticPackExecutableConformanceIssue::ExpectationMismatch)));
+    let _ = fs::remove_dir_all(dir);
+}

--- a/crates/nose-semantics/src/packs/validation.rs
+++ b/crates/nose-semantics/src/packs/validation.rs
@@ -7,6 +7,7 @@ pub(super) fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), S
     let known_refs = collect_declared_refs(manifest)?;
     validate_manifest_conformance(manifest)?;
     let conformance_refs = collect_conformance_fixture_refs(manifest)?;
+    validate_executable_conformance(manifest, &conformance_refs)?;
 
     for producer in &manifest.declares.evidence_producers {
         validate_evidence_producer(producer, &known_refs)?;
@@ -181,7 +182,92 @@ fn validate_manifest_conformance(manifest: &SemanticPackManifest) -> Result<(), 
     for proof in &manifest.conformance.proofs {
         require_non_empty("conformance.proofs[]", proof)?;
     }
+    for gate in &manifest.conformance.executable {
+        require_stable_id("conformance.executable[].id", &gate.id)?;
+        require_stable_id("conformance.executable[].row_ref", &gate.row_ref)?;
+        require_non_empty(
+            "conformance.executable[].expected_positive",
+            &gate.expected_positive,
+        )?;
+        require_non_empty(
+            "conformance.executable[].expected_hard_negative",
+            &gate.expected_hard_negative,
+        )?;
+    }
     Ok(())
+}
+
+fn validate_executable_conformance(
+    manifest: &SemanticPackManifest,
+    fixture_refs: &ConformanceFixtureRefs,
+) -> Result<(), String> {
+    let mut gate_ids = HashSet::new();
+    let exact_rows = collect_exact_capable_row_refs(manifest);
+    for gate in &manifest.conformance.executable {
+        if !gate_ids.insert(gate.id.clone()) {
+            return Err(format!(
+                "duplicate id `{}` in `conformance.executable`",
+                gate.id
+            ));
+        }
+        if !exact_rows.contains(&gate.row_ref) {
+            return Err(format!(
+                "executable conformance gate `{}` row_ref must reference an exact-capable declared row",
+                gate.id
+            ));
+        }
+        if gate.positive_fixtures.is_empty() {
+            return Err(format!(
+                "executable conformance gate `{}` must reference at least one positive fixture",
+                gate.id
+            ));
+        }
+        if gate.hard_negatives.is_empty() {
+            return Err(format!(
+                "executable conformance gate `{}` must reference at least one hard-negative fixture",
+                gate.id
+            ));
+        }
+        for id in &gate.positive_fixtures {
+            require_stable_id("conformance.executable[].positive_fixtures[]", id)?;
+            if !fixture_refs.positive.contains(id) {
+                return Err(format!(
+                    "executable conformance gate `{}` references missing positive fixture `{id}`",
+                    gate.id
+                ));
+            }
+        }
+        for id in &gate.hard_negatives {
+            require_stable_id("conformance.executable[].hard_negatives[]", id)?;
+            if !fixture_refs.hard_negative.contains(id) {
+                return Err(format!(
+                    "executable conformance gate `{}` references missing hard-negative fixture `{id}`",
+                    gate.id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_exact_capable_row_refs(manifest: &SemanticPackManifest) -> HashSet<String> {
+    let mut rows = HashSet::new();
+    for producer in &manifest.declares.evidence_producers {
+        if producer.channel.exact_capable() {
+            rows.insert(producer.id.clone());
+        }
+    }
+    for contract in &manifest.declares.contracts {
+        if contract.channel.exact_capable() {
+            rows.insert(contract.id.clone());
+        }
+    }
+    for law in &manifest.declares.value_laws {
+        if law.channel.exact_capable() {
+            rows.insert(law.id.clone());
+        }
+    }
+    rows
 }
 
 #[derive(Default)]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -49,7 +49,7 @@ nose capabilities
     "capabilities": [3],
     "query_json": [6],
     "semantic_packs": ["nose.semantic-pack.v0"],
-    "semantic_pack_conformance": [1]
+    "semantic_pack_conformance": [2]
   },
   "query": {
     "modes": ["syntax", "semantic", "near"],
@@ -147,7 +147,7 @@ release so it can't drift.
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.query_json` | array | Supported `nose query --format json` schema versions ([query-json](query-json.md)). |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
-| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 1 reports structural conformance plus row-level external influence preflight blockers. |
+| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 2 reports structural conformance, executable fixture-expectation gate results, and row-level external influence preflight blockers. |
 | `query.modes` | array | Supported `--mode` values. |
 | `query.default_modes` | array | Modes used by `nose query` when `--mode` is omitted. |
 | `query.output_formats` | array | Supported `nose query --format` values. |

--- a/docs/schemas/semantic-pack-v0.schema.json
+++ b/docs/schemas/semantic-pack-v0.schema.json
@@ -217,6 +217,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "executable": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/executable_conformance"
+          }
         }
       }
     }
@@ -495,6 +501,52 @@
         },
         "expectation": {
           "type": "string"
+        }
+      }
+    },
+    "executable_conformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "row_ref",
+        "oracle",
+        "positive_fixtures",
+        "hard_negatives",
+        "expected_positive",
+        "expected_hard_negative"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "row_ref": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "oracle": {
+          "enum": [
+            "fixture-expectations"
+          ]
+        },
+        "positive_fixtures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/stable_id"
+          }
+        },
+        "hard_negatives": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/stable_id"
+          }
+        },
+        "expected_positive": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_hard_negative": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -1,9 +1,10 @@
 # Semantic pack conformance
 
 Status: nose provides a local semantic-pack v0 conformance harness for manifest
-structure and declared fixture assets. The harness is a provider/user workflow,
-not nose approval of third-party semantic correctness. External packs remain
-`metadata-only` when loaded by `nose query`.
+structure, declared fixture assets, and declarative fixture-expectation gates for
+exact-capable rows. The harness is a provider/user workflow, not nose approval of
+third-party semantic correctness. External packs remain `metadata-only` when
+loaded by `nose query`.
 
 ## Goal
 
@@ -18,7 +19,9 @@ pack meets the extension contract's minimum structural obligations:
 - contracts and value laws declare object-shaped semantics, and exact-capable
   declarations add evidence requirements plus demand/effect semantics;
 - positive fixtures and hard negatives are declared with expectation labels;
-- fixture files exist at paths relative to the manifest file.
+- fixture files exist at paths relative to the manifest file;
+- optional executable gates bind exact-capable producer, contract, and value-law
+  rows to declared positive and hard-negative fixture expectations.
 
 This keeps the ecosystem boundary narrow: packs publish evidence, contracts, and
 fixtures; the kernel decides whether evidence is admissible for a channel; users
@@ -32,7 +35,8 @@ The harness does not:
 - register external contract rows with exact consumers;
 - treat a passing structural check as permission for external rows to influence
   analysis;
-- run a behavioral oracle over fixture contents;
+- execute fixture contents, provider commands, recognizers, parser/lowering
+  plugins, producer code, or sandboxed code as an oracle;
 - prove that the provider's semantic claims are complete or true;
 - certify, approve, rank, or endorse external packs;
 - compare `compatibility.nose` against the installed nose version beyond checking
@@ -60,10 +64,11 @@ JSON children only, sorted by filename, no recursion, no registry, and no networ
 Relative fixture paths are resolved from the manifest's directory.
 
 The command exits non-zero when any manifest is invalid, when pack ids collide
-with each other or any compiled builtin pack id, or when declared conformance
+with each other or any compiled builtin pack id, when declared conformance
 fixtures are missing a path, missing an expectation, or point at a file that does
-not exist. For `--format json`, the command still writes the report before
-returning the non-zero exit.
+not exist, or when a declared executable gate does not match its fixture
+expectation oracle. For `--format json`, the command still writes the report
+before returning the non-zero exit.
 The example [law pack](examples/semantic-packs/v0/law-pack.json) uses this
 workflow to declare value-law positives and hard negatives. Passing the check
 confirms only that the law metadata and fixture assets are structurally present;
@@ -75,19 +80,42 @@ execute them.
 
 ## JSON Report
 
-`--format json` emits schema version 1:
+`--format json` emits schema version 2:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "status": "ok",
   "totals": {
     "manifests": 1,
     "positive_fixtures": 1,
     "hard_negatives": 2,
     "fixture_issues": 0,
+    "executable_conformance_rows": 1,
+    "passed_executable_conformance_rows": 1,
+    "executable_conformance_issues": 0,
     "influence_rows": 1,
     "blocked_influence_rows": 1
+  },
+  "executable_conformance": {
+    "status": "ok",
+    "rows": [
+      {
+        "gate_id": "python.example.contract.gate",
+        "kind": "contract",
+        "row_id": "python.example.contract",
+        "row_hash": "0123456789abcdef",
+        "pack_id": "com.example.semantic-pack",
+        "pack_hash": "fedcba9876543210",
+        "manifest_path": "/repo/packs/example.json",
+        "channel": "exact-empirical",
+        "oracle": "fixture-expectations",
+        "passed": true,
+        "positive_fixtures": ["positive"],
+        "hard_negatives": ["negative"],
+        "issues": []
+      }
+    ]
   },
   "influence_preflight": {
     "status": "blocked",
@@ -104,8 +132,7 @@ execute them.
         "blockers": [
           "data-only-registration",
           "dependency-backed-evidence-unavailable",
-          "explicit-influence-trust-gate-missing",
-          "executable-conformance-unavailable"
+          "explicit-influence-trust-gate-missing"
         ]
       }
     ]
@@ -119,13 +146,20 @@ provider-supplied conformance command, proof links, and per-fixture issue labels
 such as `missing-path`, `missing-expectation`, `missing-file`, and
 `absolute-path`.
 
+The top-level `executable_conformance` object is the machine-readable proof that
+declared exact-capable rows passed the local fixture-expectation gate. Its status
+is `unavailable` when no gates are declared, `ok` when all declared gates pass,
+and `failed` when any declared gate reports issues such as `unknown-fixture`,
+`wrong-fixture-kind`, `missing-expectation`, `fixture-issue`, or
+`expectation-mismatch`.
+
 The JSON report also includes `influence_preflight`. This is a row-level
-admission preview for local external declarations, not a grant of influence. In
-v0, structurally valid external producer, contract, and value-law rows still
-report blockers such as `data-only-registration`,
-`dependency-backed-evidence-unavailable`,
-`explicit-influence-trust-gate-missing`,
-`executable-conformance-unavailable`, and `row-conflict`. The `totals` object
+admission preview for local external declarations, not a grant of influence.
+Exact-capable rows without a passed executable gate report
+`executable-conformance-unavailable`. Rows with a passed gate clear only that
+blocker; v0 external rows still report blockers such as
+`data-only-registration`, `dependency-backed-evidence-unavailable`,
+`explicit-influence-trust-gate-missing`, and `row-conflict`. The `totals` object
 includes `influence_rows` and `blocked_influence_rows` so integrations can fail a
 provider workflow when a pack is structurally valid but still not admissible for
 analysis. Row and pack hashes are stable 16-hex-digit strings.
@@ -158,6 +192,7 @@ Users who opt into external packs own the enablement decision. They should inspe
 - provider identity and repository history;
 - package/version ranges and unsupported boundaries;
 - positive and hard-negative fixtures;
+- executable fixture-expectation gates for exact-capable rows, when present;
 - whether exact-capable contracts are appropriate for their codebase;
 - the pack's own test or proof evidence outside nose.
 

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -85,7 +85,7 @@ A v0 manifest has these top-level sections:
 | `declares.evidence_producers` | facts the pack may emit |
 | `declares.contracts` | semantic contracts the pack may claim |
 | `declares.value_laws` | optional law contracts, where ready |
-| `conformance` | positive fixtures, hard negatives, commands, proof links, and unsupported edges |
+| `conformance` | positive fixtures, hard negatives, executable gates, commands, proof links, and unsupported edges |
 
 The manifest is declarative. It is not a hook API. A data-only external pack can
 declare rows that the local metadata loader validates and reports. A later
@@ -394,10 +394,10 @@ until an explicit composition or replacement policy exists.
 Local loading also exposes a data-only influence preflight report. In v0, all
 external rows are blocked from influence because they are registered as data
 only, have no dependency-backed evidence runtime, lack an explicit influence
-trust gate, and, for exact-capable rows, lack executable conformance. Conflicting
-rows carry an additional conflict blocker. This report is an implementation
-contract for future adoption work; query, normalize, and detection consumers do
-not read it.
+trust gate, and, for exact-capable rows without a passed fixture-expectation
+gate, lack executable conformance. Conflicting rows carry an additional conflict
+blocker. This report is an implementation contract for future adoption work;
+query, normalize, and detection consumers do not read it.
 
 Near-mode scoring may retain conflict provenance as a review signal. Exact
 semantic fingerprints must not.
@@ -437,6 +437,8 @@ nose validates the following through manifest loading and
 - declared compatibility ranges are syntactically valid enough to compare later;
 - conformance fixtures have expectation labels and point at files that exist
   relative to the manifest path.
+- executable conformance gates, when declared, reference exact-capable producer,
+  contract, or value-law rows plus existing positive and hard-negative fixtures.
 
 nose does not validate or certify for external packs:
 
@@ -555,6 +557,8 @@ publish:
   dynamic dispatch, mutation, lazy effects, and ambiguous dependencies;
 - known unsupported boundaries and counterexamples;
 - proof links for `exact-proven` laws;
+- executable fixture-expectation gates for exact-capable producer, contract, and
+  value-law rows that are ready for adoption review;
 - a reproducible conformance command.
 
 Builtin packs must run this checklist in nose CI before becoming default.

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -46,8 +46,9 @@ nose semantic-pack check semantic-packs --format json
 
 The conformance command validates manifest structure, trust policy, dependency
 references, exact-capable contract obligations, conformance fixture references,
-fixture expectation labels, and fixture file existence. It does not execute
-external producers or certify semantic correctness. See
+fixture expectation labels, executable fixture-expectation gates, and fixture
+file existence. It does not execute external producers, provider commands, or
+fixture contents, and it does not certify semantic correctness. See
 [semantic-pack-conformance](semantic-pack-conformance.md).
 
 ## Trust policy
@@ -174,8 +175,9 @@ The loader validates manifest shape and pack provenance, registers external
 producer, contract, and value-law declarations as data-only rows, can report
 row-id conflicts with builtin or other external rows, and can run a data-only
 influence preflight report. Today that preflight blocks all external rows until
-dependency-backed evidence, explicit influence trust gates, executable
-conformance for exact-capable rows, and conflict-free row ids exist.
+dependency-backed evidence, explicit influence trust gates, and conflict-free
+row ids exist. Exact-capable rows also remain blocked until they have passed
+declarative executable conformance.
 `nose semantic-pack check --format json` exposes that row-level preflight to
 providers and integrations, but query, normalize, value-graph, exact, and
 detection consumers do not read it. It does not yet:
@@ -183,7 +185,8 @@ detection consumers do not read it. It does not yet:
 - execute external evidence producers;
 - register external contract rows with exact consumers;
 - register external value-law rows with value-graph or exact consumers;
-- execute fixture contents or run a behavioral oracle;
+- execute fixture contents, provider commands, recognizers, parser/lowering
+  plugins, producer code, or sandboxed code;
 - compare semantic version ranges against the installed nose version beyond
   requiring a parseable declared compatibility field;
 - install packs from a registry or remote source.


### PR DESCRIPTION
Closes #483

## Summary
- adds optional `conformance.executable[]` manifest gates using the declarative `fixture-expectations` oracle
- reports machine-readable executable conformance results in `nose semantic-pack check --format json` schema v2
- lets conformance-aware influence preflight clear only `executable-conformance-unavailable` for exact-capable rows whose gates pass
- keeps external rows metadata-only and still blocked by data-only registration, dependency-backed evidence, explicit trust gate, and row conflicts

## Safety boundaries
- does not execute external producers, recognizers, parser/lowering plugins, provider commands, sandboxed code, or fixture contents
- does not let local external manifests influence query/normalize/value-graph/exact/detection consumers by manifest presence or passed conformance alone

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `scripts/check-docs.sh`
- `awiki lint --root docs`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `git diff --check`

## Quantitative behavior check
- debug binary, fixed two-file Python corpus, 8 paired runs
- query `families` unchanged with an executable-gated metadata-only pack
- mean runtime: 34.39ms without pack, 34.20ms with executable-gated pack, delta -0.19ms
