### PR TITLE
Record external pack authorability dry run

### DIFF
--- a/bench/semantic_pack/README.md
+++ b/bench/semantic_pack/README.md
@@ -14,8 +14,8 @@ python3 bench/semantic_pack/pricing.py --nose ./target/release/nose --query-samp
 Use the `--nose ./target/release/nose --query-sample-repos 1` command when
 refreshing the committed JSON/Markdown artifacts. Use `--check-artifacts` to
 verify committed artifacts, the two-reviewer log, the issue #509 v2
-blocker/matrix artifacts, and the issue #511 v3/v4 R1-R3 cycle artifacts
-without regenerating them.
+blocker/matrix artifacts, the issue #511 v3/v4 R1-R3 cycle artifacts, and the
+issue #511 R4 external authorability matrix without regenerating them.
 
 Outputs:
 
@@ -37,6 +37,8 @@ Outputs:
   external fixed result-domain authoring.
 - `kernel_capability_matrix.v4.json` — issue #511 second R1-R3 cycle capability
   matrix, metadata-only manifest validation, and transition-to-R4 assessment.
+- `external_authorability_matrix.v1.json` — issue #511 R4 external-pack
+  authorability matrix, dry-run pack assessment, and transition-to-R5 decision.
 
 The scanner reports corpus queue signals. It does not prove semantic
 correctness and does not authorize broad ecosystem packs. Only `priced-ready`

