### PR TITLE
Derive minimal semantic kernel capabilities

### DIFF
--- a/bench/semantic_pack/README.md
+++ b/bench/semantic_pack/README.md
@@ -21,6 +21,8 @@ Outputs:
 - `candidate_pricing.md` — human-readable summary of the same record.
 - `loop_reviews.v1.json` — durable two-reviewer resolution record for the 20
   pricing iterations.
+- `kernel_capability_matrix.v1.json` — issue #507 primitive census, blocker
+  taxonomy, and accept/reject matrix derived from the pricing record.
 
 The scanner reports corpus queue signals. It does not prove semantic
 correctness and does not authorize broad ecosystem packs. Only `priced-ready`

--- a/bench/semantic_pack/kernel_capability_matrix.v1.json
+++ b/bench/semantic_pack/kernel_capability_matrix.v1.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": 1,
+  "issue": 507,
+  "source_artifacts": [
+    "bench/semantic_pack/candidate_pricing.v1.json",
+    "bench/semantic_pack/candidate_pricing.md",
+    "bench/semantic_pack/loop_reviews.v1.json"
+  ],
+  "pricing_totals": {
+    "iterations": 20,
+    "priced_ready": 1,
+    "priced_but_blocked": 9,
+    "unpriced": 10
+  },
+  "primitive_census": {
+    "evidence_families": [
+      "Source",
+      "Domain",
+      "Import",
+      "Symbol",
+      "Type",
+      "Guard",
+      "Place",
+      "Effect",
+      "LibraryApi",
+      "CallTarget",
+      "SequenceSurface"
+    ],
+    "contract_substrates": [
+      "receiver-domain dependency admission",
+      "symbol/import occurrence proof",
+      "library API occurrence contracts",
+      "call-target identity proof",
+      "demand/effect profiles for admitted operations",
+      "sequence-surface proof",
+      "manifest package/version metadata",
+      "conformance fixture gates"
+    ],
+    "domain_requirement_before": {
+      "kind": "closed enum",
+      "variant_count": 25,
+      "problem": "atomic evidence domains and composite receiver requirements were separate primitive variants"
+    },
+    "domain_requirement_after": {
+      "kind": "compositional requirement",
+      "constructors": [
+        "Exact(DomainEvidence)",
+        "AnyOf(&'static [DomainEvidence])"
+      ],
+      "named_aliases": "compatibility names for builtin contracts, not new primitives"
+    }
+  },
+  "blocker_taxonomy": [
+    {
+      "id": "version_package_occurrence",
+      "blockers": [
+        "Guava Optional version/package proof",
+        "ActiveSupport version proof",
+        "Go version proof"
+      ],
+      "pricing_candidates": [
+        "java.guava.optional_presence",
+        "ruby.rails_active_support_presence",
+        "go.stdlib.maps_helpers"
+      ]
+    },
+    {
+      "id": "receiver_domain_value_boundary",
+      "blockers": [
+        "dtype/domain proof",
+        "array-vs-scalar boundary",
+        "receiver class proof",
+        "Rust trait identity proof",
+        "map iteration order boundary"
+      ],
+      "pricing_candidates": [
+        "python.numpy.scalar_integer_ufuncs",
+        "ruby.rails_active_support_presence",
+        "rust.itertools_collect_vec",
+        "go.stdlib.maps_helpers"
+      ]
+    },
+    {
+      "id": "demand_effect_lifecycle",
+      "blockers": [
+        "default-demand/effect profile",
+        "Observable demand/effect substrate",
+        "stream lifecycle proof",
+        "callback effect proof",
+        "iterator demand proof",
+        "source iteration effect proof",
+        "iterator consumption effect proof"
+      ],
+      "pricing_candidates": [
+        "java.guava.optional_presence",
+        "javascript.rxjs_observable_identity_adapters",
+        "javascript.rxjs_projection_operators",
+        "python.itertools_chain_factories",
+        "rust.itertools_collect_vec"
+      ]
+    },
+    {
+      "id": "scheduler_platform_runtime",
+      "blockers": [
+        "scheduler boundary",
+        "platform/cwd sensitivity",
+        "runtime/test boundary"
+      ],
+      "pricing_candidates": [
+        "javascript.rxjs_observable_identity_adapters",
+        "javascript.node_path_normalization",
+        "rust.tokio_future_identity_adapters"
+      ]
+    },
+    {
+      "id": "corpus_query_evidence",
+      "blockers": [
+        "external consumer corpus evidence",
+        "candidate-specific current miss/query evidence",
+        "zero corpus presence"
+      ],
+      "pricing_candidates": [
+        "java.apache_commons_lang_string_utils",
+        "javascript.lodash.collection_projection",
+        "javascript.lodash.membership_predicates",
+        "python.numpy_clip_minmax",
+        "python.pandas_series_null_predicates",
+        "python.pandas_fillna_defaults",
+        "ruby.rails_collection_helpers"
+      ]
+    }
+  ],
+  "matrix": [
+    {
+      "candidate": "domain_requirement_composition",
+      "covers_taxonomy": [
+        "receiver_domain_value_boundary"
+      ],
+      "decision": "accepted-implemented",
+      "implementation": [
+        "DomainRequirement now has Exact and AnyOf constructors",
+        "builtin receiver/domain requirements use named aliases over the constructors",
+        "tests cover builtin preservation and pack-style domain composition"
+      ],
+      "runtime_risk": "low, bounded AnyOf slices with at most four domains in current aliases",
+      "remaining_blockers": [
+        "the producer still must prove dtype, receiver class, trait identity, or map order evidence for each occurrence"
+      ]
+    },
+    {
+      "candidate": "package_version_occurrence_anchor",
+      "covers_taxonomy": [
+        "version_package_occurrence"
+      ],
+      "decision": "rejected",
+      "reason": "manifest package/version metadata already exists, but the current kernel has no lockfile/build-system occurrence producer; adding an anchor without occurrence proof would be speculative"
+    },
+    {
+      "candidate": "new_demand_effect_profiles",
+      "covers_taxonomy": [
+        "demand_effect_lifecycle"
+      ],
+      "decision": "rejected",
+      "reason": "DemandEffectProfile already covers eager, default, HOF, pull-lazy, async, generator, channel, and protocol boundaries; current blockers need API-specific proof and fixtures rather than new primitive classes"
+    },
+    {
+      "candidate": "observable_scheduler_lifecycle_substrate",
+      "covers_taxonomy": [
+        "demand_effect_lifecycle",
+        "scheduler_platform_runtime"
+      ],
+      "decision": "rejected",
+      "reason": "RxJS scheduler and stream lifecycle semantics need a dedicated producer and hard negatives; admitting them from generic demand/effect vocabulary would be unsound"
+    },
+    {
+      "candidate": "direct_method_dynamic_dispatch_producers",
+      "covers_taxonomy": [
+        "receiver_domain_value_boundary"
+      ],
+      "decision": "rejected",
+      "reason": "CallTarget vocabulary and consumers already understand DirectMethod and DynamicDispatch, but safe producers require receiver type and dispatch proof that the pricing blockers did not provide"
+    },
+    {
+      "candidate": "corpus_presence_as_kernel_primitive",
+      "covers_taxonomy": [
+        "corpus_query_evidence"
+      ],
+      "decision": "rejected",
+      "reason": "corpus presence is a queue and pricing signal, not semantic admission evidence"
+    },
+    {
+      "candidate": "platform_runtime_environment_contract",
+      "covers_taxonomy": [
+        "scheduler_platform_runtime"
+      ],
+      "decision": "rejected",
+      "reason": "platform, cwd, runtime, and test-environment sensitivity should remain unsupported or hard-negative until an explicit environment proof exists"
+    }
+  ],
+  "pricing_rerun_expectation": {
+    "priced_ready_rows": "unchanged by the domain requirement refactor",
+    "blocked_rows": "receiver/domain blockers become cheaper to express, but no row becomes exact-ready without occurrence producers and fixtures",
+    "unpriced_rows": "unchanged because corpus presence is outside the semantic kernel"
+  }
+}

--- a/bench/semantic_pack/kernel_capability_matrix.v1.json
+++ b/bench/semantic_pack/kernel_capability_matrix.v1.json
@@ -48,7 +48,234 @@
         "AnyOf(&'static [DomainEvidence])"
       ],
       "named_aliases": "compatibility names for builtin contracts, not new primitives"
