### PR TITLE
chore: release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ break.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-22
+
 ### Added
 - Added the builtin semantic-pack operating model: compiled builtin pack descriptors,
   query JSON `semantic_packs` provenance, `nose capabilities` semantic-pack support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "lasso",
  "serde",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "nose-markdown"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "rayon",
  "regex",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -26,13 +26,13 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.14.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.14.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.14.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.14.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.14.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.14.0" }
-nose-markdown = { path = "crates/nose-markdown", version = "0.14.0" }
+nose-il = { path = "crates/nose-il", version = "0.15.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.15.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.15.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.15.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.15.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.15.0" }
+nose-markdown = { path = "crates/nose-markdown", version = "0.15.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -47,7 +47,7 @@ fn semantic_pack_manifest(id: &str) -> String {
     "license": "MIT",
     "repository": "https://example.invalid/semantic-pack"
   }},
-  "compatibility": {{ "nose": ">=0.14.0 <0.15.0" }},
+  "compatibility": {{ "nose": ">=0.15.0 <0.16.0" }},
   "supported_languages": [{{ "id": "python" }}],
   "declares": {{
     "evidence_producers": [{{

--- a/crates/nose-semantics/src/packs/tests.rs
+++ b/crates/nose-semantics/src/packs/tests.rs
@@ -69,7 +69,7 @@ fn manifest(id: &str) -> String {
     "license": "MIT",
     "repository": "https://example.invalid"
   }},
-  "compatibility": {{ "nose": ">=0.14.0 <0.15.0" }},
+  "compatibility": {{ "nose": ">=0.15.0 <0.16.0" }},
   "supported_languages": [{{ "id": "python" }}],
   "declares": {{
     "evidence_producers": [{{

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
@@ -89,7 +89,7 @@ fn compatibility_nose_must_be_version_requirement_like() {
     fs::write(
         &path,
         manifest("com.example.pack").replace(
-            r#""compatibility": { "nose": ">=0.14.0 <0.15.0" }"#,
+            r#""compatibility": { "nose": ">=0.15.0 <0.16.0" }"#,
             r#""compatibility": { "nose": "current stable" }"#,
         ),
     )
@@ -102,15 +102,15 @@ fn compatibility_nose_must_be_version_requirement_like() {
 #[test]
 fn compatibility_nose_accepts_semver_operator_spacing() {
     for (tag, supported_range) in [
-        ("operator_spacing", ">= 0.14.0, < 0.15.0"),
-        ("v_prefix", ">= v0.14.0 < v0.15.0"),
+        ("operator_spacing", ">= 0.15.0, < 0.16.0"),
+        ("v_prefix", ">= v0.15.0 < v0.16.0"),
     ] {
         let dir = unique_dir(&format!("compatibility_{tag}"));
         let path = dir.join("pack.json");
         fs::write(
             &path,
             manifest("com.example.pack").replace(
-                r#""compatibility": { "nose": ">=0.14.0 <0.15.0" }"#,
+                r#""compatibility": { "nose": ">=0.15.0 <0.16.0" }"#,
                 &format!(r#""compatibility": {{ "nose": "{supported_range}" }}"#),
             ),
         )
@@ -131,7 +131,7 @@ fn compatibility_nose_must_include_current_binary_version() {
         fs::write(
             &path,
             manifest("com.example.pack").replace(
-                r#""compatibility": { "nose": ">=0.14.0 <0.15.0" }"#,
+                r#""compatibility": { "nose": ">=0.15.0 <0.16.0" }"#,
                 &format!(r#""compatibility": {{ "nose": "{unsupported_range}" }}"#),
             ),
         )

--- a/docs/examples/semantic-packs/v0/language-pack.json
+++ b/docs/examples/semantic-packs/v0/language-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.14.0 <0.15.0",
+    "nose": ">=0.15.0 <0.16.0",
     "schema": "v0",
     "notes": "Example only. The loader compares this range before accepting the manifest."
   },

--- a/docs/examples/semantic-packs/v0/law-pack.json
+++ b/docs/examples/semantic-packs/v0/law-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.14.0 <0.15.0",
+    "nose": ">=0.15.0 <0.16.0",
     "schema": "v0",
     "notes": "Example only. nose's built-in value-graph law pack uses compiled builtin code and reports as nose.value_graph.laws."
   },

--- a/docs/examples/semantic-packs/v0/library-pack.json
+++ b/docs/examples/semantic-packs/v0/library-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.14.0 <0.15.0",
+    "nose": ">=0.15.0 <0.16.0",
     "schema": "v0",
     "notes": "Example only. The loader compares this range before accepting the manifest."
   },

--- a/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
+++ b/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.14.0 <0.15.0",
+    "nose": ">=0.15.0 <0.16.0",
     "schema": "v0",
     "notes": "Example only. nose's built-in pilot uses compiled builtin code and reports as nose.python.stdlib.type_domain."
   },

--- a/docs/semantic-pack-boundary-review-2026-06-22.md
+++ b/docs/semantic-pack-boundary-review-2026-06-22.md
@@ -1,7 +1,8 @@
 # Semantic pack boundary review, 2026-06-22
 
 Status: pre-release review for the builtin semantic-pack operating model after
-the #484 stabilization tracker. This review does not bump the nose version.
+the #484 stabilization tracker. The release bump is tracked separately by the
+0.15.0 release PR.
 
 Reviewed base commit before this docs-only PR:
 `442668ab2fdb7f6c74ad73d9cfef20bef507625b`.
@@ -126,9 +127,8 @@ before broad ecosystem work or external influence:
 
 - Add checked golden fixtures for the machine-readable semantic-pack reports so
   docs and schema examples cannot drift from CLI output again.
-- Before bumping from `0.14.x` to `0.15.0`, update the example manifests and
-  tests whose `compatibility.nose` ranges intentionally mention
-  `>=0.14.0 <0.15.0`.
+- After each minor release, update the example manifests and tests whose
+  `compatibility.nose` ranges intentionally pin the current minor version.
 - Keep reducing the broad `nose.first_party` compatibility surface. It is
   acceptable as a v0 compatibility descriptor, but it should not regain active
   semantic ownership.
@@ -144,8 +144,8 @@ Before cutting the next minor release, keep the remaining unchecked items as
 release-candidate gates. Checked items below were verified during this boundary
 review and should still be re-run on the final release candidate.
 
-- [x] `CHANGELOG.md` has Unreleased notes for semantic-pack user-visible changes.
-- [ ] Example manifest `compatibility.nose` ranges match the release version.
+- [x] `CHANGELOG.md` has release notes for semantic-pack user-visible changes.
+- [x] Example manifest `compatibility.nose` ranges match the release version.
 - [x] `nose capabilities` advertises the intended schema versions.
 - [x] `nose semantic-pack inventory --format json` reports no coverage gaps.
 - [x] `nose semantic-pack adoption-gates --format json` reports no blocked packs.
@@ -153,9 +153,21 @@ review and should still be re-run on the final release candidate.
       influence as metadata-only and execution as none.
 - [x] `nose semantic-pack check docs/examples/semantic-packs/v0 --format json`
       passes.
-- [ ] `scripts/check-ci-local.sh --full` or equivalent CI has passed.
-- [ ] Query-regression/product-output and runtime drift have been recorded for
+- [x] `scripts/check-ci-local.sh --full` or equivalent CI has passed.
+- [x] Query-regression/product-output and runtime drift have been recorded for
       the final release candidate.
+
+0.15.0 release-candidate evidence, 2026-06-22:
+
+- `scripts/check-ci-local.sh --full` passed locally.
+- `python3 bench/type4/query_regression/query_regression.py compare --repeats 20`
+  compared the previous `nose 0.14.0` binary with the `nose 0.15.0` release
+  candidate over the 9-repo subset and reported 0 investigation triggers.
+- Full `scripts/corpus-verify-nightly.sh` was re-run on 120 pinned repos. It
+  still has the pre-existing `netty` canon-preservation failure already seen on
+  recent main nightly runs and reproduced with the previous `nose 0.14.0`
+  binary; track the corpus/nightly fix in
+  [#503](https://github.com/corca-ai/nose/issues/503).
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Bump workspace crates and internal dependency requirements from 0.14.0 to 0.15.0.
- Move the current CHANGELOG entries under the 2026-06-22 `0.15.0` heading.
- Update semantic-pack example/test compatibility ranges to `>=0.15.0 <0.16.0`.
- Record final release-candidate evidence in the semantic-pack boundary review.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all --check`
- `cargo build --release --bin nose`
- `target/release/nose --version` -> `nose 0.15.0`
- `scripts/check-docs.sh`
- `awiki lint --root docs`
- `target/release/nose capabilities`
- `target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json`
- `target/release/nose semantic-pack inventory --format json`
- `target/release/nose semantic-pack adoption-gates --format json`
- `target/release/nose semantic-pack compatibility --format json`
- `python3 bench/type4/query_regression/query_regression.py selftest`
- query-regression r20 comparing previous `nose 0.14.0` binary vs `nose 0.15.0` RC over the 9-repo subset: 0 investigation triggers
- `scripts/check-ci-local.sh --full`

## Corpus verify note

Full `scripts/corpus-verify-nightly.sh` was re-run locally on 120 pinned repos. It still has the pre-existing `netty` canon-preservation failure already present on recent main nightly runs and reproduced with the previous `nose 0.14.0` binary; this release bump did not introduce it. Tracking fix: #503.