### PR TITLE
Add Swift Sequence HOF capability

### DIFF
--- a/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
@@ -311,13 +311,13 @@ pub(super) fn assert_group(json: &serde_json::Value) {
     assert_eq!(sequence_hof_adapter["license"], "MIT");
     assert_eq!(
         json_array_strings(sequence_hof_adapter, "supported_languages"),
-        vec!["rust"]
+        vec!["rust", "swift"]
     );
     assert_eq!(sequence_hof_adapter["counts"]["evidence_producers"], 1);
     assert_eq!(sequence_hof_adapter["counts"]["contracts"], 1);
     assert_eq!(sequence_hof_adapter["counts"]["value_laws"], 0);
-    assert_eq!(sequence_hof_adapter["counts"]["positive_fixtures"], 7);
-    assert_eq!(sequence_hof_adapter["counts"]["hard_negatives"], 7);
+    assert_eq!(sequence_hof_adapter["counts"]["positive_fixtures"], 10);
+    assert_eq!(sequence_hof_adapter["counts"]["hard_negatives"], 14);
 
     let go_namespace_call = semantic_pack_by_id(&json, "nose.go.stdlib.namespace_calls");
     assert_eq!(go_namespace_call["hash"], "d3dfae6db995411b");

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
@@ -10,9 +10,9 @@ fn semantic_pack_inventory_json_reports_builtin_coverage() {
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["packs"], 48);
     assert_eq!(json["totals"]["builtin_packs"], 48);
-    assert_eq!(json["totals"]["positive_fixtures"], 169);
-    assert_eq!(json["totals"]["hard_negatives"], 124);
-    assert_eq!(json["totals"]["conformance_refs"], 293);
+    assert_eq!(json["totals"]["positive_fixtures"], 172);
+    assert_eq!(json["totals"]["hard_negatives"], 131);
+    assert_eq!(json["totals"]["conformance_refs"], 303);
     assert_eq!(json["totals"]["packs_needing_coverage"], 0);
     assert_eq!(
         json["evidence_policy"]["product_output"],
@@ -95,7 +95,10 @@ fn assert_sequence_hof_adapter_pack(packs: &[serde_json::Value]) {
             "rust-iterator-hof-flat-map-positive",
             "rust-iterator-hof-any-terminal-positive",
             "rust-iterator-hof-all-terminal-positive",
-            "rust-iterator-hof-count-terminal-positive"
+            "rust-iterator-hof-count-terminal-positive",
+            "swift-sequence-hof-map-positive",
+            "swift-sequence-hof-filter-positive",
+            "swift-sequence-hof-flat-map-positive"
         ]
     );
     assert_eq!(
@@ -107,12 +110,22 @@ fn assert_sequence_hof_adapter_pack(packs: &[serde_json::Value]) {
             "rust-iterator-hof-missing-terminal-proof-hard-negative",
             "rust-iterator-hof-one-shot-reuse-hard-negative",
             "rust-iterator-hof-collect-vec-hard-negative",
-            "rust-iterator-hof-find-unsupported-hard-negative"
+            "rust-iterator-hof-find-unsupported-hard-negative",
+            "swift-sequence-hof-set-order-hard-negative",
+            "swift-sequence-hof-dictionary-order-hard-negative",
+            "swift-sequence-hof-lazy-hard-negative",
+            "swift-sequence-hof-throwing-closure-hard-negative",
+            "swift-sequence-hof-mutating-closure-hard-negative",
+            "swift-sequence-hof-any-sequence-reuse-hard-negative",
+            "swift-sequence-hof-compact-map-unsupported-hard-negative"
         ]
     );
     assert_eq!(
         json_array_strings(&sequence_hof["conformance"], "unsupported_refs"),
-        vec!["rust-iterator-hof-find-unsupported-hard-negative"]
+        vec![
+            "rust-iterator-hof-find-unsupported-hard-negative",
+            "swift-sequence-hof-compact-map-unsupported-hard-negative"
+        ]
     );
 }
 

--- a/crates/nose-normalize/src/idioms/receiver_evidence.rs
+++ b/crates/nose-normalize/src/idioms/receiver_evidence.rs
@@ -9,6 +9,36 @@ pub(super) fn exact_collection_receiver(
     exact_protocol_receiver(old, interner, domains, node)
 }
 
