### PR TITLE
Validate external fixed result-domain authoring

### DIFF
--- a/bench/semantic_pack/README.md
+++ b/bench/semantic_pack/README.md
@@ -14,8 +14,8 @@ python3 bench/semantic_pack/pricing.py --nose ./target/release/nose --query-samp
 Use the `--nose ./target/release/nose --query-sample-repos 1` command when
 refreshing the committed JSON/Markdown artifacts. Use `--check-artifacts` to
 verify committed artifacts, the two-reviewer log, the issue #509 v2
-blocker/matrix artifacts, and the issue #511 v3 R1-R3 cycle artifacts without
-regenerating them.
+blocker/matrix artifacts, and the issue #511 v3/v4 R1-R3 cycle artifacts
+without regenerating them.
 
 Outputs:
 
@@ -33,6 +33,10 @@ Outputs:
   the generalized admitted API result-domain materializer.
 - `kernel_capability_matrix.v3.json` — issue #511 first R1-R3 cycle capability
   matrix, builtin expansion, R3 compression, and transition assessment.
+- `blocker_packet.v4.json` — issue #511 second R1-R3 cycle blocker packet for
+  external fixed result-domain authoring.
+- `kernel_capability_matrix.v4.json` — issue #511 second R1-R3 cycle capability
+  matrix, metadata-only manifest validation, and transition-to-R4 assessment.
 
 The scanner reports corpus queue signals. It does not prove semantic
 correctness and does not authorize broad ecosystem packs. Only `priced-ready`

--- a/bench/semantic_pack/blocker_packet.v4.json
+++ b/bench/semantic_pack/blocker_packet.v4.json
@@ -1,0 +1,183 @@
+{
+  "schema_version": 4,
+  "issue": 511,
+  "cycle": "r1-r3-cycle-2",
+  "base_artifacts": [
+    "bench/semantic_pack/blocker_packet.v3.json",
+    "bench/semantic_pack/kernel_capability_matrix.v3.json"
+  ],
+  "policy": {
+    "corpus_signals_are_admission_proof": false,
+    "minimum_probe_count": 20,
+    "purpose": "test whether the cycle-1 fixed result-domain capability can be authored by external packs without opening external influence"
+  },
+  "probes": [
+    {
+      "id": "external.pack.fixed_result_domain_authoring.schema",
+      "round": "R1/R2",
+      "proof_shape": "external_authoring_fixed_result_domain_schema",
+      "kernel_need": "manifest vocabulary for declaring a fixed call result domain",
+      "decision": "accepted",
+      "reason": "external manifests can now declare semantics.result_domain with kind=fixed and an explicit DomainEvidence vocabulary member"
+    },
+    {
+      "id": "external.pack.fixed_result_domain_authoring.domain_vocabulary",
+      "round": "R1/R2",
+      "proof_shape": "external_authoring_fixed_result_domain_schema",
+      "kernel_need": "reject unknown or ecosystem-specific result-domain names before influence",
+      "decision": "accepted",
+      "reason": "result_domain.domain is validated against the existing kernel DomainEvidence vocabulary"
+    },
+    {
+      "id": "external.pack.fixed_result_domain_authoring.api_dependency",
+      "round": "R1/R2",
+      "proof_shape": "external_authoring_dependency_backed_result_domain",
+      "kernel_need": "fixed result-domain claims must require API occurrence evidence",
+      "decision": "accepted",
+      "reason": "result_domain contracts require a required LibraryApi.Contract evidence producer or evidence-kind requirement"
+    },
+    {
+      "id": "external.pack.fixed_result_domain_authoring.data_only_preflight",
+      "round": "R2",
+      "proof_shape": "external_authoring_without_external_influence",
+      "kernel_need": "authorability must not bypass metadata-only/data-only external pack policy",
+      "decision": "accepted",
+      "reason": "fixed result-domain rows load as external contract metadata, but influence preflight still blocks them"
+    },
+    {
+      "id": "external.pack.fixed_result_domain_authoring.executable_gate_shape",
+      "round": "R2",
+      "proof_shape": "external_authoring_conformance_gate",
+      "kernel_need": "fixed result-domain contracts must remain eligible for fixture-expectation executable gates",
+      "decision": "existing",
+      "reason": "existing executable conformance gates already target exact-capable contract rows; no new oracle primitive was needed"
+    },
+    {
+      "id": "external.pack.manifest_package_metadata",
+      "round": "R1",
+      "proof_shape": "manifest_package_metadata",
+      "kernel_need": "package/version coordinates in the manifest",
+      "decision": "existing",
+      "reason": "manifest packages already validate ecosystem/name/version shape, but they remain metadata rather than occurrence proof"
+    },
+    {
+      "id": "external.pack.row_conflict_detection",
+      "round": "R1",
+      "proof_shape": "external_row_conflict_preflight",
+      "kernel_need": "external rows must not shadow builtin ids silently",
+      "decision": "existing",
+      "reason": "external row conflict reporting already covers producers, contracts, and value laws"
+    },
+    {
+      "id": "external.pack.executable_conformance_preflight",
+      "round": "R1",
+      "proof_shape": "external_authoring_conformance_gate",
+      "kernel_need": "executable fixture gates can clear only the executable-conformance blocker",
+      "decision": "existing",
+      "reason": "existing preflight keeps data-only, dependency-backed evidence, and explicit trust blockers closed"
+    },
+    {
+      "id": "java.guava.collection_factories.package_gate",
+      "round": "R1",
+      "proof_shape": "package_version_occurrence",
+      "kernel_need": "prove a project actually depends on Guava before admitting Guava factories",
+      "decision": "blocked",
+      "reason": "manifest package metadata is not a lockfile/build-system occurrence producer"
+    },
+    {
+      "id": "java.guava.optional.package_gate",
+      "round": "R1",
+      "proof_shape": "package_version_occurrence",
+      "kernel_need": "prove Guava Optional identity and version before option-like rows",
+      "decision": "blocked",
+      "reason": "package occurrence proof remains absent and Optional has additional demand/default-effect boundaries"
+    },
+    {
+      "id": "rails.activesupport.presence.package_gate",
+      "round": "R1",
+      "proof_shape": "package_version_occurrence",
+      "kernel_need": "prove ActiveSupport presence semantics by versioned package occurrence",
+      "decision": "blocked",
+      "reason": "Ruby package/version occurrence proof remains unavailable"
+    },
+    {
+      "id": "rust.itertools.collect_vec.materialization",
+      "round": "R1",
+      "proof_shape": "trait_identity_plus_materialization",
+      "kernel_need": "prove trait method identity and caller-selected Vec materialization",
+      "decision": "blocked",
+      "reason": "fixed result-domain authoring cannot express collect-like result selection or trait resolution"
+    },
+    {
+      "id": "rust.iterator.exact_size_materialization",
+      "round": "R1",
+      "proof_shape": "materialized_demand_profile",
+      "kernel_need": "distinguish lazy iterator adapters from materialized collections",
+      "decision": "blocked",
+      "reason": "demand/materialization evidence is still required before broad iterator result-domain rows"
+    },
+    {
+      "id": "python.numpy.dtype_domain_producer",
+      "round": "R1",
+      "proof_shape": "dtype_domain_producer",
+      "kernel_need": "prove scalar dtype/domain before NumPy scalar ufunc laws",
+      "decision": "blocked",
+      "reason": "DomainEvidence vocabulary exists, but no safe NumPy dtype producer exists"
+    },
+    {
+      "id": "python.numpy.ndarray_shape_domain",
+      "round": "R1",
+      "proof_shape": "array_shape_dtype_domain_producer",
+      "kernel_need": "distinguish scalar, ndarray, dtype, and broadcasting boundaries",
+      "decision": "blocked",
+      "reason": "fixed result-domain authoring is too coarse for array shape and dtype semantics"
+    },
+    {
+      "id": "external.pack.dependency_backed_evidence_runtime",
+      "round": "R4-preview",
+      "proof_shape": "external_evidence_runtime",
+      "kernel_need": "external rows need a way to produce dependency-backed evidence, not just metadata",
+      "decision": "blocked",
+      "reason": "external manifests remain data-only; no producer runtime or trust policy opens exact influence"
+    },
+    {
+      "id": "external.pack.explicit_influence_trust_gate",
+      "round": "R4-preview",
+      "proof_shape": "external_influence_trust_policy",
+      "kernel_need": "user/provider trust policy before external evidence can affect exact results",
+      "decision": "blocked",
+      "reason": "external packs intentionally remain metadata-only and disabled by default"
+    },
+    {
+      "id": "external.pack.package_metadata_as_occurrence_proof",
+      "round": "R3",
+      "proof_shape": "unsafe_metadata_to_occurrence_broadening",
+      "kernel_need": "do not treat manifest package claims as project occurrence proof",
+      "decision": "rejected",
+      "reason": "a manifest says what a pack targets, not what the analyzed project imports or depends on"
+    },
+    {
+      "id": "generic.hof.fixed_result_domain_authoring",
+      "round": "R3",
+      "proof_shape": "unsafe_hof_result_domain_broadening",
+      "kernel_need": "do not let fixed result-domain schema open broad HOF result domains",
+      "decision": "rejected",
+      "reason": "HOF result shape still needs demand/materialization and callback-effect proof"
+    },
+    {
+      "id": "generic.map_get.fixed_value_domain_authoring",
+      "round": "R3",
+      "proof_shape": "unsafe_parametric_value_domain_broadening",
+      "kernel_need": "do not let fixed result-domain schema express parametric map value domains",
+      "decision": "rejected",
+      "reason": "Map.get result depends on the map value type and presence/default semantics, not fixed API identity"
+    }
+  ],
+  "totals": {
+    "probes": 20,
+    "accepted": 4,
+    "existing": 4,
+    "blocked": 9,
+    "rejected": 3
+  }
+}