-    }
+    },
+    "kernel_primitives": [
+      {
+        "id": "domain_evidence",
+        "shape": "DomainEvidence atoms on node/param/binding anchors",
+        "producers": [
+          "type-domain extraction",
+          "binding-domain evidence",
+          "library factory result-domain evidence"
+        ],
+        "consumers": [
+          "receiver-domain admission",
+          "value-domain inference",
+          "strict exact receiver checks"
+        ],
+        "built_in_coverage": [
+          "collection membership",
+          "map defaults",
+          "scalar integer methods",
+          "promise then boundaries"
+        ],
+        "hard_negative_coverage": [
+          "wrong receiver domain",
+          "binding mutation/reassignment",
+          "stale binding evidence"
+        ],
+        "blocker_cells": {
+          "dtype/domain proof": "existing primitive; needs candidate producer",
+          "array-vs-scalar boundary": "accepted composition; Exact/AnyOf can express boundary",
+          "receiver class proof": "partly existing primitive; nominal/class producer still missing",
+          "Rust trait identity proof": "not covered; trait identity is not domain evidence alone",
+          "map iteration order boundary": "not covered; requires operation semantics, not domain evidence alone"
+        }
+      },
+      {
+        "id": "domain_requirement",
+        "shape": "Exact(DomainEvidence) or AnyOf(static domain set)",
+        "producers": [
+          "contract rows choose requirements; evidence producers still emit DomainEvidence"
+        ],
+        "consumers": [
+          "receiver_satisfies_domain",
+          "library_api receiver dependencies",
+          "normalize/detect strict exact gates"
+        ],
+        "built_in_coverage": [
+          "array/collection/set receivers",
+          "collection-or-map receivers",
+          "set-or-map receivers",
+          "future/promise aliases",
+          "numeric aliases"
+        ],
+        "hard_negative_coverage": [
+          "unproven receiver",
+          "wrong receiver domain",
+          "ambiguous/conflicting domain evidence"
+        ],
+        "blocker_cells": {
+          "dtype/domain proof": "composition-ready; occurrence proof still required",
+          "array-vs-scalar boundary": "accepted and implemented",
+          "receiver class proof": "composition-ready for domain/class atoms; class proof producer still required",
+          "Rust trait identity proof": "rejected as not expressible by domain requirement alone",
+          "map iteration order boundary": "rejected as operation semantics, not receiver requirement"
+        }
+      },
+      {
+        "id": "symbol_import_occurrence",
+        "shape": "Import and Symbol evidence with dependency-backed occurrence validation",
+        "producers": [
+          "language/core import lowering",
+          "imported occurrence symbol helpers"
+        ],
+        "consumers": [
+          "library API admission",
+          "call target admission",
+          "qualified global/static builtin gates"
+        ],
+        "built_in_coverage": [
+          "imported collection factories",
+          "Java Math",
+          "JS qualified globals",
+          "Rust std factories"
+        ],
+        "hard_negative_coverage": [
+          "shadowed imports",
+          "ambiguous imports",
+          "wrong namespace/member dependency"
+        ],
+        "blocker_cells": {
+          "Guava Optional version/package proof": "not enough; package/version occurrence missing",
+          "ActiveSupport version proof": "not enough; package/version occurrence missing",
+          "external consumer corpus evidence": "not semantic evidence"
+        }
+      },
+      {
+        "id": "library_api_occurrence",
+        "shape": "LibraryApi evidence tied to contract coordinate, arity, callee, and dependencies",
+        "producers": [
+          "compiled builtin API recognizers"
+        ],
+        "consumers": [
+          "canonical builtin admission",
+          "result-domain proof",
+          "value graph factory/default rewrites"
+        ],
+        "built_in_coverage": [
+          "collection factories",
+          "map factories",
+          "map get/default",
+          "scalar integer methods",
+          "promise then"
+        ],
+        "hard_negative_coverage": [
+          "forged wrong arity",
+          "misanchored dependency",
+          "wrong pack provenance"
+        ],
+        "blocker_cells": {
+          "candidate-specific current miss/query evidence": "pricing signal only; needs row-specific occurrence contract",
+          "default-demand/effect profile": "library occurrence can carry demand/effect once API proof exists",
+          "callback effect proof": "requires callback/effect evidence in addition to occurrence"
+        }
+      },
+      {
+        "id": "demand_effect_profile",
+        "shape": "profiles for already-admitted operations",
+        "producers": [
+          "source/API demand/effect contract rows"
+        ],
+        "consumers": [
+          "value graph and oracle demand/effect-sensitive rewrites"
+        ],
+        "built_in_coverage": [
+          "eager/default",
+          "short-circuit",
+          "eager HOF",
+          "pull-lazy HOF",
+          "async continuation",
+          "generator/channel/protocol boundaries"
+        ],
+        "hard_negative_coverage": [
+          "lazy callback errors",
+          "unproven raw HOF payloads",
+          "promise sync-erasure boundaries"
+        ],
+        "blocker_cells": {
+          "default-demand/effect profile": "existing primitive; needs API-specific row/proof",
+          "Observable demand/effect substrate": "not enough; observable lifecycle/scheduler substrate missing",
+          "stream lifecycle proof": "not enough; lifecycle occurrence proof missing",
+          "iterator demand proof": "existing profile class; source/API proof still required",
+          "iterator consumption effect proof": "existing profile class; consumption/effect proof still required"
+        }
+      },
+      {
+        "id": "call_target_identity",
+        "shape": "DirectFunction, DirectMethod, ImportedFunction, ImportedMember, DynamicDispatch evidence",
+        "producers": [
+          "DirectFunction producer",
+          "ImportedFunction/ImportedMember producers"
+        ],
+        "consumers": [
+          "strict exact call identity",
+          "value DAG referents",
+          "interpreter inline/call proofs"
+        ],
+        "built_in_coverage": [
+          "same-file direct functions",
+          "imported function/member identity"
+        ],
+        "hard_negative_coverage": [
+          "decorated/rebound functions",
+          "ambiguous call targets",
+          "method receiver identity still required"
+        ],
+        "blocker_cells": {
+          "Rust trait identity proof": "not covered by current producers",
+          "receiver class proof": "DirectMethod vocabulary exists but safe producer missing",
+          "stream lifecycle proof": "not a call-target identity proof"
+        }
+      },
+      {
+        "id": "manifest_package_metadata",
+        "shape": "manifest supported languages/packages/dependencies and compatibility ranges",
+        "producers": [
+          "semantic pack manifest loader"
+        ],
+        "consumers": [
+          "metadata reports",
+          "compatibility/adoption gates"
+        ],
+        "built_in_coverage": [
+          "metadata-only external packs",
+          "builtin inventory reports"
+        ],
+        "hard_negative_coverage": [
+          "unsupported nose version",
+          "unknown schema fields",
+          "local external builtin-trust claims"
+        ],
+        "blocker_cells": {
+          "Guava Optional version/package proof": "metadata only; occurrence proof missing",
+          "ActiveSupport version proof": "metadata only; occurrence proof missing",
+          "Go version proof": "language/runtime metadata exists; per-repo occurrence proof missing"
+        }
+      },
+      {
+        "id": "corpus_pricing_signal",
+        "shape": "candidate pricing artifact, not kernel admission evidence",
+        "producers": [
+          "bench/semantic_pack/pricing.py"
+        ],
+        "consumers": [
+          "planning and issue prioritization only"
+        ],
+        "built_in_coverage": [
+          "20 candidate row pricing loop"
+        ],
+        "hard_negative_coverage": [
+          "zero-presence rows stay unpriced",
+          "blocked rows require proof before implementation"
+        ],
+        "blocker_cells": {
+          "external consumer corpus evidence": "pricing-only; rejected as kernel primitive",
+          "zero corpus presence": "pricing-only; no kernel primitive",
+          "candidate-specific current miss/query evidence": "pricing-only; informs future row work"
+        }
+      }
+    ]
   },
   "blocker_taxonomy": [
     {
@@ -134,17 +361,26 @@
     {
       "candidate": "domain_requirement_composition",
       "covers_taxonomy": [
-        "receiver_domain_value_boundary"
+        "receiver_domain_value_boundary:domain_and_receiver_requirements_only"
       ],
       "decision": "accepted-implemented",
       "implementation": [
         "DomainRequirement now has Exact and AnyOf constructors",
         "builtin receiver/domain requirements use named aliases over the constructors",
-        "tests cover builtin preservation and pack-style domain composition"
+        "tests cover builtin preservation, pack-style domain composition, and every named alias domain set"
       ],
       "runtime_risk": "low, bounded AnyOf slices with at most four domains in current aliases",
       "remaining_blockers": [
         "the producer still must prove dtype, receiver class, trait identity, or map order evidence for each occurrence"
+      ],
+      "covers_blockers": [
+        "dtype/domain proof",
+        "array-vs-scalar boundary",
+        "receiver class proof"
+      ],
+      "does_not_cover_blockers": [
+        "Rust trait identity proof",
+        "map iteration order boundary"
       ]
     },
     {
@@ -161,7 +397,13 @@
         "demand_effect_lifecycle"
       ],
       "decision": "rejected",
-      "reason": "DemandEffectProfile already covers eager, default, HOF, pull-lazy, async, generator, channel, and protocol boundaries; current blockers need API-specific proof and fixtures rather than new primitive classes"
+      "reason": "DemandEffectProfile already covers eager, default, HOF, pull-lazy, async, generator, channel, and protocol boundaries; current blockers need API-specific proof and fixtures rather than new primitive classes",
+      "covers_blockers": [
+        "default-demand/effect profile",
+        "iterator demand proof",
+        "source iteration effect proof",
+        "iterator consumption effect proof"
+      ]
     },
     {
       "candidate": "observable_scheduler_lifecycle_substrate",
@@ -170,12 +412,17 @@
         "scheduler_platform_runtime"
       ],
       "decision": "rejected",
-      "reason": "RxJS scheduler and stream lifecycle semantics need a dedicated producer and hard negatives; admitting them from generic demand/effect vocabulary would be unsound"
+      "reason": "RxJS scheduler and stream lifecycle semantics need a dedicated producer and hard negatives; admitting them from generic demand/effect vocabulary would be unsound",
+      "covers_blockers": [
+        "Observable demand/effect substrate",
+        "scheduler boundary",
+        "stream lifecycle proof"
+      ]
     },
     {
       "candidate": "direct_method_dynamic_dispatch_producers",
       "covers_taxonomy": [
-        "receiver_domain_value_boundary"
+        "receiver_domain_value_boundary:trait_and_dispatch_identity_only"
       ],
       "decision": "rejected",
       "reason": "CallTarget vocabulary and consumers already understand DirectMethod and DynamicDispatch, but safe producers require receiver type and dispatch proof that the pricing blockers did not provide"
@@ -201,5 +448,97 @@
     "priced_ready_rows": "unchanged by the domain requirement refactor",
     "blocked_rows": "receiver/domain blockers become cheaper to express, but no row becomes exact-ready without occurrence producers and fixtures",
     "unpriced_rows": "unchanged because corpus presence is outside the semantic kernel"
-  }
+  },
+  "blocker_primitive_matrix": [
+    {
+      "blocker": "Guava Optional version/package proof",
+      "primitive": "manifest_package_metadata",
+      "cell": "existing metadata only; reject new occurrence primitive until lockfile/build proof exists"
+    },
+    {
+      "blocker": "default-demand/effect profile",
+      "primitive": "demand_effect_profile",
+      "cell": "existing primitive; candidate needs API-specific row/proof"
+    },
+    {
+      "blocker": "dtype/domain proof",
+      "primitive": "domain_evidence + domain_requirement",
+      "cell": "partly covered; accepted composition lowers expression cost, producer still missing"
+    },
+    {
+      "blocker": "array-vs-scalar boundary",
+      "primitive": "domain_requirement",
+      "cell": "accepted; Exact/AnyOf expresses the boundary"
+    },
+    {
+      "blocker": "Observable demand/effect substrate",
+      "primitive": "demand_effect_profile",
+      "cell": "rejected; lifecycle/scheduler substrate missing"
+    },
+    {
+      "blocker": "scheduler boundary",
+      "primitive": "platform/runtime environment proof",
+      "cell": "rejected; no occurrence proof or hard negatives"
+    },
+    {
+      "blocker": "stream lifecycle proof",
+      "primitive": "demand_effect_profile + lifecycle proof",
+      "cell": "rejected; requires dedicated stream lifecycle substrate"
+    },
+    {
+      "blocker": "callback effect proof",
+      "primitive": "Effect + demand_effect_profile",
+      "cell": "existing primitives; candidate proof/fixtures missing"
+    },
+    {
+      "blocker": "ActiveSupport version proof",
+      "primitive": "manifest_package_metadata",
+      "cell": "metadata only; occurrence proof missing"
+    },
+    {
+      "blocker": "receiver class proof",
+      "primitive": "domain_evidence + domain_requirement",
+      "cell": "composition-ready; class/nominal producer still missing"
+    },
+    {
+      "blocker": "iterator demand proof",
+      "primitive": "demand_effect_profile",
+      "cell": "existing profile class; API/source proof missing"
+    },
+    {
+      "blocker": "source iteration effect proof",
+      "primitive": "Effect + demand_effect_profile",
+      "cell": "existing primitives; source-specific proof missing"
+    },
+    {
+      "blocker": "Go version proof",
+      "primitive": "manifest_package_metadata",
+      "cell": "metadata exists; per-repo language/runtime occurrence proof missing"
+    },
+    {
+      "blocker": "map iteration order boundary",
+      "primitive": "operation semantics",
+      "cell": "not covered by accepted domain composition; leave blocked"
+    },
+    {
+      "blocker": "external consumer corpus evidence",
+      "primitive": "corpus_pricing_signal",
+      "cell": "rejected as kernel primitive"
+    },
+    {
+      "blocker": "candidate-specific current miss/query evidence",
+      "primitive": "corpus_pricing_signal",
+      "cell": "pricing-only; not semantic admission"
+    },
+    {
+      "blocker": "Rust trait identity proof",
+      "primitive": "call_target_identity / type-domain proof",
+      "cell": "not covered by accepted domain composition; safe trait producer missing"
+    },
+    {
+      "blocker": "iterator consumption effect proof",
+      "primitive": "demand_effect_profile + Effect",
+      "cell": "existing primitives insufficient without candidate producer/fixtures"
+    }
+  ]
 }

