### PR TITLE
Close semantic kernel expansion tracker

### DIFF
--- a/bench/semantic_pack/README.md
+++ b/bench/semantic_pack/README.md
@@ -14,8 +14,9 @@ python3 bench/semantic_pack/pricing.py --nose ./target/release/nose --query-samp
 Use the `--nose ./target/release/nose --query-sample-repos 1` command when
 refreshing the committed JSON/Markdown artifacts. Use `--check-artifacts` to
 verify committed artifacts, the two-reviewer log, the issue #509 v2
-blocker/matrix artifacts, the issue #511 v3/v4 R1-R3 cycle artifacts, and the
-issue #511 R4 external authorability matrix without regenerating them.
+blocker/matrix artifacts, the issue #511 v3/v4 R1-R3 cycle artifacts, the issue
+#511 R4 external authorability matrix, and the issue #511 R5/R6 closeout
+artifacts without regenerating them.
 
 Outputs:
 
@@ -39,6 +40,11 @@ Outputs:
   matrix, metadata-only manifest validation, and transition-to-R4 assessment.
 - `external_authorability_matrix.v1.json` — issue #511 R4 external-pack
   authorability matrix, dry-run pack assessment, and transition-to-R5 decision.
+- `hof_demand_materialization_matrix.v1.json` — issue #511 R5 HOF, demand, and
+  materialization boundary matrix.
+- `kernel_expansion_closeout.v1.json` — issue #511 R6 closeout snapshot for the
+  primitive set, builtin expansion, external authorability, remaining blockers,
+  product-output gate, and runtime gate.
 
 The scanner reports corpus queue signals. It does not prove semantic
 correctness and does not authorize broad ecosystem packs. Only `priced-ready`