--- a/bench/semantic_pack/kernel_capability_matrix.v4.json
+++ b/bench/semantic_pack/kernel_capability_matrix.v4.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": 4,
+  "issue": 511,
+  "cycle": "r1-r3-cycle-2",
+  "source_artifacts": [
+    "bench/semantic_pack/blocker_packet.v3.json",
+    "bench/semantic_pack/kernel_capability_matrix.v3.json",
+    "bench/semantic_pack/blocker_packet.v4.json"
+  ],
+  "scope_bar": {
+    "selected_bar": "second R1-R3 internal capability cycle with R4 transition decision",
+    "foundational_primitive": "admitted_api_result_domain_materializer",
+    "accepted_generalization": "external_fixed_result_domain_authoring_contract",
+    "new_primitives": 0,
+    "exact_capable_surfaces_exercising_it": [
+      "external.contract.semantics.result_domain.fixed",
+      "external.contract.result_domain.domain_vocabulary",
+      "external.contract.result_domain.required_library_api_dependency",
+      "external.contract.result_domain.data_only_preflight"
+    ],
+    "external_influence_opened": false
+  },
+  "r1_blocker_summary": {
+    "probe_count": 20,
+    "accepted": 4,
+    "existing": 4,
+    "blocked": 9,
+    "rejected": 3,
+    "dominant_proof_shape": "external_authoring_fixed_result_domain_schema",
+    "decision": "make fixed result-domain rows authorable and validated in external manifests while keeping influence blocked"
+  },
+  "r2_builtin_and_external_expansion": {
+    "accepted_change": {
+      "id": "external_fixed_result_domain_authoring_contract",
+      "type": "external-authoring-surface",
+      "shape": "Manifest contract semantics may declare result_domain { kind: fixed, domain, subject: call }; validation requires a known DomainEvidence vocabulary member and required LibraryApi.Contract evidence",
+      "producer": "semantic-pack manifest validator",
+      "consumers": [
+        "external contract row metadata",
+        "semantic-pack conformance and preflight reporting",
+        "future R4 external producer runtime design"
+      ],
+      "hard_negative_boundary": [
+        "unknown result-domain names are rejected",
+        "fixed result-domain claims without required LibraryApi.Contract evidence are rejected",
+        "external rows remain data-only and metadata-only",
+        "manifest package metadata is not project package occurrence proof",
+        "HOF and Map.get value-domain broadening remain rejected"
+      ]
+    },
+    "implemented_rows": [
+      "semantics.result_domain.kind=fixed",
+      "semantics.result_domain.domain=Array",
+      "semantics.result_domain.domain=Boolean",
+      "semantics.result_domain.domain=ByteArray",
+      "semantics.result_domain.domain=Collection",
+      "semantics.result_domain.domain=Float",
+      "semantics.result_domain.domain=FutureLike",
+      "semantics.result_domain.domain=Integer",
+      "semantics.result_domain.domain=Iterable",
+      "semantics.result_domain.domain=Iterator",
+      "semantics.result_domain.domain=Map",
+      "semantics.result_domain.domain=Number",
+      "semantics.result_domain.domain=Option",
+      "semantics.result_domain.domain=PromiseLike",
+      "semantics.result_domain.domain=Record",
+      "semantics.result_domain.domain=Result",
+      "semantics.result_domain.domain=Set",
+      "semantics.result_domain.domain=String"
+    ]
+  },
+  "r3_compression": {
+    "centralized_paths": [
+      "external result-domain schema validation lives in packs/result_domain_semantics.rs instead of expanding the already-large manifest validator",
+      "the authoring surface reuses existing ManifestRequirement and LibraryApi.Contract producer vocabulary",
+      "no new EvidenceRecord kind, DomainEvidence variant, or semantic-kernel primitive was added"
+    ],
+    "compatibility_lanes_kept_separate": [
+      "external fixed result-domain rows are metadata/data-only until a future R4 producer runtime and trust lane exist",
+      "package/version manifest metadata remains separate from project occurrence proof",
+      "generic HOF and Map.get parametric value-domain rows remain closed"
+    ],
+    "primitive_surface_delta": {
+      "added": [],
+      "generalized": [],
+      "external_authoring_surfaces": [
+        "semantics.result_domain.fixed"
+      ],
+      "removed": [],
+      "net_new_primitives": 0
+    }
+  },
+  "blocker_taxonomy_v4": [
+    {
+      "proof_shape": "external_authoring_fixed_result_domain_schema",
+      "decision": "accepted",
+      "covered_probes": [
+        "external.pack.fixed_result_domain_authoring.schema",
+        "external.pack.fixed_result_domain_authoring.domain_vocabulary",
+        "external.pack.fixed_result_domain_authoring.api_dependency",
+        "external.pack.fixed_result_domain_authoring.data_only_preflight"
+      ],
+      "rationale": "cycle 1 created a fixed result-domain materializer; cycle 2 makes that shape explicit in external manifest authoring without granting influence"
+    },
+    {
+      "proof_shape": "manifest_and_conformance_preflight",
+      "decision": "existing",
+      "covered_probes": [
+        "external.pack.fixed_result_domain_authoring.executable_gate_shape",
+        "external.pack.manifest_package_metadata",
+        "external.pack.row_conflict_detection",
+        "external.pack.executable_conformance_preflight"
+      ],
+      "rationale": "existing external-pack metadata, conflict, and executable conformance gates already describe these rows but do not make them executable"
+    },
+    {
+      "proof_shape": "package_version_occurrence",
+      "decision": "blocked",
+      "covered_probes": [
+        "java.guava.collection_factories.package_gate",
+        "java.guava.optional.package_gate",
+        "rails.activesupport.presence.package_gate"
+      ],
+      "rationale": "manifest package metadata is not project dependency occurrence proof; lockfile/build-system producers are still missing"
+    },
+    {
+      "proof_shape": "materialization_dtype_or_external_runtime",
+      "decision": "blocked",
+      "covered_probes": [
+        "rust.itertools.collect_vec.materialization",
+        "rust.iterator.exact_size_materialization",
+        "python.numpy.dtype_domain_producer",
+        "python.numpy.ndarray_shape_domain",
+        "external.pack.dependency_backed_evidence_runtime",
+        "external.pack.explicit_influence_trust_gate"
+      ],
+      "rationale": "these blockers require producer/runtime work, not more fixed result-domain schema"
+    },
+    {
+      "proof_shape": "unsafe_metadata_or_result_domain_broadening",
+      "decision": "rejected",
+      "covered_probes": [
+        "external.pack.package_metadata_as_occurrence_proof",
+        "generic.hof.fixed_result_domain_authoring",
+        "generic.map_get.fixed_value_domain_authoring"
+      ],
+      "rationale": "metadata-only package claims and fixed-domain declarations must not erase occurrence, demand, materialization, or parametric value boundaries"
+    }
+  ],
+  "transition_assessment": {
+    "continue_r1_r3": false,
+    "move_to_r4": true,
+    "criteria_met": [
+      "new primitive additions stayed at zero across the two post-#507 cycles",
+      "existing primitive composition explains the fixed result-domain rows accepted in cycle 1",
+      "cycle 2 found that the main remaining fixed-domain blocker is external authorability and producer runtime, not kernel vocabulary",
+      "R3 kept the new authoring surface separate from exact influence",
+      "remaining blockers are dominated by package/version occurrence, external producer runtime, trait/materialization, dtype, and trust-lane gaps"
+    ],
+    "criteria_not_met": [
+      "external packs still cannot produce dependency-backed evidence at analysis time",
+      "package/version occurrence producers are still absent",
+      "HOF demand/materialization and dtype producers remain blocked"
+    ],
+    "next_phase_goal": "start R4 external-pack authorability with a realistic fixed result-domain dry-run pack, package occurrence matrix, and explicit builtin-only versus externalizable capability list"
+  },
+  "product_output_gate": {
+    "classification": "metadata-only manifest validation change; no semantic query product-output drift expected",
+    "reason": "external manifests remain metadata-only and no builtin recognizer/result-domain materializer behavior changed"
+  },
+  "performance_gate": {
+    "limit": "no more than 10% median runtime regression",
+    "expected_hot_path_change": "none on normal query without external manifest loading; manifest validation does one small JSON object check per declared contract",
+    "measurement_required": false,
+    "decision": "covered by CI build/test/lint and no hot-path semantic analysis change"
+  }
+}