--- a/bench/semantic_pack/external_authorability_matrix.v1.json
+++ b/bench/semantic_pack/external_authorability_matrix.v1.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 1,
+  "issue": 511,
+  "phase": "R4",
+  "source_artifacts": [
+    "bench/semantic_pack/blocker_packet.v4.json",
+    "bench/semantic_pack/kernel_capability_matrix.v4.json",
+    "docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json"
+  ],
+  "purpose": "test whether a realistic external provider can author fixed result-domain rows, fixtures, hard negatives, and conformance gates without opening external influence",
+  "dry_run_pack": {
+    "pack_id": "com.example.java-guava-immutable-collections",
+    "manifest": "docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json",
+    "ecosystem": "maven",
+    "package": "com.google.guava:guava",
+    "slice": "ImmutableList.of and ImmutableSet.of fixed collection result domains",
+    "conformance_command": "nose semantic-pack check docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json --format json",
+    "expected_conformance_status": "ok",
+    "expected_influence_status": "blocked",
+    "expected_remaining_blockers": [
+      "data-only-registration",
+      "dependency-backed-evidence-unavailable",
+      "explicit-influence-trust-gate-missing",
+      "executable-conformance-unavailable"
+    ]
+  },
+  "authorability_rows": [
+    {
+      "capability": "manifest package metadata",
+      "builtin_status": "builtin descriptors can name package or stdlib ownership",
+      "external_authoring": "authorable",
+      "external_influence": "metadata-only",
+      "builtin_only_intentional": false,
+      "result": "available for provenance and compatibility, but not occurrence proof"
+    },
+    {
+      "capability": "Import.Binding producer declaration",
+      "builtin_status": "compiled language/import producers can emit dependency-backed evidence",
+      "external_authoring": "authorable-metadata-only",
+      "external_influence": "blocked",
+      "builtin_only_intentional": true,
+      "result": "providers can declare the producer shape, but v0 cannot execute it"
+    },
+    {
+      "capability": "LibraryApi.Contract producer declaration",
+      "builtin_status": "compiled builtin packs emit admitted LibraryApi occurrence evidence",
+      "external_authoring": "authorable-metadata-only",
+      "external_influence": "blocked",
+      "builtin_only_intentional": true,
+      "result": "required for fixed result-domain rows, but external producer runtime remains absent"
+    },
+    {
+      "capability": "semantics.result_domain fixed call domain",
+      "builtin_status": "cycle 1 materializes fixed call domains for admitted builtin LibraryApi rows",
+      "external_authoring": "authorable-metadata-only",
+      "external_influence": "blocked",
+      "builtin_only_intentional": false,
+      "result": "external manifests can express the row using the same domain vocabulary"
+    },
+    {
+      "capability": "positive and hard-negative fixture metadata",
+      "builtin_status": "builtin inventory audits descriptor coverage",
+      "external_authoring": "authorable",
+      "external_influence": "metadata-only",
+      "builtin_only_intentional": false,
+      "result": "provider can publish useful review evidence without influence"
+    },
+    {
+      "capability": "fixture-expectation executable conformance gate",
+      "builtin_status": "builtin gates are owned by release tests and inventory",
+      "external_authoring": "authorable",
+      "external_influence": "blocked",
+      "builtin_only_intentional": false,
+      "result": "a passed gate clears only executable-conformance-unavailable"
+    },
+    {
+      "capability": "project package/version occurrence proof",
+      "builtin_status": "not generalized across ecosystem lockfiles yet",
+      "external_authoring": "blocked",
+      "external_influence": "blocked",
+      "builtin_only_intentional": false,
+      "result": "manifest package metadata must not be treated as project dependency proof"
+    },
+    {
+      "capability": "external exact evidence runtime",
+      "builtin_status": "compiled Rust producers are the only exact evidence runtime",
+      "external_authoring": "blocked",
+      "external_influence": "blocked",
+      "builtin_only_intentional": true,
+      "result": "requires separate trust, sandbox, provenance, and rollback design"
+    },
+    {
+      "capability": "HOF demand and materialization result shape",
+      "builtin_status": "narrow builtin iterator/promise rows exist, broad HOF result-domain rows remain closed",
+      "external_authoring": "blocked-for-exact",
+      "external_influence": "blocked",
+      "builtin_only_intentional": true,
+      "result": "deferred to R5 because callback demand, laziness, materialization, and effects are high-risk"
+    },
+    {
+      "capability": "dtype, tensor shape, and vector mask domains",
+      "builtin_status": "no accepted kernel substrate",
+      "external_authoring": "blocked-for-exact",
+      "external_influence": "blocked",
+      "builtin_only_intentional": false,
+      "result": "requires future producer vocabulary; not solved by fixed result-domain authoring"
+    }
+  ],
+  "summary": {
+    "external_pack_authorability": "partial",
+    "external_influence_opened": false,
+    "new_primitives": 0,
+    "accepted_for_r4": [
+      "realistic fixed result-domain manifest dry-run",
+      "fixture and hard-negative authoring",
+      "executable conformance gate authoring",
+      "builtin-only versus externalizable capability classification"
+    ],
+    "remaining_before_external_influence": [
+      "dependency-backed external evidence runtime",
+      "explicit influence trust gate",
+      "conflict-free row adoption or replacement policy",
+      "package/version occurrence producers",
+      "rollback and disable policy for external exact rows"
+    ],
+    "move_to_r5": true
+  },
+  "product_output_gate": {
+    "classification": "metadata-only example and artifact change; no semantic query drift expected",
+    "reason": "the dry-run pack passes conformance but external rows remain blocked from query, normalize, value-graph, exact, and detection consumers"
+  },
+  "performance_gate": {
+    "limit": "no more than 10% median runtime regression",
+    "expected_hot_path_change": "none",
+    "measurement_required": false,
+    "decision": "documentation, example manifest, conformance, and artifact validation only"
+  }
+}

--- a/bench/semantic_pack/pricing.py
+++ b/bench/semantic_pack/pricing.py
@@ -33,6 +33,9 @@ DEFAULT_BLOCKER_PACKET_V3 = ROOT / "bench" / "semantic_pack" / "blocker_packet.v
 DEFAULT_KERNEL_MATRIX_V3 = ROOT / "bench" / "semantic_pack" / "kernel_capability_matrix.v3.json"
 DEFAULT_BLOCKER_PACKET_V4 = ROOT / "bench" / "semantic_pack" / "blocker_packet.v4.json"
 DEFAULT_KERNEL_MATRIX_V4 = ROOT / "bench" / "semantic_pack" / "kernel_capability_matrix.v4.json"
+DEFAULT_EXTERNAL_AUTHORABILITY_MATRIX_V1 = (
+    ROOT / "bench" / "semantic_pack" / "external_authorability_matrix.v1.json"
+)
 
 SCHEMA_VERSION = 1
 TOOL_VERSION = "semantic-pack-pricing/1"
@@ -1543,6 +1546,68 @@ def validate_kernel_matrix_v4(matrix: dict, probe_ids: set[str]) -> None:
         raise SystemExit("kernel capability matrix v4 must document no hot-path measurement requirement")
 
 