--- a/bench/semantic_pack/hof_demand_materialization_matrix.v1.json
+++ b/bench/semantic_pack/hof_demand_materialization_matrix.v1.json
@@ -1,0 +1,262 @@
+{
+  "schema_version": 1,
+  "issue": 511,
+  "phase": "R5",
+  "source_artifacts": [
+    "bench/semantic_pack/blocker_packet.v4.json",
+    "bench/semantic_pack/kernel_capability_matrix.v4.json",
+    "bench/semantic_pack/external_authorability_matrix.v1.json"
+  ],
+  "scope_bar": {
+    "selected_bar": "HOF, demand, and materialization boundary review after external authorability",
+    "new_primitives": 0,
+    "external_influence_opened": false,
+    "broad_generic_hof_result_domains_admitted": false,
+    "accepted_strategy": "compose existing DemandEffectProfile, DomainEvidence, LibraryApi.Contract, and receiver/domain proof instead of adding a broad HOF primitive",
+    "no_new_primitive_reason": "the implemented demand/effect vocabulary already distinguishes eager per-element HOFs, pull-lazy HOFs, async continuations, generators, channels, and protocol boundaries; remaining blockers need producer, receiver, trait, materialization, or lifecycle proof"
+  },
+  "accepted_narrow_lanes": [
+    {
+      "id": "source.python.list_comprehension.eager_hof_profile",
+      "status": "accepted-profile-only",
+      "proof_required": [
+        "SourceComprehensionKind::PythonListComprehension",
+        "HoFKind",
+        "DemandEffectProfile::PerElementHof"
+      ],
+      "influence": "demand/effect classification only",
+      "boundary": "does not emit a fixed collection result-domain claim for arbitrary library HOF calls"
+    },
+    {
+      "id": "library.js_like.array_hof.eager_profile",
+      "status": "accepted-profile-only",
+      "proof_required": [
+        "js-like language family",
+        "admitted library HOF kind",
+        "eager per-element timing"
+      ],
+      "influence": "callback demand/effect profile only",
+      "boundary": "does not admit Lodash, RxJS, or custom map/filter selectors by spelling"
+    },
+    {
+      "id": "library.rust_java.pull_lazy_hof.profile",
+      "status": "accepted-profile-only",
+      "proof_required": [
+        "Rust or Java library HOF timing",
+        "pull-lazy DemandEffectProfile",
+        "delayed callback effects"
+      ],
+      "influence": "lazy callback timing only",
+      "boundary": "does not prove terminal materialization, repeated demand, or one-shot iterator safety"
+    },
+    {
+      "id": "library.promise.then.async_continuation",
+      "status": "accepted-narrow",
+      "proof_required": [
+        "ExactPromiseLike receiver",
+        "Promise.then arity",
+        "AsyncContinuation demand profile",
+        "admitted LibraryApi.Contract occurrence"
+      ],
+      "influence": "fixed PromiseLike result-domain materialization and async demand/effect profile",
+      "boundary": "does not generalize to arbitrary thenables, schedulers, Observables, or callback-side effects"
+    },
+    {
+      "id": "protocol.iterator_identity_adapter.domain_forwarding",
+      "status": "accepted-narrow",
+      "proof_required": [
+        "ExactIterableValue receiver",
+        "admitted iterator identity adapter API occurrence",
+        "supported zero-argument adapter shape"
+      ],
+      "influence": "protocol receiver evidence for narrow iterator adapter rows",
+      "boundary": "does not open external trait methods, caller-selected collection types, or collect_vec materialization"
+    }
+  ],
+  "boundary_rows": [
+    {
+      "id": "generic.hof.fixed_result_domain",
+      "decision": "rejected",
+      "risk": "generic-hof-broadening",
+      "reason": "a HOF-shaped call does not prove result shape, callback timing, or materialization"
+    },
+    {
+      "id": "javascript.array.map.result_domain",
+      "decision": "profile-only",
+      "risk": "callback-effect",
+      "reason": "array HOF timing can be described, but callback purity and exact result value are separate proof obligations"
+    },
+    {
+      "id": "javascript.lodash.map_filter",
+      "decision": "blocked",
+      "risk": "callback-effect",
+      "reason": "import identity, shorthand forms, object receivers, lazy chains, and iteratee semantics are not proven"
+    },
+    {
+      "id": "javascript.rxjs.observable.map_filter",
+      "decision": "blocked",
+      "risk": "lifecycle",
+      "reason": "scheduler, hot/cold stream, subscription, completion, error, and cancellation semantics need a dedicated producer"
+    },
+    {
+      "id": "javascript.promise.then.chain",
+      "decision": "accepted-narrow",
+      "risk": "async-boundary",
+      "reason": "exact PromiseLike receiver plus admitted Promise.then API occurrence supports PromiseLike result-domain chaining"
+    },
+    {
+      "id": "rust.iterator.map_filter",
+      "decision": "profile-only",
+      "risk": "laziness",
+      "reason": "pull-lazy callback timing is known, but terminal consumption and materialized result shape are not implied"
+    },
+    {
+      "id": "rust.itertools.collect_vec",
+      "decision": "blocked",
+      "risk": "materialization",
+      "reason": "trait import identity, caller-selected Vec materialization, allocation boundary, and consumption effects are unproven"
+    },
+    {
+      "id": "rust.iterator.collect_selected_type",
+      "decision": "blocked",
+      "risk": "materialization",
+      "reason": "collect-like result type is caller-selected and cannot be emitted as a fixed result domain"
+    },
+    {
+      "id": "java.stream.map_filter",
+      "decision": "profile-only",
+      "risk": "laziness",
+      "reason": "stream HOFs have pull-lazy timing, but terminal materialization and side effects are separate"
+    },
+    {
+      "id": "java.stream.collect_to_list",
+      "decision": "blocked",
+      "risk": "materialization",
+      "reason": "collector identity, encounter order, mutability, parallel stream behavior, and terminal effects are not proven"
+    },
+    {
+      "id": "python.generator_expression.map_like",
+      "decision": "profile-only",
+      "risk": "laziness",
+      "reason": "generator suspension and delayed effects are known, but materialized output is not implied"
+    },
+    {
+      "id": "python.itertools.chain",
+      "decision": "blocked",
+      "risk": "repeated-demand",
+      "reason": "one-shot iterators, source iteration effects, infinite inputs, and repeated consumption remain unproven"
+    },
+    {
+      "id": "map.get.fixed_value_domain",
+      "decision": "rejected",
+      "risk": "parametric-result",
+      "reason": "map lookup value domain is parametric in key/value evidence, not a fixed call result domain"
+    },
+    {
+      "id": "external.pack.hof_result_domain_authoring",
+      "decision": "rejected",
+      "risk": "external-influence",
+      "reason": "external fixed result-domain metadata must not open exact HOF influence without producer runtime, trust, and hard negatives"
+    }
+  ],
+  "hard_negative_families": [
+    {
+      "risk": "laziness",
+      "examples": [
+        "generator expression with side-effecting callback",
+        "Rust Iterator::map before terminal consumption",
+        "Java Stream.map before terminal operation"
+      ]
+    },
+    {
+      "risk": "callback-effect",
+      "examples": [
+        "Array.map callback mutates captured state",
+        "Lodash iteratee shorthand changes receiver semantics",
+        "filter predicate throws or observes index/order"
+      ]
+    },
+    {
+      "risk": "repeated-demand",
+      "examples": [
+        "one-shot iterator reused after chain",
+        "iterator source with observable next() side effects",
+        "lazy source consumed twice by a proposed rewrite"
+      ]
+    },
+    {
+      "risk": "async-boundary",
+      "examples": [
+        "Promise.then callback timing",
+        "thenable object without exact PromiseLike proof",
+        "future cancellation or wake-order sensitive rewrite"
+      ]
+    },
+    {
+      "risk": "scheduler",
+      "examples": [
+        "RxJS scheduler argument",
+        "hot Observable subscription timing",
+        "Tokio task scheduling or select race"
+      ]
+    },
+    {
+      "risk": "lifecycle",
+      "examples": [
+        "Observable completion/error behavior",
+        "stream cancellation",
+        "generator close/finally side effects"
+      ]
+    },
+    {
+      "risk": "materialization",
+      "examples": [
+        "collect chooses caller result type",
+        "collect_vec allocates a Vec",
+        "Java Collector changes mutability or encounter order"
+      ]
+    }
+  ],
+  "primitive_assessment": {
+    "existing_primitives_are_sufficient_for": [
+      "describing demand/effect timing for already-admitted HOF-like operations",
+      "materializing fixed call result domains for admitted LibraryApi rows",
+      "keeping Promise.then result-domain chaining narrow",
+      "keeping iterator identity adapter rows separate from materialization rows"
+    ],
+    "existing_primitives_are_not_sufficient_for": [
+      "proving package/version occurrence from metadata",
+      "executing external evidence producers",
+      "proving external trait identity and caller-selected materialization",
+      "modeling Observable lifecycle and scheduler semantics",
+      "emitting parametric result domains such as Map.get values"
+    ],
+    "r5_decision": "do not add a primitive in this round; keep broad HOF/materialization rows blocked and use the existing primitives only in narrow admitted lanes"
+  },
+  "product_output_gate": {
+    "classification": "artifact and documentation boundary change only",
+    "expected_drift": "none",
+    "reason": "R5 records admission boundaries and does not change query, normalize, value-graph, exact, or detection consumers"
+  },
+  "performance_gate": {
+    "limit": "no more than 10% median runtime regression",
+    "expected_hot_path_change": "none",
+    "measurement_required": false,
+    "decision": "no runtime measurement required because no semantic analysis hot path changed"
+  },
+  "transition_assessment": {
+    "move_to_r6": true,
+    "criteria_met": [
+      "broad generic HOF result domains remain rejected",
+      "demand/effect vocabulary is confirmed sufficient for current narrow lanes",
+      "materialization, repeated-demand, async, scheduler, and lifecycle blockers are explicit",
+      "external influence remains closed"
+    ],
+    "criteria_not_met": [
+      "external producer runtime is still absent",
+      "trait/materialization producers are still absent",
+      "stream lifecycle and scheduler producers are still absent"
+    ],
+    "next_phase_goal": "R6 closeout snapshot: summarize the minimal primitive set, builtin expansion, external authorability, remaining blockers, validation, and close criteria for issue #511"
+  }
+}