--- a/bench/semantic_pack/pricing.py
+++ b/bench/semantic_pack/pricing.py
@@ -31,6 +31,8 @@ DEFAULT_BLOCKER_PACKET_V2 = ROOT / "bench" / "semantic_pack" / "blocker_packet.v
 DEFAULT_KERNEL_MATRIX_V2 = ROOT / "bench" / "semantic_pack" / "kernel_capability_matrix.v2.json"
 DEFAULT_BLOCKER_PACKET_V3 = ROOT / "bench" / "semantic_pack" / "blocker_packet.v3.json"
 DEFAULT_KERNEL_MATRIX_V3 = ROOT / "bench" / "semantic_pack" / "kernel_capability_matrix.v3.json"
+DEFAULT_BLOCKER_PACKET_V4 = ROOT / "bench" / "semantic_pack" / "blocker_packet.v4.json"
+DEFAULT_KERNEL_MATRIX_V4 = ROOT / "bench" / "semantic_pack" / "kernel_capability_matrix.v4.json"
 
 SCHEMA_VERSION = 1
 TOOL_VERSION = "semantic-pack-pricing/1"
@@ -1463,6 +1465,84 @@ def validate_kernel_matrix_v3(matrix: dict, probe_ids: set[str]) -> None:
             raise SystemExit("kernel capability matrix v3 performance delta exceeds 10%")
 
 