--- a/crates/nose-detect/src/strict_exact/collections.rs
+++ b/crates/nose-detect/src/strict_exact/collections.rs
@@ -261,7 +261,7 @@ fn strict_exact_typed_set_param_receiver_safe(
     facts: &StrictFacts,
     receiver: NodeId,
 ) -> bool {
-    strict_exact_typed_receiver_safe(il, interner, facts, receiver, DomainRequirement::Set)
+    strict_exact_typed_receiver_safe(il, interner, facts, receiver, DomainRequirement::SET)
 }
 
 fn strict_exact_typed_collection_param_receiver_safe(
@@ -275,7 +275,7 @@ fn strict_exact_typed_collection_param_receiver_safe(
         interner,
         facts,
         receiver,
-        DomainRequirement::ArrayCollectionOrSet,
+        DomainRequirement::ARRAY_COLLECTION_OR_SET,
     )
 }
 
@@ -307,7 +307,7 @@ fn strict_exact_typed_map_param_receiver_safe(
     facts: &StrictFacts,
     receiver: NodeId,
 ) -> bool {
-    strict_exact_typed_receiver_safe(il, interner, facts, receiver, DomainRequirement::Map)
+    strict_exact_typed_receiver_safe(il, interner, facts, receiver, DomainRequirement::MAP)
 }
 
 pub(super) fn strict_exact_proven_map_receiver_safe(

--- a/crates/nose-normalize/src/desugar.rs
+++ b/crates/nose-normalize/src/desugar.rs
@@ -267,7 +267,7 @@ fn property_receiver_exact_safe(
     node: NodeId,
 ) -> bool {
     seq_receiver_exact_collection_safe(il, interner, node)
-        || domains.receiver_satisfies_domain(node, DomainRequirement::ArrayOrCollection)
+        || domains.receiver_satisfies_domain(node, DomainRequirement::ARRAY_OR_COLLECTION)
         || property_receiver_exact_hof_node(il, interner, domains, node)
         || property_receiver_exact_hof_call(il, interner, domains, node)
 }

--- a/crates/nose-normalize/src/idioms/receiver_evidence.rs
+++ b/crates/nose-normalize/src/idioms/receiver_evidence.rs
@@ -63,7 +63,7 @@ pub(super) fn exact_collection_param(
     domains: &ReceiverDomainEvidenceIndex<'_>,
     node: NodeId,
 ) -> bool {
-    domains.receiver_satisfies_domain(node, DomainRequirement::ArrayCollectionOrSet)
+    domains.receiver_satisfies_domain(node, DomainRequirement::ARRAY_COLLECTION_OR_SET)
 }
 
 pub(super) fn static_collection_adapter_arg(
@@ -77,11 +77,11 @@ pub(super) fn static_collection_adapter_arg(
 }
 
 pub(super) fn exact_set_param(domains: &ReceiverDomainEvidenceIndex<'_>, node: NodeId) -> bool {
-    domains.receiver_satisfies_domain(node, DomainRequirement::Set)
+    domains.receiver_satisfies_domain(node, DomainRequirement::SET)
 }
 
 pub(super) fn exact_map_param(domains: &ReceiverDomainEvidenceIndex<'_>, node: NodeId) -> bool {
-    domains.receiver_satisfies_domain(node, DomainRequirement::Map)
+    domains.receiver_satisfies_domain(node, DomainRequirement::MAP)
 }
 
 pub(super) fn exact_map_receiver(
@@ -94,7 +94,7 @@ pub(super) fn exact_map_receiver(
 }
 
 pub(super) fn exact_option_param(domains: &ReceiverDomainEvidenceIndex<'_>, node: NodeId) -> bool {
-    domains.receiver_satisfies_domain(node, DomainRequirement::Option)
+    domains.receiver_satisfies_domain(node, DomainRequirement::OPTION)
 }
 
 pub(super) fn exact_collection_literal(old: &Il, interner: &Interner, node: NodeId) -> bool {
@@ -134,7 +134,7 @@ pub(super) fn exact_string_receiver(
     matches!(
         old.node(node).payload,
         Payload::LitStr(_) | Payload::Lit(nose_il::LitClass::Str)
-    ) || domains.receiver_satisfies_domain(node, DomainRequirement::String)
+    ) || domains.receiver_satisfies_domain(node, DomainRequirement::STRING)
 }
 
 pub(super) fn literal_string_receiver(
@@ -153,5 +153,5 @@ pub(super) fn exact_integer_receiver(
     matches!(
         old.node(node).payload,
         Payload::LitInt(_) | Payload::Lit(nose_il::LitClass::Int)
-    ) || domains.receiver_satisfies_domain(node, DomainRequirement::Integer)
+    ) || domains.receiver_satisfies_domain(node, DomainRequirement::INTEGER)
 }

--- a/crates/nose-normalize/src/value_graph/state.rs
+++ b/crates/nose-normalize/src/value_graph/state.rs
@@ -486,7 +486,7 @@ impl<'a> Builder<'a> {
             self.il,
             self.interner,
             expr,
-            DomainRequirement::ArrayCollectionOrSet,
+            DomainRequirement::ARRAY_COLLECTION_OR_SET,
         )
     }
 
@@ -495,7 +495,7 @@ impl<'a> Builder<'a> {
             self.il,
             self.interner,
             expr,
-            DomainRequirement::Set,
+            DomainRequirement::SET,
         )
     }
 
@@ -504,7 +504,7 @@ impl<'a> Builder<'a> {
             self.il,
             self.interner,
             expr,
-            DomainRequirement::Map,
+            DomainRequirement::MAP,
         )
     }
 