--- a/bench/semantic_pack/kernel_expansion_closeout.v1.json
+++ b/bench/semantic_pack/kernel_expansion_closeout.v1.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": 1,
+  "issue": 511,
+  "phase": "R6",
+  "source_artifacts": [
+    "bench/semantic_pack/blocker_packet.v3.json",
+    "bench/semantic_pack/kernel_capability_matrix.v3.json",
+    "bench/semantic_pack/blocker_packet.v4.json",
+    "bench/semantic_pack/kernel_capability_matrix.v4.json",
+    "bench/semantic_pack/external_authorability_matrix.v1.json",
+    "bench/semantic_pack/hof_demand_materialization_matrix.v1.json"
+  ],
+  "scope_completion": {
+    "r1_r3_cycles_completed": 2,
+    "r4_external_authorability_completed": true,
+    "r5_hof_demand_materialization_completed": true,
+    "r6_closeout_completed": true,
+    "issue_goal_satisfied": true,
+    "close_issue_after_merge": true
+  },
+  "primitive_delta": {
+    "new_primitives_total": 0,
+    "accepted_generalizations": [
+      {
+        "id": "admitted_api_result_domain_materializer",
+        "type": "existing primitive composition",
+        "result": "fixed call result domains now materialize through admitted LibraryApi occurrence evidence across builtin rows"
+      },
+      {
+        "id": "external_fixed_result_domain_authoring_contract",
+        "type": "external authoring surface",
+        "result": "external manifests can declare dependency-backed fixed result-domain metadata while exact influence remains closed"
+      }
+    ],
+    "rejected_broadenings": [
+      "generic HOF fixed result-domain admission",
+      "Map.get fixed value-domain admission",
+      "package metadata as occurrence proof",
+      "external metadata as exact influence"
+    ]
+  },
+  "minimal_capability_set": [
+    {
+      "id": "domain_requirement_composition",
+      "role": "compose exact and narrow-union domain requirements instead of adding one primitive per receiver family"
+    },
+    {
+      "id": "library_api_contract_occurrence",
+      "role": "prove a concrete API occurrence through callee, arity, receiver, import, shadowing, and dependency evidence"
+    },
+    {
+      "id": "admitted_api_result_domain_materializer",
+      "role": "emit fixed call-node DomainEvidence only after the LibraryApi row is admitted for that call"
+    },
+    {
+      "id": "demand_effect_profile",
+      "role": "describe eager, lazy, short-circuit, async, generator, channel, and protocol demand/effect timing for already-admitted operations"
+    },
+    {
+      "id": "external_manifest_metadata_schema",
+      "role": "let providers author fixed result-domain contracts, fixtures, hard negatives, and executable gate metadata without opening influence"
+    },
+    {
+      "id": "conformance_and_preflight_gates",
+      "role": "validate manifests, fixtures, unsupported boundaries, conflicts, and data-only influence blockers before any external exact path exists"
+    }
+  ],
+  "builtin_expansion_summary": {
+    "fixed_result_domain_builtin_rows": [
+      "Python builtin and imported collection factories",
+      "Rust Vec, std collection, std map, and Some rows",
+      "Java collection and map factories and constructors",
+      "Ruby Set.new",
+      "JavaScript/TypeScript Set, Map, Array.from, and Promise.resolve",
+      "existing receiver rows such as map key views, scalar integer methods, Rust Option.and_then, and Promise.then"
+    ],
+    "compression_result": [
+      "receiver-method result-domain emission uses the shared materializer",
+      "Rust Some call result-domain emission uses the shared materializer",
+      "external result-domain validation is isolated in result_domain_semantics.rs",
+      "HOF compatibility and exact fixed-domain emission stay separate"
+    ]
+  },
+  "external_pack_readiness": {
+    "authorable_now": [
+      "package metadata",
+      "Import.Binding producer metadata",
+      "LibraryApi.Contract producer metadata",
+      "fixed call result-domain contract metadata",
+      "fixtures and hard negatives",
+      "fixture-expectation executable gate metadata"
+    ],
+    "still_blocked_for_exact_influence": [
+      "dependency-backed external evidence runtime",
+      "explicit influence trust gate",
+      "package/version occurrence producers",
+      "external recognizer/parser hooks",
+      "rollback and adoption gates for exact influence"
+    ],
+    "dry_run_pack": "docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json"
+  },
+  "remaining_blockers": [
+    {
+      "id": "package_version_occurrence",
+      "status": "blocked",
+      "reason": "manifest package metadata is provenance, not proof that a target project depends on that package/version"
+    },
+    {
+      "id": "external_evidence_runtime",
+      "status": "blocked",
+      "reason": "external rows remain metadata-only until a sandboxed, trusted, dependency-backed producer runtime exists"
+    },
+    {
+      "id": "trait_and_materialization",
+      "status": "blocked",
+      "reason": "collect-like rows need trait/import identity, terminal consumption, result selection, and materialization proof"
+    },
+    {
+      "id": "dtype_tensor_vector_domains",
+      "status": "blocked",
+      "reason": "NumPy, pandas, tensor, and vector mask rows need dtype, shape, index, and broadcasting producers"
+    },
+    {
+      "id": "stream_lifecycle_scheduler",
+      "status": "blocked",
+      "reason": "Observable, async stream, and scheduler rows need lifecycle, cancellation, error, completion, and timing producers"
+    },
+    {
+      "id": "broad_hof_result_domains",
+      "status": "rejected",
+      "reason": "HOF spelling does not imply result shape, callback demand, materialization, or effect safety"
+    }
+  ],
+  "product_output_gate": {
+    "cycle_1_measurement": {
+      "focused_subset_total_delta_percent": -5.08,
+      "classification": "no product-output drift after volatile timing fields were removed"
+    },
+    "later_cycles": {
+      "classification": "metadata, validation, documentation, and artifact changes only",
+      "expected_drift": "none"
+    }
+  },
+  "performance_gate": {
+    "limit": "no more than 10% median runtime regression",
+    "measurements": [
+      {
+        "phase": "R1-R3 cycle 1",
+        "delta_percent": -5.08,
+        "decision": "passes 10% runtime gate"
+      },
+      {
+        "phase": "R1-R3 cycle 2",
+        "measurement_required": false,
+        "decision": "metadata-only manifest validation path; no semantic hot-path change"
+      },
+      {
+        "phase": "R4",
+        "measurement_required": false,
+        "decision": "docs, example manifest, conformance, and artifact validation only"
+      },
+      {
+        "phase": "R5",
+        "measurement_required": false,
+        "decision": "boundary matrix and docs only"
+      }
+    ],
+    "closeout_decision": "passes"
+  },
+  "validation_summary": {
+    "local_required_before_merge": [
+      "python3 -m py_compile bench/semantic_pack/pricing.py",
+      "python3 bench/semantic_pack/pricing.py --check-artifacts",
+      "python3 scripts/check-file-lengths.py --self-test",
+      "python3 scripts/check-file-lengths.py --ratchet-base origin/main",
+      "awiki lint --root docs",
+      "cargo test -p nose-semantics result_domain -- --nocapture",
+      "cargo clippy --workspace --all-targets -- -D warnings",
+      "cargo test --workspace"
+    ],
+    "ci_required_before_close": [
+      "build · test · lint · dup-gate",
+      "docs wiki connectivity (awiki)",
+      "formal obligations · lean proofs",
+      "minimum supported rust version",
+      "test coverage (llvm-cov)",
+      "unused-deps · advisories · licenses"
+    ]
+  },
+  "closeout_decision": {
+    "status": "complete-after-pr-merge",
+    "issue_goal_satisfied": true,
+    "summary": "issue #511 leaves the kernel with a broader fixed-result builtin surface, external fixed-domain authorability, explicit HOF/materialization boundaries, zero new primitives, and remaining blockers recorded as producer/runtime/trust work rather than imagined kernel vocabulary"
+  }
+}