+def validate_blocker_packet_v4(packet: dict) -> set[str]:
+    if packet.get("schema_version") != 4:
+        raise SystemExit("blocker packet v4 must use schema_version 4")
+    if packet.get("issue") != 511:
+        raise SystemExit("blocker packet v4 must be tied to issue 511")
+    if packet.get("cycle") != "r1-r3-cycle-2":
+        raise SystemExit("blocker packet v4 must identify r1-r3-cycle-2")
+    probes = packet.get("probes")
+    if not isinstance(probes, list) or len(probes) != 20:
+        raise SystemExit("blocker packet v4 must contain exactly 20 probes")
+    totals = packet.get("totals")
+    if not isinstance(totals, dict):
+        raise SystemExit("blocker packet v4 needs totals")
+    decisions = {"accepted": 0, "existing": 0, "blocked": 0, "rejected": 0}
+    seen = set()
+    for probe in probes:
+        probe_id = probe.get("id")
+        if not isinstance(probe_id, str) or not probe_id:
+            raise SystemExit("blocker packet v4 probe is missing id")
+        if probe_id in seen:
+            raise SystemExit(f"blocker packet v4 duplicate probe id: {probe_id}")
+        seen.add(probe_id)
+        decision = probe.get("decision")
+        if decision not in decisions:
+            raise SystemExit(f"{probe_id}: invalid blocker packet v4 decision {decision}")
+        decisions[decision] += 1
+        for key in ["round", "proof_shape", "kernel_need", "reason"]:
+            if not probe.get(key):
+                raise SystemExit(f"{probe_id}: blocker packet v4 missing {key}")
+    expected_totals = {"probes": len(probes), **decisions}
+    if totals != expected_totals:
+        raise SystemExit("blocker packet v4 totals do not match probe decisions")
+    return seen
+
+
+def validate_kernel_matrix_v4(matrix: dict, probe_ids: set[str]) -> None:
+    if matrix.get("schema_version") != 4:
+        raise SystemExit("kernel capability matrix v4 must use schema_version 4")
+    if matrix.get("issue") != 511:
+        raise SystemExit("kernel capability matrix v4 must be tied to issue 511")
+    if matrix.get("cycle") != "r1-r3-cycle-2":
+        raise SystemExit("kernel capability matrix v4 must identify r1-r3-cycle-2")
+    if "bench/semantic_pack/blocker_packet.v4.json" not in matrix.get("source_artifacts", []):
+        raise SystemExit("kernel capability matrix v4 must reference blocker_packet.v4.json")
+    scope = matrix.get("scope_bar", {})
+    if scope.get("accepted_generalization") != "external_fixed_result_domain_authoring_contract":
+        raise SystemExit("kernel capability matrix v4 must name the accepted generalization")
+    if scope.get("new_primitives") != 0:
+        raise SystemExit("kernel capability matrix v4 must record zero new primitives")
+    if scope.get("external_influence_opened") is not False:
+        raise SystemExit("kernel capability matrix v4 must keep external influence closed")
+    accepted = matrix.get("r2_builtin_and_external_expansion", {}).get("accepted_change", {})
+    if accepted.get("id") != "external_fixed_result_domain_authoring_contract":
+        raise SystemExit("kernel capability matrix v4 accepted_change id mismatch")
+    implemented = matrix.get("r2_builtin_and_external_expansion", {}).get("implemented_rows")
+    if not isinstance(implemented, list) or "semantics.result_domain.domain=Collection" not in implemented:
+        raise SystemExit("kernel capability matrix v4 must list result-domain vocabulary rows")
+    taxonomy = matrix.get("blocker_taxonomy_v4")
+    if not isinstance(taxonomy, list) or not taxonomy:
+        raise SystemExit("kernel capability matrix v4 needs blocker_taxonomy_v4 rows")
+    taxonomy_decisions = {row.get("decision") for row in taxonomy}
+    if not {"accepted", "blocked", "rejected"}.issubset(taxonomy_decisions):
+        raise SystemExit("kernel capability matrix v4 taxonomy must cover accepted/blocked/rejected")
+    for row in taxonomy:
+        covered = row.get("covered_probes")
+        if not isinstance(covered, list) or not covered:
+            raise SystemExit("kernel capability matrix v4 taxonomy rows need covered probes")
+        unknown = sorted(set(covered) - probe_ids)
+        if unknown:
+            raise SystemExit(f"kernel capability matrix v4 references unknown probes: {unknown}")
+    transition = matrix.get("transition_assessment", {})
+    if transition.get("move_to_r4") is not True or transition.get("continue_r1_r3") is not False:
+        raise SystemExit("kernel capability matrix v4 must move #511 from R1-R3 to R4")
+    performance = matrix.get("performance_gate", {})
+    if performance.get("measurement_required") is not False:
+        raise SystemExit("kernel capability matrix v4 must document no hot-path measurement requirement")
+
+
 def check_artifacts(
     corpus_path: Path,
     json_out: Path,
@@ -1472,6 +1552,8 @@ def check_artifacts(
     kernel_matrix_v2: Path,
     blocker_packet_v3: Path,
     kernel_matrix_v3: Path,
+    blocker_packet_v4: Path,
+    kernel_matrix_v4: Path,
 ) -> None:
     report = json.loads(json_out.read_text(encoding="utf-8"))
     validate_report(report)
@@ -1494,6 +1576,10 @@ def check_artifacts(
     probe_ids_v3 = validate_blocker_packet_v3(packet_v3)
     matrix_v3 = json.loads(kernel_matrix_v3.read_text(encoding="utf-8"))
     validate_kernel_matrix_v3(matrix_v3, probe_ids_v3)
+    packet_v4 = json.loads(blocker_packet_v4.read_text(encoding="utf-8"))
+    probe_ids_v4 = validate_blocker_packet_v4(packet_v4)
+    matrix_v4 = json.loads(kernel_matrix_v4.read_text(encoding="utf-8"))
+    validate_kernel_matrix_v4(matrix_v4, probe_ids_v4)
     print("semantic-pack pricing artifact check passed")
 
 
@@ -1552,6 +1638,8 @@ def main() -> int:
     parser.add_argument("--kernel-matrix-v2", type=Path, default=DEFAULT_KERNEL_MATRIX_V2)
     parser.add_argument("--blocker-packet-v3", type=Path, default=DEFAULT_BLOCKER_PACKET_V3)
     parser.add_argument("--kernel-matrix-v3", type=Path, default=DEFAULT_KERNEL_MATRIX_V3)
+    parser.add_argument("--blocker-packet-v4", type=Path, default=DEFAULT_BLOCKER_PACKET_V4)
+    parser.add_argument("--kernel-matrix-v4", type=Path, default=DEFAULT_KERNEL_MATRIX_V4)
     parser.add_argument(
         "--nose",
         type=Path,
@@ -1582,6 +1670,8 @@ def main() -> int:
             args.kernel_matrix_v2,
             args.blocker_packet_v3,
             args.kernel_matrix_v3,
+            args.blocker_packet_v4,
+            args.kernel_matrix_v4,
         )
         return 0
 

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -87,6 +87,7 @@ mod conformance;
 mod external;
 mod loading;
 mod manifest;
+mod result_domain_semantics;
 mod validation;
 
 pub use compiled::{

--- a/crates/nose-semantics/src/packs/result_domain_semantics.rs
+++ b/crates/nose-semantics/src/packs/result_domain_semantics.rs
@@ -1,0 +1,116 @@
+use super::*;
+use std::collections::HashMap;
+
+const RESULT_DOMAIN_KEYS: &[&str] = &["kind", "domain", "subject", "notes"];
+const FIXED_RESULT_DOMAINS: &[&str] = &[
+    "Array",
+    "Boolean",
+    "ByteArray",
+    "Collection",
+    "Float",
+    "FutureLike",
+    "Integer",
+    "Iterable",
+    "Iterator",
+    "Map",
+    "Number",
+    "Option",
+    "PromiseLike",
+    "Record",
+    "Result",
+    "Set",
+    "String",
+];
+
+pub(super) fn validate_result_domain_semantics(
+    kind: &str,
+    id: &str,
+    semantics: &serde_json::Map<String, serde_json::Value>,
+    requirements: &[ManifestRequirement],
+    evidence_producer_kinds: &HashMap<String, String>,
+) -> Result<(), String> {
+    let Some(value) = semantics.get("result_domain") else {
+        return Ok(());
+    };
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("{kind} `{id}` semantics.result_domain must be an object"))?;
+    for key in object.keys() {
+        if !RESULT_DOMAIN_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "{kind} `{id}` semantics.result_domain has unknown key `{key}`"
+            ));
+        }
+    }
+    require_result_domain_string(kind, id, object, "kind").and_then(|value| {
+        (value == "fixed")
+            .then_some(())
+            .ok_or_else(|| format!("{kind} `{id}` semantics.result_domain.kind must be `fixed`"))
+    })?;
+    let domain = require_result_domain_string(kind, id, object, "domain")?;
+    if !FIXED_RESULT_DOMAINS.contains(&domain) {
+        return Err(format!(
+            "{kind} `{id}` semantics.result_domain.domain has unknown domain `{domain}`"
+        ));
+    }
+    if let Some(subject) = optional_result_domain_string(kind, id, object, "subject")? {
+        if subject != "call" {
+            return Err(format!(
+                "{kind} `{id}` semantics.result_domain.subject must be `call`"
+            ));
+        }
+    }
+    optional_result_domain_string(kind, id, object, "notes")?;
+    if !requirements.iter().any(|requirement| {
+        requirement.required
+            && (requirement.ref_id == "LibraryApi.Contract"
+                || evidence_producer_kinds
+                    .get(&requirement.ref_id)
+                    .is_some_and(|producer_kind| producer_kind == "LibraryApi.Contract"))
+    }) {
+        return Err(format!(
+            "{kind} `{id}` semantics.result_domain requires required LibraryApi.Contract evidence"
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn collect_evidence_producer_kinds(
+    manifest: &SemanticPackManifest,
+) -> HashMap<String, String> {
+    manifest
+        .declares
+        .evidence_producers
+        .iter()
+        .map(|producer| (producer.id.clone(), producer.kind.clone()))
+        .collect()
+}
+
+fn require_result_domain_string<'a>(
+    kind: &str,
+    id: &str,
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<&'a str, String> {
+    optional_result_domain_string(kind, id, object, key)?.ok_or_else(|| {
+        format!("{kind} `{id}` semantics.result_domain.{key} must be a non-empty string")
+    })
+}
+
+fn optional_result_domain_string<'a>(
+    kind: &str,
+    id: &str,
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<&'a str>, String> {
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .map(Some)
+        .ok_or_else(|| {
+            format!("{kind} `{id}` semantics.result_domain.{key} must be a non-empty string")
+        })
+}

--- a/crates/nose-semantics/src/packs/tests.rs
+++ b/crates/nose-semantics/src/packs/tests.rs
@@ -142,6 +142,20 @@ fn manifest_with_value_law(id: &str) -> String {
     )
 }
 