@@ -513,7 +513,7 @@ impl<'a> Builder<'a> {
             self.il,
             self.interner,
             expr,
-            DomainRequirement::Integer,
+            DomainRequirement::INTEGER,
         )
     }
 

--- a/crates/nose-semantics/src/evidence/domain.rs
+++ b/crates/nose-semantics/src/evidence/domain.rs
@@ -28,65 +28,65 @@ pub fn domain_evidence_for_param(il: &Il, param: NodeId) -> Option<DomainEvidenc
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DomainRequirement {
-    Array,
-    Boolean,
-    ByteArray,
-    Collection,
-    CollectionOrSet,
-    CollectionOrMap,
-    Float,
-    FutureLike,
-    ArrayOrCollection,
-    ArrayCollectionOrSet,
-    Iterable,
-    IterableOrIterator,
-    Iterator,
-    Set,
-    SetOrMap,
-    Map,
-    Nominal { type_hash: u64 },
-    Number,
-    Option,
-    PromiseLike,
-    Record,
-    Result,
-    String,
-    Integer,
-    IntegerOrNumber,
+    Exact(DomainEvidence),
+    AnyOf(&'static [DomainEvidence]),
 }
 
 impl DomainRequirement {
+    pub const ARRAY: Self = Self::Exact(DomainEvidence::Array);
+    pub const BOOLEAN: Self = Self::Exact(DomainEvidence::Boolean);
+    pub const BYTE_ARRAY: Self = Self::Exact(DomainEvidence::ByteArray);
+    pub const COLLECTION: Self = Self::Exact(DomainEvidence::Collection);
+    pub const COLLECTION_OR_SET: Self =
+        Self::AnyOf(&[DomainEvidence::Collection, DomainEvidence::Set]);
+    pub const COLLECTION_OR_MAP: Self = Self::AnyOf(&[
+        DomainEvidence::Array,
+        DomainEvidence::Collection,
+        DomainEvidence::Set,
+        DomainEvidence::Map,
+    ]);
+    pub const FLOAT: Self = Self::Exact(DomainEvidence::Float);
+    pub const FUTURE_LIKE: Self =
+        Self::AnyOf(&[DomainEvidence::FutureLike, DomainEvidence::PromiseLike]);
+    pub const ARRAY_OR_COLLECTION: Self =
+        Self::AnyOf(&[DomainEvidence::Array, DomainEvidence::Collection]);
+    pub const ARRAY_COLLECTION_OR_SET: Self = Self::AnyOf(&[
+        DomainEvidence::Array,
+        DomainEvidence::Collection,
+        DomainEvidence::Set,
+    ]);
+    pub const ITERABLE: Self = Self::Exact(DomainEvidence::Iterable);
+    pub const ITERABLE_OR_ITERATOR: Self =
+        Self::AnyOf(&[DomainEvidence::Iterable, DomainEvidence::Iterator]);
+    pub const ITERATOR: Self = Self::Exact(DomainEvidence::Iterator);
+    pub const SET: Self = Self::Exact(DomainEvidence::Set);
+    pub const SET_OR_MAP: Self = Self::AnyOf(&[DomainEvidence::Set, DomainEvidence::Map]);
+    pub const MAP: Self = Self::Exact(DomainEvidence::Map);
+    pub const NUMBER: Self = Self::AnyOf(&[DomainEvidence::Number, DomainEvidence::Float]);
+    pub const OPTION: Self = Self::Exact(DomainEvidence::Option);
+    pub const PROMISE_LIKE: Self = Self::Exact(DomainEvidence::PromiseLike);
+    pub const RECORD: Self = Self::Exact(DomainEvidence::Record);
+    pub const RESULT: Self = Self::Exact(DomainEvidence::Result);
+    pub const STRING: Self = Self::Exact(DomainEvidence::String);
+    pub const INTEGER: Self = Self::Exact(DomainEvidence::Integer);
+    pub const INTEGER_OR_NUMBER: Self = Self::AnyOf(&[
+        DomainEvidence::Integer,
+        DomainEvidence::Float,
+        DomainEvidence::Number,
+    ]);
+
+    pub const fn exact(domain: DomainEvidence) -> Self {
+        Self::Exact(domain)
+    }
+
+    pub const fn any_of(domains: &'static [DomainEvidence]) -> Self {
+        Self::AnyOf(domains)
+    }
+
     pub fn accepts(self, domain: DomainEvidence) -> bool {
         match self {
-            DomainRequirement::Array => domain.is_array(),
-            DomainRequirement::Boolean => domain.is_boolean(),
-            DomainRequirement::ByteArray => domain.is_byte_array(),
-            DomainRequirement::Collection => domain == DomainEvidence::Collection,
-            DomainRequirement::CollectionOrSet => domain.is_collection_or_set(),
-            DomainRequirement::CollectionOrMap => {
-                domain.is_array_collection_or_set() || domain.is_map()
-            }
-            DomainRequirement::Float => domain.is_float(),
-            DomainRequirement::FutureLike => domain.is_future_like(),
-            DomainRequirement::ArrayOrCollection => domain.is_array_or_collection(),
-            DomainRequirement::ArrayCollectionOrSet => domain.is_array_collection_or_set(),
-            DomainRequirement::Iterable => domain.is_iterable(),
-            DomainRequirement::IterableOrIterator => domain.is_iterable_or_iterator(),
-            DomainRequirement::Iterator => domain.is_iterator(),
-            DomainRequirement::Set => domain.is_set(),
-            DomainRequirement::SetOrMap => domain.is_set() || domain.is_map(),
-            DomainRequirement::Map => domain.is_map(),
-            DomainRequirement::Nominal { type_hash } => domain.is_nominal(type_hash),
-            DomainRequirement::Number => {
-                matches!(domain, DomainEvidence::Number | DomainEvidence::Float)
-            }
-            DomainRequirement::Option => domain.is_option(),
-            DomainRequirement::PromiseLike => domain.is_promise_like(),
-            DomainRequirement::Record => domain.is_record(),
-            DomainRequirement::Result => domain.is_result(),
-            DomainRequirement::String => domain.is_string(),
-            DomainRequirement::Integer => domain.is_integer(),
-            DomainRequirement::IntegerOrNumber => domain.is_integer_or_number(),
+            DomainRequirement::Exact(expected) => domain == expected,
+            DomainRequirement::AnyOf(domains) => domains.contains(&domain),
         }
     }
 }

--- a/crates/nose-semantics/src/library_api/receiver_dependencies.rs
+++ b/crates/nose-semantics/src/library_api/receiver_dependencies.rs
@@ -113,7 +113,7 @@ fn integer_value_argument_dependency_ids(
             il,
             interner,
             arg,
-            DomainRequirement::Integer,
+            DomainRequirement::INTEGER,
             cache,
         )
         .or_else(|| {
@@ -121,7 +121,7 @@ fn integer_value_argument_dependency_ids(
                 il,
                 interner,
                 arg,
-                DomainRequirement::Integer,
+                DomainRequirement::INTEGER,
             )
         })?;
         dependencies.push(dependency);
@@ -181,7 +181,7 @@ pub(in crate::library_api) fn async_receiver_dependency_ids(
             il,
             interner,
             receiver,
-            DomainRequirement::PromiseLike,
+            DomainRequirement::PROMISE_LIKE,
             cache,
         )
         .or_else(|| {
@@ -189,7 +189,7 @@ pub(in crate::library_api) fn async_receiver_dependency_ids(
                 il,
                 interner,
                 receiver,
-                DomainRequirement::PromiseLike,
+                DomainRequirement::PROMISE_LIKE,
             )
         })
         .map(|id| vec![id]),

--- a/crates/nose-semantics/src/library_api/receiver_dependencies/api_records/receiver_proofs.rs
+++ b/crates/nose-semantics/src/library_api/receiver_dependencies/api_records/receiver_proofs.rs
@@ -475,7 +475,7 @@ pub(super) fn library_api_dependency_record_has_required_dependencies(
                 il,
                 record,
                 receiver,
-                DomainRequirement::Map,
+                DomainRequirement::MAP,
             )
         }),
         _ => true,

