### PR TITLE
Add builtin semantic pack adoption gates

### DIFF
--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -49,6 +49,7 @@ struct Schemas {
     semantic_packs: Vec<&'static str>,
     semantic_pack_conformance: Vec<u32>,
     semantic_pack_inventory: Vec<u32>,
+    semantic_pack_adoption_gates: Vec<u32>,
 }
 
 #[derive(serde::Serialize)]
@@ -69,6 +70,8 @@ struct SemanticPacks {
     conformance_output_formats: Vec<&'static str>,
     inventory: Vec<&'static str>,
     inventory_output_formats: Vec<&'static str>,
+    adoption_gates: Vec<&'static str>,
+    adoption_gate_output_formats: Vec<&'static str>,
     trust: Vec<&'static str>,
     external_packs_enabled_by_default: bool,
     external_pack_influence: &'static str,
@@ -110,13 +113,7 @@ impl Report {
                 stable: vec!["capabilities", "il", "query", "semantic-pack", "stats"],
                 deprecated: Vec::new(),
             },
-            schemas: Schemas {
-                capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
-                query_json: vec![crate::schema_versions::QUERY_JSON_SCHEMA_VERSION],
-                semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
-                semantic_pack_conformance: vec![crate::semantic_pack::CONFORMANCE_SCHEMA_VERSION],
-                semantic_pack_inventory: vec![crate::semantic_pack::INVENTORY_SCHEMA_VERSION],
-            },
+            schemas: current_schemas(),
             query: QuerySurface {
                 modes: vec!["syntax", "semantic", "near"],
                 default_modes: vec!["syntax", "semantic", "near"],
@@ -135,32 +132,7 @@ impl Report {
                 ],
                 capabilities: query_capability_flags(),
             },
-            semantic_packs: SemanticPacks {
-                api_versions: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
-                loading: vec![
-                    "compiled-builtin",
-                    "local-manifest-file",
-                    "local-manifest-directory",
-                ],
-                conformance: vec!["local-manifest-file", "local-manifest-directory"],
-                conformance_output_formats: vec!["human", "json"],
-                inventory: vec!["compiled-builtin"],
-                inventory_output_formats: vec!["human", "json"],
-                trust: vec!["builtin-default", "builtin-optional", "external-opt-in"],
-                external_packs_enabled_by_default: false,
-                external_pack_influence: "metadata-only",
-                external_influence_blockers: vec![
-                    nose_semantics::ExternalInfluenceBlocker::DataOnlyRegistration.as_str(),
-                    nose_semantics::ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable
-                        .as_str(),
-                    nose_semantics::ExternalInfluenceBlocker::ExplicitInfluenceTrustGateMissing
-                        .as_str(),
-                    nose_semantics::ExternalInfluenceBlocker::ExecutableConformanceUnavailable
-                        .as_str(),
-                    nose_semantics::ExternalInfluenceBlocker::RowConflict.as_str(),
-                ],
-                external_pack_execution: "none",
-            },
+            semantic_packs: current_semantic_packs(),
             il: Il {
                 output_formats: vec!["sexpr", "json"],
                 normalized: true,
@@ -170,6 +142,45 @@ impl Report {
                 output_formats: vec!["human", "json"],
             },
         }
+    }
+}
+
+fn current_schemas() -> Schemas {
+    Schemas {
+        capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
+        query_json: vec![crate::schema_versions::QUERY_JSON_SCHEMA_VERSION],
+        semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+        semantic_pack_conformance: vec![crate::semantic_pack::CONFORMANCE_SCHEMA_VERSION],
+        semantic_pack_inventory: vec![crate::semantic_pack::INVENTORY_SCHEMA_VERSION],
+        semantic_pack_adoption_gates: vec![crate::semantic_pack::ADOPTION_GATES_SCHEMA_VERSION],
+    }
+}
+
+fn current_semantic_packs() -> SemanticPacks {
+    SemanticPacks {
+        api_versions: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+        loading: vec![
+            "compiled-builtin",
+            "local-manifest-file",
+            "local-manifest-directory",
+        ],
+        conformance: vec!["local-manifest-file", "local-manifest-directory"],
+        conformance_output_formats: vec!["human", "json"],
+        inventory: vec!["compiled-builtin"],
+        inventory_output_formats: vec!["human", "json"],
+        adoption_gates: vec!["compiled-builtin"],
+        adoption_gate_output_formats: vec!["human", "json"],
+        trust: vec!["builtin-default", "builtin-optional", "external-opt-in"],
+        external_packs_enabled_by_default: false,
+        external_pack_influence: "metadata-only",
+        external_influence_blockers: vec![
+            nose_semantics::ExternalInfluenceBlocker::DataOnlyRegistration.as_str(),
+            nose_semantics::ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable.as_str(),
+            nose_semantics::ExternalInfluenceBlocker::ExplicitInfluenceTrustGateMissing.as_str(),
+            nose_semantics::ExternalInfluenceBlocker::ExecutableConformanceUnavailable.as_str(),
+            nose_semantics::ExternalInfluenceBlocker::RowConflict.as_str(),
+        ],
+        external_pack_execution: "none",
     }
 }
 