+fn manifest_with_fixed_result_domain(id: &str) -> String {
+    manifest(id).replace(
+        r#""operation": "Example",
+        "demand": { "arguments": "eager-left-to-right" }"#,
+        r#""operation": "Example",
+        "result_domain": {
+          "kind": "fixed",
+          "domain": "Collection",
+          "subject": "call"
+        },
+        "demand": { "arguments": "eager-left-to-right" }"#,
+    )
+}
+
 fn manifest_with_executable_gates(id: &str) -> String {
     manifest(id).replace(
         r#""known_unsupported": []"#,

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_1.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_1.rs
@@ -206,6 +206,53 @@ fn local_manifest_registers_external_producer_and_contract_rows_as_data_only() {
 }
 
 #[test]
+fn external_fixed_result_domain_contract_rows_stay_data_only() {
+    let dir = unique_dir("external_fixed_result_domain_rows");
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest_with_fixed_result_domain("com.example.fixed-result-domain"),
+    )
+    .unwrap();
+
+    let set = SemanticPackSet::new_local(std::slice::from_ref(&path))
+        .expect("fixed result-domain metadata pack loads");
+    let external = set.packs().last().expect("external pack summary");
+    assert_eq!(external.id, "com.example.fixed-result-domain");
+    assert_eq!(external.influence, SemanticPackInfluence::MetadataOnly);
+    assert_eq!(external.counts.evidence_producers, 1);
+    assert_eq!(external.counts.contracts, 1);
+
+    let contracts = set.external_contract_rows();
+    assert_eq!(contracts.len(), 1);
+    let contract = &contracts[0];
+    assert_eq!(contract.contract_id, "python.example.contract");
+    assert_eq!(contract.semantics["result_domain"]["kind"], "fixed");
+    assert_eq!(contract.semantics["result_domain"]["domain"], "Collection");
+    assert_eq!(contract.semantics["result_domain"]["subject"], "call");
+    assert_eq!(
+        contract.requirements[0].ref_id,
+        "python.library-api.example"
+    );
+    assert!(contract.requirements[0].required);
+
+    let preflight = set.external_influence_preflight();
+    let contract_row = preflight
+        .rows
+        .iter()
+        .find(|row| row.kind == ExternalRowKind::Contract)
+        .expect("contract preflight row");
+    assert!(contract_row
+        .blockers
+        .contains(&ExternalInfluenceBlocker::DataOnlyRegistration));
+    assert!(contract_row
+        .blockers
+        .contains(&ExternalInfluenceBlocker::DependencyBackedEvidenceUnavailable));
+    assert!(!contract_row.passed());
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn external_rows_report_builtin_id_conflicts_without_rejecting_metadata_only_pack() {
     let dir = unique_dir("external_builtin_row_conflicts");
     let path = dir.join("pack.json");

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
@@ -238,6 +238,48 @@ fn exact_capable_contracts_must_have_required_evidence_requirements() {
 }
 
 #[test]
+fn fixed_result_domain_contracts_require_known_domain_vocabulary() {
+    let dir = unique_dir("fixed_result_domain_unknown_domain");
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest_with_fixed_result_domain("com.example.fixed-result-domain").replace(
+            r#""domain": "Collection""#,
+            r#""domain": "MaybeLazyCollection""#,
+        ),
+    )
+    .unwrap();
+    let err = load_local_manifest(&path).expect_err("unknown result domains must fail closed");
+    assert!(
+        err.to_string()
+            .contains("semantics.result_domain.domain has unknown domain"),
+        "{err}"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn fixed_result_domain_contracts_require_library_api_evidence() {
+    let dir = unique_dir("fixed_result_domain_requires_api");
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest_with_fixed_result_domain("com.example.fixed-result-domain")
+            .replace("python.library-api.example", "Domain.Collection")
+            .replace("LibraryApi.Contract", "Domain.TypeAlias"),
+    )
+    .unwrap();
+    let err = load_local_manifest(&path)
+        .expect_err("fixed result-domain rows need API occurrence evidence");
+    assert!(
+        err.to_string()
+            .contains("semantics.result_domain requires required LibraryApi.Contract evidence"),
+        "{err}"
+    );
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn evidence_kind_must_match_schema_shape() {
     let dir = unique_dir("evidence_kind_shape");
     let path = dir.join("pack.json");

--- a/crates/nose-semantics/src/packs/validation.rs
+++ b/crates/nose-semantics/src/packs/validation.rs
@@ -1,10 +1,15 @@
 use super::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+use super::result_domain_semantics::{
+    collect_evidence_producer_kinds, validate_result_domain_semantics,
+};
 
 pub(super) fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), String> {
     validate_manifest_header(manifest)?;
     validate_manifest_targets(manifest)?;
     let known_refs = collect_declared_refs(manifest)?;
+    let evidence_producer_kinds = collect_evidence_producer_kinds(manifest);
     validate_manifest_conformance(manifest)?;
     let conformance_refs = collect_conformance_fixture_refs(manifest)?;
     validate_executable_conformance(manifest, &conformance_refs)?;
@@ -33,6 +38,7 @@ pub(super) fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), S
             &contract.conformance_refs,
             &known_refs,
             &conformance_refs,
+            &evidence_producer_kinds,
         )?;
     }
     for law in &manifest.declares.value_laws {
@@ -46,6 +52,7 @@ pub(super) fn validate_manifest(manifest: &SemanticPackManifest) -> Result<(), S
             &law.conformance_refs,
             &known_refs,
             &conformance_refs,
+            &evidence_producer_kinds,
         )?;
     }
     Ok(())
@@ -381,6 +388,7 @@ fn validate_contract(
     conformance_refs: &[String],
     known_refs: &HashSet<String>,
     fixture_refs: &ConformanceFixtureRefs,
+    evidence_producer_kinds: &HashMap<String, String>,
 ) -> Result<(), String> {
     require_stable_id("declares.contracts[].id", id)?;
     let semantics = semantics
@@ -410,6 +418,7 @@ fn validate_contract(
             ));
         }
     }