--- a/crates/nose-semantics/src/method_contracts.rs
+++ b/crates/nose-semantics/src/method_contracts.rs
@@ -30,21 +30,21 @@ pub fn method_receiver_domain_requirement(
         | MethodReceiverContract::ExactProtocol
         | MethodReceiverContract::ExactProtocolPairArgument
         | MethodReceiverContract::ExactCollectionOrJavaKeySet => {
-            Some(DomainRequirement::ArrayCollectionOrSet)
+            Some(DomainRequirement::ARRAY_COLLECTION_OR_SET)
         }
         MethodReceiverContract::ExactOption | MethodReceiverContract::RustMapGetOrExactOption => {
-            Some(DomainRequirement::Option)
+            Some(DomainRequirement::OPTION)
         }
         MethodReceiverContract::ExactString | MethodReceiverContract::LiteralString => {
-            Some(DomainRequirement::String)
+            Some(DomainRequirement::STRING)
         }
-        MethodReceiverContract::ExactInteger => Some(DomainRequirement::Integer),
-        MethodReceiverContract::ExactMap => Some(DomainRequirement::Map),
+        MethodReceiverContract::ExactInteger => Some(DomainRequirement::INTEGER),
+        MethodReceiverContract::ExactMap => Some(DomainRequirement::MAP),
         MethodReceiverContract::ExactCollectionOrMap
         | MethodReceiverContract::ExactCollectionOrMapLiteral => {
-            Some(DomainRequirement::CollectionOrMap)
+            Some(DomainRequirement::COLLECTION_OR_MAP)
         }
-        MethodReceiverContract::ExactSetOrMap => Some(DomainRequirement::SetOrMap),
+        MethodReceiverContract::ExactSetOrMap => Some(DomainRequirement::SET_OR_MAP),
         MethodReceiverContract::ExactMapLiteral
         | MethodReceiverContract::UnshadowedGlobal(_)
         | MethodReceiverContract::ImportedNamespace(_) => None,

--- a/crates/nose-semantics/src/operators.rs
+++ b/crates/nose-semantics/src/operators.rs
@@ -579,7 +579,7 @@ impl OperatorSemantics {
     ) -> Option<CIntegerBytePackContract> {
         (self.lang == Lang::C).then_some(CIntegerBytePackContract {
             width,
-            base_domain: DomainRequirement::ByteArray,
+            base_domain: DomainRequirement::BYTE_ARRAY,
             required_high_lane_cast: match width {
                 CBytePackWidth::U16 => None,
                 CBytePackWidth::U32 => Some(SourceFactKind::Cast(SourceCastKind::CUnsigned32)),

--- a/crates/nose-semantics/src/tests/library_api_contracts/predicates.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/predicates.rs
@@ -13,7 +13,7 @@ fn language_predicates_preserve_existing_gates() {
             .c_integer_byte_pack_contract(CBytePackWidth::U32);
         assert_eq!(byte_pack.is_some(), lang == Lang::C);
         if let Some(contract) = byte_pack {
-            assert_eq!(contract.base_domain, DomainRequirement::ByteArray);
+            assert_eq!(contract.base_domain, DomainRequirement::BYTE_ARRAY);
             assert_eq!(
                 contract.required_high_lane_cast,
                 Some(SourceFactKind::Cast(SourceCastKind::CUnsigned32))

--- a/crates/nose-semantics/src/tests/semantic_evidence/domain_core.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/domain_core.rs
@@ -323,3 +323,105 @@ fn domain_requirements_compose_pack_boundaries_without_new_variants() {
     assert!(ARRAY_SCALAR_BOUNDARY.accepts(DomainEvidence::Integer));
     assert!(!ARRAY_SCALAR_BOUNDARY.accepts(DomainEvidence::Map));
 }
+
+#[test]
+fn named_domain_requirement_aliases_match_their_domain_sets() {
+    const ALL_DOMAINS: &[DomainEvidence] = &[
+        DomainEvidence::Array,
+        DomainEvidence::Boolean,
+        DomainEvidence::ByteArray,
+        DomainEvidence::Collection,
+        DomainEvidence::Float,
+        DomainEvidence::FutureLike,
+        DomainEvidence::Integer,
+        DomainEvidence::Iterable,
+        DomainEvidence::Iterator,
+        DomainEvidence::Map,
+        DomainEvidence::Number,
+        DomainEvidence::Option,
+        DomainEvidence::PromiseLike,
+        DomainEvidence::Record,
+        DomainEvidence::Result,
+        DomainEvidence::Set,
+        DomainEvidence::String,
+    ];
+    const CASES: &[(DomainRequirement, &[DomainEvidence])] = &[
+        (DomainRequirement::ARRAY, &[DomainEvidence::Array]),
+        (DomainRequirement::BOOLEAN, &[DomainEvidence::Boolean]),
+        (DomainRequirement::BYTE_ARRAY, &[DomainEvidence::ByteArray]),
+        (DomainRequirement::COLLECTION, &[DomainEvidence::Collection]),
+        (
+            DomainRequirement::COLLECTION_OR_SET,
+            &[DomainEvidence::Collection, DomainEvidence::Set],
+        ),
+        (
+            DomainRequirement::COLLECTION_OR_MAP,
+            &[
+                DomainEvidence::Array,
+                DomainEvidence::Collection,
+                DomainEvidence::Set,
+                DomainEvidence::Map,
+            ],
+        ),
+        (DomainRequirement::FLOAT, &[DomainEvidence::Float]),
+        (
+            DomainRequirement::FUTURE_LIKE,
+            &[DomainEvidence::FutureLike, DomainEvidence::PromiseLike],
+        ),
+        (
+            DomainRequirement::ARRAY_OR_COLLECTION,
+            &[DomainEvidence::Array, DomainEvidence::Collection],
+        ),
+        (
+            DomainRequirement::ARRAY_COLLECTION_OR_SET,
+            &[
+                DomainEvidence::Array,
+                DomainEvidence::Collection,
+                DomainEvidence::Set,
+            ],
+        ),
+        (DomainRequirement::ITERABLE, &[DomainEvidence::Iterable]),
+        (
+            DomainRequirement::ITERABLE_OR_ITERATOR,
+            &[DomainEvidence::Iterable, DomainEvidence::Iterator],
+        ),
+        (DomainRequirement::ITERATOR, &[DomainEvidence::Iterator]),
+        (DomainRequirement::SET, &[DomainEvidence::Set]),
+        (
+            DomainRequirement::SET_OR_MAP,
+            &[DomainEvidence::Set, DomainEvidence::Map],
+        ),
+        (DomainRequirement::MAP, &[DomainEvidence::Map]),
+        (
+            DomainRequirement::NUMBER,
+            &[DomainEvidence::Number, DomainEvidence::Float],
+        ),
+        (DomainRequirement::OPTION, &[DomainEvidence::Option]),
+        (
+            DomainRequirement::PROMISE_LIKE,
+            &[DomainEvidence::PromiseLike],
+        ),
+        (DomainRequirement::RECORD, &[DomainEvidence::Record]),
+        (DomainRequirement::RESULT, &[DomainEvidence::Result]),
+        (DomainRequirement::STRING, &[DomainEvidence::String]),
+        (DomainRequirement::INTEGER, &[DomainEvidence::Integer]),
+        (
+            DomainRequirement::INTEGER_OR_NUMBER,
+            &[
+                DomainEvidence::Integer,
+                DomainEvidence::Float,
+                DomainEvidence::Number,
+            ],
+        ),
+    ];
+
+    for &(requirement, accepted) in CASES {
+        for &domain in ALL_DOMAINS {
+            assert_eq!(
+                requirement.accepts(domain),
+                accepted.contains(&domain),
+                "{requirement:?} acceptance drifted for {domain:?}"
+            );
+        }
+    }
+}

--- a/crates/nose-semantics/src/tests/semantic_evidence/domain_core.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/domain_core.rs
@@ -272,19 +272,19 @@ fn scalar_domain_evidence_predicates_keep_numeric_axes_separate() {
 
 #[test]
 fn domain_requirements_accept_matching_evidence() {
-    assert!(DomainRequirement::Boolean.accepts(DomainEvidence::Boolean));
-    assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Array));
-    assert!(DomainRequirement::CollectionOrMap.accepts(DomainEvidence::Map));
-    assert!(DomainRequirement::Float.accepts(DomainEvidence::Float));
-    assert!(DomainRequirement::FutureLike.accepts(DomainEvidence::FutureLike));
-    assert!(DomainRequirement::FutureLike.accepts(DomainEvidence::PromiseLike));
-    assert!(DomainRequirement::Iterable.accepts(DomainEvidence::Iterable));
-    assert!(DomainRequirement::Iterator.accepts(DomainEvidence::Iterator));
-    assert!(DomainRequirement::IterableOrIterator.accepts(DomainEvidence::Iterable));
-    assert!(DomainRequirement::IterableOrIterator.accepts(DomainEvidence::Iterator));
-    assert!(DomainRequirement::Nominal {
+    assert!(DomainRequirement::BOOLEAN.accepts(DomainEvidence::Boolean));
+    assert!(DomainRequirement::COLLECTION_OR_MAP.accepts(DomainEvidence::Array));
+    assert!(DomainRequirement::COLLECTION_OR_MAP.accepts(DomainEvidence::Map));
+    assert!(DomainRequirement::FLOAT.accepts(DomainEvidence::Float));
+    assert!(DomainRequirement::FUTURE_LIKE.accepts(DomainEvidence::FutureLike));
+    assert!(DomainRequirement::FUTURE_LIKE.accepts(DomainEvidence::PromiseLike));
+    assert!(DomainRequirement::ITERABLE.accepts(DomainEvidence::Iterable));
+    assert!(DomainRequirement::ITERATOR.accepts(DomainEvidence::Iterator));
+    assert!(DomainRequirement::ITERABLE_OR_ITERATOR.accepts(DomainEvidence::Iterable));
+    assert!(DomainRequirement::ITERABLE_OR_ITERATOR.accepts(DomainEvidence::Iterator));
+    assert!(DomainRequirement::exact(DomainEvidence::Nominal {
         type_hash: stable_symbol_hash("pkg.Widget")
-    }
+    })
     .accepts(DomainEvidence::Nominal {
         type_hash: stable_symbol_hash("pkg.Widget")
     }));
@@ -292,14 +292,14 @@ fn domain_requirements_accept_matching_evidence() {
 
 #[test]
 fn domain_requirements_reject_mismatches_and_map_value_domains() {
-    assert!(DomainRequirement::Number.accepts(DomainEvidence::Float));
-    assert!(DomainRequirement::Record.accepts(DomainEvidence::Record));
-    assert!(DomainRequirement::Result.accepts(DomainEvidence::Result));
-    assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Set));
-    assert!(DomainRequirement::SetOrMap.accepts(DomainEvidence::Map));
-    assert!(!DomainRequirement::SetOrMap.accepts(DomainEvidence::Collection));
-    assert!(DomainRequirement::PromiseLike.accepts(DomainEvidence::PromiseLike));
-    assert!(!DomainRequirement::PromiseLike.accepts(DomainEvidence::String));
+    assert!(DomainRequirement::NUMBER.accepts(DomainEvidence::Float));
+    assert!(DomainRequirement::RECORD.accepts(DomainEvidence::Record));
+    assert!(DomainRequirement::RESULT.accepts(DomainEvidence::Result));
+    assert!(DomainRequirement::SET_OR_MAP.accepts(DomainEvidence::Set));
+    assert!(DomainRequirement::SET_OR_MAP.accepts(DomainEvidence::Map));
+    assert!(!DomainRequirement::SET_OR_MAP.accepts(DomainEvidence::Collection));
+    assert!(DomainRequirement::PROMISE_LIKE.accepts(DomainEvidence::PromiseLike));
+    assert!(!DomainRequirement::PROMISE_LIKE.accepts(DomainEvidence::String));
     assert_eq!(
         ValueDomain::from_domain_evidence(DomainEvidence::Boolean),
         Some(ValueDomain::Boolean)
@@ -312,4 +312,14 @@ fn domain_requirements_reject_mismatches_and_map_value_domains() {
         ValueDomain::from_domain_evidence(DomainEvidence::PromiseLike),
         None
     );
+}
+
+#[test]
+fn domain_requirements_compose_pack_boundaries_without_new_variants() {
+    const ARRAY_SCALAR_BOUNDARY: DomainRequirement =
+        DomainRequirement::any_of(&[DomainEvidence::Array, DomainEvidence::Integer]);
+
+    assert!(ARRAY_SCALAR_BOUNDARY.accepts(DomainEvidence::Array));
+    assert!(ARRAY_SCALAR_BOUNDARY.accepts(DomainEvidence::Integer));
+    assert!(!ARRAY_SCALAR_BOUNDARY.accepts(DomainEvidence::Map));
 }

--- a/crates/nose-semantics/src/tests/semantic_evidence/receiver_domains.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/receiver_domains.rs
@@ -4,23 +4,23 @@ use super::*;
 fn method_receiver_contracts_expose_only_domain_backed_obligations() {
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactCollection),
-        Some(DomainRequirement::ArrayCollectionOrSet)
+        Some(DomainRequirement::ARRAY_COLLECTION_OR_SET)
     );
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactProtocol),
-        Some(DomainRequirement::ArrayCollectionOrSet)
+        Some(DomainRequirement::ARRAY_COLLECTION_OR_SET)
     );
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactCollectionOrMap),
-        Some(DomainRequirement::CollectionOrMap)
+        Some(DomainRequirement::COLLECTION_OR_MAP)
     );
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactSetOrMap),
-        Some(DomainRequirement::SetOrMap)
+        Some(DomainRequirement::SET_OR_MAP)
     );
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::RustMapGetOrExactOption),
-        Some(DomainRequirement::Option)
+        Some(DomainRequirement::OPTION)
     );
     assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactMapLiteral),