+def validate_external_authorability_matrix_v1(matrix: dict) -> None:
+    if matrix.get("schema_version") != 1:
+        raise SystemExit("external authorability matrix must use schema_version 1")
+    if matrix.get("issue") != 511:
+        raise SystemExit("external authorability matrix must be tied to issue 511")
+    if matrix.get("phase") != "R4":
+        raise SystemExit("external authorability matrix must identify phase R4")
+    sources = matrix.get("source_artifacts", [])
+    expected_manifest = (
+        "docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json"
+    )
+    if expected_manifest not in sources:
+        raise SystemExit("external authorability matrix must reference the dry-run manifest")
+    dry_run = matrix.get("dry_run_pack", {})
+    if dry_run.get("pack_id") != "com.example.java-guava-immutable-collections":
+        raise SystemExit("external authorability matrix dry-run pack id mismatch")
+    if dry_run.get("expected_conformance_status") != "ok":
+        raise SystemExit("external authorability matrix must expect conformance success")
+    if dry_run.get("expected_influence_status") != "blocked":
+        raise SystemExit("external authorability matrix must keep external influence blocked")
+    blockers = set(dry_run.get("expected_remaining_blockers", []))
+    required_blockers = {
+        "data-only-registration",
+        "dependency-backed-evidence-unavailable",
+        "explicit-influence-trust-gate-missing",
+    }
+    if not required_blockers.issubset(blockers):
+        raise SystemExit("external authorability matrix is missing required influence blockers")
+    rows = matrix.get("authorability_rows")
+    if not isinstance(rows, list) or len(rows) < 8:
+        raise SystemExit("external authorability matrix needs a broad authorability row set")
+    seen = set()
+    statuses = set()
+    for row in rows:
+        capability = row.get("capability")
+        if not isinstance(capability, str) or not capability:
+            raise SystemExit("external authorability row missing capability")
+        if capability in seen:
+            raise SystemExit(f"duplicate external authorability capability: {capability}")
+        seen.add(capability)
+        for key in ["builtin_status", "external_authoring", "external_influence", "result"]:
+            if not row.get(key):
+                raise SystemExit(f"{capability}: external authorability row missing {key}")
+        if not isinstance(row.get("builtin_only_intentional"), bool):
+            raise SystemExit(f"{capability}: builtin_only_intentional must be boolean")
+        if row.get("external_influence") == "open":
+            raise SystemExit("R4 must not open external influence")
+        statuses.add(row.get("external_authoring"))
+    if "authorable-metadata-only" not in statuses or "blocked" not in statuses:
+        raise SystemExit("external authorability matrix must cover authorable and blocked rows")
+    summary = matrix.get("summary", {})
+    if summary.get("external_influence_opened") is not False:
+        raise SystemExit("external authorability matrix summary must keep influence closed")
+    if summary.get("new_primitives") != 0:
+        raise SystemExit("external authorability matrix must add zero primitives")
+    if summary.get("move_to_r5") is not True:
+        raise SystemExit("external authorability matrix must record the R5 transition")
+    performance = matrix.get("performance_gate", {})
+    if performance.get("measurement_required") is not False:
+        raise SystemExit("external authorability matrix must document no hot-path measurement")
+
+
 def check_artifacts(
     corpus_path: Path,
     json_out: Path,
@@ -1554,6 +1619,7 @@ def check_artifacts(
     kernel_matrix_v3: Path,
     blocker_packet_v4: Path,
     kernel_matrix_v4: Path,
+    external_authorability_matrix_v1: Path,
 ) -> None:
     report = json.loads(json_out.read_text(encoding="utf-8"))
     validate_report(report)
@@ -1580,6 +1646,8 @@ def check_artifacts(
     probe_ids_v4 = validate_blocker_packet_v4(packet_v4)
     matrix_v4 = json.loads(kernel_matrix_v4.read_text(encoding="utf-8"))
     validate_kernel_matrix_v4(matrix_v4, probe_ids_v4)
+    authorability_v1 = json.loads(external_authorability_matrix_v1.read_text(encoding="utf-8"))
+    validate_external_authorability_matrix_v1(authorability_v1)
     print("semantic-pack pricing artifact check passed")
 
 
@@ -1641,6 +1709,11 @@ def main() -> int:
     parser.add_argument("--blocker-packet-v4", type=Path, default=DEFAULT_BLOCKER_PACKET_V4)
     parser.add_argument("--kernel-matrix-v4", type=Path, default=DEFAULT_KERNEL_MATRIX_V4)
     parser.add_argument(
+        "--external-authorability-matrix-v1",
+        type=Path,
+        default=DEFAULT_EXTERNAL_AUTHORABILITY_MATRIX_V1,
+    )
+    parser.add_argument(
         "--nose",
         type=Path,
         default=None,
@@ -1672,6 +1745,7 @@ def main() -> int:
             args.kernel_matrix_v3,
             args.blocker_packet_v4,
             args.kernel_matrix_v4,
+            args.external_authorability_matrix_v1,
         )
         return 0
 

--- a/crates/nose-semantics/src/packs/result_domain_semantics.rs
+++ b/crates/nose-semantics/src/packs/result_domain_semantics.rs
@@ -32,9 +32,9 @@ pub(super) fn validate_result_domain_semantics(
     let Some(value) = semantics.get("result_domain") else {
         return Ok(());
     };
-    let object = value
-        .as_object()
-        .ok_or_else(|| format!("{kind} `{id}` semantics.result_domain must be an object"))?;
+    let Some(object) = value.as_object() else {
+        return Ok(());
+    };
     for key in object.keys() {
         if !RESULT_DOMAIN_KEYS.contains(&key.as_str()) {
             return Err(format!(

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_1.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_1.rs
@@ -253,6 +253,30 @@ fn external_fixed_result_domain_contract_rows_stay_data_only() {
 }
 
 #[test]
+fn legacy_string_result_domain_metadata_stays_authorable() {
+    let dir = unique_dir("legacy_string_result_domain");
+    let path = dir.join("pack.json");
+    fs::write(
+        &path,
+        manifest("com.example.legacy-result-domain").replace(
+            r#""operation": "Example",
+        "demand": { "arguments": "eager-left-to-right" }"#,
+            r#""operation": "Example",
+        "result_domain": "NumberOrUnknown",
+        "demand": { "arguments": "eager-left-to-right" }"#,
+        ),
+    )
+    .unwrap();
+
+    let set = SemanticPackSet::new_local(std::slice::from_ref(&path))
+        .expect("legacy string result-domain metadata pack loads");
+    let contracts = set.external_contract_rows();
+    assert_eq!(contracts.len(), 1);
+    assert_eq!(contracts[0].semantics["result_domain"], "NumberOrUnknown");
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn external_rows_report_builtin_id_conflicts_without_rejecting_metadata_only_pack() {
     let dir = unique_dir("external_builtin_row_conflicts");
     let path = dir.join("pack.json");

--- a/docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json
+++ b/docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v0.schema.json",
+  "api_version": "nose.semantic-pack.v0",
+  "pack": {
+    "id": "com.example.java-guava-immutable-collections",
+    "kind": "LibraryPack",
+    "version": "0.1.0",
+    "display_name": "Example Guava immutable collection factories",
+    "description": "R4 dry-run metadata for Guava ImmutableList.of and ImmutableSet.of fixed result-domain authoring. Loading this example is metadata-only.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false,
+    "status": "draft-example"
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/java-guava-immutable-collections",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.15.0 <0.16.0",
+    "schema": "v0",
+    "notes": "Example only. v0 can validate the authoring shape but cannot execute external Guava evidence producers."
+  },
+  "supported_languages": [
+    {
+      "id": "java",
+      "language_version": ">=17",
+      "runtime": "jvm",
+      "runtime_versions": [
+        ">=17"
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "ecosystem": "maven",
+      "name": "com.google.guava:guava",
+      "versions": ">=32.0 <34.0",
+      "stdlib": false
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "nose.protocol.collection",
+      "version": ">=0.1.0 <1.0.0",
+      "required": true
+    }
+  ],
+  "declares": {
+    "evidence_producers": [
+      {
+        "id": "java.guava.import.immutable-collection-factory",
+        "kind": "Import.Binding",
+        "anchors": [
+          "binding",
+          "module"
+        ],
+        "channel": "exact-empirical",
+        "emits": [
+          "Import.Binding",
+          "Symbol.ImportedBinding"
+        ],
+        "requires": [],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "package.name",
+          "module_name",
+          "exported_name",
+          "binding_hash",
+          "source_span"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "Proves an imported Java binding denotes Guava ImmutableList or ImmutableSet, not a local same-named class."
+      },
+      {
+        "id": "java.guava.library-api.immutable-collection-factory",
+        "kind": "LibraryApi.Contract",
+        "anchors": [
+          "node"
+        ],
+        "channel": "exact-empirical",
+        "emits": [
+          "LibraryApi.Contract"
+        ],
+        "requires": [
+          {
+            "ref": "java.guava.import.immutable-collection-factory",
+            "subject": "callee.class",
+            "required": true,
+            "within_scope": "call"
+          }
+        ],
+        "stable_hash_inputs": [
+          "api_version",
+          "pack.id",
+          "producer.id",
+          "language.id",
+          "package.name",
+          "class_name",
+          "method_name",
+          "arity",
+          "call_span",
+          "dependency_ids"
+        ],
+        "conflict_policy": "fail-closed",
+        "notes": "The occurrence proof is for Guava static factories only; java.util.List.of and local ImmutableList classes are hard negatives."
+      }
+    ],
+    "contracts": [
+      {
+        "id": "java.guava.immutable-collection-factory.fixed-result-domain",
+        "surface": {
+          "kind": "static-factory-call",
+          "language": "java",
+          "package": "com.google.guava:guava",
+          "classes": [
+            "com.google.common.collect.ImmutableList",
+            "com.google.common.collect.ImmutableSet"
+          ],
+          "method": "of",
+          "arity": {
+            "min": 0,
+            "max": 12
+          },
+          "receiver": "none"
+        },
+        "requires": [
+          {
+            "ref": "java.guava.library-api.immutable-collection-factory",
+            "subject": "call",
+            "required": true,
+            "same_anchor_as": "call-node"
+          },
+          {
+            "ref": "java.guava.import.immutable-collection-factory",
+            "subject": "callee.class",
+            "required": true,
+            "within_scope": "call"
+          }
+        ],
+        "semantics": {
+          "operation": "Collection.Factory",
+          "result_domain": {
+            "kind": "fixed",
+            "domain": "Collection",
+            "subject": "call",
+            "notes": "ImmutableList.of and ImmutableSet.of return collection-like values; mutability and element type are not claimed."
+          },
+          "demand": {
+            "arguments": "eager-left-to-right",
+            "callbacks": "none"
+          },
+          "effects": [
+            "argument-effects-in-order",
+            "allocates-new-container"
+          ],
+          "exceptions": "java-guava-factory-null-policy-version-sensitive",
+          "mutation": "does-not-mutate-inputs-by-contract",
+          "identity": "no-cross-call-identity-claim"
+        },
+        "channel": "exact-empirical",
+        "proof_status": "covered",
+        "conformance_refs": [
+          "guava-immutable-collection-positive",
+          "guava-immutable-collection-local-shadow-hard-negative",
+          "guava-immutable-collection-wrong-package-hard-negative"
+        ],
+        "known_unsupported": [
+          "copyOf rows need source-domain, iteration, and mutability boundary proof and are intentionally not claimed here.",
+          "Builder chains and collectors need separate materialization and demand contracts.",
+          "Manifest package metadata is not project dependency occurrence proof."
+        ],
+        "notes": "This row demonstrates external authorability of the cycle-2 fixed result-domain vocabulary. It remains metadata-only in v0."
+      }
+    ],
+    "value_laws": []
+  },
+  "conformance": {
+    "positive_fixtures": [
+      {
+        "id": "guava-immutable-collection-positive",
+        "description": "Imported Guava ImmutableList.of and ImmutableSet.of are the intended fixed collection result-domain surface.",
+        "path": "fixtures/java/guava_immutable_collections_positive.java",
+        "expectation": "fixed-result-domain-contract-open"
+      }
+    ],
+    "hard_negatives": [
+      {
+        "id": "guava-immutable-collection-local-shadow-hard-negative",
+        "description": "A local ImmutableList class must not satisfy the Guava package contract.",
+        "path": "fixtures/java/guava_immutable_collections_shadowed.java",
+        "expectation": "exact-contract-closed"
+      },
+      {
+        "id": "guava-immutable-collection-wrong-package-hard-negative",
+        "description": "java.util.List.of is a different package surface and must not satisfy the Guava row.",
+        "path": "fixtures/java/guava_immutable_collections_wrong_package.java",
+        "expectation": "exact-contract-closed"
+      }
+    ],
+    "known_unsupported": [
+      "This example does not prove that the analyzed project depends on Guava.",
+      "This example does not execute an external import or LibraryApi producer.",
+      "This example does not open external exact influence."
+    ],
+    "command": "nose semantic-pack check external-guava-immutable-collections-pack.json --format json",
+    "proofs": [
+      "https://example.invalid/semantic-packs/java-guava-immutable-collections/conformance"
+    ],
+    "executable": [
+      {
+        "id": "guava-immutable-collection-fixed-result-domain.gate",
+        "row_ref": "java.guava.immutable-collection-factory.fixed-result-domain",
+        "oracle": "fixture-expectations",
+        "positive_fixtures": [
+          "guava-immutable-collection-positive"
+        ],
+        "hard_negatives": [
+          "guava-immutable-collection-local-shadow-hard-negative",
+          "guava-immutable-collection-wrong-package-hard-negative"
+        ],
+        "expected_positive": "fixed-result-domain-contract-open",
+        "expected_hard_negative": "exact-contract-closed"
+      }
+    ]
+  }
+}

--- a/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_positive.java
+++ b/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_positive.java
@@ -1,0 +1,12 @@
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+final class GuavaImmutableCollectionsPositive {
+    Object list() {
+        return ImmutableList.of("alpha", "beta");
+    }
+
+    Object set() {
+        return ImmutableSet.of("alpha", "beta");
+    }
+}

--- a/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_shadowed.java
+++ b/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_shadowed.java
@@ -1,0 +1,11 @@
+final class ImmutableList {
+    static Object of(Object value) {
+        return value;
+    }
+}
+
+final class GuavaImmutableCollectionsShadowed {
+    Object value() {
+        return ImmutableList.of("not-guava");
+    }
+}

--- a/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_wrong_package.java
+++ b/docs/examples/semantic-packs/v0/fixtures/java/guava_immutable_collections_wrong_package.java
@@ -1,0 +1,7 @@
+import java.util.List;
+
+final class GuavaImmutableCollectionsWrongPackage {
+    Object value() {
+        return List.of("not", "guava");
+    }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -87,6 +87,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-kernel-capability-minimization](semantic-kernel-capability-minimization.md) — issue #507 primitive census, blocker taxonomy, and accept/reject matrix for deriving minimal kernel capabilities from pack blockers.
 - [semantic-kernel-builtin-expansion-509](semantic-kernel-builtin-expansion-509.md) — issue #509 blocker packet, admitted API result-domain primitive, and builtin expansion record.
 - [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md) — issue #511 R1-R3 cycles: generalized admitted API result-domain materialization, external fixed-domain authoring, and transition assessment.
+- [semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md) — issue #511 R4: external-pack authorability matrix, Guava fixed-domain dry run, and transition-to-R5 assessment.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-expansion-511.md
+++ b/docs/semantic-kernel-expansion-511.md
@@ -238,7 +238,9 @@ The R1-R3 loop has now met the threshold for moving to R4:
 - external influence is still blocked by explicit data-only and
   dependency-backed-evidence gates.
 
-R4 should now focus on external pack authorability and conformance: prove that a
+R4 is recorded separately in
+[semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md).
+It focuses on external pack authorability and conformance: proving that a
 provider can write useful manifests, fixture gates, and unsupported-boundary
 metadata for the capabilities already rehearsed by builtin rows, while exact
 analysis continues to ignore external rows until the later influence gates

--- a/docs/semantic-kernel-external-authorability-511.md
+++ b/docs/semantic-kernel-external-authorability-511.md
@@ -1,0 +1,110 @@
+# Semantic kernel external authorability 511
+
+Status: issue #511 R4 implementation record.
+
+Source artifacts:
+
+- [external_authorability_matrix.v1.json](../bench/semantic_pack/external_authorability_matrix.v1.json)
+- [external-guava-immutable-collections-pack.json](examples/semantic-packs/v0/external-guava-immutable-collections-pack.json)
+- [kernel_capability_matrix.v4.json](../bench/semantic_pack/kernel_capability_matrix.v4.json)
+
+## Goal
+
+R4 tests whether the kernel material proven by the R1-R3 cycles can be authored
+by external pack providers without granting external influence.
+
+The answer is partial but useful:
+
+- fixed call result-domain contracts are authorable as metadata;
+- fixtures, hard negatives, and fixture-expectation gates are authorable;
+- external rows still cannot emit dependency-backed evidence;
+- package metadata still cannot prove project package occurrence;
+- exact influence remains builtin-only until separate runtime, trust, conflict,
+  and rollback gates exist.
+
+## Dry-Run Pack
+
+The dry-run pack is
+[`com.example.java-guava-immutable-collections`](examples/semantic-packs/v0/external-guava-immutable-collections-pack.json).
+It models a realistic Guava slice from the blocker corpus:
+`ImmutableList.of(...)` and `ImmutableSet.of(...)` as fixed `Collection`
+result-domain factory calls.
+
+The manifest declares:
+
+- Maven package metadata for `com.google.guava:guava`;
+- an `Import.Binding` producer for Guava immutable collection classes;
+- a `LibraryApi.Contract` producer for the static factory occurrence;
+- a contract with `semantics.result_domain.kind = fixed` and
+  `domain = Collection`;
+- one positive fixture and two hard negatives;
+- one fixture-expectation executable conformance gate.
+
+This is a provider authoring test. Loading the manifest remains
+`metadata-only`; query, normalize, value-graph, exact, and detection consumers do
+not read the external rows.
+The contract row's fixture-expectation gate passes, but the producer rows still
+report `executable-conformance-unavailable` because v0 does not execute external
+evidence producers.
+
+## Authorability Matrix
+
+The R4 matrix records these decisions:
+
+| capability | external authoring | influence | decision |
+|---|---|---|---|
+| package metadata | authorable | metadata-only | useful for provenance, not occurrence proof |
+| `Import.Binding` producer | authorable metadata-only | blocked | builtin-only execution remains intentional |
+| `LibraryApi.Contract` producer | authorable metadata-only | blocked | external producer runtime is absent |
+| fixed call result domain | authorable metadata-only | blocked | externalizable vocabulary exists |
+| fixture and hard-negative metadata | authorable | metadata-only | provider review evidence exists |
+| fixture-expectation gate | authorable | blocked | clears only executable-conformance blocker |
+| package/version occurrence proof | blocked | blocked | needs lockfile/build-system producers |
+| external exact evidence runtime | blocked | blocked | needs trust, provenance, sandbox, rollback design |
+| HOF demand/materialization | blocked for exact | blocked | deferred to R5 |
+| dtype, tensor shape, vector masks | blocked for exact | blocked | needs future domain producers |
+
+## Builtin-Only Boundaries
+
+Some builtin-only status is intentional:
+
+- compiled Rust producers are currently the only exact evidence runtime;
+- builtin rows own product-output and performance gates;
+- builtin packs own rollback through normal release control;
+- HOF, stream, async, dtype, and materialization semantics remain too risky for
+  generic external exact rows.
+
+Other builtin-only gaps are not intended as permanent policy:
+
+- external packs should be able to author fixed-domain rows, as R4 now proves;
+- package/version occurrence proof should become an explicit evidence substrate;
+- fixture and hard-negative metadata should stay provider-authorable;
+- adoption gates should eventually describe how a proven external row becomes
+  builtin, optional, or disabled.
+
+## Product And Performance Gates
+
+R4 adds an example manifest, fixtures, documentation, and a machine-readable
+matrix. It does not change normal query behavior. The only executable path used
+by the dry-run is `nose semantic-pack check`, which validates manifest structure,
+fixtures, executable gate metadata, and row-level influence preflight.
+
+The authorability matrix records no hot-path change and no external influence
+opening, so the 10% runtime gate does not require a query benchmark in this
+round. Any later PR that lets external rows influence analysis must run the full
+product-output and runtime gates.
+
+## Transition
+
+R4 is complete enough to move #511 to R5:
+
+- an external provider can author a realistic fixed result-domain pack slice;
+- conformance fixtures and hard negatives can be attached to that slice;
+- executable conformance can pass without opening influence;
+- the remaining blockers are now explicit runtime/trust/package-occurrence or
+  high-risk HOF/materialization issues.
+
+R5 should focus on narrow HOF, demand, and materialization boundaries. It should
+not admit broad generic HOF result domains.
+
+Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -243,6 +243,10 @@ then validate the matching metadata-only external authoring surface through
 external rows still do not influence exact analysis. The cycle record and R4
 transition assessment are in
 [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md).
+The R4 authorability pass then uses a Guava fixed-domain dry-run pack to show
+which capabilities are authorable as external metadata, which remain
+intentionally builtin-only, and which blockers move to R5. That record is in
+[semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md).
 
 ### Effects and observations
 

--- a/docs/semantic-pack-candidate-pricing.md
+++ b/docs/semantic-pack-candidate-pricing.md
@@ -59,8 +59,9 @@ records the sample product-query overlay. The `--check-artifacts` form verifies
 that the committed JSON, Markdown, and review log are internally consistent with
 the current tool and corpus digest without requiring a release binary. It also
 validates the issue #509 v2 blocker packet and capability matrix and the issue
-#511 v3/v4 R1-R3 cycle artifacts for count, cross-reference,
-accepted-generalization, transition, and performance-gate consistency.
+#511 v3/v4 R1-R3 cycle artifacts plus the R4 authorability matrix for count,
+cross-reference, accepted-generalization, transition, and performance-gate
+consistency.
 
 The tool emits:
 
@@ -84,6 +85,8 @@ pack influence is opened. Its current artifacts are
 [`kernel_capability_matrix.v3.json`](../bench/semantic_pack/kernel_capability_matrix.v3.json),
 [`blocker_packet.v4.json`](../bench/semantic_pack/blocker_packet.v4.json), and
 [`kernel_capability_matrix.v4.json`](../bench/semantic_pack/kernel_capability_matrix.v4.json).
+The R4 external authorability pass is recorded in
+[`external_authorability_matrix.v1.json`](../bench/semantic_pack/external_authorability_matrix.v1.json).
 
 The current artifact records 20 candidate iterations. It starts from a curated
 seed list instead of attempting automatic API discovery. The scanner uses

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -81,6 +81,11 @@ Its expectation labels distinguish report-visible positives such as
 `semantic-law-provenance-present` from narrower unit-level fixtures such as
 `internal-law-unit-positive`; the harness preserves those labels but does not
 execute them.
+The R4 [Guava immutable collection example](examples/semantic-packs/v0/external-guava-immutable-collections-pack.json)
+uses the same workflow for a fixed result-domain contract. It demonstrates that
+external providers can author `semantics.result_domain`, fixtures, hard
+negatives, and a fixture-expectation gate while the influence preflight still
+blocks exact use of the row.
 
 Builtin packs use a separate inventory command because they are compiled into
 nose and already influence analysis:

--- a/docs/semantic-pack-extension-api-v0.md
+++ b/docs/semantic-pack-extension-api-v0.md
@@ -303,8 +303,10 @@ rather than selected by the caller:
 }
 ```
 
-The local v0 validator accepts only object-shaped fixed result-domain
-declarations. The `domain` must be one of the kernel's known domain vocabulary
+The local v0 validator applies this strict rule only to object-shaped
+`semantics.result_domain` declarations. Older scalar result-domain notes remain
+unstructured metadata; they do not get fixed-domain authoring semantics. For the
+object shape, `domain` must be one of the kernel's known domain vocabulary
 labels, `subject` is optional and currently limited to `call`, and the contract
 must require `LibraryApi.Contract` evidence. This prevents a manifest from
 claiming result-domain facts from a selector string or package presence alone.


### PR DESCRIPTION
Refs #511

## Summary
- add the #511 R4 external authorability matrix and documentation
- add a realistic external Guava fixed result-domain dry-run pack with Java fixtures and a fixture-expectation gate
- keep external influence closed, and fix result_domain validation so legacy scalar metadata remains authorable while object-shaped fixed domains get strict validation

## Validation
- `cargo fmt`
- `python3 -m py_compile bench/semantic_pack/pricing.py`
- `python3 bench/semantic_pack/pricing.py --check-artifacts`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `awiki lint --root docs`
- `cargo test -p nose-semantics result_domain -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --bin nose`
- `./target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json`
- `./target/release/nose query docs/examples/semantic-packs/v0/fixtures/java --semantic-pack docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json --format json`
- `./scripts/check-duplication.sh`