+    validate_result_domain_semantics(kind, id, semantics, requirements, evidence_producer_kinds)?;
     for requirement in requirements {
         validate_requirement(id, requirement, known_refs)?;
     }

--- a/docs/home.md
+++ b/docs/home.md
@@ -86,7 +86,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-candidate-pricing](semantic-pack-candidate-pricing.md) — corpus-backed pricing loop for deciding which narrow semantic-pack rows are ready, blocked, or unpriced before implementation.
 - [semantic-kernel-capability-minimization](semantic-kernel-capability-minimization.md) — issue #507 primitive census, blocker taxonomy, and accept/reject matrix for deriving minimal kernel capabilities from pack blockers.
 - [semantic-kernel-builtin-expansion-509](semantic-kernel-builtin-expansion-509.md) — issue #509 blocker packet, admitted API result-domain primitive, and builtin expansion record.
-- [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md) — issue #511 R1-R3 cycle 1: generalized admitted API result-domain materialization, builtin expansion, and transition assessment.
+- [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md) — issue #511 R1-R3 cycles: generalized admitted API result-domain materialization, external fixed-domain authoring, and transition assessment.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-expansion-511.md
+++ b/docs/semantic-kernel-expansion-511.md
@@ -1,9 +1,11 @@
 # Semantic kernel expansion 511
 
-Status: issue #511 implementation record, cycle 1 of the R1-R3 loop.
+Status: issue #511 implementation record, cycles 1 and 2 of the R1-R3 loop.
 
 Source artifacts:
 
+- [blocker_packet.v4.json](../bench/semantic_pack/blocker_packet.v4.json)
+- [kernel_capability_matrix.v4.json](../bench/semantic_pack/kernel_capability_matrix.v4.json)
 - [blocker_packet.v3.json](../bench/semantic_pack/blocker_packet.v3.json)
 - [kernel_capability_matrix.v3.json](../bench/semantic_pack/kernel_capability_matrix.v3.json)
 - [blocker_packet.v2.json](../bench/semantic_pack/blocker_packet.v2.json)
@@ -21,10 +23,11 @@ readiness is declared. This first cycle keeps the #509 discipline:
 5. compress special-case paths in the same wave;
 6. keep hard negatives, product-output classification, and the 10% runtime gate.
 
-The cycle deliberately does not move to R4 yet. It widens one existing primitive
-and records what still blocks external pack authorability.
+Cycle 1 deliberately did not move to R4. It widened one existing primitive and
+recorded what still blocked external pack authorability. Cycle 2 then tested the
+largest remaining authoring blocker without opening external influence.
 