@@ -118,13 +118,13 @@ fn receiver_domain_evidence_at_node_is_preferred_over_param_evidence() {
         &il,
         &interner,
         receiver,
-        DomainRequirement::Map
+        DomainRequirement::MAP
     ));
     assert!(!receiver_satisfies_domain(
         &il,
         &interner,
         receiver,
-        DomainRequirement::Set
+        DomainRequirement::SET
     ));
 }
 
@@ -493,7 +493,7 @@ fn receiver_domain_index_uses_kernel_fail_closed_policy() {
 
     let domains = ReceiverDomainEvidenceIndex::new(&il, &interner);
     assert_eq!(domains.domain_evidence_for_receiver(receiver), None);
-    assert!(!domains.receiver_satisfies_domain(receiver, DomainRequirement::Collection));
+    assert!(!domains.receiver_satisfies_domain(receiver, DomainRequirement::COLLECTION));
 }
 
 #[test]

--- a/docs/home.md
+++ b/docs/home.md
@@ -84,6 +84,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-ecosystem-candidates](semantic-pack-ecosystem-candidates.md) — narrow-slice candidate matrix for future large-ecosystem builtin packs such as Guava, Lodash, NumPy, and RxJS.
 - [semantic-pack-candidate-pricing](semantic-pack-candidate-pricing.md) — corpus-backed pricing loop for deciding which narrow semantic-pack rows are ready, blocked, or unpriced before implementation.