--- a/crates/nose-cli/src/cli_args.rs
+++ b/crates/nose-cli/src/cli_args.rs
@@ -328,6 +328,13 @@ pub(crate) enum SemanticPackCmd {
         #[arg(long, default_value = "human")]
         format: semantic_pack::CheckFormat,
     },
+    /// Report builtin semantic-pack adoption gates for optional/default lanes.
+    #[command(name = "adoption-gates")]
+    AdoptionGates {
+        /// Output format.
+        #[arg(long, default_value = "human")]
+        format: semantic_pack::AdoptionGateFormat,
+    },
     /// Report builtin semantic-pack declarations, conformance refs, and coverage gaps.
     Inventory {
         /// Output format.

--- a/crates/nose-cli/src/command_dispatch.rs
+++ b/crates/nose-cli/src/command_dispatch.rs
@@ -30,6 +30,7 @@ pub(crate) fn run() -> Result<()> {
         Cmd::Capabilities => capabilities::print(),
         Cmd::SemanticPack { cmd } => match cmd {
             SemanticPackCmd::Check { paths, format } => semantic_pack::cmd_check(paths, format),
+            SemanticPackCmd::AdoptionGates { format } => semantic_pack::cmd_adoption_gates(format),
             SemanticPackCmd::Inventory { format } => semantic_pack::cmd_inventory(format),
         },
         cmd @ Cmd::Detect { .. } => run_detect_cmd(cmd),

--- a/crates/nose-cli/src/semantic_pack.rs
+++ b/crates/nose-cli/src/semantic_pack.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
+mod adoption_gates;
 mod inventory;
 
+pub(crate) use adoption_gates::{
+    cmd_adoption_gates, AdoptionGateFormat, ADOPTION_GATES_SCHEMA_VERSION,
+};
 pub(crate) use inventory::{cmd_inventory, InventoryFormat, INVENTORY_SCHEMA_VERSION};
 
 pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 2;

--- a/crates/nose-cli/src/semantic_pack/adoption_gates.rs
+++ b/crates/nose-cli/src/semantic_pack/adoption_gates.rs
@@ -1,0 +1,322 @@
+use anyhow::Result;
+
+use super::inventory::{InventoryJsonPack, InventoryJsonReport};
+
+pub(crate) const ADOPTION_GATES_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
+pub(crate) enum AdoptionGateFormat {
+    Human,
+    Json,
+}
+
+#[derive(serde::Serialize)]
+struct AdoptionGateReport {
+    schema_version: u32,
+    status: &'static str,
+    totals: AdoptionGateTotals,
+    policy: AdoptionGatePolicy,
+    checklist: AdoptionGateChecklist,
+    packs: Vec<AdoptionGatePack>,
+}
+
+#[derive(serde::Serialize)]
+struct AdoptionGateTotals {
+    builtin_packs: usize,
+    builtin_default_packs: usize,
+    builtin_optional_packs: usize,
+    exact_capable_packs: usize,
+    packs_needing_coverage: usize,
+    blocked_packs: usize,
+}
+
+#[derive(serde::Serialize)]
+struct AdoptionGatePolicy {
+    scope: &'static str,
+    default_lane: &'static str,
+    optional_lane: &'static str,
+    external_influence: &'static str,
+    product_behavior_gate: &'static str,
+    performance_gate: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct AdoptionGateChecklist {
+    builtin_optional: Vec<&'static str>,
+    builtin_default: Vec<&'static str>,
+    rollback: Vec<&'static str>,
+}
+
+#[derive(serde::Serialize)]
+struct AdoptionGatePack {
+    id: String,
+    trust: &'static str,
+    enabled_by_default: bool,
+    exact_capable: bool,
+    coverage_status: &'static str,
+    adoption_status: &'static str,
+    required_evidence: Vec<&'static str>,
+    blockers: Vec<&'static str>,
+    rollback_actions: Vec<&'static str>,
+}
+
+impl AdoptionGateReport {
+    fn new() -> Self {
+        let inventory = InventoryJsonReport::new();
+        let packs = inventory
+            .packs
+            .iter()
+            .map(AdoptionGatePack::new)
+            .collect::<Vec<_>>();
+        let blocked_packs = packs
+            .iter()
+            .filter(|pack| !pack.blockers.is_empty())
+            .count();
+        Self {
+            schema_version: ADOPTION_GATES_SCHEMA_VERSION,
+            status: if blocked_packs == 0 {
+                inventory.status
+            } else {
+                "needs-evidence"
+            },
+            totals: AdoptionGateTotals {
+                builtin_packs: inventory.totals.builtin_packs,
+                builtin_default_packs: packs
+                    .iter()
+                    .filter(|pack| pack.trust == "builtin-default")
+                    .count(),
+                builtin_optional_packs: packs
+                    .iter()
+                    .filter(|pack| pack.trust == "builtin-optional")
+                    .count(),
+                exact_capable_packs: inventory.totals.exact_capable_packs,
+                packs_needing_coverage: inventory.totals.packs_needing_coverage,
+                blocked_packs,
+            },
+            policy: AdoptionGatePolicy {
+                scope: "compiled-builtin",
+                default_lane: "builtin-default",
+                optional_lane: "builtin-optional",
+                external_influence: "metadata-only",
+                product_behavior_gate: "required-for-builtin-default-promotion",
+                performance_gate: "required-for-builtin-default-promotion",
+            },
+            checklist: AdoptionGateChecklist {
+                builtin_optional: builtin_optional_checklist(),
+                builtin_default: builtin_default_checklist(),
+                rollback: rollback_checklist(),
+            },
+            packs,
+        }
+    }
+}
+
+impl AdoptionGatePack {
+    fn new(pack: &InventoryJsonPack) -> Self {
+        let blockers = adoption_blockers(
+            pack.trust,
+            pack.enabled_by_default,
+            pack.audit.exact_capable,
+            pack.audit.coverage_status,
+            &pack.audit.gaps,
+        );
+        Self {
+            id: pack.id.clone(),
+            trust: pack.trust,
+            enabled_by_default: pack.enabled_by_default,
+            exact_capable: pack.audit.exact_capable,
+            coverage_status: pack.audit.coverage_status,
+            adoption_status: adoption_status(pack.trust, pack.enabled_by_default, &blockers),
+            required_evidence: required_evidence(pack.trust),
+            blockers,
+            rollback_actions: rollback_checklist(),
+        }
+    }
+}
+
+fn adoption_status(
+    trust: &str,
+    enabled_by_default: bool,
+    blockers: &[&'static str],
+) -> &'static str {
+    if !blockers.is_empty() {
+        "blocked"
+    } else if trust == "builtin-default" && enabled_by_default {
+        "default-gated"
+    } else if trust == "builtin-optional" && !enabled_by_default {
+        "optional-gated"
+    } else {
+        "tracked"
+    }
+}
+
+fn adoption_blockers(
+    trust: &str,
+    enabled_by_default: bool,
+    exact_capable: bool,
+    coverage_status: &str,
+    inventory_gaps: &[&'static str],
+) -> Vec<&'static str> {
+    let mut blockers = Vec::new();
+    match trust {
+        "builtin-default" => {
+            if !enabled_by_default {
+                blockers.push("builtin-default-not-enabled");
+            }
+        }
+        "builtin-optional" => {
+            if enabled_by_default {
+                blockers.push("builtin-optional-enabled-by-default");
+            }
+        }
+        _ => blockers.push("unexpected-trust-lane"),
+    }
+    if exact_capable && coverage_status != "covered" {
+        blockers.push("exact-capable-coverage-gap");
+    }
+    if !inventory_gaps.is_empty() {
+        blockers.push("inventory-audit-gap");
+    }
+    blockers
+}
+
+fn required_evidence(trust: &str) -> Vec<&'static str> {
+    match trust {
+        "builtin-default" => builtin_default_checklist(),
+        "builtin-optional" => builtin_optional_checklist(),
+        _ => vec!["ownership-and-trust-lane-decision"],
+    }
+}
+
+fn builtin_optional_checklist() -> Vec<&'static str> {
+    vec![
+        "stable-pack-id-owner-version-policy",
+        "structural-conformance",
+        "positive-fixtures-and-hard-negatives",
+        "dependency-backed-evidence-for-exact-rows",
+        "unsupported-boundary-docs",
+        "maintainer-owner",
+        "rollback-plan",
+    ]
+}
+
+fn builtin_default_checklist() -> Vec<&'static str> {
+    vec![
+        "inventory-covered",
+        "query-regression-summary",
+        "runtime-drift-measurement",
+        "default-surface-noise-review",
+        "docs-examples-capabilities",
+        "release-note",
+        "rollback-plan",
+    ]
+}
+
+fn rollback_checklist() -> Vec<&'static str> {
+    vec![
+        "demote-pack-to-builtin-optional",
+        "disable-risky-row-when-practical",
+        "tighten-dependency-or-hard-negative-admission",
+        "preserve-pack-provenance-in-reports",
+    ]
+}
+
+pub(crate) fn cmd_adoption_gates(format: AdoptionGateFormat) -> Result<()> {
+    let report = AdoptionGateReport::new();
+    match format {
+        AdoptionGateFormat::Human => print_adoption_gates_human(&report),
+        AdoptionGateFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+    }
+    Ok(())
+}
+
+fn print_adoption_gates_human(report: &AdoptionGateReport) {
+    println!("builtin semantic-pack adoption gates: {}", report.status);
+    println!(
+        "packs: {}; default: {}; optional: {}; exact-capable: {}; blocked: {}",
+        report.totals.builtin_packs,
+        report.totals.builtin_default_packs,
+        report.totals.builtin_optional_packs,
+        report.totals.exact_capable_packs,
+        report.totals.blocked_packs
+    );
+    println!("builtin-default promotion requires:");
+    for item in &report.checklist.builtin_default {
+        println!("  - {item}");
+    }
+    for pack in &report.packs {
+        println!(
+            "  {}: {} ({}, coverage {})",
+            pack.id, pack.adoption_status, pack.trust, pack.coverage_status
+        );
+        if !pack.blockers.is_empty() {
+            println!("    blockers: {}", pack.blockers.join(", "));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{adoption_blockers, adoption_status, required_evidence};
+
+    #[test]
+    fn adoption_status_reports_supported_lanes() {
+        assert_eq!(
+            adoption_status("builtin-default", true, &[]),
+            "default-gated"
+        );
+        assert_eq!(
+            adoption_status("builtin-optional", false, &[]),
+            "optional-gated"
+        );
+    }
+
+    #[test]
+    fn adoption_status_blocks_when_lane_or_coverage_is_invalid() {
+        let optional_enabled = adoption_blockers(
+            "builtin-optional",
+            true,
+            false,
+            "tracked-no-exact-rows",
+            &[],
+        );
+        assert_eq!(
+            optional_enabled,
+            vec!["builtin-optional-enabled-by-default"]
+        );
+        assert_eq!(
+            adoption_status("builtin-optional", true, &optional_enabled),
+            "blocked"
+        );
+
+        let coverage_gap = adoption_blockers(
+            "builtin-default",
+            true,
+            true,
+            "needs-coverage",
+            &["exact-capable-missing-hard-negatives"],
+        );
+        assert_eq!(
+            coverage_gap,
+            vec!["exact-capable-coverage-gap", "inventory-audit-gap"]
+        );
+        assert_eq!(
+            adoption_status("builtin-default", true, &coverage_gap),
+            "blocked"
+        );
+    }
+
+    #[test]
+    fn required_evidence_differs_by_lane() {
+        assert!(required_evidence("builtin-default").contains(&"query-regression-summary"));
+        assert!(
+            required_evidence("builtin-optional").contains(&"positive-fixtures-and-hard-negatives")
+        );
+        assert_eq!(
+            required_evidence("external-opt-in"),
+            vec!["ownership-and-trust-lane-decision"]
+        );
+    }
+}

--- a/crates/nose-cli/src/semantic_pack/inventory.rs
+++ b/crates/nose-cli/src/semantic_pack/inventory.rs
@@ -9,20 +9,20 @@ pub(crate) enum InventoryFormat {
 }
 
 #[derive(serde::Serialize)]
-struct InventoryJsonReport {
+pub(super) struct InventoryJsonReport {
     schema_version: u32,
-    status: &'static str,
-    totals: InventoryJsonTotals,
+    pub(super) status: &'static str,
+    pub(super) totals: InventoryJsonTotals,
     evidence_policy: InventoryJsonEvidencePolicy,
-    packs: Vec<InventoryJsonPack>,
+    pub(super) packs: Vec<InventoryJsonPack>,
 }
 
 #[derive(serde::Serialize)]
-struct InventoryJsonTotals {
-    packs: usize,
-    builtin_packs: usize,
-    exact_capable_packs: usize,
-    packs_needing_coverage: usize,
+pub(super) struct InventoryJsonTotals {
+    pub(super) packs: usize,
+    pub(super) builtin_packs: usize,
+    pub(super) exact_capable_packs: usize,
+    pub(super) packs_needing_coverage: usize,
     positive_fixtures: usize,
     hard_negatives: usize,
     conformance_refs: usize,
@@ -36,14 +36,14 @@ struct InventoryJsonEvidencePolicy {
 }
 
 #[derive(serde::Serialize)]
-struct InventoryJsonPack {
-    id: String,
+pub(super) struct InventoryJsonPack {
+    pub(super) id: String,
     hash: String,
     kind: &'static str,
     version: String,
     display_name: String,
-    trust: &'static str,
-    enabled_by_default: bool,
+    pub(super) trust: &'static str,
+    pub(super) enabled_by_default: bool,
     source: &'static str,
     influence: &'static str,
     provider: String,
@@ -53,7 +53,7 @@ struct InventoryJsonPack {
     supported_packages: Vec<String>,
     declarations: InventoryJsonDeclarations,
     conformance: InventoryJsonConformance,
-    audit: InventoryJsonAudit,
+    pub(super) audit: InventoryJsonAudit,
 }
 
 #[derive(serde::Serialize)]
@@ -84,16 +84,16 @@ struct InventoryJsonConformance {
 }
 
 #[derive(serde::Serialize)]
-struct InventoryJsonAudit {
-    exact_capable: bool,
-    coverage_status: &'static str,
-    gaps: Vec<&'static str>,
-    product_output_evidence: &'static str,
-    performance_evidence: &'static str,
+pub(super) struct InventoryJsonAudit {
+    pub(super) exact_capable: bool,
+    pub(super) coverage_status: &'static str,
+    pub(super) gaps: Vec<&'static str>,
+    pub(super) product_output_evidence: &'static str,
+    pub(super) performance_evidence: &'static str,
 }
 
 impl InventoryJsonReport {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let builtin = nose_semantics::SemanticPackSet::builtin_only();
         let packs = nose_semantics::builtin_pack_descriptors()
             .iter()

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -12,5 +12,7 @@ mod ignores_sarif;
 mod proposal_query;
 #[path = "commands/query_reinvented.rs"]
 mod query_reinvented;
+#[path = "commands/semantic_pack_adoption_gates.rs"]
+mod semantic_pack_adoption_gates;
 #[path = "commands/semantic_pack_inventory.rs"]
 mod semantic_pack_inventory;

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -51,6 +51,7 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
     );
     assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 2);
     assert_eq!(json["schemas"]["semantic_pack_inventory"][0], 1);
+    assert_eq!(json["schemas"]["semantic_pack_adoption_gates"][0], 1);
 }
 
 #[test]
@@ -124,6 +125,14 @@ fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
     );
     assert_eq!(
         json_array_strings(&json["semantic_packs"], "inventory_output_formats"),
+        vec!["human", "json"]
+    );
+    assert_eq!(
+        json_array_strings(&json["semantic_packs"], "adoption_gates"),
+        vec!["compiled-builtin"]
+    );
+    assert_eq!(
+        json_array_strings(&json["semantic_packs"], "adoption_gate_output_formats"),
         vec!["human", "json"]
     );
     assert_eq!(

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[test]
+fn semantic_pack_adoption_gates_json_reports_builtin_gate_status() {
+    let out = run(&["semantic-pack", "adoption-gates", "--format", "json"]);
+    let json: serde_json::Value =
+        serde_json::from_str(&out).expect("adoption gates must emit valid JSON");
+
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["policy"]["scope"], "compiled-builtin");
+    assert_eq!(json["policy"]["external_influence"], "metadata-only");
+    assert_eq!(json["totals"]["builtin_packs"], 43);
+    assert_eq!(json["totals"]["builtin_default_packs"], 43);
+    assert_eq!(json["totals"]["builtin_optional_packs"], 0);
+    assert_eq!(json["totals"]["packs_needing_coverage"], 0);
+    assert_eq!(json["totals"]["blocked_packs"], 0);
+    assert!(json_array_strings(&json["checklist"], "builtin_optional")
+        .contains(&"stable-pack-id-owner-version-policy"));
+    assert!(json_array_strings(&json["checklist"], "builtin_default")
+        .contains(&"query-regression-summary"));
+    assert!(json_array_strings(&json["checklist"], "rollback")
+        .contains(&"demote-pack-to-builtin-optional"));
+
+    let packs = json["packs"]
+        .as_array()
+        .expect("adoption gate packs should be an array");
+    let c_language = packs
+        .iter()
+        .find(|pack| pack["id"] == "nose.lang.c")
+        .expect("C language pack should be reported");
+    assert_eq!(c_language["trust"], "builtin-default");
+    assert_eq!(c_language["enabled_by_default"], true);
+    assert_eq!(c_language["adoption_status"], "default-gated");
+    assert_eq!(c_language["coverage_status"], "covered");
+    assert!(json_array_strings(c_language, "blockers").is_empty());
+    assert!(
+        json_array_strings(c_language, "required_evidence").contains(&"runtime-drift-measurement")
+    );
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -50,7 +50,8 @@ nose capabilities
     "query_json": [6],
     "semantic_packs": ["nose.semantic-pack.v0"],
     "semantic_pack_conformance": [2],
-    "semantic_pack_inventory": [1]
+    "semantic_pack_inventory": [1],
+    "semantic_pack_adoption_gates": [1]
   },
   "query": {
     "modes": ["syntax", "semantic", "near"],
@@ -97,6 +98,8 @@ nose capabilities
     "conformance_output_formats": ["human", "json"],
     "inventory": ["compiled-builtin"],
     "inventory_output_formats": ["human", "json"],
+    "adoption_gates": ["compiled-builtin"],
+    "adoption_gate_output_formats": ["human", "json"],
     "trust": [
       "builtin-default",
       "builtin-optional",
@@ -152,6 +155,7 @@ release so it can't drift.
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
 | `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 2 reports structural conformance, executable fixture-expectation gate results, and row-level external influence preflight blockers. |
 | `schemas.semantic_pack_inventory` | array | Supported `nose semantic-pack inventory --format json` schema versions. Version 1 reports compiled builtin pack declarations, conformance refs, coverage status, and audit gaps. |
+| `schemas.semantic_pack_adoption_gates` | array | Supported `nose semantic-pack adoption-gates --format json` schema versions. Version 1 reports compiled builtin pack optional/default promotion gates, rollback actions, and blocker status. |
 | `query.modes` | array | Supported `--mode` values. |
 | `query.default_modes` | array | Modes used by `nose query` when `--mode` is omitted. |
 | `query.output_formats` | array | Supported `nose query --format` values. |
@@ -164,6 +168,8 @@ release so it can't drift.
 | `semantic_packs.conformance_output_formats` | array | Supported `nose semantic-pack check --format` values. |
 | `semantic_packs.inventory` | array | Supported inventory sources. Version 4 reports `compiled-builtin`. |
 | `semantic_packs.inventory_output_formats` | array | Supported `nose semantic-pack inventory --format` values. |
+| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 4 may report `compiled-builtin`; consumers should treat absence as unsupported. |
+| `semantic_packs.adoption_gate_output_formats` | array | Supported `nose semantic-pack adoption-gates --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
 | `semantic_packs.external_pack_influence` | string | Current influence of loaded external packs, `metadata-only`. |

--- a/docs/home.md
+++ b/docs/home.md
@@ -79,7 +79,7 @@ fundamentals; the rest is grouped by area.
 
 - [semantic-kernel](semantic-kernel.md) — semantic-kernel and pack architecture: language/library semantics, extension boundaries, responsibility model, and exact-channel eligibility.
 - [semantic-pack-architecture](semantic-pack-architecture.md) — the #473 migration rulebook for builtin/external pack terminology, kernel-vs-pack ownership, behavior gates, and performance gates.
-- [semantic-pack-adoption](semantic-pack-adoption.md) — promotion and rollback gates for moving external or optional packs into official builtin support without forking semantic vocabulary.
+- [semantic-pack-adoption](semantic-pack-adoption.md) — promotion, rollback, and adoption-gate reports for moving external or optional packs into official builtin support without forking semantic vocabulary.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.
 - [semantic-kernel-audit-2026-06-09](semantic-kernel-audit-2026-06-09.md) — post-PR #147 audit of remaining raw/local semantic pockets and follow-up owners.

--- a/docs/semantic-pack-adoption.md
+++ b/docs/semantic-pack-adoption.md
@@ -58,6 +58,20 @@ Promotion does not imply default enablement. A newly builtin-optional pack may
 still have recall gaps or ecosystem-version risk, but its influence path must be
 owned and testable by nose.
 
+Implementation PR checklist:
+
+- Name the pack id, owner, version policy, support boundary, and unsupported
+  cases.
+- Link structural conformance or builtin inventory output.
+- List exact-capable producers, contracts, laws, or aliases changed by the PR.
+- Attach positive fixtures and hard negatives for the changed exact-capable
+  rows.
+- Classify product behavior drift as unchanged metadata, precision improvement,
+  measured recall change, or bug fix.
+- Report runtime drift against `main` when the PR changes analysis behavior.
+- State the rollback action: demote pack, disable row, tighten admission, or
+  revert.
+
 ## Builtin Optional To Builtin Default
 
 Promote `builtin-optional` to `builtin-default` only after corpus evidence shows
@@ -78,6 +92,21 @@ Requirements:
 Default enablement is a product decision layered on top of the same kernel
 admission checks. It must not bypass external/builtin parity rules.
 
+Implementation PR checklist:
+
+- Include `nose semantic-pack adoption-gates --format json` output or a summary
+  of its blocker status for the changed pack.
+- Include `nose semantic-pack inventory --format json` output or a summary of
+  exact-capable coverage for the changed rows.
+- Attach query-regression output against representative repositories, or explain
+  why the change is descriptor/reporting-only.
+- Attach runtime measurements against `main`; use the pack architecture
+  performance threshold.
+- Note docs, examples, capabilities, and release-note changes for the new
+  default behavior.
+- Name the smallest rollback path if false merges, noise, or runtime regression
+  appears after release.
+
 ## Rollback
 
 If a builtin pack causes false merges, unacceptable noise, or runtime regression,
@@ -94,6 +123,63 @@ prefer the smallest reversible action:
 Rollback must preserve provenance. Reports should still make it clear which pack
 or row was responsible for the disabled behavior, so users and maintainers can
 track the fix.
+
+## Adoption Gate Report
+
+Builtin packs have a lightweight gate report:
+
+```sh
+nose semantic-pack adoption-gates
+nose semantic-pack adoption-gates --format json
+```
+
+The report reads compiled builtin descriptors through the same static inventory
+surface as `nose semantic-pack inventory`. It does not run queries, parse
+external manifests, execute provider code, or enable external influence.
+
+JSON schema version 1 reports:
+
+- current builtin lane counts;
+- optional/default PR checklist requirements;
+- rollback actions;
+- per-pack trust lane, default enablement, exact-capable coverage status, and
+  blockers.
+
+The checklist and `required_evidence` arrays are static policy requirements for
+PR authors. They are not proof that a PR has attached the evidence; the
+mechanical pass/fail signal is `status`, `totals.blocked_packs`, and each
+pack's `blockers`.
+
+Important fields:
+
+| Field | Values |
+|---|---|
+| `schema_version` | `1` |
+| `status` | `ok` or `needs-evidence` |
+| `totals.builtin_packs` | Number of compiled builtin packs inspected. |
+| `totals.builtin_default_packs` | Builtin packs in the `builtin-default` trust lane. |
+| `totals.builtin_optional_packs` | Builtin packs in the `builtin-optional` trust lane. |
+| `totals.exact_capable_packs` | Builtin packs with exact-capable inventory coverage. |
+| `totals.packs_needing_coverage` | Exact-capable builtin packs whose inventory audit needs coverage. |
+| `totals.blocked_packs` | Packs with lane, enablement, or inventory blockers. |
+| `policy.scope` | `compiled-builtin` |
+| `policy.default_lane` | `builtin-default` |
+| `policy.optional_lane` | `builtin-optional` |
+| `policy.external_influence` | `metadata-only` |
+| `policy.product_behavior_gate` | `required-for-builtin-default-promotion` |
+| `policy.performance_gate` | `required-for-builtin-default-promotion` |
+| `packs[].adoption_status` | `default-gated`, `optional-gated`, `blocked`, or `tracked` |
+| `packs[].coverage_status` | `covered`, `needs-coverage`, or `tracked-no-exact-rows` |
+| `packs[].blockers[]` | `builtin-default-not-enabled`, `builtin-optional-enabled-by-default`, `unexpected-trust-lane`, `exact-capable-coverage-gap`, or `inventory-audit-gap` |
+| `packs[].required_evidence[]` | Static checklist labels for the pack's trust lane. |
+| `packs[].rollback_actions[]` | Static rollback action labels maintainers may choose from. |
+
+`status: "ok"` means the current compiled builtin packs satisfy the mechanical
+lane checks: `builtin-default` packs are enabled by default,
+`builtin-optional` packs are not, and exact-capable packs are covered by the
+builtin inventory audit. It is not a product decision by itself; promotion to
+`builtin-default` still requires the behavior, runtime, docs, release-note, and
+rollback evidence above.
 
 ## Implementation Rule
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -291,6 +291,9 @@ and may change to improve readability. The stable contract is documented in
 - `nose semantic-pack inventory [--format human|json]` — inspect compiled
   builtin pack declarations, conformance refs, exact-capable coverage status,
   and coverage gaps without running a query.
+- `nose semantic-pack adoption-gates [--format human|json]` — inspect compiled
+  builtin pack optional/default promotion gates, rollback actions, and blocker
+  status without running a query.
 - `nose il <file> [--normalized] [--no-cfg-norm] [--format sexpr|json]` — dump the IL
   for one file (`--normalized` shows the canonical form after the
   [normalization](normalization.md) passes). A debugging tool for understanding why two


### PR DESCRIPTION
Closes #489.

## Summary

- add `nose semantic-pack adoption-gates [--format human|json]` for compiled builtin optional/default gate status
- report builtin lane counts, per-pack blockers, required promotion evidence, and rollback actions
- expose adoption-gate support as additive capabilities schema v4 metadata
- document the builtin adoption PR checklist, gate report JSON schema v1, rollback expectations, and usage entry
- keep the report descriptor-only by reusing the compiled builtin inventory audit

## Product behavior

- Query analysis paths are not changed; the new command reads static compiled builtin descriptors and inventory audit state.
- External packs remain explicit opt-in and metadata-only; the report does not parse manifests, execute provider code, or enable influence.
- Public behavior change is limited to the new `semantic-pack adoption-gates` command and additive capabilities metadata.

## Performance

- No per-node/per-unit hot path work added.
- Release measurement after warm-up: `target/release/nose semantic-pack adoption-gates --format json`, 20 runs, median 2.48 ms, min 2.36 ms, max 2.62 ms.
- Duplication gate remains at 55 with no baseline change after splitting `capabilities` helpers.

## Review follow-up

- Added unit coverage for optional/default lane blockers, coverage-gap blockers, and per-lane required evidence.
- Kept capabilities schema at v4 because the new capabilities fields are additive and consumers are expected to ignore unknown fields.
- Expanded `docs/semantic-pack-adoption.md` with the adoption-gates JSON schema v1 field/enum contract and clarified that checklist arrays are policy requirements, not completed evidence.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p nose-cli --lib adoption_gates -- --test-threads=1`
- `cargo test -p nose-cli --test cli`
- `cargo test -p nose-cli --test cli semantic_pack_adoption_gates_json_reports_builtin_gate_status -- --test-threads=1`
- `cargo test -p nose-cli --test cli capabilities_command_lists_stable_commands_and_schemas -- --test-threads=1`
- `cargo test -p nose-cli --test cli capabilities_command_reports_semantic_pack_il_and_stats_surfaces -- --test-threads=1`
- `cargo build --release -p nose-cli`
- `scripts/check-duplication.sh`
- `scripts/check-docs.sh`
- `awiki lint --root docs`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `git diff --check`