-## R1 Blocker Packet
+## Cycle 1 R1 Blocker Packet
 
 [`blocker_packet.v3.json`](../bench/semantic_pack/blocker_packet.v3.json)
 records 20 probes. The dominant proof shape is
@@ -39,7 +42,7 @@ single path that materializes that fact as call-node `DomainEvidence`.
 | blocked | 4 | external authoring, package/version, trait/materialization, or dtype proof is missing |
 | rejected | 2 | HOF result domains and `Map.get` value domains remain unsafe to emit broadly |
 
-## Accepted Generalization
+## Cycle 1 Accepted Generalization
 
 No new primitive was added. The accepted change generalizes
 `admitted_api_result_domain` into a shared materializer:
@@ -55,7 +58,7 @@ No new primitive was added. The accepted change generalizes
 This keeps the primitive small: API occurrence proof plus domain evidence. It
 does not introduce a result type system or a broad HOF rule.
 
-## Builtin Expansion
+## Cycle 1 Builtin Expansion
 
 The materializer now covers fixed-result call rows across multiple languages:
 
@@ -73,7 +76,7 @@ The materializer now covers fixed-result call rows across multiple languages:
 | #509 receiver rows | unchanged result domains through the shared path |
 | Rust `Some(...)` | `Option` through the shared path |
 
-## R3 Compression
+## Cycle 1 R3 Compression
 
 The cycle reduces special-case emission paths:
 
@@ -90,7 +93,7 @@ That separation matters: existing protocol consumers may keep their conservative
 compatibility behavior, while emitted exact evidence stays dependency-backed and
 fixed-domain only.
 
-## Hard Boundaries
+## Cycle 1 Hard Boundaries
 
 The materializer stays closed when:
 
@@ -102,7 +105,7 @@ The materializer stays closed when:
 - Java `Arrays.asList(x)` has the ambiguous single-argument array-vs-element
   boundary.
 
-## Product And Performance Gates
+## Cycle 1 Product And Performance Gates
 
 The focused semantic-query subset compared `boltons`, `serde_json`, and `junit5`
 between the `origin/main` baseline and this cycle's release binary. After
@@ -119,7 +122,7 @@ gate:
 | `serde_json` | 61.14 ms | 62.50 ms | +2.22% |
 | `junit5` | 533.35 ms | 508.90 ms | -4.58% |
 
-## Transition Assessment
+## Cycle 1 Transition Assessment
 
 This cycle is progress, but it is not enough to move #511 to R4.
 
@@ -142,5 +145,103 @@ The next cycle should choose another 20-row packet biased toward the remaining
 package/version, materialization, dtype, and external-authoring blockers. R4
 should start early only if builtin rows can now express useful fixed-domain
 capabilities that external packs still cannot express.
+
+## Cycle 2 R1 Blocker Packet
+
+[`blocker_packet.v4.json`](../bench/semantic_pack/blocker_packet.v4.json)
+records the second 20-probe R1-R3 cycle. The packet is biased toward the
+authoring gap left by cycle 1: external packs could see the vocabulary but could
+not yet declare fixed result-domain contracts in a validated, dependency-backed
+shape.
+
+| decision | count | meaning |
+|---|---:|---|
+| accepted | 4 | external fixed result-domain authoring can be structurally validated |
+| existing | 4 | existing metadata-only, conflict, and preflight gates already preserve the boundary |
+| blocked | 9 | package/version, external execution, dtype/materialization, and runtime trust remain missing |
+| rejected | 3 | package metadata, broad HOF rows, and parametric value-domain rows are still not semantic proof |
+
+## Cycle 2 Accepted Generalization
+
+No new primitive was added. The accepted change is a manifest authoring
+validation rule for fixed call result domains:
+
+- `semantics.result_domain` must be an object;
+- `kind` must be `fixed`;
+- `domain` must be one of the known kernel `DomainEvidence` labels;
+- `subject`, when present, must be `call`;
+- `notes`, when present, must be a non-empty string;
+- the contract must require `LibraryApi.Contract` evidence, either directly or
+  through a declared evidence producer of that kind.
+
+This is deliberately an authoring surface, not an influence surface. External
+manifest rows that pass validation are still registered as data-only rows. They
+remain blocked by the external influence preflight because no external producer
+runtime, influence trust gate, or dependency-backed evidence channel has been
+opened.
+
+## Cycle 2 R3 Compression
+
+The R3 check did not find another builtin emission path to collapse. That is the
+important result: cycle 1 had already moved fixed-domain emission into the
+shared admitted-API materializer, and cycle 2 showed the matching external
+manifest shape can reuse the same vocabulary without adding another primitive.
+
+The kernel now has two halves of the same capability:
+
+- compiled builtin rows can emit fixed call result-domain evidence only through
+  admitted `LibraryApi` occurrence evidence;
+- external manifests can declare the same fixed-domain intent only as
+  dependency-backed, metadata-only rows.
+
+## Cycle 2 Hard Boundaries
+
+The second cycle keeps these blockers closed:
+
+- package or module presence alone does not prove a `LibraryApi` occurrence;
+- external rows cannot influence normalize, value-graph, exact, or detection
+  consumers;
+- executable producer hooks, recognizers, parser plugins, and sandboxed runtime
+  code are not part of v0;
+- broad HOF rows cannot claim a fixed result domain without materialization
+  proof;
+- `Map.get`-style value domains remain parametric and cannot be emitted as a
+  fixed call result domain;
+- dtype, tensor shape, stream lifecycle, and package-version proof are still
+  separate future substrates.
+
+## Cycle 2 Product And Performance Gates
+
+The implementation changes manifest validation and committed assessment
+artifacts only. No query, normalize, value-graph, fragment, oracle, or detection
+hot path reads external result-domain rows. Product output is therefore expected
+to be unchanged except for additive semantic-pack check/loading metadata.
+
+The cycle records this as a descriptor/validation-only change in
+[`kernel_capability_matrix.v4.json`](../bench/semantic_pack/kernel_capability_matrix.v4.json):
+no hot-path measurement is required for the 10% runtime gate, and any later PR
+that opens external influence must run the normal product-output and runtime
+measurement gates.
+
+## Cycle 2 Transition Assessment
+
+The R1-R3 loop has now met the threshold for moving to R4:
+
+- cycle 1 generalized a builtin primitive and applied it across existing
+  builtins;
+- cycle 1 compressed special-case fixed-domain emission paths;
+- cycle 2 exposed the same capability as strict metadata-only external manifest
+  vocabulary;
+- both cycles added zero new primitives;
+- hard negatives for HOF result domains, `Map.get` value domains, and
+  package-presence-only claims remain closed;
+- external influence is still blocked by explicit data-only and
+  dependency-backed-evidence gates.
+
+R4 should now focus on external pack authorability and conformance: prove that a
+provider can write useful manifests, fixture gates, and unsupported-boundary
+metadata for the capabilities already rehearsed by builtin rows, while exact
+analysis continues to ignore external rows until the later influence gates
+exist.
 
 Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -235,10 +235,13 @@ Rust `abs().max(...)`, Rust `and_then(...).and_then(...)`, and JavaScript
 `then(...).then(...)` without adding a primitive per chain. The #509 blocker
 packet, hard boundaries, and builtin rollout are recorded in
 [semantic-kernel-builtin-expansion-509](semantic-kernel-builtin-expansion-509.md).