+- [semantic-kernel-capability-minimization](semantic-kernel-capability-minimization.md) — issue #507 primitive census, blocker taxonomy, and accept/reject matrix for deriving minimal kernel capabilities from pack blockers.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-capability-minimization.md
+++ b/docs/semantic-kernel-capability-minimization.md
@@ -1,0 +1,196 @@
+# Semantic kernel capability minimization
+
+Status: issue #507 implementation record. This page turns the 20-iteration
+semantic-pack pricing loop into a primitive census, blocker taxonomy, and
+accept/reject matrix. Accepted kernel reductions are implemented in the same
+change; rejected rows stay out of the kernel until a future pricing packet
+brings evidence, fixtures, and a performance budget.
+
+Source artifacts:
+
+- [candidate_pricing.v1.json](../bench/semantic_pack/candidate_pricing.v1.json)
+- [candidate_pricing.md](../bench/semantic_pack/candidate_pricing.md)
+- [loop_reviews.v1.json](../bench/semantic_pack/loop_reviews.v1.json)
+- [kernel_capability_matrix.v1.json](../bench/semantic_pack/kernel_capability_matrix.v1.json)
+
+## Goal
+
+The target is not to add more semantic-pack rows. The target is to keep the
+kernel small enough that broad packs can share a few admission primitives, while
+still having enough material to support meaningful external packs later.
+
+The rule for this pass:
+
+1. Start from the 20 priced candidate rows.
+2. Group their blockers by repeated proof shape.
+3. Check whether an existing primitive can be generalized or removed.
+4. Implement every accepted reduction in this issue.
+5. Reject anything that would add speculative vocabulary without occurrence
+   proof, hard negatives, and runtime evidence.
+6. Keep the query-regression subset within the semantic-pack performance gate:
+   no more than 10% median runtime regression.
+
+## Primitive Census
+
+Implemented evidence families are:
+
+| family | role |
+|---|---|
+| `Source` | source-syntax and construct provenance |
+| `Domain` | proven value or receiver domain |
+| `Import` | import and require facts |
+| `Symbol` | unshadowed, imported, and qualified symbol identity |
+| `Type` | nominal and C type-domain facts |
+| `Guard` | shape and own-property guards |
+| `Place` | exact receiver/place facts |
+| `Effect` | mutation and escape facts |
+| `LibraryApi` | occurrence proof for admitted library/API contracts |
+| `CallTarget` | direct/imported/dynamic call target identity |
+| `SequenceSurface` | aggregate and sequence surface proof |
+
+Implemented contract substrates are receiver-domain dependency admission,
+symbol/import occurrence proof, library API occurrence contracts, call-target
+identity proof, demand/effect profiles, sequence-surface proof, manifest
+package/version metadata, and conformance fixture gates.
+
+The only accepted primitive reduction in this pass is in receiver/domain
+requirements. Before this issue, `DomainRequirement` mixed atomic evidence
+domains with composite requirements such as collection-or-map, set-or-map, and
+array-collection-or-set. After this issue, the primitive representation is:
+
+```rust
+DomainRequirement::Exact(DomainEvidence)
+DomainRequirement::AnyOf(&'static [DomainEvidence])
+```
+
+Existing built-in contracts use named aliases such as
+`DomainRequirement::ARRAY_COLLECTION_OR_SET`; those names are compatibility
+conveniences over the two constructors, not separate primitives.
+
+## Blocker Taxonomy
+
+The pricing loop found one ready row, nine priced-but-blocked rows, and ten
+unpriced rows. The blocker labels were mostly unique, but they collapse into
+five proof shapes:
+
+| proof shape | source blockers | candidate examples |
+|---|---|---|
+| version/package occurrence | Guava Optional version/package proof, ActiveSupport version proof, Go version proof | Guava Optional, Rails presence, Go maps helpers |
+| receiver/domain/value boundary | dtype/domain proof, array-vs-scalar boundary, receiver class proof, Rust trait identity proof, map iteration order boundary | NumPy scalar ufuncs, Rails presence, Rust itertools, Go maps |
+| demand/effect/lifecycle | default-demand/effect profile, Observable demand/effect substrate, stream lifecycle proof, callback effect proof, iterator demand/effect proof | Guava Optional, RxJS, itertools, Rust itertools |
+| scheduler/platform/runtime | scheduler boundary, platform/cwd sensitivity, runtime/test boundary | RxJS adapters, Node path, Tokio |
+| corpus/query evidence | external consumer corpus evidence, candidate-specific current miss/query evidence, zero corpus presence | Commons Lang, Lodash, Pandas, Rails helpers |
+
+## Decision Matrix
+
+| candidate | decision | reason |
+|---|---|---|
+| Domain requirement composition | accepted and implemented | Multiple blockers need receiver/domain boundary combinations. The old enum spent a primitive variant per combination; `Exact` plus `AnyOf` covers existing built-ins and future domain boundaries without adding variants. |
+| Package/version occurrence anchor | rejected | Manifest package/version metadata already exists, but there is no lockfile/build-system occurrence producer. Adding a package anchor without occurrence proof would be speculative. |
+| New demand/effect profile classes | rejected | `DemandEffectProfile` already covers eager, default, HOF, pull-lazy, async, generator, channel, and protocol boundaries. Current blockers need API-specific proof and hard negatives, not new primitive classes. |
+| Observable scheduler/lifecycle substrate | rejected | RxJS scheduler and stream lifecycle semantics need dedicated occurrence proof and hard negatives. Generic demand/effect vocabulary would make exact admission too broad. |
+| DirectMethod/DynamicDispatch producers | rejected | The vocabulary and consumers already exist. Safe producers require receiver type and dispatch proof that the pricing blockers did not supply. |
+| Corpus presence primitive | rejected | Corpus presence is useful for pricing and queue ordering. It is not semantic evidence and must not admit exact contracts. |
+| Platform/runtime environment contract | rejected | Platform, cwd, runtime, and test-environment sensitivity stays unsupported or hard-negative until an explicit environment proof exists. |
+
+## Implementation
+
+The accepted reduction is implemented in
+[`crates/nose-semantics/src/evidence/domain.rs`](../crates/nose-semantics/src/evidence/domain.rs).
+Built-in consumers in `nose-semantics`, `nose-normalize`, and `nose-detect` now
+use named domain-requirement aliases backed by `Exact` or `AnyOf`.
+
+The focused test addition is
+`domain_requirements_compose_pack_boundaries_without_new_variants`, which shows
+that a pack-style domain boundary can be expressed as an `AnyOf` requirement
+without adding another enum variant. Existing receiver-domain and library API
+predicate tests continue to assert built-in behavior.
+
+## Pricing Impact
+
+This pass does not promote any blocked row to ready by itself. That is
+intentional: the accepted reduction lowers the cost of representing
+receiver/domain blockers, but it does not prove a NumPy dtype, Rails receiver
+class, Rust trait identity, or Go map-order boundary for a concrete occurrence.
+
+The pricing scanner was rerun with:
+
+```sh
+python3 bench/semantic_pack/pricing.py --nose ./target/release/nose --query-sample-repos 1
+```
+
+The rerun produced no diff to `candidate_pricing.v1.json` or
+`candidate_pricing.md`, which matches the expectation: this issue changes the
+kernel requirement representation, not the corpus pricing candidates.
+
+Rows that become easier to implement later:
+
+- `python.numpy.scalar_integer_ufuncs`: scalar-vs-array and dtype boundaries can
+  be expressed without minting a new domain-requirement variant.
+- `ruby.rails_active_support_presence`: receiver class/domain proof can reuse
+  `Exact` or `AnyOf` requirements once the occurrence producer exists.
+- `go.stdlib.maps_helpers`: map/set/collection boundaries reuse the same
+  requirement model; map iteration order remains a separate semantic blocker.
+- `rust.itertools_collect_vec`: iterator/collection result boundaries reuse the
+  same requirement model; trait identity and consumption effects remain blocked.
+
+Rows that remain blocked:
+
+- version/package blockers, until package-manager or build metadata can prove
+  occurrence-level package/version identity;
+- RxJS scheduler, observable, and stream-lifecycle blockers, until a dedicated
+  substrate exists;
+- corpus-only blockers, until the pricing loop finds meaningful presence and
+  row-specific current misses.
+
+## Performance Gate
+
+The issue uses the semantic-pack performance gate from
+[semantic-pack-architecture](semantic-pack-architecture.md): the normal target is
+within 5% median growth, and any greater than 10% median growth on the
+query-regression subset blocks the PR unless explicitly accepted as a product
+decision.
+
+The measurement command is:
+
+```sh
+cargo build --release --bin nose
+python3 bench/type4/query_regression/query_regression.py baseline \
+  --nose ./target/release/nose \
+  --repos-root bench/repos \
+  --repeats 3 \
+  --build-ref "issue507-pre@<sha>" \
+  --out target/issue507/query-baseline-pre.json
+python3 bench/type4/query_regression/query_regression.py compare \
+  --nose ./target/release/nose \
+  --repos-root bench/repos \
+  --repeats 3 \
+  --build-ref "issue507-post@<sha>" \
+  --baseline target/issue507/query-baseline-pre.json \
+  --summary target/issue507/query-compare-post.md
+```
+
+The first `--repeats 3` compare showed a small-repo phase trigger in `chi` on
+`lower` and `parse+lower`; the changed code does not touch parser or lowering
+paths. A fresh baseline binary from commit `768c102f` was then built in
+`target/issue507/base-worktree` and compared with `--repeats 7`. That compare
+showed no output drift and no HoF budget failure. It still reported
+investigation triggers in `lower`/`parse+lower` for `boltons` and `ky`, again
+outside the changed path.
+
+Because those triggers were in unrelated small-repo phases, the runtime decision
+uses paired alternating measurements between the baseline and current release
+binaries:
+
+| measurement | baseline | current | delta |
+|---|---:|---:|---:|
+| query-regression subset, sum of repo wall medians, alternating r9 | 1223.21 ms | 1223.15 ms | -0.0% |
+| `gin`, alternating r31 wall median | 55.15 ms | 56.34 ms | +2.2% |
+| `chi`, alternating r31 wall median | 34.30 ms | 34.01 ms | -0.9% |
+
+The accepted implementation therefore stays under the 10% runtime-regression
+limit. The phase-trigger root-cause note is measurement noise in parser/lower
+stages that this issue did not modify; the relevant aggregate and focused
+paired measurements are performance-neutral.
+
+Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel-capability-minimization.md
+++ b/docs/semantic-kernel-capability-minimization.md
@@ -53,6 +53,22 @@ symbol/import occurrence proof, library API occurrence contracts, call-target
 identity proof, demand/effect profiles, sequence-surface proof, manifest
 package/version metadata, and conformance fixture gates.
 
+The machine-readable census in
+[`kernel_capability_matrix.v1.json`](../bench/semantic_pack/kernel_capability_matrix.v1.json)
+also records the primitive-level rows that were checked before accepting or
+rejecting changes:
+
+| primitive | producer/consumer coverage | blocker cells |
+|---|---|---|
+| `domain_evidence` | type-domain, binding-domain, and factory result-domain producers feed receiver admission, value-domain inference, and strict-exact receiver gates | covers existing domain proof shape; still needs dtype/class/trait producers for candidate rows |
+| `domain_requirement` | contract rows choose receiver/domain requirements consumed by semantic, normalize, and detect gates | accepted for dtype/domain, array-vs-scalar, and receiver-domain expression; does not cover Rust trait identity or map iteration order |
+| `symbol_import_occurrence` | import and symbol producers feed library API and call-target admission | supports import-backed APIs but does not prove package/version occurrence |
+| `library_api_occurrence` | compiled API recognizers feed canonical builtin admission, result-domain proof, and value-graph rewrites | supports row-specific API proof once a row exists; corpus misses remain pricing-only |
+| `demand_effect_profile` | source/API demand rows feed value graph and oracle timing/effect-sensitive rewrites | already covers default, HOF, pull-lazy, async, generator, channel, and protocol classes; RxJS lifecycle/scheduler proof is still missing |
+| `call_target_identity` | direct/imported call-target producers feed strict exact call identity and value-DAG referents | DirectMethod/DynamicDispatch vocabulary exists, but safe receiver/dispatch producers are not justified by this pricing packet |
+| `manifest_package_metadata` | manifest loader feeds metadata, compatibility, and adoption reports | metadata exists, but package/version occurrence proof is missing |
+| `corpus_pricing_signal` | pricing script feeds planning only | rejected as a semantic kernel primitive |
+
 The only accepted primitive reduction in this pass is in receiver/domain
 requirements. Before this issue, `DomainRequirement` mixed atomic evidence
 domains with composite requirements such as collection-or-map, set-or-map, and