--- a/bench/semantic_pack/pricing.py
+++ b/bench/semantic_pack/pricing.py
@@ -36,6 +36,12 @@ DEFAULT_KERNEL_MATRIX_V4 = ROOT / "bench" / "semantic_pack" / "kernel_capability
 DEFAULT_EXTERNAL_AUTHORABILITY_MATRIX_V1 = (
     ROOT / "bench" / "semantic_pack" / "external_authorability_matrix.v1.json"
 )
+DEFAULT_HOF_DEMAND_MATERIALIZATION_MATRIX_V1 = (
+    ROOT / "bench" / "semantic_pack" / "hof_demand_materialization_matrix.v1.json"
+)
+DEFAULT_KERNEL_EXPANSION_CLOSEOUT_V1 = (
+    ROOT / "bench" / "semantic_pack" / "kernel_expansion_closeout.v1.json"
+)
 
 SCHEMA_VERSION = 1
 TOOL_VERSION = "semantic-pack-pricing/1"
@@ -1608,6 +1614,171 @@ def validate_external_authorability_matrix_v1(matrix: dict) -> None:
         raise SystemExit("external authorability matrix must document no hot-path measurement")
 
 
+def validate_hof_demand_materialization_matrix_v1(matrix: dict) -> None:
+    if matrix.get("schema_version") != 1:
+        raise SystemExit("HOF demand/materialization matrix must use schema_version 1")
+    if matrix.get("issue") != 511:
+        raise SystemExit("HOF demand/materialization matrix must be tied to issue 511")
+    if matrix.get("phase") != "R5":
+        raise SystemExit("HOF demand/materialization matrix must identify phase R5")
+    sources = matrix.get("source_artifacts", [])
+    if "bench/semantic_pack/external_authorability_matrix.v1.json" not in sources:
+        raise SystemExit("HOF demand/materialization matrix must reference the R4 artifact")
+    scope = matrix.get("scope_bar", {})
+    if scope.get("new_primitives") != 0:
+        raise SystemExit("HOF demand/materialization matrix must add zero primitives")
+    if scope.get("external_influence_opened") is not False:
+        raise SystemExit("HOF demand/materialization matrix must keep external influence closed")
+    if scope.get("broad_generic_hof_result_domains_admitted") is not False:
+        raise SystemExit("HOF demand/materialization matrix must reject broad generic HOF domains")
+
+    lanes = matrix.get("accepted_narrow_lanes")
+    if not isinstance(lanes, list) or len(lanes) < 4:
+        raise SystemExit("HOF demand/materialization matrix needs accepted narrow lanes")
+    lane_statuses = {lane.get("status") for lane in lanes if isinstance(lane, dict)}
+    if not {"accepted-narrow", "accepted-profile-only"}.issubset(lane_statuses):
+        raise SystemExit("HOF demand/materialization matrix must cover exact and profile-only lanes")
+    for lane in lanes:
+        lane_id = lane.get("id")
+        if not isinstance(lane_id, str) or not lane_id:
+            raise SystemExit("HOF demand/materialization lane missing id")
+        for key in ["status", "proof_required", "influence", "boundary"]:
+            if not lane.get(key):
+                raise SystemExit(f"{lane_id}: HOF demand/materialization lane missing {key}")
+
+    boundary_rows = matrix.get("boundary_rows")
+    if not isinstance(boundary_rows, list) or len(boundary_rows) < 12:
+        raise SystemExit("HOF demand/materialization matrix needs broad boundary coverage")
+    decisions = set()
+    seen = set()
+    for row in boundary_rows:
+        row_id = row.get("id")
+        if not isinstance(row_id, str) or not row_id:
+            raise SystemExit("HOF demand/materialization boundary row missing id")
+        if row_id in seen:
+            raise SystemExit(f"duplicate HOF demand/materialization boundary row: {row_id}")
+        seen.add(row_id)
+        decision = row.get("decision")
+        if decision not in {"accepted-narrow", "profile-only", "blocked", "rejected"}:
+            raise SystemExit(f"{row_id}: invalid HOF demand/materialization decision {decision}")
+        decisions.add(decision)
+        for key in ["risk", "reason"]:
+            if not row.get(key):
+                raise SystemExit(f"{row_id}: HOF demand/materialization row missing {key}")
+    if not {"accepted-narrow", "profile-only", "blocked", "rejected"}.issubset(decisions):
+        raise SystemExit("HOF demand/materialization matrix must cover all boundary decisions")
+
+    hard_negatives = matrix.get("hard_negative_families")
+    if not isinstance(hard_negatives, list):
+        raise SystemExit("HOF demand/materialization matrix needs hard negative families")
+    risks = {row.get("risk") for row in hard_negatives if isinstance(row, dict)}
+    required_risks = {
+        "laziness",
+        "callback-effect",
+        "repeated-demand",
+        "async-boundary",
+        "scheduler",
+        "lifecycle",
+        "materialization",
+    }
+    if not required_risks.issubset(risks):
+        raise SystemExit("HOF demand/materialization matrix is missing required hard negative risks")
+
+    primitive_assessment = matrix.get("primitive_assessment", {})
+    if not primitive_assessment.get("r5_decision"):
+        raise SystemExit("HOF demand/materialization matrix needs an R5 primitive decision")
+    transition = matrix.get("transition_assessment", {})
+    if transition.get("move_to_r6") is not True:
+        raise SystemExit("HOF demand/materialization matrix must move #511 to R6")
+    performance = matrix.get("performance_gate", {})
+    if performance.get("measurement_required") is not False:
+        raise SystemExit("HOF demand/materialization matrix must document no hot-path measurement")
+
+
+def validate_kernel_expansion_closeout_v1(closeout: dict) -> None:
+    if closeout.get("schema_version") != 1:
+        raise SystemExit("kernel expansion closeout must use schema_version 1")
+    if closeout.get("issue") != 511:
+        raise SystemExit("kernel expansion closeout must be tied to issue 511")
+    if closeout.get("phase") != "R6":
+        raise SystemExit("kernel expansion closeout must identify phase R6")
+    sources = closeout.get("source_artifacts", [])
+    required_sources = {
+        "bench/semantic_pack/kernel_capability_matrix.v3.json",
+        "bench/semantic_pack/kernel_capability_matrix.v4.json",
+        "bench/semantic_pack/external_authorability_matrix.v1.json",
+        "bench/semantic_pack/hof_demand_materialization_matrix.v1.json",
+    }
+    if not required_sources.issubset(set(sources)):
+        raise SystemExit("kernel expansion closeout is missing required source artifacts")
+
+    completion = closeout.get("scope_completion", {})
+    if completion.get("r1_r3_cycles_completed") < 2:
+        raise SystemExit("kernel expansion closeout must cover at least two R1-R3 cycles")
+    for key in [
+        "r4_external_authorability_completed",
+        "r5_hof_demand_materialization_completed",
+        "r6_closeout_completed",
+        "issue_goal_satisfied",
+        "close_issue_after_merge",
+    ]:
+        if completion.get(key) is not True:
+            raise SystemExit(f"kernel expansion closeout must set {key}=true")
+
+    primitive_delta = closeout.get("primitive_delta", {})
+    if primitive_delta.get("new_primitives_total") != 0:
+        raise SystemExit("kernel expansion closeout must record zero new primitives")
+    generalizations = {
+        row.get("id")
+        for row in primitive_delta.get("accepted_generalizations", [])
+        if isinstance(row, dict)
+    }
+    if not {
+        "admitted_api_result_domain_materializer",
+        "external_fixed_result_domain_authoring_contract",
+    }.issubset(generalizations):
+        raise SystemExit("kernel expansion closeout must name the accepted generalizations")
+    if "generic HOF fixed result-domain admission" not in primitive_delta.get(
+        "rejected_broadenings", []
+    ):
+        raise SystemExit("kernel expansion closeout must reject generic HOF broadening")
+
+    minimal = closeout.get("minimal_capability_set")
+    if not isinstance(minimal, list) or len(minimal) < 6:
+        raise SystemExit("kernel expansion closeout needs a minimal capability set")
+    capability_ids = {row.get("id") for row in minimal if isinstance(row, dict)}
+    if "demand_effect_profile" not in capability_ids:
+        raise SystemExit("kernel expansion closeout must include demand/effect profile")
+
+    remaining = closeout.get("remaining_blockers")
+    if not isinstance(remaining, list) or len(remaining) < 5:
+        raise SystemExit("kernel expansion closeout needs remaining blockers")
+    blocker_statuses = {row.get("status") for row in remaining if isinstance(row, dict)}
+    if not {"blocked", "rejected"}.issubset(blocker_statuses):
+        raise SystemExit("kernel expansion closeout must cover blocked and rejected blockers")
+
+    performance = closeout.get("performance_gate", {})
+    if performance.get("closeout_decision") != "passes":
+        raise SystemExit("kernel expansion closeout performance gate must pass")
+    measurements = performance.get("measurements")
+    if not isinstance(measurements, list) or not measurements:
+        raise SystemExit("kernel expansion closeout needs performance measurements")
+    measured = [
+        row
+        for row in measurements
+        if isinstance(row, dict) and isinstance(row.get("delta_percent"), (int, float))
+    ]
+    if not measured:
+        raise SystemExit("kernel expansion closeout needs at least one measured runtime row")
+    for row in measured:
+        if row["delta_percent"] > 10.0:
+            raise SystemExit("kernel expansion closeout runtime delta exceeds 10%")
+
+    decision = closeout.get("closeout_decision", {})
+    if decision.get("issue_goal_satisfied") is not True:
+        raise SystemExit("kernel expansion closeout must mark issue goal satisfied")
+
+
 def check_artifacts(
     corpus_path: Path,
     json_out: Path,
@@ -1620,6 +1791,8 @@ def check_artifacts(
     blocker_packet_v4: Path,
     kernel_matrix_v4: Path,
     external_authorability_matrix_v1: Path,
+    hof_demand_materialization_matrix_v1: Path,
+    kernel_expansion_closeout_v1: Path,
 ) -> None:
     report = json.loads(json_out.read_text(encoding="utf-8"))
     validate_report(report)
@@ -1648,6 +1821,10 @@ def check_artifacts(
     validate_kernel_matrix_v4(matrix_v4, probe_ids_v4)
     authorability_v1 = json.loads(external_authorability_matrix_v1.read_text(encoding="utf-8"))
     validate_external_authorability_matrix_v1(authorability_v1)
+    hof_demand_v1 = json.loads(hof_demand_materialization_matrix_v1.read_text(encoding="utf-8"))
+    validate_hof_demand_materialization_matrix_v1(hof_demand_v1)
+    closeout_v1 = json.loads(kernel_expansion_closeout_v1.read_text(encoding="utf-8"))
+    validate_kernel_expansion_closeout_v1(closeout_v1)
     print("semantic-pack pricing artifact check passed")
 
 
@@ -1714,6 +1891,16 @@ def main() -> int:
         default=DEFAULT_EXTERNAL_AUTHORABILITY_MATRIX_V1,
     )
     parser.add_argument(
+        "--hof-demand-materialization-matrix-v1",
+        type=Path,
+        default=DEFAULT_HOF_DEMAND_MATERIALIZATION_MATRIX_V1,
+    )
+    parser.add_argument(
+        "--kernel-expansion-closeout-v1",
+        type=Path,
+        default=DEFAULT_KERNEL_EXPANSION_CLOSEOUT_V1,
+    )
+    parser.add_argument(
         "--nose",
         type=Path,
         default=None,
@@ -1746,6 +1933,8 @@ def main() -> int:
             args.blocker_packet_v4,
             args.kernel_matrix_v4,
             args.external_authorability_matrix_v1,
+            args.hof_demand_materialization_matrix_v1,
+            args.kernel_expansion_closeout_v1,
         )
         return 0
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -88,6 +88,8 @@ fundamentals; the rest is grouped by area.
 - [semantic-kernel-builtin-expansion-509](semantic-kernel-builtin-expansion-509.md) — issue #509 blocker packet, admitted API result-domain primitive, and builtin expansion record.
 - [semantic-kernel-expansion-511](semantic-kernel-expansion-511.md) — issue #511 R1-R3 cycles: generalized admitted API result-domain materialization, external fixed-domain authoring, and transition assessment.
 - [semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md) — issue #511 R4: external-pack authorability matrix, Guava fixed-domain dry run, and transition-to-R5 assessment.
+- [semantic-kernel-hof-demand-511](semantic-kernel-hof-demand-511.md) — issue #511 R5: HOF, demand, and materialization boundary matrix.
+- [semantic-kernel-expansion-closeout-511](semantic-kernel-expansion-closeout-511.md) — issue #511 R6 closeout: minimal capability set, builtin expansion, external authorability, remaining blockers, and validation gates.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-expansion-511.md
+++ b/docs/semantic-kernel-expansion-511.md
@@ -6,6 +6,8 @@ Source artifacts:
 
 - [blocker_packet.v4.json](../bench/semantic_pack/blocker_packet.v4.json)
 - [kernel_capability_matrix.v4.json](../bench/semantic_pack/kernel_capability_matrix.v4.json)
+- [hof_demand_materialization_matrix.v1.json](../bench/semantic_pack/hof_demand_materialization_matrix.v1.json)
+- [kernel_expansion_closeout.v1.json](../bench/semantic_pack/kernel_expansion_closeout.v1.json)
 - [blocker_packet.v3.json](../bench/semantic_pack/blocker_packet.v3.json)
 - [kernel_capability_matrix.v3.json](../bench/semantic_pack/kernel_capability_matrix.v3.json)
 - [blocker_packet.v2.json](../bench/semantic_pack/blocker_packet.v2.json)
@@ -245,5 +247,11 @@ provider can write useful manifests, fixture gates, and unsupported-boundary
 metadata for the capabilities already rehearsed by builtin rows, while exact
 analysis continues to ignore external rows until the later influence gates
 exist.
+
+R5 and R6 are recorded in
+[semantic-kernel-hof-demand-511](semantic-kernel-hof-demand-511.md) and
+[semantic-kernel-expansion-closeout-511](semantic-kernel-expansion-closeout-511.md).
+They keep broad HOF/materialization influence closed, record the minimal
+capability set, and close the issue after the final validation PR.
 
 Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel-expansion-closeout-511.md
+++ b/docs/semantic-kernel-expansion-closeout-511.md
@@ -1,0 +1,117 @@
+# Semantic kernel expansion closeout 511
+
+Status: issue #511 R6 closeout record.
+
+Source artifacts:
+
+- [kernel_expansion_closeout.v1.json](../bench/semantic_pack/kernel_expansion_closeout.v1.json)
+- [hof_demand_materialization_matrix.v1.json](../bench/semantic_pack/hof_demand_materialization_matrix.v1.json)
+- [external_authorability_matrix.v1.json](../bench/semantic_pack/external_authorability_matrix.v1.json)
+- [kernel_capability_matrix.v4.json](../bench/semantic_pack/kernel_capability_matrix.v4.json)
+- [kernel_capability_matrix.v3.json](../bench/semantic_pack/kernel_capability_matrix.v3.json)
+
+## Goal
+
+Issue #511 was created to keep improving the semantic kernel before widening
+semantic packs. The target was not to add imagined mechanisms. The target was to
+put enough real material into the kernel so meaningful external packs can be
+authored later, while keeping the exact channel fail-closed.
+
+The issue is complete when the R6 PR merges.
+
+## Completed Work
+
+The issue completed two R1-R3 cycles, R4, R5, and this R6 closeout.
+
+| phase | result |
+|---|---|
+| R1-R3 cycle 1 | generalized admitted API fixed result-domain materialization across builtin rows |
+| R1-R3 cycle 2 | added strict external fixed result-domain authoring validation while keeping influence metadata-only |
+| R4 | proved a realistic Guava fixed-domain external dry-run pack is authorable |
+| R5 | fixed HOF, demand, and materialization boundaries without adding a broad primitive |
+| R6 | records the minimal capability set, remaining blockers, and validation gates |
+
+No new kernel primitive was added. The work generalizes existing primitive
+composition.
+
+## Minimal Capability Set
+
+The closeout artifact records the current minimal set:
+
+- domain requirement composition;
+- admitted `LibraryApi.Contract` occurrence evidence;
+- admitted API result-domain materialization;
+- demand/effect profiles for already-admitted operations;
+- external manifest metadata schema;
+- conformance and preflight gates.
+
+This is enough to support a wider builtin fixed-result surface and metadata-only
+external authoring. It is not enough to open arbitrary external exact influence.
+
+## Builtin Expansion
+
+The shared fixed-result materializer now covers rows such as:
+
+- Python builtin and imported collection factories;
+- Rust `Vec`, std collection, std map, and `Some` rows;
+- Java collection and map factories and constructors;
+- Ruby `Set.new`;
+- JavaScript/TypeScript `Set`, `Map`, `Array.from`, and `Promise.resolve`;
+- existing receiver rows such as map key views, scalar integer methods, Rust
+  `Option.and_then`, and `Promise.then`.
+
+The compression matters: receiver-method result domains and Rust `Some` now use
+the same shared materializer, while HOF compatibility remains separate from
+exact fixed-domain evidence emission.
+
+## External Pack Readiness
+
+External providers can now author:
+
+- package metadata;
+- evidence producer metadata;
+- `LibraryApi.Contract` producer metadata;
+- fixed call result-domain contract metadata;
+- fixtures and hard negatives;
+- fixture-expectation gate metadata.
+
+External rows still cannot influence exact analysis. That remains blocked until
+dependency-backed producer runtime, explicit trust, package/version occurrence,
+recognizer/parser hooks, and rollback/adoption gates exist.
+
+## Remaining Blockers
+
+The remaining blockers are evidence and runtime problems, not missing imagined
+vocabulary:
+
+- package/version occurrence proof;
+- external evidence producer runtime;
+- trait identity and materialization proof;
+- dtype, tensor, vector mask, shape, and broadcasting domains;
+- stream lifecycle and scheduler proof;
+- broad HOF result-domain claims, which remain rejected.
+
+## Product And Performance Gates
+
+Cycle 1 ran a focused product-output and runtime comparison. Product output was
+unchanged after volatile timing fields were ignored, and the warmed subset median
+runtime improved by 5.08%.
+
+Later phases are metadata, validation, documentation, and artifact changes only.
+They do not change semantic hot paths.
+
+The issue-level runtime gate therefore passes the "no more than 10% median
+regression" rule.
+
+## Closeout
+
+The #511 goal is satisfied after the R6 PR merges:
+
+- the kernel has broader builtin fixed-result coverage;
+- external fixed-domain authoring is real and validated;
+- broad HOF/materialization influence remains closed;
+- no new primitive was added;
+- remaining blockers are explicitly recorded as producer, runtime, trust, or
+  domain-model work.
+
+Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel-external-authorability-511.md
+++ b/docs/semantic-kernel-external-authorability-511.md
@@ -105,6 +105,9 @@ R4 is complete enough to move #511 to R5:
   high-risk HOF/materialization issues.
 
 R5 should focus on narrow HOF, demand, and materialization boundaries. It should
-not admit broad generic HOF result domains.
+not admit broad generic HOF result domains. The R5 result is recorded in
+[semantic-kernel-hof-demand-511](semantic-kernel-hof-demand-511.md), and the
+issue closeout is recorded in
+[semantic-kernel-expansion-closeout-511](semantic-kernel-expansion-closeout-511.md).
 
 Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel-hof-demand-511.md
+++ b/docs/semantic-kernel-hof-demand-511.md
@@ -1,0 +1,89 @@
+# Semantic kernel HOF demand 511
+
+Status: issue #511 R5 implementation record.
+
+Source artifacts:
+
+- [hof_demand_materialization_matrix.v1.json](../bench/semantic_pack/hof_demand_materialization_matrix.v1.json)
+- [external_authorability_matrix.v1.json](../bench/semantic_pack/external_authorability_matrix.v1.json)
+- [kernel_capability_matrix.v4.json](../bench/semantic_pack/kernel_capability_matrix.v4.json)
+
+## Goal
+
+R5 reviews the high-risk boundary left after R4: higher-order functions,
+demand/effect timing, and materialization.
+
+The result is intentionally conservative. The kernel already has enough
+vocabulary to describe narrow admitted lanes, so R5 does not add a new
+primitive. It keeps broad HOF result-domain claims closed.
+
+## Accepted Lanes
+
+The accepted lanes are narrow:
+
+| lane | status | boundary |
+|---|---|---|
+| Python list comprehension HOF demand | profile-only | describes eager callback demand, not arbitrary library result shape |
+| JS-like array HOF demand | profile-only | describes timing, not Lodash, RxJS, or callback purity |
+| Rust/Java pull-lazy HOF demand | profile-only | describes delayed callback effects, not terminal materialization |
+| `Promise.then` | accepted narrow | requires exact `PromiseLike` receiver and admitted API occurrence |
+| iterator identity adapters | accepted narrow | requires exact iterable receiver and supported zero-argument adapter shape |
+
+These lanes reuse existing `DemandEffectProfile`, `DomainEvidence`, and
+`LibraryApi.Contract` evidence. They do not create a generic HOF result-domain
+rule.
+
+## Closed Boundaries
+
+The matrix keeps these shapes blocked or rejected:
+
+- generic HOF fixed result domains;
+- Lodash and RxJS collection operators;
+- Rust `itertools::collect_vec`;
+- caller-selected `collect` materialization;
+- Java Stream terminal collectors;
+- Python `itertools.chain` and one-shot iterator reuse;
+- `Map.get` fixed value-domain claims;
+- external HOF result-domain influence through metadata.
+
+The hard negatives are grouped by laziness, callback effects, repeated demand,
+async boundaries, scheduler behavior, lifecycle behavior, and materialization.
+
+## Primitive Decision
+
+R5 adds zero primitives.
+
+The important distinction is this:
+
+- `DemandEffectProfile` can describe timing once an operation is already
+  admitted.
+- It cannot prove that a raw selector is a safe API occurrence.
+- It cannot prove terminal materialization.
+- It cannot prove external trait identity, stream lifecycle, scheduler behavior,
+  or parametric result domains.
+
+Those remaining blockers need producers, runtime, or trust gates. Adding another
+kernel primitive would hide the missing evidence instead of solving it.
+
+## Product And Performance Gates
+
+R5 changes artifacts and documentation only. It does not alter query,
+normalization, value-graph, exact, or detection consumers, so no product-output
+drift is expected.
+
+The R5 matrix records no semantic hot-path change, so the 10% runtime gate does
+not require a new benchmark in this round.
+
+## Transition
+
+R5 is complete enough to move to R6:
+
+- broad generic HOF result domains remain rejected;
+- narrow existing lanes are documented;
+- materialization and lifecycle blockers are explicit;
+- external influence remains closed.
+
+R6 closes #511 by recording the final primitive set, builtin expansion,
+external-pack readiness, remaining blockers, and validation requirements.
+
+Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -247,6 +247,12 @@ The R4 authorability pass then uses a Guava fixed-domain dry-run pack to show
 which capabilities are authorable as external metadata, which remain
 intentionally builtin-only, and which blockers move to R5. That record is in
 [semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md).
+R5 then keeps broad HOF result domains closed and records the narrow admitted
+demand/materialization lanes in
+[semantic-kernel-hof-demand-511](semantic-kernel-hof-demand-511.md). The #511 R6
+closeout records the minimal capability set, builtin expansion, external
+authorability, remaining blockers, and validation gates in
+[semantic-kernel-expansion-closeout-511](semantic-kernel-expansion-closeout-511.md).
 
 ### Effects and observations
 

--- a/docs/semantic-pack-candidate-pricing.md
+++ b/docs/semantic-pack-candidate-pricing.md
@@ -59,7 +59,8 @@ records the sample product-query overlay. The `--check-artifacts` form verifies
 that the committed JSON, Markdown, and review log are internally consistent with
 the current tool and corpus digest without requiring a release binary. It also
 validates the issue #509 v2 blocker packet and capability matrix and the issue
-#511 v3/v4 R1-R3 cycle artifacts plus the R4 authorability matrix for count,
+#511 v3/v4 R1-R3 cycle artifacts, R4 authorability matrix, R5
+HOF/demand/materialization matrix, and R6 closeout snapshot for count,
 cross-reference, accepted-generalization, transition, and performance-gate
 consistency.
 
@@ -87,6 +88,10 @@ pack influence is opened. Its current artifacts are
 [`kernel_capability_matrix.v4.json`](../bench/semantic_pack/kernel_capability_matrix.v4.json).
 The R4 external authorability pass is recorded in
 [`external_authorability_matrix.v1.json`](../bench/semantic_pack/external_authorability_matrix.v1.json).
+The R5/R6 closeout artifacts are
+[`hof_demand_materialization_matrix.v1.json`](../bench/semantic_pack/hof_demand_materialization_matrix.v1.json)
+and
+[`kernel_expansion_closeout.v1.json`](../bench/semantic_pack/kernel_expansion_closeout.v1.json).
 
 The current artifact records 20 candidate iterations. It starts from a curated
 seed list instead of attempting automatic API discovery. The scanner uses


### PR DESCRIPTION
## Summary

Closes #511.

This finishes R5 and R6 for the semantic kernel expansion tracker:

- adds `hof_demand_materialization_matrix.v1.json` for the R5 HOF/demand/materialization boundary review;
- adds `kernel_expansion_closeout.v1.json` for the R6 closeout snapshot;
- extends `bench/semantic_pack/pricing.py --check-artifacts` so CI validates both new artifacts;
- adds docs for R5 and R6 and wires them into the semantic-kernel wiki graph.

The R5 decision is conservative: no broad generic HOF result-domain primitive is admitted. Existing `DemandEffectProfile`, `DomainEvidence`, and `LibraryApi.Contract` composition is enough for narrow admitted/profile-only lanes; collect-like materialization, stream lifecycle, scheduler, repeated-demand, and external influence remain blocked or rejected.

## Validation

- `python3 -m py_compile bench/semantic_pack/pricing.py`
- `python3 bench/semantic_pack/pricing.py --check-artifacts`
- `jq empty bench/semantic_pack/hof_demand_materialization_matrix.v1.json bench/semantic_pack/kernel_expansion_closeout.v1.json`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `awiki lint --root docs`
- `cargo fmt --check`
- `cargo test -p nose-semantics result_domain -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --release --bin nose`
- `./scripts/check-duplication.sh`