+pub(super) fn exact_array_or_collection_receiver(
+    old: &Il,
+    interner: &Interner,
+    domains: &ReceiverDomainEvidenceIndex<'_>,
+    node: NodeId,
+) -> bool {
+    if exact_collection_literal(old, interner, node)
+        || domains.receiver_satisfies_domain(node, DomainRequirement::ARRAY_OR_COLLECTION)
+    {
+        return true;
+    }
+    if old.kind(node) != NodeKind::Call {
+        return false;
+    }
+    let Some(admitted) = admitted_library_method_call_at_call(old, interner, node) else {
+        return false;
+    };
+    if !matches!(
+        admitted.contract.result.semantic,
+        MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+    ) || admitted.contract.result.receiver != MethodReceiverContract::ExactArrayOrCollection
+    {
+        return false;
+    }
+    let Some(receiver) = admitted.receiver else {
+        return false;
+    };
+    exact_array_or_collection_receiver(old, interner, domains, receiver)
+}
+
 pub(super) fn exact_array_receiver(
     old: &Il,
     interner: &Interner,

--- a/crates/nose-normalize/src/idioms/receivers.rs
+++ b/crates/nose-normalize/src/idioms/receivers.rs
@@ -17,6 +17,10 @@ pub(super) fn prove_method_receiver(
     match contract {
         MethodReceiverContract::ExactArray => exact_array_receiver(old, interner, domains, base)
             .then_some(ProvenReceiver::Direct(base)),
+        MethodReceiverContract::ExactArrayOrCollection => {
+            exact_array_or_collection_receiver(old, interner, domains, base)
+                .then_some(ProvenReceiver::Direct(base))
+        }
         MethodReceiverContract::ExactCollection => {
             exact_collection_receiver(old, interner, domains, base)
                 .then_some(ProvenReceiver::Direct(base))

--- a/crates/nose-normalize/src/idioms/tests/contracts.rs
+++ b/crates/nose-normalize/src/idioms/tests/contracts.rs
@@ -97,6 +97,36 @@ fn method_hof_allows_literal_array_receiver() {
 }
 
 #[test]
+fn swift_method_hof_requires_ordered_collection_receiver() {
+    let (collection, collection_interner, collection_call) =
+        typed_method_call_il(Lang::Swift, "map", ParamSemantic::Collection, false);
+    assert!(matches!(
+        canon_call(&collection, &collection_interner, collection_call),
+        CallCanon::HoF {
+            kind: HoFKind::Map,
+            ..
+        }
+    ));
+
+    let (set, set_interner, set_call) =
+        typed_method_call_il(Lang::Swift, "map", ParamSemantic::Set, false);
+    assert!(
+        matches!(canon_call(&set, &set_interner, set_call), CallCanon::None),
+        "Swift Set.map stays closed until order semantics are explicit"
+    );
+
+    let (sequence, sequence_interner, sequence_call) =
+        typed_method_call_il(Lang::Swift, "map", ParamSemantic::Iterable, false);
+    assert!(
+        matches!(
+            canon_call(&sequence, &sequence_interner, sequence_call),
+            CallCanon::None
+        ),
+        "Swift Sequence/AnySequence stays closed until one-shot reuse is represented"
+    );
+}
+
+#[test]
 fn go_strings_contains_is_substring_not_slice_membership() {
     let (mut strings_il, strings_interner, strings_call, strings_receiver) =
         go_namespace_contains_call("strings");

--- a/crates/nose-normalize/src/value_graph/tests/support/library_api/library_api_push.rs
+++ b/crates/nose-normalize/src/value_graph/tests/support/library_api/library_api_push.rs
@@ -34,7 +34,7 @@ pub(crate) fn push_method_call_library_api_evidence(
             Some(stable_symbol_hash(RECEIVER_MEMBERSHIP_PROTOCOL_PACK_ID));
         record.provenance.rule_hash =
             Some(stable_symbol_hash(RECEIVER_MEMBERSHIP_PROTOCOL_PRODUCER_ID));
-    } else if is_rust_sequence_hof_method_call(il.meta.lang, contract.id, contract.callee) {
+    } else if is_sequence_hof_method_call(il.meta.lang, contract.id, contract.callee) {
         record.provenance.pack_hash =
             Some(stable_symbol_hash(SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID));
         record.provenance.rule_hash = Some(stable_symbol_hash(
@@ -77,13 +77,13 @@ fn is_map_get_default_method_call(contract: LibraryMethodCallContract) -> bool {
         )
 }
 
-fn is_rust_sequence_hof_method_call(
+fn is_sequence_hof_method_call(
     lang: Lang,
     contract_id: LibraryApiContractId,
     callee: LibraryApiCalleeContract,
 ) -> bool {
-    lang == Lang::Rust
-        && matches!(
+    match lang {
+        Lang::Rust => matches!(
             (contract_id, callee),
             (
                 LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
@@ -108,7 +108,21 @@ fn is_rust_sequence_hof_method_call(
                     receiver: MethodReceiverContract::ExactProtocol,
                 },
             )
-        )
+        ),
+        Lang::Swift => matches!(
+            (contract_id, callee),
+            (
+                LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
+                    HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
+                )),
+                LibraryApiCalleeContract::Method {
+                    method: "map" | "filter" | "flatMap",
+                    receiver: MethodReceiverContract::ExactArrayOrCollection,
+                },
+            )
+        ),
+        _ => false,
+    }
 }
 
 pub(crate) fn push_library_api_evidence_for_callee(
@@ -174,7 +188,7 @@ pub(crate) fn push_library_api_evidence_for_callee(
             arity,
             dependencies,
         )
-    } else if is_rust_sequence_hof_method_call(il.meta.lang, contract_id, callee) {
+    } else if is_sequence_hof_method_call(il.meta.lang, contract_id, callee) {
         rust_sequence_hof_adapter_evidence(
             id,
             il.node(call).span,

--- a/crates/nose-semantics/src/library_api/admission/iterator_sources.rs
+++ b/crates/nose-semantics/src/library_api/admission/iterator_sources.rs
@@ -7,8 +7,8 @@ pub(in crate::library_api) fn library_api_contract_obligations_match_call(
     id: LibraryApiContractId,
     record: &EvidenceRecord,
 ) -> bool {
-    if js_like_array_hof_callback_obligation_required(il.meta.lang, id) {
-        return js_like_array_hof_callback_obligation_matches_node(il, interner, call);
+    if method_hof_callback_obligation_required(il.meta.lang, id) {
+        return method_hof_callback_obligation_matches_node(il, interner, call);
     }
 
     let source_args = match (il.meta.lang, id) {
@@ -45,8 +45,8 @@ pub(in crate::library_api) fn library_api_contract_obligations_match_node(
     node: NodeId,
     id: LibraryApiContractId,
 ) -> bool {
-    if js_like_array_hof_callback_obligation_required(il.meta.lang, id) {
-        return js_like_array_hof_callback_obligation_matches_node(il, interner, node);
+    if method_hof_callback_obligation_required(il.meta.lang, id) {
+        return method_hof_callback_obligation_matches_node(il, interner, node);
     }
     true
 }
@@ -56,7 +56,7 @@ pub(in crate::library_api) fn library_api_contract_requires_call_obligations(
     id: LibraryApiContractId,
 ) -> bool {
     iterable_source_obligation_required(lang, id)
-        || js_like_array_hof_callback_obligation_required(lang, id)
+        || method_hof_callback_obligation_required(lang, id)
 }
 
 fn iterable_source_obligation_required(lang: Lang, id: LibraryApiContractId) -> bool {
@@ -72,18 +72,20 @@ fn iterable_source_obligation_required(lang: Lang, id: LibraryApiContractId) -> 
     )
 }
 
-fn js_like_array_hof_callback_obligation_required(lang: Lang, id: LibraryApiContractId) -> bool {
-    js_like_lang(lang)
-        && matches!(
-            id,
-            LibraryApiContractId::MethodCall(
-                MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
-                    | MethodSemanticContract::Builtin(Builtin::Any | Builtin::All),
-            )
-        )
+fn method_hof_callback_obligation_required(lang: Lang, id: LibraryApiContractId) -> bool {
+    match id {
+        LibraryApiContractId::MethodCall(
+            MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+            | MethodSemanticContract::Builtin(Builtin::Any | Builtin::All),
+        ) if js_like_lang(lang) => true,
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
+            HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
+        )) if lang == Lang::Swift => true,
+        _ => false,
+    }
 }
 
-fn js_like_array_hof_callback_obligation_matches_node(
+fn method_hof_callback_obligation_matches_node(
     il: &Il,
     interner: Option<&Interner>,
     node: NodeId,
@@ -91,10 +93,10 @@ fn js_like_array_hof_callback_obligation_matches_node(
     let Some(&callback) = il.children(node).get(1) else {
         return false;
     };
-    js_like_array_hof_callback_effect_closed(il, interner, callback)
+    method_hof_callback_effect_closed(il, interner, callback)
 }
 
-fn js_like_array_hof_callback_effect_closed(
+fn method_hof_callback_effect_closed(
     il: &Il,
     interner: Option<&Interner>,
     callback: NodeId,
@@ -105,7 +107,7 @@ fn js_like_array_hof_callback_effect_closed(
     let mut stack = vec![callback];
     while let Some(node) = stack.pop() {
         if il.kind(node) == NodeKind::Call {
-            if !js_like_array_hof_callback_nested_call_effect_closed(il, interner, node) {
+            if !method_hof_callback_nested_call_effect_closed(il, interner, node) {
                 return false;
             }
             continue;
@@ -116,7 +118,7 @@ fn js_like_array_hof_callback_effect_closed(
             }
             continue;
         }
-        if !js_like_array_hof_callback_node_effect_closed(il.kind(node)) {
+        if !method_hof_callback_node_effect_closed(il.kind(node)) {
             return false;
         }
         stack.extend(il.children(node).iter().copied());
@@ -124,7 +126,7 @@ fn js_like_array_hof_callback_effect_closed(
     true
 }
 
-fn js_like_array_hof_callback_node_effect_closed(kind: NodeKind) -> bool {
+fn method_hof_callback_node_effect_closed(kind: NodeKind) -> bool {
     matches!(
         kind,
         NodeKind::Func
@@ -141,7 +143,7 @@ fn js_like_array_hof_callback_node_effect_closed(kind: NodeKind) -> bool {
     )
 }
 
-fn js_like_array_hof_callback_nested_call_effect_closed(
+fn method_hof_callback_nested_call_effect_closed(
     il: &Il,
     interner: Option<&Interner>,
     call: NodeId,
@@ -161,7 +163,7 @@ fn js_like_array_hof_callback_nested_call_effect_closed(
     let arg_count = il.children(call).len().saturating_sub(1);
     library_method_call_contracts(il.meta.lang, interner.resolve(method), arg_count)
         .into_iter()
-        .filter(|contract| js_like_array_hof_method_call(il.meta.lang, contract.result))
+        .filter(|contract| method_hof_callback_nested_method_call(il.meta.lang, contract.result))
         .any(|contract| {
             matches!(
                 library_api_contract_evidence_for_call(
@@ -175,6 +177,10 @@ fn js_like_array_hof_callback_nested_call_effect_closed(
                 LibraryApiEvidenceStatus::Admitted
             )
         })
+}
+
+fn method_hof_callback_nested_method_call(lang: Lang, contract: MethodCallContract) -> bool {
+    js_like_array_hof_method_call(lang, contract) || swift_sequence_hof_method_call(lang, contract)
 }
 
 fn library_api_record_has_iterable_source_dependency(

--- a/crates/nose-semantics/src/library_api/admission/provenance.rs
+++ b/crates/nose-semantics/src/library_api/admission/provenance.rs
@@ -29,7 +29,7 @@ fn library_api_contract_provenance_ids(
 ) -> Option<(&'static str, &'static str)> {
     python_library_api_contract_provenance_ids(id)
         .or_else(|| js_like_library_api_contract_provenance_ids(lang, id, callee))
-        .or_else(|| swift_library_api_contract_provenance_ids(id))
+        .or_else(|| swift_library_api_contract_provenance_ids(lang, id, callee))
         .or_else(|| rust_library_api_contract_provenance_ids(lang, id, callee))
         .or_else(|| java_library_api_contract_provenance_ids(id, callee))
         .or_else(|| go_library_api_contract_provenance_ids(id, callee))
@@ -66,7 +66,9 @@ fn python_library_api_contract_provenance_ids(
 }
 
 fn swift_library_api_contract_provenance_ids(
+    lang: Lang,
     id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
 ) -> Option<(&'static str, &'static str)> {
     match id {
         LibraryApiContractId::SwiftCollectionFactory(_)
@@ -74,8 +76,34 @@ fn swift_library_api_contract_provenance_ids(
             SWIFT_STDLIB_COLLECTION_FACTORY_PACK_ID,
             SWIFT_STDLIB_COLLECTION_FACTORY_PRODUCER_ID,
         )),
+        LibraryApiContractId::MethodCall(_)
+            if lang == Lang::Swift && swift_sequence_hof_method_callee(id, callee) =>
+        {
+            Some((
+                SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+                SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
+            ))
+        }
         _ => None,
     }
+}
+
+fn swift_sequence_hof_method_callee(
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+) -> bool {
+    matches!(
+        (id, callee),
+        (
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
+                HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
+            )),
+            LibraryApiCalleeContract::Method {
+                method: "map" | "filter" | "flatMap",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+        )
+    )
 }
 
 fn js_like_library_api_contract_provenance_ids(

--- a/crates/nose-semantics/src/library_api/contract_keys.rs
+++ b/crates/nose-semantics/src/library_api/contract_keys.rs
@@ -271,6 +271,7 @@ pub(super) fn library_api_callee_contract_key(callee: LibraryApiCalleeContract) 
 fn method_receiver_contract_key(receiver: MethodReceiverContract) -> String {
     match receiver {
         MethodReceiverContract::ExactArray => "exact_array".into(),
+        MethodReceiverContract::ExactArrayOrCollection => "exact_array_or_collection".into(),
         MethodReceiverContract::ExactCollection => "exact_collection".into(),
         MethodReceiverContract::ExactProtocol => "exact_protocol".into(),
         MethodReceiverContract::ExactProtocolPairArgument => "exact_protocol_pair_argument".into(),

--- a/crates/nose-semantics/src/library_api/receiver_dependencies.rs
+++ b/crates/nose-semantics/src/library_api/receiver_dependencies.rs
@@ -301,7 +301,9 @@ pub(in crate::library_api) fn receiver_dependency_ids(
         MethodReceiverContract::ExactCollectionOrMapLiteral => {
             domain_or_sequence_dependency_ids(il, interner, receiver, contract, cache)
         }
-        MethodReceiverContract::ExactCollection | MethodReceiverContract::ExactCollectionOrMap => {
+        MethodReceiverContract::ExactArrayOrCollection
+        | MethodReceiverContract::ExactCollection
+        | MethodReceiverContract::ExactCollectionOrMap => {
             collection_receiver_dependency_ids(il, interner, receiver, contract, cache)
         }
         MethodReceiverContract::RustMapGetOrExactOption => {

--- a/crates/nose-semantics/src/library_api/receiver_dependencies/api_records/receiver_proofs.rs
+++ b/crates/nose-semantics/src/library_api/receiver_dependencies/api_records/receiver_proofs.rs
@@ -492,7 +492,8 @@ pub(super) fn sequence_surface_kind_satisfies_method_receiver(
 ) -> bool {
     match contract {
         MethodReceiverContract::ExactArray => kind == SequenceSurfaceKind::Collection,
-        MethodReceiverContract::ExactCollection
+        MethodReceiverContract::ExactArrayOrCollection
+        | MethodReceiverContract::ExactCollection
         | MethodReceiverContract::ExactProtocol
         | MethodReceiverContract::ExactProtocolPairArgument
         | MethodReceiverContract::ExactCollectionOrJavaKeySet => {

--- a/crates/nose-semantics/src/library_api/receiver_dependencies/surface.rs
+++ b/crates/nose-semantics/src/library_api/receiver_dependencies/surface.rs
@@ -92,6 +92,11 @@ pub(in crate::library_api) fn sequence_surface_satisfies_method_receiver(
         MethodReceiverContract::ExactArray => {
             surface.imported_literal && surface.value_tag == SEQ_VALUE_COLLECTION
         }
+        MethodReceiverContract::ExactArrayOrCollection
+            if surface.value_tag == SEQ_VALUE_COLLECTION =>
+        {
+            surface.membership_collection
+        }
         MethodReceiverContract::ExactCollection
         | MethodReceiverContract::ExactProtocol
         | MethodReceiverContract::ExactProtocolPairArgument

--- a/crates/nose-semantics/src/library_api/rows/methods.rs
+++ b/crates/nose-semantics/src/library_api/rows/methods.rs
@@ -437,7 +437,9 @@ fn method_call_contract_provenance(
     lang: Lang,
     contract: MethodCallContract,
 ) -> (&'static str, &'static str) {
-    if rust_sequence_hof_method_call(lang, contract) {
+    if rust_sequence_hof_method_call(lang, contract)
+        || swift_sequence_hof_method_call(lang, contract)
+    {
         (
             SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
             SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
@@ -566,5 +568,6 @@ mod receiver;
 mod selectors;
 pub(in crate::library_api) use classification::js_like_array_hof_method_call;
 use classification::rust_sequence_hof_method_call;
+pub(in crate::library_api) use classification::swift_sequence_hof_method_call;
 pub use receiver::{library_receiver_method_api_contract, library_receiver_method_api_contracts};
 pub(crate) use selectors::library_method_selector_name;

--- a/crates/nose-semantics/src/library_api/rows/methods/classification.rs
+++ b/crates/nose-semantics/src/library_api/rows/methods/classification.rs
@@ -40,3 +40,18 @@ pub(super) fn rust_sequence_hof_method_call(lang: Lang, contract: MethodCallCont
             )
         )
 }
+
+pub(in crate::library_api) fn swift_sequence_hof_method_call(
+    lang: Lang,
+    contract: MethodCallContract,
+) -> bool {
+    lang == Lang::Swift
+        && matches!(
+            (contract.semantic, contract.receiver, contract.args),
+            (
+                MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap),
+                MethodReceiverContract::ExactArrayOrCollection,
+                MethodBuiltinArgs::Hof,
+            )
+        )
+}

--- a/crates/nose-semantics/src/method_contracts.rs
+++ b/crates/nose-semantics/src/method_contracts.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum MethodReceiverContract {
     ExactArray,
+    ExactArrayOrCollection,
     ExactCollection,
     ExactProtocol,
     ExactProtocolPairArgument,
@@ -29,6 +30,9 @@ pub fn method_receiver_domain_requirement(
 ) -> Option<DomainRequirement> {
     match receiver {
         MethodReceiverContract::ExactArray => Some(DomainRequirement::ARRAY),
+        MethodReceiverContract::ExactArrayOrCollection => {
+            Some(DomainRequirement::ARRAY_OR_COLLECTION)
+        }
         MethodReceiverContract::ExactCollection
         | MethodReceiverContract::ExactProtocol
         | MethodReceiverContract::ExactProtocolPairArgument
@@ -207,6 +211,18 @@ pub(super) fn method_call_contract_shapes(
         return vec![MethodCallContract {
             semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
             receiver: Receiver::ExactArray,
+            args: Args::Hof,
+        }];
+    } else if lang == Lang::Swift
+        && matches!(
+            method_hof_contract(lang, name),
+            Some(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+        )
+        && arg_count == 1
+    {
+        return vec![MethodCallContract {
+            semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
+            receiver: Receiver::ExactArrayOrCollection,
             args: Args::Hof,
         }];
     } else if !js_like_lang(lang) && method_hof_contract(lang, name).is_some() && arg_count > 0 {

--- a/crates/nose-semantics/src/packs/compiled/constants.rs
+++ b/crates/nose-semantics/src/packs/compiled/constants.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 mod rust;
+mod sequence_hof;
 mod swift;
 mod type_domains;
 pub(super) use rust::*;
+pub(super) use sequence_hof::*;
 pub(super) use swift::*;
 pub(super) use type_domains::*;
 
@@ -151,7 +153,6 @@ pub(super) const NO_LANGUAGES: &[&str] = &[];
 pub(super) const PYTHON_LANGUAGE: &[&str] = &["python"];
 pub(super) const RUBY_LANGUAGE: &[&str] = &["ruby"];
 pub(super) const RUST_LANGUAGE: &[&str] = &["rust"];
-pub(super) const SEQUENCE_HOF_ADAPTER_PROTOCOL_LANGUAGES: &[&str] = &["rust"];
 pub(super) const NO_PACKAGES: &[&str] = &[];
 pub(super) const JAVA_STDLIB_MAP_FACTORY_PACKAGES: &[&str] = &["java.util"];
 pub(super) const JAVA_STDLIB_MAP_ENTRY_PACKAGES: &[&str] = &["java.util"];
@@ -162,7 +163,6 @@ pub(super) const JAVA_GUAVA_IMMUTABLE_COLLECTION_FACTORY_PACKAGES: &[&str] =
 pub(super) const JAVA_STDLIB_MATH_PACKAGES: &[&str] = &["java.lang"];
 pub(super) const JAVA_STDLIB_STATIC_COLLECTION_ADAPTER_PACKAGES: &[&str] = &["java.util"];
 pub(super) const ITERATOR_IDENTITY_ADAPTER_PACKAGES: &[&str] = &["core::iter", "java.util.stream"];
-pub(super) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PACKAGES: &[&str] = &["core::iter"];
 pub(super) const MAP_GET_PROTOCOL_PACKAGES: &[&str] = &["Map", "java.util", "std::collections"];
 pub(super) const MAP_GET_DEFAULT_PROTOCOL_PACKAGES: &[&str] = &["dict", "Hash", "java.util"];
 pub(super) const FREE_FUNCTION_BUILTIN_PROTOCOL_PACKAGES: &[&str] =
@@ -460,26 +460,6 @@ pub(super) const BUILTIN_METHOD_CALL_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
     "builtin-method-call-missing-receiver-proof-hard-negative",
     "builtin-method-call-wrong-pack-hard-negative",
     "builtin-method-call-unsupported-arity-hard-negative",
-];
-pub(super) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_IDS: &[&str] =
-    &[SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID];
-pub(super) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONTRACT_IDS: &[&str] =
-    &[SEQUENCE_HOF_ADAPTER_CONTRACT_ID];
-pub(super) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
-    "rust-iterator-hof-map-positive",
-    "rust-iterator-hof-filter-positive",
-    "rust-iterator-hof-filter-map-positive",
-    "rust-iterator-hof-flat-map-positive",
-    "rust-iterator-hof-any-terminal-positive",
-    "rust-iterator-hof-all-terminal-positive",
-    "rust-iterator-hof-count-terminal-positive",
-    "rust-iterator-hof-custom-method-hard-negative",
-    "rust-iterator-hof-missing-receiver-proof-hard-negative",
-    "rust-iterator-hof-eager-callback-hard-negative",
-    "rust-iterator-hof-missing-terminal-proof-hard-negative",
-    "rust-iterator-hof-one-shot-reuse-hard-negative",
-    "rust-iterator-hof-collect-vec-hard-negative",
-    "rust-iterator-hof-find-unsupported-hard-negative",
 ];
 pub(super) const GO_STDLIB_NAMESPACE_CALL_PRODUCER_IDS: &[&str] =
     &[GO_STDLIB_NAMESPACE_CALL_PRODUCER_ID];

--- a/crates/nose-semantics/src/packs/compiled/constants/sequence_hof.rs
+++ b/crates/nose-semantics/src/packs/compiled/constants/sequence_hof.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_LANGUAGES: &[&str] =
+    &["rust", "swift"];
+pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PACKAGES: &[&str] =
+    &["core::iter", "Swift.Collection"];
+pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_IDS: &[&str] =
+    &[SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID];
+pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONTRACT_IDS: &[&str] =
+    &[SEQUENCE_HOF_ADAPTER_CONTRACT_ID];
+pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
+    "rust-iterator-hof-map-positive",
+    "rust-iterator-hof-filter-positive",
+    "rust-iterator-hof-filter-map-positive",
+    "rust-iterator-hof-flat-map-positive",
+    "rust-iterator-hof-any-terminal-positive",
+    "rust-iterator-hof-all-terminal-positive",
+    "rust-iterator-hof-count-terminal-positive",
+    "rust-iterator-hof-custom-method-hard-negative",
+    "rust-iterator-hof-missing-receiver-proof-hard-negative",
+    "rust-iterator-hof-eager-callback-hard-negative",
+    "rust-iterator-hof-missing-terminal-proof-hard-negative",
+    "rust-iterator-hof-one-shot-reuse-hard-negative",
+    "rust-iterator-hof-collect-vec-hard-negative",
+    "rust-iterator-hof-find-unsupported-hard-negative",
+    "swift-sequence-hof-map-positive",
+    "swift-sequence-hof-filter-positive",
+    "swift-sequence-hof-flat-map-positive",
+    "swift-sequence-hof-set-order-hard-negative",
+    "swift-sequence-hof-dictionary-order-hard-negative",
+    "swift-sequence-hof-lazy-hard-negative",
+    "swift-sequence-hof-throwing-closure-hard-negative",
+    "swift-sequence-hof-mutating-closure-hard-negative",
+    "swift-sequence-hof-any-sequence-reuse-hard-negative",
+    "swift-sequence-hof-compact-map-unsupported-hard-negative",
+];

--- a/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
+++ b/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
@@ -349,8 +349,11 @@ pub(super) fn assert_group() {
     let sequence_hof_adapter = builtin_pack_descriptor(SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID)
         .expect("sequence HOF adapter protocol descriptor");
     assert_eq!(sequence_hof_adapter.kind, SemanticPackKind::ProtocolPack);
-    assert_eq!(sequence_hof_adapter.supported_languages, &["rust"]);
-    assert_eq!(sequence_hof_adapter.supported_packages, &["core::iter"]);
+    assert_eq!(sequence_hof_adapter.supported_languages, &["rust", "swift"]);
+    assert_eq!(
+        sequence_hof_adapter.supported_packages,
+        &["core::iter", "Swift.Collection"]
+    );
     assert_eq!(
         sequence_hof_adapter.evidence_producer_ids,
         &[SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID]
@@ -362,14 +365,20 @@ pub(super) fn assert_group() {
     );
     assert_eq!(sequence_hof_adapter.counts().evidence_producers, 1);
     assert_eq!(sequence_hof_adapter.counts().contracts, 1);
-    assert_eq!(sequence_hof_adapter.counts().positive_fixtures, 7);
-    assert_eq!(sequence_hof_adapter.counts().hard_negatives, 7);
+    assert_eq!(sequence_hof_adapter.counts().positive_fixtures, 10);
+    assert_eq!(sequence_hof_adapter.counts().hard_negatives, 14);
     assert!(sequence_hof_adapter
         .conformance_refs()
         .contains(&"rust-iterator-hof-missing-terminal-proof-hard-negative"));
     assert!(sequence_hof_adapter
         .conformance_refs()
         .contains(&"rust-iterator-hof-one-shot-reuse-hard-negative"));
+    assert!(sequence_hof_adapter
+        .conformance_refs()
+        .contains(&"swift-sequence-hof-flat-map-positive"));
+    assert!(sequence_hof_adapter
+        .conformance_refs()
+        .contains(&"swift-sequence-hof-any-sequence-reuse-hard-negative"));
 
     let go_namespace_call = builtin_pack_descriptor(GO_STDLIB_NAMESPACE_CALL_PACK_ID)
         .expect("Go stdlib namespace-call descriptor");

--- a/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod sequence_hof_rows;
+
 #[test]
 fn method_protocol_contracts_are_language_constrained() {
     assert!(method_fold_name(Lang::Ruby, "inject"));
@@ -146,7 +148,7 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
         method_call_contract(Lang::Swift, "map", 1),
         Some(MethodCallContract {
             semantic: MethodSemanticContract::HoF(HoFKind::Map),
-            receiver: MethodReceiverContract::ExactProtocol,
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
             args: MethodBuiltinArgs::Hof,
         })
     );
@@ -154,7 +156,7 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
         method_call_contract(Lang::Swift, "filter", 1),
         Some(MethodCallContract {
             semantic: MethodSemanticContract::HoF(HoFKind::Filter),
-            receiver: MethodReceiverContract::ExactProtocol,
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
             args: MethodBuiltinArgs::Hof,
         })
     );
@@ -162,7 +164,7 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
         method_call_contract(Lang::Swift, "flatMap", 1),
         Some(MethodCallContract {
             semantic: MethodSemanticContract::HoF(HoFKind::FlatMap),
-            receiver: MethodReceiverContract::ExactProtocol,
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
             args: MethodBuiltinArgs::Hof,
         })
     );
@@ -309,66 +311,6 @@ fn method_call_contracts_cover_membership_and_map_default_lookups() {
         })
     );
     assert_eq!(method_call_contract(Lang::JavaScript, "abs", 0), None);
-}
-
-#[test]
-fn rust_iterator_hof_rows_use_sequence_hof_protocol_pack() {
-    for (method, arity) in [
-        ("map", 1),
-        ("filter", 1),
-        ("filter_map", 1),
-        ("flat_map", 1),
-        ("any", 1),
-        ("all", 1),
-        ("count", 0),
-    ] {
-        let contract =
-            library_method_call_contract(Lang::Rust, method, arity).expect("Rust method row");
-        assert_eq!(contract.pack_id, SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID);
-        assert_eq!(
-            contract.producer_id,
-            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID
-        );
-        assert_eq!(
-            contract.callee,
-            LibraryApiCalleeContract::Method {
-                method,
-                receiver: MethodReceiverContract::ExactProtocol,
-            }
-        );
-    }
-
-    for (method, arity) in [
-        ("map", 1),
-        ("filter", 1),
-        ("flatMap", 1),
-        ("some", 1),
-        ("every", 1),
-    ] {
-        let contract =
-            library_method_call_contract(Lang::JavaScript, method, arity).expect("JS method row");
-        assert_eq!(contract.pack_id, JS_LIKE_BUILTIN_ARRAY_PACK_ID);
-        assert_eq!(contract.producer_id, JS_LIKE_BUILTIN_ARRAY_PRODUCER_ID);
-        assert_eq!(
-            contract.callee,
-            LibraryApiCalleeContract::Method {
-                method,
-                receiver: MethodReceiverContract::ExactArray,
-            }
-        );
-    }
-    assert!(
-        library_method_call_contract(Lang::JavaScript, "map", 2).is_none(),
-        "JS Array.map with thisArg remains closed until callback binding is modeled"
-    );
-
-    let swift_map = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
-    assert_eq!(swift_map.pack_id, BUILTIN_METHOD_CALL_PROTOCOL_PACK_ID);
-
-    assert!(
-        library_method_call_contract(Lang::Rust, "find", 1).is_none(),
-        "Rust find stays closed until optional-result semantics are represented"
-    );
 }
 
 #[test]

--- a/crates/nose-semantics/src/tests/library_api_contracts/method_protocols/sequence_hof_rows.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/method_protocols/sequence_hof_rows.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+#[test]
+fn rust_iterator_hof_rows_use_sequence_hof_protocol_pack() {
+    for (method, arity) in [
+        ("map", 1),
+        ("filter", 1),
+        ("filter_map", 1),
+        ("flat_map", 1),
+        ("any", 1),
+        ("all", 1),
+        ("count", 0),
+    ] {
+        let contract =
+            library_method_call_contract(Lang::Rust, method, arity).expect("Rust method row");
+        assert_eq!(contract.pack_id, SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID);
+        assert_eq!(
+            contract.producer_id,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID
+        );
+        assert_eq!(
+            contract.callee,
+            LibraryApiCalleeContract::Method {
+                method,
+                receiver: MethodReceiverContract::ExactProtocol,
+            }
+        );
+    }
+
+    for (method, arity) in [
+        ("map", 1),
+        ("filter", 1),
+        ("flatMap", 1),
+        ("some", 1),
+        ("every", 1),
+    ] {
+        let contract =
+            library_method_call_contract(Lang::JavaScript, method, arity).expect("JS method row");
+        assert_eq!(contract.pack_id, JS_LIKE_BUILTIN_ARRAY_PACK_ID);
+        assert_eq!(contract.producer_id, JS_LIKE_BUILTIN_ARRAY_PRODUCER_ID);
+        assert_eq!(
+            contract.callee,
+            LibraryApiCalleeContract::Method {
+                method,
+                receiver: MethodReceiverContract::ExactArray,
+            }
+        );
+    }
+    assert!(
+        library_method_call_contract(Lang::JavaScript, "map", 2).is_none(),
+        "JS Array.map with thisArg remains closed until callback binding is modeled"
+    );
+
+    for method in ["map", "filter", "flatMap"] {
+        let contract =
+            library_method_call_contract(Lang::Swift, method, 1).expect("Swift Sequence HOF row");
+        assert_eq!(contract.pack_id, SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID);
+        assert_eq!(
+            contract.producer_id,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID
+        );
+        assert_eq!(
+            contract.callee,
+            LibraryApiCalleeContract::Method {
+                method,
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            }
+        );
+    }
+    assert!(
+        library_method_call_contract(Lang::Swift, "compactMap", 1).is_none(),
+        "Swift compactMap stays closed until optional-channel semantics are represented"
+    );
+
+    assert!(
+        library_method_call_contract(Lang::Rust, "find", 1).is_none(),
+        "Rust find stays closed until optional-result semantics are represented"
+    );
+}

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/js_array_hof.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/js_array_hof.rs
@@ -38,6 +38,18 @@ enum JsArrayCallbackShape {
     EffectfulInlineCall,
 }
 
+impl JsArrayCallbackShape {
+    fn fixture(self) -> CallbackFixtureShape {
+        match self {
+            Self::Reference => CallbackFixtureShape::Reference { name: "callback" },
+            Self::EffectfulInlineCall => CallbackFixtureShape::EffectfulCall {
+                callee: "sideEffect",
+                arg_cid: 1,
+            },
+        }
+    }
+}
+
 fn js_array_hof_call_with_callback_il(
     method: &str,
     callback_shape: JsArrayCallbackShape,
@@ -51,7 +63,7 @@ fn js_array_hof_call_with_callback_il(
         sp(241),
         &[receiver],
     );
-    let callback = js_array_callback_node(&mut b, &interner, callback_shape, 242);
+    let callback = callback_fixture_node(&mut b, &interner, callback_shape.fixture(), 242);
     let call = b.add(NodeKind::Call, Payload::None, sp(249), &[callee, callback]);
     let root = b.add(NodeKind::Func, Payload::None, sp(250), &[call]);
     (
@@ -60,45 +72,6 @@ fn js_array_hof_call_with_callback_il(
         call,
         receiver,
     )
-}
-
-fn js_array_callback_node(
-    b: &mut IlBuilder,
-    interner: &Interner,
-    callback_shape: JsArrayCallbackShape,
-    span_base: u32,
-) -> NodeId {
-    match callback_shape {
-        JsArrayCallbackShape::Reference => b.add(
-            NodeKind::Var,
-            Payload::Name(interner.intern("callback")),
-            sp(span_base),
-            &[],
-        ),
-        JsArrayCallbackShape::EffectfulInlineCall => {
-            let effect_callee = b.add(
-                NodeKind::Var,
-                Payload::Name(interner.intern("sideEffect")),
-                sp(span_base + 1),
-                &[],
-            );
-            let effect_arg = b.add(NodeKind::Var, Payload::Cid(1), sp(span_base + 2), &[]);
-            let effect = b.add(
-                NodeKind::Call,
-                Payload::None,
-                sp(span_base + 3),
-                &[effect_callee, effect_arg],
-            );
-            let ret = b.add(
-                NodeKind::Return,
-                Payload::None,
-                sp(span_base + 4),
-                &[effect],
-            );
-            let body = b.add(NodeKind::Block, Payload::None, sp(span_base + 5), &[ret]);
-            b.add(NodeKind::Lambda, Payload::None, sp(span_base + 6), &[body])
-        }
-    }
 }
 
 fn js_array_hof_chain_with_map_callback_il(
@@ -113,7 +86,7 @@ fn js_array_hof_chain_with_map_callback_il(
         sp(261),
         &[receiver],
     );
-    let map_fn = js_array_callback_node(&mut b, &interner, callback_shape, 262);
+    let map_fn = callback_fixture_node(&mut b, &interner, callback_shape.fixture(), 262);
     let map_call = b.add(
         NodeKind::Call,
         Payload::None,
@@ -149,7 +122,7 @@ fn js_array_normalized_hof_with_callback_il(
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
     let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(280), &[]);
-    let callback = js_array_callback_node(&mut b, &interner, callback_shape, 281);
+    let callback = callback_fixture_node(&mut b, &interner, callback_shape.fixture(), 281);
     let hof = b.add(
         NodeKind::HoF,
         Payload::HoF(HoFKind::Map),

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod swift;
+
 fn sequence_hof_call_il(method: &str, arg_count: usize) -> (Il, Interner, NodeId, NodeId) {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
@@ -29,10 +31,14 @@ fn sequence_hof_call_il(method: &str, arg_count: usize) -> (Il, Interner, NodeId
 }
 
 fn push_protocol_receiver_dependency(il: &mut Il, receiver: NodeId) {
+    push_receiver_domain_dependency(il, 0, receiver, DomainEvidence::Collection);
+}
+
+fn push_receiver_domain_dependency(il: &mut Il, id: u32, receiver: NodeId, domain: DomainEvidence) {
     il.evidence.push(evidence(
-        0,
+        id,
         EvidenceAnchor::node(il.node(receiver).span, il.kind(receiver)),
-        EvidenceKind::Domain(DomainEvidence::Collection),
+        EvidenceKind::Domain(domain),
         EvidenceStatus::Asserted,
     ));
 }

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/swift.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/swift.rs
@@ -1,0 +1,379 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum SwiftCallbackShape {
+    Inline,
+    Reference,
+    EffectfulCall,
+    MutatingAssign,
+    Throwing,
+}
+
+impl SwiftCallbackShape {
+    fn fixture(self) -> CallbackFixtureShape {
+        match self {
+            Self::Inline => CallbackFixtureShape::InlineFunc { cid: 1 },
+            Self::Reference => CallbackFixtureShape::Reference { name: "transform" },
+            Self::EffectfulCall => CallbackFixtureShape::EffectfulCall {
+                callee: "sideEffect",
+                arg_cid: 1,
+            },
+            Self::MutatingAssign => CallbackFixtureShape::MutatingAssign {
+                lhs_cid: 2,
+                rhs_cid: 1,
+            },
+            Self::Throwing => CallbackFixtureShape::Throwing { err_cid: 1 },
+        }
+    }
+}
+
+fn swift_sequence_hof_call_il(
+    method: &str,
+    shape: SwiftCallbackShape,
+) -> (Il, Interner, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(300), &[]);
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(301),
+        &[receiver],
+    );
+    let callback = callback_fixture_node(&mut b, &interner, shape.fixture(), 302);
+    let call = b.add(NodeKind::Call, Payload::None, sp(310), &[callee, callback]);
+    let root = b.add(NodeKind::Func, Payload::None, sp(311), &[call]);
+    (finish_il(b, root, Lang::Swift), interner, call, receiver)
+}
+
+fn swift_lazy_sequence_hof_call_il(method: &str) -> (Il, Interner, NodeId, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(320), &[]);
+    let lazy = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("lazy")),
+        sp(321),
+        &[receiver],
+    );
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(322),
+        &[lazy],
+    );
+    let callback =
+        callback_fixture_node(&mut b, &interner, SwiftCallbackShape::Inline.fixture(), 323);
+    let call = b.add(NodeKind::Call, Payload::None, sp(324), &[callee, callback]);
+    let root = b.add(NodeKind::Func, Payload::None, sp(325), &[call]);
+    (
+        finish_il(b, root, Lang::Swift),
+        interner,
+        call,
+        receiver,
+        lazy,
+    )
+}
+
+fn swift_sequence_hof_chain_il() -> (Il, Interner, NodeId, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(330), &[]);
+    let map_callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("map")),
+        sp(331),
+        &[receiver],
+    );
+    let map_fn = b.add(NodeKind::Func, Payload::Cid(1), sp(332), &[]);
+    let map_call = b.add(
+        NodeKind::Call,
+        Payload::None,
+        sp(333),
+        &[map_callee, map_fn],
+    );
+    let filter_callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("filter")),
+        sp(334),
+        &[map_call],
+    );
+    let filter_fn = b.add(NodeKind::Func, Payload::Cid(2), sp(335), &[]);
+    let filter_call = b.add(
+        NodeKind::Call,
+        Payload::None,
+        sp(336),
+        &[filter_callee, filter_fn],
+    );
+    let root = b.add(NodeKind::Func, Payload::None, sp(337), &[filter_call]);
+    (
+        finish_il(b, root, Lang::Swift),
+        interner,
+        filter_call,
+        map_call,
+        receiver,
+    )
+}
+
+#[test]
+fn swift_sequence_hof_pack_rejects_lazy_adapter_receiver() {
+    let contract = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
+
+    let (mut base_proof, interner, call, receiver, _lazy) = swift_lazy_sequence_hof_call_il("map");
+    push_receiver_domain_dependency(&mut base_proof, 0, receiver, DomainEvidence::Collection);
+    base_proof
+        .evidence
+        .push(sequence_hof_record(1, &base_proof, call, contract, 1, &[0]));
+    assert!(
+        admitted_library_method_call_at_call(&base_proof, &interner, call).is_none(),
+        "Swift .lazy.map does not inherit eager Array/Collection proof from the base receiver"
+    );
+
+    let (mut lazy_iterable, interner, call, _receiver, lazy) =
+        swift_lazy_sequence_hof_call_il("map");
+    push_receiver_domain_dependency(&mut lazy_iterable, 0, lazy, DomainEvidence::Iterable);
+    lazy_iterable.evidence.push(sequence_hof_record(
+        1,
+        &lazy_iterable,
+        call,
+        contract,
+        1,
+        &[0],
+    ));
+    assert!(
+        admitted_library_method_call_at_call(&lazy_iterable, &interner, call).is_none(),
+        "Swift .lazy.map stays closed until lazy demand and one-shot semantics are modeled"
+    );
+}
+
+#[test]
+fn admitted_swift_sequence_hof_requires_sequence_hof_pack_and_ordered_collection_receiver() {
+    let (mut raw_shape, interner, call, receiver) =
+        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut raw_shape, 0, receiver, DomainEvidence::Collection);
+    assert!(
+        admitted_library_method_call_at_call(&raw_shape, &interner, call).is_none(),
+        "raw Swift map shape plus collection receiver proof is not enough"
+    );
+
+    let contract = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
+    assert_eq!(
+        contract.callee,
+        LibraryApiCalleeContract::Method {
+            method: "map",
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
+        }
+    );
+
+    let (mut missing_dependency, interner, call, _receiver) =
+        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+    missing_dependency.evidence.push(sequence_hof_record(
+        1,
+        &missing_dependency,
+        call,
+        contract,
+        1,
+        &[],
+    ));
+    assert!(
+        admitted_library_method_call_at_call(&missing_dependency, &interner, call).is_none(),
+        "same-span Swift HOF evidence without ordered collection proof is rejected"
+    );
+
+    let (mut wrong_pack, interner, call, receiver) =
+        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut wrong_pack, 0, receiver, DomainEvidence::Collection);
+    wrong_pack
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            wrong_pack.node(call).span,
+            contract.id,
+            contract.callee,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            BUILTIN_METHOD_CALL_PROTOCOL_PACK_ID,
+            BUILTIN_METHOD_CALL_PROTOCOL_PRODUCER_ID,
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_pack, &interner, call).is_none(),
+        "Swift HOF evidence under the generic method-call pack is rejected"
+    );
+
+    let (mut wrong_producer, interner, call, receiver) =
+        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut wrong_producer, 0, receiver, DomainEvidence::Collection);
+    wrong_producer
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            wrong_producer.node(call).span,
+            contract.id,
+            contract.callee,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+            "wrong.protocols.sequence-hof-adapter-api",
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_producer, &interner, call).is_none(),
+        "Swift HOF evidence with the wrong producer is rejected"
+    );
+
+    for (domain, message) in [
+        (
+            DomainEvidence::Set,
+            "Swift Set receiver proof stays closed because order is not represented",
+        ),
+        (
+            DomainEvidence::Map,
+            "Swift Dictionary receiver proof stays closed for Sequence HOF admission",
+        ),
+        (
+            DomainEvidence::Iterable,
+            "Swift AnySequence/one-shot receiver proof stays closed",
+        ),
+    ] {
+        let (mut il, interner, call, receiver) =
+            swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+        push_receiver_domain_dependency(&mut il, 0, receiver, domain);
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        assert!(
+            admitted_library_method_call_at_call(&il, &interner, call).is_none(),
+            "{message}"
+        );
+    }
+
+    let (mut admitted, interner, call, receiver) =
+        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut admitted, 0, receiver, DomainEvidence::Collection);
+    admitted
+        .evidence
+        .push(sequence_hof_record(1, &admitted, call, contract, 1, &[0]));
+    let occurrence = admitted_library_method_call_at_call(&admitted, &interner, call)
+        .expect("Swift map with ordered collection proof admits");
+    assert_eq!(
+        occurrence.contract.id,
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map))
+    );
+    assert_eq!(
+        occurrence.contract.pack_id,
+        SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID
+    );
+    assert_eq!(occurrence.receiver, Some(receiver));
+    assert_eq!(occurrence.arg_count, 1);
+}
+
+#[test]
+fn admitted_swift_sequence_hof_pack_covers_supported_eager_hofs() {
+    for (method, semantic) in [
+        ("map", MethodSemanticContract::HoF(HoFKind::Map)),
+        ("filter", MethodSemanticContract::HoF(HoFKind::Filter)),
+        ("flatMap", MethodSemanticContract::HoF(HoFKind::FlatMap)),
+    ] {
+        let (mut il, interner, call, receiver) =
+            swift_sequence_hof_call_il(method, SwiftCallbackShape::Inline);
+        push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+        let contract = library_method_call_contract(Lang::Swift, method, 1).expect("Swift HOF row");
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        let occurrence = admitted_library_method_call_at_call(&il, &interner, call)
+            .expect("supported Swift Sequence HOF admits");
+        assert_eq!(
+            occurrence.contract.id,
+            LibraryApiContractId::MethodCall(semantic)
+        );
+        assert_eq!(
+            occurrence.contract.pack_id,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID
+        );
+    }
+}
+
+#[test]
+fn swift_sequence_hof_pack_rejects_unsupported_optional_channel_surface() {
+    let (mut il, interner, call, receiver) =
+        swift_sequence_hof_call_il("compactMap", SwiftCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+    il.evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            il.node(call).span,
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map)),
+            LibraryApiCalleeContract::Method {
+                method: "compactMap",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&il, &interner, call).is_none(),
+        "Swift compactMap remains closed until optional-channel semantics are represented"
+    );
+}
+
+#[test]
+fn swift_sequence_hof_pack_rejects_non_inline_or_effectful_callbacks() {
+    let contract = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
+    for (shape, message) in [
+        (
+            SwiftCallbackShape::Reference,
+            "callback references stay closed until callable effects are proven",
+        ),
+        (
+            SwiftCallbackShape::EffectfulCall,
+            "unknown calls inside Swift HOF callbacks stay closed",
+        ),
+        (
+            SwiftCallbackShape::MutatingAssign,
+            "captured mutation inside Swift HOF callbacks stays closed",
+        ),
+        (
+            SwiftCallbackShape::Throwing,
+            "throwing Swift HOF callbacks stay closed",
+        ),
+    ] {
+        let (mut il, interner, call, receiver) = swift_sequence_hof_call_il("map", shape);
+        push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        assert!(
+            admitted_library_method_call_at_call(&il, &interner, call).is_none(),
+            "{message}"
+        );
+    }
+}
+
+#[test]
+fn swift_sequence_hof_result_domain_can_prove_follow_on_ordered_receiver() {
+    let (mut il, interner, filter_call, map_call, receiver) = swift_sequence_hof_chain_il();
+    push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+    let map_contract = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
+    il.evidence
+        .push(sequence_hof_record(1, &il, map_call, map_contract, 1, &[0]));
+    let filter_contract =
+        library_method_call_contract(Lang::Swift, "filter", 1).expect("Swift filter row");
+    il.evidence.push(sequence_hof_record(
+        2,
+        &il,
+        filter_call,
+        filter_contract,
+        1,
+        &[1],
+    ));
+
+    let occurrence = admitted_library_method_call_at_call(&il, &interner, filter_call)
+        .expect("Swift map result proves follow-on Swift filter receiver");
+    assert_eq!(
+        occurrence.contract.id,
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Filter))
+    );
+    assert_eq!(occurrence.receiver, Some(map_call));
+}

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/support_core.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/support_core.rs
@@ -40,6 +40,70 @@ pub(crate) fn asserted_library_api_node_record_with_provenance(
     record
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum CallbackFixtureShape {
+    InlineFunc { cid: u32 },
+    Reference { name: &'static str },
+    EffectfulCall { callee: &'static str, arg_cid: u32 },
+    MutatingAssign { lhs_cid: u32, rhs_cid: u32 },
+    Throwing { err_cid: u32 },
+}
+
+pub(crate) fn callback_fixture_node(
+    b: &mut IlBuilder,
+    interner: &Interner,
+    shape: CallbackFixtureShape,
+    span_base: u32,
+) -> NodeId {
+    match shape {
+        CallbackFixtureShape::InlineFunc { cid } => {
+            b.add(NodeKind::Func, Payload::Cid(cid), sp(span_base), &[])
+        }
+        CallbackFixtureShape::Reference { name } => b.add(
+            NodeKind::Var,
+            Payload::Name(interner.intern(name)),
+            sp(span_base),
+            &[],
+        ),
+        CallbackFixtureShape::EffectfulCall { callee, arg_cid } => {
+            let callee = b.add(
+                NodeKind::Var,
+                Payload::Name(interner.intern(callee)),
+                sp(span_base + 1),
+                &[],
+            );
+            let arg = b.add(NodeKind::Var, Payload::Cid(arg_cid), sp(span_base + 2), &[]);
+            let call = b.add(
+                NodeKind::Call,
+                Payload::None,
+                sp(span_base + 3),
+                &[callee, arg],
+            );
+            let ret = b.add(NodeKind::Return, Payload::None, sp(span_base + 4), &[call]);
+            let body = b.add(NodeKind::Block, Payload::None, sp(span_base + 5), &[ret]);
+            b.add(NodeKind::Lambda, Payload::None, sp(span_base + 6), &[body])
+        }
+        CallbackFixtureShape::MutatingAssign { lhs_cid, rhs_cid } => {
+            let lhs = b.add(NodeKind::Var, Payload::Cid(lhs_cid), sp(span_base + 1), &[]);
+            let rhs = b.add(NodeKind::Var, Payload::Cid(rhs_cid), sp(span_base + 2), &[]);
+            let assign = b.add(
+                NodeKind::Assign,
+                Payload::None,
+                sp(span_base + 3),
+                &[lhs, rhs],
+            );
+            let body = b.add(NodeKind::Block, Payload::None, sp(span_base + 4), &[assign]);
+            b.add(NodeKind::Lambda, Payload::None, sp(span_base + 5), &[body])
+        }
+        CallbackFixtureShape::Throwing { err_cid } => {
+            let err = b.add(NodeKind::Var, Payload::Cid(err_cid), sp(span_base + 1), &[]);
+            let throw = b.add(NodeKind::Throw, Payload::None, sp(span_base + 2), &[err]);
+            let body = b.add(NodeKind::Block, Payload::None, sp(span_base + 3), &[throw]);
+            b.add(NodeKind::Lambda, Payload::None, sp(span_base + 4), &[body])
+        }
+    }
+}
+
 pub(crate) fn js_length_field_il() -> (Il, Interner, NodeId, NodeId) {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));

--- a/crates/nose-semantics/src/tests/semantic_evidence/receiver_domains.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/receiver_domains.rs
@@ -11,6 +11,10 @@ fn method_receiver_contracts_expose_only_domain_backed_obligations() {
         Some(DomainRequirement::ARRAY_COLLECTION_OR_SET)
     );
     assert_eq!(
+        method_receiver_domain_requirement(MethodReceiverContract::ExactArrayOrCollection),
+        Some(DomainRequirement::ARRAY_OR_COLLECTION)
+    );
+    assert_eq!(
         method_receiver_domain_requirement(MethodReceiverContract::ExactProtocol),
         Some(DomainRequirement::ARRAY_COLLECTION_OR_SET)
     );
@@ -132,8 +136,7 @@ fn receiver_domain_evidence_at_node_is_preferred_over_param_evidence() {
     ));
 }
 
-#[test]
-fn ambiguous_receiver_domain_evidence_blocks_param_fallback() {
+fn cid_param_receiver_fixture() -> (Il, Interner, NodeId) {
     let mut b = IlBuilder::new(FileId(0));
     let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
     let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
@@ -144,27 +147,38 @@ fn ambiguous_receiver_domain_evidence_blocks_param_fallback() {
         span(0, 30, 1),
         &[param, body],
     );
-    let mut il = finish_il(b, root, Lang::TypeScript);
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::param(span(10, 12, 1)),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        EvidenceStatus::Asserted,
-    ));
-    il.evidence.push(evidence(
-        1,
-        EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
-        EvidenceKind::Domain(DomainEvidence::Set),
-        EvidenceStatus::Asserted,
-    ));
-    il.evidence.push(evidence(
-        2,
-        EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        EvidenceStatus::Asserted,
-    ));
+    (
+        finish_il(b, root, Lang::TypeScript),
+        Interner::new(),
+        receiver,
+    )
+}
 
-    let interner = Interner::new();
+fn push_cid_param_domain(il: &mut Il, id: u32, domain: DomainEvidence) {
+    il.evidence.push(evidence(
+        id,
+        EvidenceAnchor::param(span(10, 12, 1)),
+        EvidenceKind::Domain(domain),
+        EvidenceStatus::Asserted,
+    ));
+}
+
+fn push_cid_receiver_domain(il: &mut Il, id: u32, domain: DomainEvidence, status: EvidenceStatus) {
+    il.evidence.push(evidence(
+        id,
+        EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
+        EvidenceKind::Domain(domain),
+        status,
+    ));
+}
+
+#[test]
+fn ambiguous_receiver_domain_evidence_blocks_param_fallback() {
+    let (mut il, interner, receiver) = cid_param_receiver_fixture();
+    push_cid_param_domain(&mut il, 0, DomainEvidence::Map);
+    push_cid_receiver_domain(&mut il, 1, DomainEvidence::Set, EvidenceStatus::Asserted);
+    push_cid_receiver_domain(&mut il, 2, DomainEvidence::Map, EvidenceStatus::Asserted);
+
     assert_eq!(domain_evidence_for_receiver(&il, &interner, receiver), None);
 }
 
@@ -439,24 +453,8 @@ fn cid_receiver_domain_uses_nearest_function_scope() {
 
 #[test]
 fn dependency_broken_receiver_domain_evidence_blocks_param_fallback() {
-    let interner = Interner::new();
-    let mut b = IlBuilder::new(FileId(0));
-    let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
-    let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
-    let body = b.add(NodeKind::Block, Payload::None, span(18, 24, 2), &[receiver]);
-    let root = b.add(
-        NodeKind::Func,
-        Payload::None,
-        span(0, 30, 1),
-        &[param, body],
-    );
-    let mut il = finish_il(b, root, Lang::TypeScript);
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::param(span(10, 12, 1)),
-        EvidenceKind::Domain(DomainEvidence::Set),
-        EvidenceStatus::Asserted,
-    ));
+    let (mut il, interner, receiver) = cid_param_receiver_fixture();
+    push_cid_param_domain(&mut il, 0, DomainEvidence::Set);
     il.evidence.push(evidence_with_dependencies(
         1,
         EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
@@ -470,30 +468,9 @@ fn dependency_broken_receiver_domain_evidence_blocks_param_fallback() {
 
 #[test]
 fn receiver_domain_index_uses_kernel_fail_closed_policy() {
-    let interner = Interner::new();
-    let mut b = IlBuilder::new(FileId(0));
-    let param = b.add(NodeKind::Param, Payload::Cid(0), span(10, 12, 1), &[]);
-    let receiver = b.add(NodeKind::Var, Payload::Cid(0), span(20, 22, 2), &[]);
-    let body = b.add(NodeKind::Block, Payload::None, span(18, 24, 2), &[receiver]);
-    let root = b.add(
-        NodeKind::Func,
-        Payload::None,
-        span(0, 30, 1),
-        &[param, body],
-    );
-    let mut il = finish_il(b, root, Lang::TypeScript);
-    il.evidence.push(evidence(
-        0,
-        EvidenceAnchor::param(span(10, 12, 1)),
-        EvidenceKind::Domain(DomainEvidence::Collection),
-        EvidenceStatus::Asserted,
-    ));
-    il.evidence.push(evidence(
-        1,
-        EvidenceAnchor::node(span(20, 22, 2), NodeKind::Var),
-        EvidenceKind::Domain(DomainEvidence::Map),
-        EvidenceStatus::Ambiguous,
-    ));
+    let (mut il, interner, receiver) = cid_param_receiver_fixture();
+    push_cid_param_domain(&mut il, 0, DomainEvidence::Collection);
+    push_cid_receiver_domain(&mut il, 1, DomainEvidence::Map, EvidenceStatus::Ambiguous);
 
     let domains = ReceiverDomainEvidenceIndex::new(&il, &interner);
     assert_eq!(domains.domain_evidence_for_receiver(receiver), None);

--- a/crates/nose-semantics/src/tests/semantic_evidence/type_domains.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/type_domains.rs
@@ -142,6 +142,11 @@ fn type_domain_contracts_cover_swift_signatures() {
         "items: AnySequence<Int>",
         Some(DomainEvidence::Iterable),
     );
+    assert_type_domain(
+        Lang::Swift,
+        "items: AnyCollection<Int>",
+        Some(DomainEvidence::Collection),
+    );
     assert_type_domain(Lang::Swift, "text: String", Some(DomainEvidence::String));
     assert_type_domain(Lang::Swift, "ok: Bool", Some(DomainEvidence::Boolean));
     assert_type_domain(Lang::Swift, "xs: Bitmap<String>", None);

--- a/crates/nose-semantics/src/type_domain.rs
+++ b/crates/nose-semantics/src/type_domain.rs
@@ -252,10 +252,10 @@ fn swift_type_domain(text: &str) -> Option<DomainEvidence> {
     if ty.starts_with("result<") {
         return Some(DomainEvidence::Result);
     }
-    if matches!(
-        swift_type_name(&ty),
-        "sequence" | "anysequence" | "collection" | "anycollection"
-    ) {
+    if matches!(swift_type_name(&ty), "collection" | "anycollection") {
+        return Some(DomainEvidence::Collection);
+    }
+    if matches!(swift_type_name(&ty), "sequence" | "anysequence") {
         return Some(DomainEvidence::Iterable);
     }
     match swift_type_name(&ty) {

--- a/docs/demand-effect-semantics.md
+++ b/docs/demand-effect-semantics.md
@@ -48,17 +48,22 @@ list/dict-comprehension surfaces use eager per-element demand where modeled.
 Python generator-expression surfaces use pull-lazy demand: callback errors and
 effects are delayed until a terminal consumer pulls an element. First-party
 library/API HOF rows now carry explicit timing for the supported surfaces:
-JS-like and Ruby `map`/`flatMap`/`filter` rows are eager per element where
-available, while Rust iterator and Java Stream `map`/`flatMap`/`filter` rows are
-pull-lazy. Python builtin `map`/`filter` rows are also pull-lazy, but only when
+JS-like, Ruby, and Swift `map`/`flatMap`/`filter` rows are eager per element
+where available, while Rust iterator and Java Stream `map`/`flatMap`/`filter`
+rows are pull-lazy. Python builtin `map`/`filter` rows are also pull-lazy, but only when
 they are admitted through `nose.protocols.iterator_builtins` with unshadowed
 builtin proof, iterable-source proof, and a lambda callback shape. Rust
 iterator HOF rows require
 `nose.protocols.sequence_hof_adapters` occurrence provenance on a proven
 protocol receiver; `any`/`all` and `count` terminal rows use the same provenance
-boundary, while `collect` remains in the iterator identity/materialization
-adapter slice. Admitted HOF identity alone is still not enough; consumers
-resolve the node-level demand/effect profile before opening exact behavior.
+boundary, while Swift `map`/`filter`/`flatMap` rows use the same pack only on
+proven Array/Collection receivers with inline effect-closed callbacks.
+`Sequence`/`AnySequence`, `Set`, `Dictionary`, `compactMap`, and `.lazy`
+surfaces remain closed until their one-shot, ordering, optional-channel, or
+deferred-demand semantics are represented. `collect` remains in the iterator
+identity/materialization adapter slice. Admitted HOF identity alone is still not
+enough; consumers resolve the node-level demand/effect profile before opening
+exact behavior.
 
 Promise `.then` now carries an async-continuation demand/effect profile in its
 contract row. That does not open exact beta-reduction by itself. The value-graph

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -416,3 +416,11 @@ value-graph collection representative: `1639812e75927a23` disappears and `44bfd7
 appears. The new representative is a whole-impl-span `cardinality`/small `reductions` match with
 only 2 shared lines, not new extractable duplication. No new family appears, so the baseline budget
 is tightened to 54.
+
+The #537 Swift Sequence HOF capability PR tightens the count from 54 to 53. The first draft
+surfaced two avoidable test-scope families while adding Swift `map`/`filter`/`flatMap` admission:
+JS/Swift callback fixture builders and receiver-domain fail-closed IL setup. Both were deduped by
+sharing a callback fixture node helper in the admission resolver support module and a named
+cid-param/receiver fixture in receiver-domain tests. After that cleanup, accepted representative
+`1096a4a828c21a80` no longer reports and no new family appears, so the baseline budget is tightened
+again.

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -594,7 +594,9 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   proof is present, Rust iterator `map`/`filter`/`filter_map`/`flat_map` HOF
   adapters and `any`/`all`/`count` terminals with
   `nose.protocols.sequence_hof_adapters` provenance when protocol receiver proof
-  is present, generic method-call and namespace-call builtin semantics with
+  is present, and Swift `map`/`filter`/`flatMap` HOFs with the same provenance
+  when Array/Collection receiver proof and inline effect-closed callback proof
+  are present, generic method-call and namespace-call builtin semantics with
   `nose.protocols.builtin_method_calls` provenance when no narrower pack owns
   the row, Go `fmt.Print*`, `strings.HasPrefix`/`HasSuffix`,
   `strings.Contains`, and `slices.Contains` namespace calls with
@@ -780,7 +782,8 @@ callers:
   pack-proven map get-default, pack-proven map-key
   views, iterator identity adapters with
   `nose.protocols.iterator_identity_adapters` provenance, Rust sequence-HOF
-  adapters with `nose.protocols.sequence_hof_adapters` provenance, Java
+  adapters and Swift Array/Collection HOFs with
+  `nose.protocols.sequence_hof_adapters` provenance, Java
   `Arrays.stream`, Java map entries, Rust `Some(...)`, Rust map factory receiver
   proof, and HOF receiver proof instead of locally recombining selector strings
   with `LibraryApi` evidence checks.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -152,7 +152,8 @@ The next code slices are intentionally incremental:
    then
    `nose.protocols.sequence_hof_adapters` for Rust iterator
    `map`/`filter`/`filter_map`/`flat_map` HOF adapter occurrence provenance plus
-   `any`/`all`/`count` terminal proof,
+   `any`/`all`/`count` terminal proof and Swift Array/Collection
+   `map`/`filter`/`flatMap` HOF occurrence provenance,
    then
    `nose.protocols.iterator_identity_adapters` for Rust
    `iter`/`into_iter`/`iter_mut`/`collect`/`to_vec`/`copied`/`cloned` and Java
@@ -1518,6 +1519,33 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   167.22 ms -> 171.97 ms. The corpus-free HoF budget smoke stayed under budget
   (`features` 9.30 ms, semantic query 10.33 ms; deep chain 592 tokens / 152
   value-fingerprint nodes, wide chain 1455 / 324).
+- The Swift Sequence HOF slice moved Swift `map`/`filter`/`flatMap` from the
+  generic method-call protocol pack into `nose.protocols.sequence_hof_adapters`
+  for proven Array/Collection receivers. Admission now requires the sequence-HOF
+  pack provenance, Array/Collection receiver proof, and inline effect-closed
+  callbacks before Swift HOF callback demand or follow-on HOF receiver proof can
+  participate in exact behavior. `Set`, `Dictionary`, `Sequence`/`AnySequence`,
+  `.lazy`, `compactMap`, callback references, unknown calls inside callbacks,
+  captured mutation, and throwing callbacks remain closed until their ordering,
+  one-shot, optional-channel, deferred-demand, or effect contracts are modeled.
+  Inventory before/after against `main@ca7acf38`: builtin packs 48 -> 48,
+  exact-capable packs 38 -> 38, positive fixtures 169 -> 172, hard negatives
+  124 -> 131, conformance refs 293 -> 303, unsupported refs 16 -> 17. The
+  sequence-HOF pack metadata changed from Rust-only to Rust+Swift, positives
+  7 -> 10, and hard negatives 7 -> 14. Focused admission coverage for the Swift
+  HOF surfaces in scope moved from 0/3 sequence-HOF pack rows to 3/3, while the
+  adjacent hard negatives remained 0 admitted false merges. 2026-06-26 product
+  query-regression compared clean `origin/main@ca7acf38` with the
+  `issue-537-swift-sequence-hof` working-tree binary over the standard 9-repo
+  subset, repeats=5: the first run reported a noisy unrelated `boltons`
+  normalize+extract runtime trigger, and an immediate rerun with the same
+  binaries reported 9 repos compared and 0 triggers. On the Swift
+  `swift-metrics` representative, output size changed 31489 -> 31499 bytes,
+  distinct location sets stayed 3 -> 3, and the saved artifact median wall time
+  measured 37.72 ms -> 29.08 ms. The corpus-free HoF budget smoke stayed under
+  budget on the final compare rerun (`features` 9.94 ms, semantic query
+  7.81 ms; deep chain 592 tokens / 152 value-fingerprint nodes, wide chain 1455
+  / 324).
 - The static API occurrence slice moved Java empty collection constructors and
   JS-like static `indexOf`/`findIndex` membership behind the same
   dependency-backed occurrence boundary. `new ArrayList<>()`/

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -207,10 +207,15 @@ still being migrated toward it.
   arities remain hard negatives. The
   `nose.protocols.sequence_hof_adapters` descriptor owns Rust iterator
   `map`/`filter`/`filter_map`/`flat_map` HOF adapter occurrence provenance and
-  `any`/`all`/`count` terminal proof on explicit protocol receivers, while
-  custom methods, missing receiver proof, eager callback assumptions, missing
-  terminal proof, one-shot iterator reuse, `collect_vec`, and `find` remain hard
-  negatives or unsupported boundaries. The `nose.go.stdlib.namespace_calls`
+  `any`/`all`/`count` terminal proof on explicit protocol receivers. It also
+  owns Swift `map`/`filter`/`flatMap` HOF occurrence provenance on proven
+  Array/Collection receivers with inline effect-closed callbacks, while Swift
+  `Set`, `Dictionary`, `Sequence`/`AnySequence`, `.lazy`, throwing or mutating
+  callbacks, and `compactMap` remain hard negatives or unsupported boundaries.
+  Rust custom methods, missing receiver proof, eager callback assumptions,
+  missing terminal proof, one-shot iterator reuse, `collect_vec`, and `find`
+  remain hard negatives or unsupported boundaries. The
+  `nose.go.stdlib.namespace_calls`
   descriptor owns Go `fmt.Print*`, `strings.HasPrefix`/`HasSuffix`,
   `strings.Contains`, and `slices.Contains` namespace-call API occurrence
   provenance under imported namespace proof. `strings.Contains` lowers to the
@@ -713,7 +718,11 @@ migrated.
   occurrence as protocol evidence, so downstream adapters such as Rust
   `.collect()` can consume a canonicalized `filter_map` receiver without trusting
   the `collect` selector alone; for Rust iterator HOFs this same-span occurrence
-  is admitted under `nose.protocols.sequence_hof_adapters`. Value-graph filter
+  is admitted under `nose.protocols.sequence_hof_adapters`. Swift
+  `map`/`filter`/`flatMap` same-span occurrences use the same pack only when
+  their receiver proof is Array/Collection rather than arbitrary `Sequence`,
+  `Set`, or `Dictionary`, so chained Swift HOFs can reuse pack-backed receiver
+  proof without opening one-shot or ordering assumptions. Value-graph filter
   consumers such as `len(filter(...))`, explicit reductions over a filter, and
   static literal membership shortcuts reuse HOF admission as well, so raw
   `HoF(Filter)` cannot bypass the source/API HOF gate by appearing under another

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -80,6 +80,9 @@ set -euo pipefail
 # 56 -> 54 (#536 JS/TS Array HOF): adding the callback-obligation review fix unifies the inline
 # callback shape in method-call and typed/free-call IL fixtures, so two accepted test-fixture
 # families disappear. The budget is tightened with the resolved families removed.
+# 54 -> 53 (#537 Swift Sequence HOF): shared callback fixture nodes and receiver-domain setup
+# remove the draft Swift-HOF test-scope duplication plus one accepted representative from the
+# baseline. The budget is tightened again.
 BIN="${NOSE_BIN:-./target/release/nose}"
 BASELINE="${NOSE_DUP_BASELINE:-scripts/duplication-baseline.json}"
 

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -8,7 +8,6 @@
     "1dfaba2582163d7c",
     "1fc08105c8b5d5c0",
     "209fdc39157ececd",
-    "1096a4a828c21a80",
     "3cdf8f9a869d1932",
     "2b26aa8a17d81eae",
     "4890b7227d416249",
@@ -55,7 +54,7 @@
     "f57a5ee0ebbdf114",
     "f88aeebdec4f2c68"
   ],
-  "budget": 54,
+  "budget": 53,
   "generated_by": "target/release/nose query crates all top=0 --mode near --min-value 40 --format json",
   "min_value": 40,
   "mode": "near",


### PR DESCRIPTION
Closes #537.

## Summary
- Move Swift `map`/`filter`/`flatMap` onto `nose.protocols.sequence_hof_adapters` instead of the generic method-call pack.
- Require sequence-HOF pack provenance, Array/Collection receiver proof, and inline effect-closed callback proof before admission.
- Keep `Set`, `Dictionary`, `Sequence`/`AnySequence`, `.lazy`, `compactMap`, callback references, unknown callback calls, captured mutation, and throwing callbacks fail-closed, with an executable `.lazy.map` hard-negative covering both base-collection proof and lazy-iterable proof.
- Add shared test fixtures for callback nodes and receiver-domain setup, and tighten the dogfooding duplication budget from 54 to 53.

## Quantified Change
- Builtin packs: 48 -> 48; exact-capable packs: 38 -> 38.
- Positive fixtures: 169 -> 172; hard negatives: 124 -> 131; conformance refs: 293 -> 303; unsupported refs: 16 -> 17.
- Sequence-HOF pack: supported languages Rust-only -> Rust+Swift; positives 7 -> 10; hard negatives 7 -> 14.
- Focused Swift HOF admission coverage: 0/3 -> 3/3 sequence-HOF rows, with adjacent hard negatives at 0 admitted false merges.
- Query regression over the standard 9-repo subset, repeats=5: first run had one noisy unrelated `boltons` runtime trigger; immediate rerun reported 9 repos compared and 0 triggers. Swift `swift-metrics` location sets stayed 3 -> 3 and median wall time measured 37.72 ms -> 29.08 ms in the saved artifact.

## Verification
- `cargo fmt --all`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-frontend -p nose-cli --all-targets -- -D warnings`
- `cargo test -p nose-semantics -p nose-normalize -p nose-frontend --lib`
- `cargo test -p nose-cli --test cli`
- `cargo test -p nose-cli --test equivalence`
- `cargo test -p nose-semantics library_api_evidence::admission_resolvers::sequence_hof --lib` (10 tests after review hardening)
- `cargo test -p nose-semantics library_api_evidence::admission_resolvers::js_array_hof --lib`
- `cargo test -p nose-semantics library_api_contracts::method_protocols --lib`
- `cargo test -p nose-semantics semantic_evidence::receiver_domains --lib`
- `cargo test -p nose-semantics semantic_evidence::type_domains --lib`
- `cargo test -p nose-normalize idioms::tests::contracts --lib`
- `cargo test -p nose-normalize value_graph::tests::source_evidence::hof_demand --lib`
- `cargo test -p nose-cli --test equivalence collection_streams`
- `cargo test -p nose-semantics descriptor_enumeration --lib`
- `cargo test -p nose-cli --test cli semantic_pack_inventory`
- `cargo test -p nose-cli --test cli builtin_report`
- `cargo build --release`
- `python3 bench/type4/query_regression/query_regression.py baseline --nose /tmp/nose-537-baseline --repos-root /Users/ak/prjs/cc/nose/bench/repos --out /tmp/nose-537-query-baseline.json --repeats 5 --build-ref origin/main@ca7acf38`
- `python3 bench/type4/query_regression/query_regression.py compare --nose /tmp/nose-537-current --repos-root bench/repos --baseline /tmp/nose-537-query-baseline.json --summary /tmp/nose-537-query-summary-rerun.md --repeats 5 --build-ref issue-537-swift-sequence-hof@working-tree-rerun`
- `cargo llvm-cov --workspace --summary-only --fail-under-lines 83`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`