@@ -81,11 +97,39 @@ five proof shapes:
 | scheduler/platform/runtime | scheduler boundary, platform/cwd sensitivity, runtime/test boundary | RxJS adapters, Node path, Tokio |
 | corpus/query evidence | external consumer corpus evidence, candidate-specific current miss/query evidence, zero corpus presence | Commons Lang, Lodash, Pandas, Rails helpers |
 
+## Primitive x Blocker Matrix
+
+This is the decision-relevant slice of the full JSON matrix. `Accepted` means
+the primitive was changed in this issue. `Existing` means the primitive already
+exists and the candidate row still needs occurrence proof, fixtures, or a row
+producer. `Rejected` means adding vocabulary now would be speculative.
+
+| blocker | primitive cell | decision |
+|---|---|---|
+| Guava Optional version/package proof | `manifest_package_metadata` is metadata-only; no lockfile/build occurrence producer exists | rejected |
+| default-demand/effect profile | `demand_effect_profile` already has default/eager profiles; Guava needs API-specific proof | existing |
+| dtype/domain proof | `domain_evidence` exists; `domain_requirement` now composes required domain sets | accepted for requirement composition, producer still missing |
+| array-vs-scalar boundary | `domain_requirement::Exact` and `AnyOf` can express the exact domain boundary | accepted |
+| Observable demand/effect substrate | generic demand/effect profiles do not prove observable lifecycle or subscription semantics | rejected |
+| scheduler boundary | no scheduler/environment occurrence proof or hard negatives exist | rejected |
+| stream lifecycle proof | current profiles do not model stream lifecycle ownership | rejected |
+| callback effect proof | `Effect` plus demand profiles exist, but candidate-specific callback proof is missing | existing |
+| ActiveSupport version proof | package metadata exists, occurrence-level version proof does not | rejected |
+| receiver class proof | `DomainEvidence::Nominal` plus `DomainRequirement::Exact/AnyOf` can express it once a class producer exists | accepted for requirement composition, producer still missing |
+| iterator demand proof | pull-lazy/eager profile classes exist, but source/API proof is missing | existing |
+| source iteration effect proof | effect and demand primitives exist, but source-specific proof is missing | existing |
+| Go version proof | language/runtime metadata exists, occurrence-level version proof does not | rejected |
+| map iteration order boundary | operation-order semantics are not a receiver/domain requirement | rejected |
+| external consumer corpus evidence | corpus evidence is a pricing signal, not semantic proof | rejected |
+| candidate-specific current miss/query evidence | query evidence informs row selection only | rejected |
+| Rust trait identity proof | call-target/type-domain vocabulary is insufficient without a safe trait producer | rejected |
+| iterator consumption effect proof | demand/effect primitives exist, but consumption proof and fixtures are missing | existing |
+
 ## Decision Matrix
 
 | candidate | decision | reason |
 |---|---|---|
-| Domain requirement composition | accepted and implemented | Multiple blockers need receiver/domain boundary combinations. The old enum spent a primitive variant per combination; `Exact` plus `AnyOf` covers existing built-ins and future domain boundaries without adding variants. |
+| Domain requirement composition | accepted and implemented | Domain-side blockers need receiver/domain boundary combinations. The old enum spent a primitive variant per combination; `Exact` plus `AnyOf` covers existing built-ins and the dtype/domain, array-vs-scalar, and receiver-class requirement cells without adding variants. It does not solve Rust trait identity or map iteration order. |
 | Package/version occurrence anchor | rejected | Manifest package/version metadata already exists, but there is no lockfile/build-system occurrence producer. Adding a package anchor without occurrence proof would be speculative. |
 | New demand/effect profile classes | rejected | `DemandEffectProfile` already covers eager, default, HOF, pull-lazy, async, generator, channel, and protocol boundaries. Current blockers need API-specific proof and hard negatives, not new primitive classes. |
 | Observable scheduler/lifecycle substrate | rejected | RxJS scheduler and stream lifecycle semantics need dedicated occurrence proof and hard negatives. Generic demand/effect vocabulary would make exact admission too broad. |
@@ -100,11 +144,14 @@ The accepted reduction is implemented in
 Built-in consumers in `nose-semantics`, `nose-normalize`, and `nose-detect` now
 use named domain-requirement aliases backed by `Exact` or `AnyOf`.
 
-The focused test addition is
+The focused test additions are
 `domain_requirements_compose_pack_boundaries_without_new_variants`, which shows
 that a pack-style domain boundary can be expressed as an `AnyOf` requirement
-without adding another enum variant. Existing receiver-domain and library API
-predicate tests continue to assert built-in behavior.
+without adding another enum variant, and
+`named_domain_requirement_aliases_match_their_domain_sets`, which table-tests
+every named alias against the expected accepted domain set. Existing
+receiver-domain and library API predicate tests continue to assert built-in
+behavior.
 
 ## Pricing Impact
 

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -217,6 +217,16 @@ sequence, map, set, option/nullish, result/error, future/promise, observable, an
 domain-specific collection types. Unknown stays top: exact rewrites fire only
 when a required domain is proven.
 
+Receiver/domain preconditions are represented as a small compositional
+requirement language, not one primitive per domain combination:
+`DomainRequirement::Exact(DomainEvidence)` for one proven domain, and
+`DomainRequirement::AnyOf(&[DomainEvidence])` for narrow unions such as
+collection-or-map or array-collection-or-set. Builtin aliases keep current
+contracts readable, but new pack blockers should first try to compose these
+requirements before adding vocabulary. The #507 audit and implementation record
+is in
+[semantic-kernel-capability-minimization](semantic-kernel-capability-minimization.md).
+
 ### Effects and observations
 
 Behavior is not just a return value. The kernel must distinguish ordered effects,

--- a/docs/semantic-pack-candidate-pricing.md
+++ b/docs/semantic-pack-candidate-pricing.md
@@ -65,6 +65,11 @@ The tool emits:
 - [`candidate_pricing.md`](../bench/semantic_pack/candidate_pricing.md)
 - [`loop_reviews.v1.json`](../bench/semantic_pack/loop_reviews.v1.json)
 
+The follow-up primitive census, blocker taxonomy, and accept/reject matrix for
+issue #507 are recorded in
+[semantic-kernel-capability-minimization](semantic-kernel-capability-minimization.md)
+and [`kernel_capability_matrix.v1.json`](../bench/semantic_pack/kernel_capability_matrix.v1.json).
+
 The current artifact records 20 candidate iterations. It starts from a curated
 seed list instead of attempting automatic API discovery. The scanner uses
 language-specific regexes plus package/import context where practical. Its


### PR DESCRIPTION
## Summary

Closes #507.

This PR turns the 20-iteration semantic-pack pricing loop into a kernel capability minimization pass:

- adds `bench/semantic_pack/kernel_capability_matrix.v1.json` with the primitive census, blocker taxonomy, and accept/reject matrix;
- adds `docs/semantic-kernel-capability-minimization.md` and links it from the semantic-pack docs/wiki;
- reduces `DomainRequirement` from a closed list of atomic and composite enum variants to two primitives: `Exact(DomainEvidence)` and `AnyOf(&'static [DomainEvidence])`;
- updates existing built-in receiver/domain consumers to use named aliases over those primitives;
- rejects speculative package/version, scheduler/lifecycle, direct-method producer, corpus-presence, and environment primitives with documented rationale.

## Notes

The accepted implementation does not promote a blocked pack row to ready by itself. It lowers the primitive cost for receiver/domain blockers while preserving fail-closed occurrence proof requirements.

The pricing rerun produced no diff to `candidate_pricing.v1.json` or `candidate_pricing.md`, as expected.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --release --bin nose`
- `python3 bench/semantic_pack/pricing.py --selftest`
- `python3 bench/semantic_pack/pricing.py --check-artifacts`
- `python3 bench/semantic_pack/pricing.py --nose ./target/release/nose --query-sample-repos 1`
- `awiki lint --root docs`
- `git diff --check`
- `python3 -m json.tool bench/semantic_pack/kernel_capability_matrix.v1.json >/dev/null`

Performance:

- `query_regression.py compare` r7 had no output drift and no HoF budget failure.
- r7 investigation triggers were only in `lower`/`parse+lower`, which this PR does not modify.
- Paired alternating wall measurements:
  - query-regression subset median-wall sum: `1223.21 ms -> 1223.15 ms` (`-0.0%`)
  - `gin` r31 focused: `55.15 ms -> 56.34 ms` (`+2.2%`)
  - `chi` r31 focused: `34.30 ms -> 34.01 ms` (`-0.9%`)