-The #511 first R1-R3 cycle generalizes the same primitive from receiver-only
-emission to a shared admitted-API materializer for fixed-result call rows such as
+The #511 R1-R3 cycles generalize the same primitive from receiver-only emission
+to a shared admitted-API materializer for fixed-result call rows such as
 collection/map factories, `Array.from`, `Promise.resolve`, and Rust `Some(...)`,
-while keeping HOF and `Map.get` result domains closed. That cycle record is in
+then validate the matching metadata-only external authoring surface through
+`semantics.result_domain`. HOF and `Map.get` result domains remain closed, and
+external rows still do not influence exact analysis. The cycle record and R4
+transition assessment are in
 [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md).
 
 ### Effects and observations

--- a/docs/semantic-pack-candidate-pricing.md
+++ b/docs/semantic-pack-candidate-pricing.md
@@ -58,8 +58,9 @@ command for refreshing the committed pricing JSON and Markdown because it
 records the sample product-query overlay. The `--check-artifacts` form verifies
 that the committed JSON, Markdown, and review log are internally consistent with
 the current tool and corpus digest without requiring a release binary. It also
-validates the issue #509 v2 blocker packet and capability matrix for count,
-cross-reference, accepted-primitive, and performance-gate consistency.
+validates the issue #509 v2 blocker packet and capability matrix and the issue
+#511 v3/v4 R1-R3 cycle artifacts for count, cross-reference,
+accepted-generalization, transition, and performance-gate consistency.
 
 The tool emits:
 
@@ -77,6 +78,12 @@ blocker packet and capability matrix:
 [`kernel_capability_matrix.v2.json`](../bench/semantic_pack/kernel_capability_matrix.v2.json),
 and
 [semantic-kernel-builtin-expansion-509](semantic-kernel-builtin-expansion-509.md).
+Issue #511 continues the same loop through repeated R1-R3 cycles before external
+pack influence is opened. Its current artifacts are
+[`blocker_packet.v3.json`](../bench/semantic_pack/blocker_packet.v3.json),
+[`kernel_capability_matrix.v3.json`](../bench/semantic_pack/kernel_capability_matrix.v3.json),
+[`blocker_packet.v4.json`](../bench/semantic_pack/blocker_packet.v4.json), and
+[`kernel_capability_matrix.v4.json`](../bench/semantic_pack/kernel_capability_matrix.v4.json).
 
 The current artifact records 20 candidate iterations. It starts from a curated
 seed list instead of attempting automatic API discovery. The scanner uses

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -18,6 +18,8 @@ pack meets the extension contract's minimum structural obligations:
   are internally linked;
 - contracts and value laws declare object-shaped semantics, and exact-capable
   declarations add evidence requirements plus demand/effect semantics;
+- fixed call result-domain declarations use known domain vocabulary and require
+  `LibraryApi.Contract` occurrence evidence;
 - positive fixtures and hard negatives are declared with expectation labels;
 - fixture files exist at paths relative to the manifest file;
 - optional executable gates bind exact-capable producer, contract, and value-law

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -287,6 +287,30 @@ Domain evidence can satisfy receiver-domain preconditions. It is not a proof
 that an opaque binding value is exact-tree safe, immutable, or mutation-free
 unless separate effect/place/import facts prove those obligations.
 
+Exact-capable contract rows may declare a fixed call result domain through
+`semantics.result_domain` when the result domain is part of the API contract
+rather than selected by the caller:
+
+```json
+{
+  "semantics": {
+    "result_domain": {
+      "kind": "fixed",
+      "domain": "Collection",
+      "subject": "call"
+    }
+  }
+}
+```
+
+The local v0 validator accepts only object-shaped fixed result-domain
+declarations. The `domain` must be one of the kernel's known domain vocabulary
+labels, `subject` is optional and currently limited to `call`, and the contract
+must require `LibraryApi.Contract` evidence. This prevents a manifest from
+claiming result-domain facts from a selector string or package presence alone.
+Local external manifests that pass this validation still remain metadata-only;
+they do not emit domain evidence or influence exact analysis.
+
 ### Library API Occurrence Contracts
 
 `LibraryApi` is occurrence evidence: it says this specific call, field, macro,

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -177,10 +177,12 @@ snapshot prose may group packs by migration narrative instead.
 The loader validates manifest shape and pack provenance, registers external
 producer, contract, and value-law declarations as data-only rows, can report
 row-id conflicts with builtin or other external rows, and can run a data-only
-influence preflight report. Today that preflight blocks all external rows until
-dependency-backed evidence, explicit influence trust gates, and conflict-free
-row ids exist. Exact-capable rows also remain blocked until they have passed
-declarative executable conformance.
+influence preflight report. It also validates fixed call result-domain
+declarations in `semantics.result_domain` against the known domain vocabulary
+and requires required `LibraryApi.Contract` evidence for those rows. Today that
+preflight blocks all external rows until dependency-backed evidence, explicit
+influence trust gates, and conflict-free row ids exist. Exact-capable rows also
+remain blocked until they have passed declarative executable conformance.
 `nose semantic-pack check --format json` exposes that row-level preflight to
 providers and integrations, but query, normalize, value-graph, exact, and
 detection consumers do not read it. It does not yet:


### PR DESCRIPTION
Refs #511

## Summary
- add strict metadata-only validation for external `semantics.result_domain` fixed call result-domain declarations
- require known domain vocabulary and required `LibraryApi.Contract` evidence for those declarations
- add #511 cycle 2 blocker/matrix artifacts and document the R1-R3 to R4 transition assessment

## Validation
- `cargo fmt`
- `python3 bench/semantic_pack/pricing.py --check-artifacts`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `awiki lint --root docs`
- `cargo test -p nose-semantics fixed_result_domain -- --nocapture`
- `cargo clippy -p nose-semantics --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --bin nose`
- `./scripts/check-duplication.sh`