### PR TITLE
Add Ruby Enumerable HOF sequence capability

### DIFF
--- a/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
@@ -311,13 +311,13 @@ pub(super) fn assert_group(json: &serde_json::Value) {
     assert_eq!(sequence_hof_adapter["license"], "MIT");
     assert_eq!(
         json_array_strings(sequence_hof_adapter, "supported_languages"),
-        vec!["rust", "swift"]
+        vec!["rust", "swift", "ruby"]
     );
     assert_eq!(sequence_hof_adapter["counts"]["evidence_producers"], 1);
     assert_eq!(sequence_hof_adapter["counts"]["contracts"], 1);
     assert_eq!(sequence_hof_adapter["counts"]["value_laws"], 0);
-    assert_eq!(sequence_hof_adapter["counts"]["positive_fixtures"], 10);
-    assert_eq!(sequence_hof_adapter["counts"]["hard_negatives"], 14);
+    assert_eq!(sequence_hof_adapter["counts"]["positive_fixtures"], 15);
+    assert_eq!(sequence_hof_adapter["counts"]["hard_negatives"], 22);
 
     let go_namespace_call = semantic_pack_by_id(&json, "nose.go.stdlib.namespace_calls");
     assert_eq!(go_namespace_call["hash"], "d3dfae6db995411b");

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
@@ -10,9 +10,9 @@ fn semantic_pack_inventory_json_reports_builtin_coverage() {
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["packs"], 48);
     assert_eq!(json["totals"]["builtin_packs"], 48);
-    assert_eq!(json["totals"]["positive_fixtures"], 172);
-    assert_eq!(json["totals"]["hard_negatives"], 131);
-    assert_eq!(json["totals"]["conformance_refs"], 303);
+    assert_eq!(json["totals"]["positive_fixtures"], 177);
+    assert_eq!(json["totals"]["hard_negatives"], 139);
+    assert_eq!(json["totals"]["conformance_refs"], 316);
     assert_eq!(json["totals"]["packs_needing_coverage"], 0);
     assert_eq!(
         json["evidence_policy"]["product_output"],
@@ -98,7 +98,12 @@ fn assert_sequence_hof_adapter_pack(packs: &[serde_json::Value]) {
             "rust-iterator-hof-count-terminal-positive",
             "swift-sequence-hof-map-positive",
             "swift-sequence-hof-filter-positive",
-            "swift-sequence-hof-flat-map-positive"
+            "swift-sequence-hof-flat-map-positive",
+            "ruby-enumerable-hof-map-positive",
+            "ruby-enumerable-hof-collect-positive",
+            "ruby-enumerable-hof-select-positive",
+            "ruby-enumerable-hof-filter-positive",
+            "ruby-enumerable-hof-reject-positive"
         ]
     );
     assert_eq!(
@@ -117,14 +122,23 @@ fn assert_sequence_hof_adapter_pack(packs: &[serde_json::Value]) {
             "swift-sequence-hof-throwing-closure-hard-negative",
             "swift-sequence-hof-mutating-closure-hard-negative",
             "swift-sequence-hof-any-sequence-reuse-hard-negative",
-            "swift-sequence-hof-compact-map-unsupported-hard-negative"
+            "swift-sequence-hof-compact-map-unsupported-hard-negative",
+            "ruby-enumerable-hof-no-block-hard-negative",
+            "ruby-enumerable-hof-lazy-enumerator-hard-negative",
+            "ruby-enumerable-hof-framework-relation-hard-negative",
+            "ruby-enumerable-hof-custom-method-hard-negative",
+            "ruby-enumerable-hof-hash-order-hard-negative",
+            "ruby-enumerable-hof-set-order-hard-negative",
+            "ruby-enumerable-hof-mutating-block-hard-negative",
+            "ruby-enumerable-hof-flat-map-unsupported-hard-negative"
         ]
     );
     assert_eq!(
         json_array_strings(&sequence_hof["conformance"], "unsupported_refs"),
         vec![
             "rust-iterator-hof-find-unsupported-hard-negative",
-            "swift-sequence-hof-compact-map-unsupported-hard-negative"
+            "swift-sequence-hof-compact-map-unsupported-hard-negative",
+            "ruby-enumerable-hof-flat-map-unsupported-hard-negative"
         ]
     );
 }

--- a/crates/nose-detect/src/strict_exact/hof.rs
+++ b/crates/nose-detect/src/strict_exact/hof.rs
@@ -108,7 +108,13 @@ fn strict_exact_hof_internal_safe(
 ) -> bool {
     matches!(
         il.node(node).payload,
-        Payload::HoF(HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter | HoFKind::FilterMap)
+        Payload::HoF(
+            HoFKind::Map
+                | HoFKind::FlatMap
+                | HoFKind::Filter
+                | HoFKind::FilterMap
+                | HoFKind::Reject,
+        )
     ) && strict_exact_hof_children_safe(il, interner, facts, node)
 }
 

--- a/crates/nose-il/src/node/ops.rs
+++ b/crates/nose-il/src/node/ops.rs
@@ -177,4 +177,6 @@ pub enum HoFKind {
     /// Option/null-producing map: `Null` drops the item, `Err` propagates, every
     /// other value is emitted.
     FilterMap,
+    /// Inverted predicate filter, as in Ruby `Enumerable#reject`.
+    Reject,
 }

--- a/crates/nose-normalize/src/idioms/receiver_evidence.rs
+++ b/crates/nose-normalize/src/idioms/receiver_evidence.rs
@@ -28,7 +28,9 @@ pub(super) fn exact_array_or_collection_receiver(
     };
     if !matches!(
         admitted.contract.result.semantic,
-        MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+        MethodSemanticContract::HoF(
+            HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap | HoFKind::Reject,
+        )
     ) || admitted.contract.result.receiver != MethodReceiverContract::ExactArrayOrCollection
     {
         return false;
@@ -58,7 +60,9 @@ pub(super) fn exact_array_receiver(
     };
     if !matches!(
         admitted.contract.result.semantic,
-        MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+        MethodSemanticContract::HoF(
+            HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap | HoFKind::Reject,
+        )
     ) || admitted.contract.result.receiver != MethodReceiverContract::ExactArray
     {
         return false;

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -18,7 +18,9 @@
 //! proof-obligation: normalize.value_graph.field_writes
 //! proof-obligation: normalize.value_graph.free_monoid
 
-use nose_il::{stable_symbol_hash, Builtin, Il, Interner, LoopKind, NodeId, NodeKind, Op, Payload};
+use nose_il::{
+    stable_symbol_hash, Builtin, HoFKind, Il, Interner, LoopKind, NodeId, NodeKind, Op, Payload,
+};
 use nose_semantics::{
     admitted_builtin_semantics_at_call_with_interner, builtin_demand_profile,
     direct_function_call_target_at_call, exact_java_this_field, exact_java_this_var,

--- a/crates/nose-normalize/src/interp/hof.rs
+++ b/crates/nose-normalize/src/interp/hof.rs
@@ -65,7 +65,9 @@ impl<'a> Interp<'a> {
                     if matches!(keep, Value::Err) {
                         return Ok(Value::Err);
                     }
-                    if truthy(&keep).ok_or(Unsupported)? {
+                    let keep = truthy(&keep).ok_or(Unsupported)?;
+                    let keep = if kind == HoFKind::Reject { !keep } else { keep };
+                    if keep {
                         out.push(x);
                     }
                 }

--- a/crates/nose-normalize/src/interp/tests/hof.rs
+++ b/crates/nose-normalize/src/interp/tests/hof.rs
@@ -204,6 +204,10 @@ fn hof_empty_collections_skip_lambda_errors() {
         empty
     );
     assert_eq!(
+        hof_with_empty_collection_and_error_lambda(HoFKind::Reject),
+        empty
+    );
+    assert_eq!(
         hof_with_empty_collection_and_error_lambda(HoFKind::FlatMap),
         empty
     );

--- a/crates/nose-normalize/src/value_graph/collections/hof.rs
+++ b/crates/nose-normalize/src/value_graph/collections/hof.rs
@@ -117,7 +117,7 @@ impl<'a> Builder<'a> {
                     None => self.mk(ValOp::Hof(HoFKind::Map as u32), vec![contrib]),
                 }
             }
-            HoFKind::Filter => {
+            HoFKind::Filter | HoFKind::Reject => {
                 // `filter(p, coll)` ≡ the identity map with a predicate. This keeps the
                 // element stream attached, lets nested filters fuse, and matches filtered
                 // comprehensions/builders without letting raw HOF payloads bypass proof.
@@ -130,6 +130,11 @@ impl<'a> Builder<'a> {
                 let own_pred = kids
                     .get(1)
                     .and_then(|&lambda| self.eval_lambda_body(lambda, &elems, env));
+                let own_pred = if kind == HoFKind::Reject {
+                    own_pred.map(|predicate| self.mk(ValOp::Un(Op::Not as u32), vec![predicate]))
+                } else {
+                    own_pred
+                };
                 match self.and_preds(own_pred, carried_pred) {
                     Some(predicate) => {
                         self.mk(ValOp::Hof(HoFKind::Map as u32), vec![elem, predicate])

--- a/crates/nose-normalize/src/value_graph/control/static_errors.rs
+++ b/crates/nose-normalize/src/value_graph/control/static_errors.rs
@@ -89,7 +89,7 @@ impl<'a> Builder<'a> {
         if self.il.kind(expr) == NodeKind::HoF
             && matches!(
                 self.il.node(expr).payload,
-                Payload::HoF(HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter)
+                Payload::HoF(HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter | HoFKind::Reject,)
                     | Payload::HoF(HoFKind::FilterMap)
             )
         {

--- a/crates/nose-normalize/src/value_graph/tests/source_evidence/hof_demand.rs
+++ b/crates/nose-normalize/src/value_graph/tests/source_evidence/hof_demand.rs
@@ -65,11 +65,14 @@ fn raw_hof_value_graph_requires_source_or_api_admission() {
     );
 }
 
-fn div_zero_map_len_il() -> (Il, NodeId) {
+fn map_len_il_with_lambda(
+    lambda: impl FnOnce(&mut IlBuilder) -> NodeId,
+    lang: Lang,
+) -> (Il, NodeId, NodeId) {
     let mut b = IlBuilder::new(FileId(0));
     let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(1), &[]);
     let coll = b.add(NodeKind::Seq, Payload::None, sp(1), &[item]);
-    let lambda = div_zero_lambda(&mut b, 2, sp(2));
+    let lambda = lambda(&mut b);
     let hof = b.add(
         NodeKind::HoF,
         Payload::HoF(HoFKind::Map),
@@ -82,7 +85,28 @@ fn div_zero_map_len_il() -> (Il, NodeId) {
         sp(4),
         &[hof],
     );
-    (finish_test_il(b, count, Lang::Rust), hof)
+    (finish_test_il(b, count, lang), hof, count)
+}
+
+fn div_zero_map_len_il() -> (Il, NodeId) {
+    let (il, hof, _count) = map_len_il_with_lambda(|b| div_zero_lambda(b, 2, sp(2)), Lang::Rust);
+    (il, hof)
+}
+
+fn bool_predicate_source(b: &mut IlBuilder) -> (NodeId, NodeId) {
+    let coll = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
+    let pred = const_bool_lambda(b, 2, true, sp(2));
+    (coll, pred)
+}
+
+fn predicate_hof(
+    b: &mut IlBuilder,
+    kind: HoFKind,
+    span: Span,
+    coll: NodeId,
+    pred: NodeId,
+) -> NodeId {
+    b.add(NodeKind::HoF, Payload::HoF(kind), span, &[coll, pred])
 }
 
 fn push_map_contract_evidence(il: &mut Il, lang: Lang, hof: NodeId, expect_msg: &str) {
@@ -137,6 +161,24 @@ fn push_map_contract_evidence(il: &mut Il, lang: Lang, hof: NodeId, expect_msg: 
         )
     };
     il.evidence.push(evidence);
+}
+
+fn push_ruby_sequence_hof_contract_evidence(
+    il: &mut Il,
+    id: u32,
+    hof: NodeId,
+    method: &str,
+    dependency: EvidenceId,
+) {
+    let contract = library_method_call_contract(Lang::Ruby, method, 1).expect("Ruby HOF contract");
+    il.evidence.push(rust_sequence_hof_adapter_evidence(
+        id,
+        il.node(hof).span,
+        contract.id,
+        contract.callee,
+        1,
+        vec![dependency],
+    ));
 }
 
 #[test]
@@ -278,23 +320,7 @@ fn raw_builtin_payload_does_not_prove_static_error_demand() {
 #[test]
 fn len_of_library_hof_requires_materialized_demand_profile() {
     let interner = Interner::new();
-    let mut b = IlBuilder::new(FileId(0));
-    let item = b.add(NodeKind::Lit, Payload::LitInt(1), sp(1), &[]);
-    let coll = b.add(NodeKind::Seq, Payload::None, sp(1), &[item]);
-    let lambda = identity_lambda(&mut b, 2, sp(2));
-    let hof = b.add(
-        NodeKind::HoF,
-        Payload::HoF(HoFKind::Map),
-        sp(3),
-        &[coll, lambda],
-    );
-    let count = b.add(
-        NodeKind::Call,
-        Payload::Builtin(Builtin::Len),
-        sp(4),
-        &[hof],
-    );
-    let mut il = finish_test_il(b, count, Lang::Rust);
+    let (mut il, hof, count) = map_len_il_with_lambda(|b| identity_lambda(b, 2, sp(2)), Lang::Rust);
     push_map_contract_evidence(&mut il, Lang::Rust, hof, "Rust map contract");
     let mut builder = Builder::new(&il, &interner);
     assert!(
@@ -349,14 +375,8 @@ fn len_of_library_hof_requires_materialized_demand_profile() {
 fn source_comprehension_admits_internal_python_filter_hof_only_in_context() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
-    let coll = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
-    let pred = const_bool_lambda(&mut b, 2, true, sp(2));
-    let filter = b.add(
-        NodeKind::HoF,
-        Payload::HoF(HoFKind::Filter),
-        sp(3),
-        &[coll, pred],
-    );
+    let (coll, pred) = bool_predicate_source(&mut b);
+    let filter = predicate_hof(&mut b, HoFKind::Filter, sp(3), coll, pred);
     let mapper = identity_lambda(&mut b, 3, sp(4));
     let map = b.add(
         NodeKind::HoF,
@@ -392,14 +412,8 @@ fn source_comprehension_admits_internal_python_filter_hof_only_in_context() {
 fn len_of_raw_filter_hof_requires_filter_admission() {
     let interner = Interner::new();
     let mut b = IlBuilder::new(FileId(0));
-    let coll = b.add(NodeKind::Var, Payload::Cid(1), sp(1), &[]);
-    let pred = const_bool_lambda(&mut b, 2, true, sp(2));
-    let filter = b.add(
-        NodeKind::HoF,
-        Payload::HoF(HoFKind::Filter),
-        sp(3),
-        &[coll, pred],
-    );
+    let (coll, pred) = bool_predicate_source(&mut b);
+    let filter = predicate_hof(&mut b, HoFKind::Filter, sp(3), coll, pred);
     let len = b.add(
         NodeKind::Call,
         Payload::Builtin(Builtin::Len),
@@ -423,5 +437,41 @@ fn len_of_raw_filter_hof_requires_filter_admission() {
     assert!(
         !matches!(builder.nodes[value as usize].op, ValOp::Reduce(op) if op == Op::Add as u32),
         "admitted len must not turn an unadmitted raw filter HOF into a predicate count"
+    );
+}
+
+#[test]
+fn ruby_reject_hof_carries_negated_predicate() {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let (coll, pred) = bool_predicate_source(&mut b);
+    let filter = predicate_hof(&mut b, HoFKind::Filter, sp(3), coll, pred);
+    let reject = predicate_hof(&mut b, HoFKind::Reject, sp(4), coll, pred);
+    let root = b.add(NodeKind::Block, Payload::None, sp(5), &[filter, reject]);
+    let mut il = finish_test_il(b, root, Lang::Ruby);
+    il.evidence.push(evidence(
+        0,
+        EvidenceAnchor::node(il.node(coll).span, il.kind(coll)),
+        EvidenceKind::Domain(DomainEvidence::Collection),
+    ));
+    push_ruby_sequence_hof_contract_evidence(&mut il, 1, filter, "filter", EvidenceId(0));
+    push_ruby_sequence_hof_contract_evidence(&mut il, 2, reject, "reject", EvidenceId(0));
+
+    let mut builder = Builder::new(&il, &interner);
+    let filter_value = builder.eval(filter, &FxHashMap::default());
+    let reject_value = builder.eval(reject, &FxHashMap::default());
+    assert_ne!(
+        filter_value, reject_value,
+        "Ruby reject must not collapse to the same predicate as select/filter"
+    );
+    let reject_node = &builder.nodes[reject_value as usize];
+    assert!(
+        matches!(reject_node.op, ValOp::Hof(k) if k == HoFKind::Map as u32)
+            && reject_node.args.len() == 2
+            && matches!(
+                builder.nodes[reject_node.args[1] as usize].op,
+                ValOp::Un(op) if op == Op::Not as u32
+            ),
+        "Ruby reject should carry Not(predicate) through filter-like HOF semantics"
     );
 }

--- a/crates/nose-normalize/src/value_graph/tests/support/library_api/library_api_push.rs
+++ b/crates/nose-normalize/src/value_graph/tests/support/library_api/library_api_push.rs
@@ -113,10 +113,22 @@ fn is_sequence_hof_method_call(
             (contract_id, callee),
             (
                 LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
-                    HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
+                    HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap | HoFKind::Reject,
                 )),
                 LibraryApiCalleeContract::Method {
                     method: "map" | "filter" | "flatMap",
+                    receiver: MethodReceiverContract::ExactArrayOrCollection,
+                },
+            )
+        ),
+        Lang::Ruby => matches!(
+            (contract_id, callee),
+            (
+                LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
+                    HoFKind::Map | HoFKind::Filter | HoFKind::Reject,
+                )),
+                LibraryApiCalleeContract::Method {
+                    method: "map" | "collect" | "select" | "filter" | "reject",
                     receiver: MethodReceiverContract::ExactArrayOrCollection,
                 },
             )

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -396,7 +396,7 @@ pub fn hof_contract(kind: HoFKind) -> HofContract {
         HoFKind::FilterMap => HofDemandProfile::FilterMap {
             callback: CallbackDemandProfile::unary_element(CallbackResultDemand::OptionalValue),
         },
-        HoFKind::Filter => HofDemandProfile::Filter {
+        HoFKind::Filter | HoFKind::Reject => HofDemandProfile::Filter {
             callback: CallbackDemandProfile::unary_element(CallbackResultDemand::Predicate),
         },
         HoFKind::Reduce => HofDemandProfile::Reduce {
@@ -421,7 +421,7 @@ pub fn library_hof_demand_timing(lang: Lang, kind: HoFKind) -> Option<HofDemandT
             Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html,
             HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter,
         )
-        | (Lang::Ruby, HoFKind::Map | HoFKind::Filter)
+        | (Lang::Ruby, HoFKind::Map | HoFKind::Filter | HoFKind::Reject)
         | (Lang::Swift, HoFKind::Map | HoFKind::FlatMap | HoFKind::Filter) => {
             HofDemandTiming::EagerPerElement
         }

--- a/crates/nose-semantics/src/library_api/admission/iterator_sources.rs
+++ b/crates/nose-semantics/src/library_api/admission/iterator_sources.rs
@@ -81,6 +81,9 @@ fn method_hof_callback_obligation_required(lang: Lang, id: LibraryApiContractId)
         LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
             HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
         )) if lang == Lang::Swift => true,
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
+            HoFKind::Map | HoFKind::Filter | HoFKind::Reject,
+        )) if lang == Lang::Ruby => true,
         _ => false,
     }
 }
@@ -180,7 +183,9 @@ fn method_hof_callback_nested_call_effect_closed(
 }
 
 fn method_hof_callback_nested_method_call(lang: Lang, contract: MethodCallContract) -> bool {
-    js_like_array_hof_method_call(lang, contract) || swift_sequence_hof_method_call(lang, contract)
+    js_like_array_hof_method_call(lang, contract)
+        || swift_sequence_hof_method_call(lang, contract)
+        || ruby_sequence_hof_method_call(lang, contract)
 }
 
 fn library_api_record_has_iterable_source_dependency(

--- a/crates/nose-semantics/src/library_api/admission/provenance.rs
+++ b/crates/nose-semantics/src/library_api/admission/provenance.rs
@@ -30,10 +30,57 @@ fn library_api_contract_provenance_ids(
     python_library_api_contract_provenance_ids(id)
         .or_else(|| js_like_library_api_contract_provenance_ids(lang, id, callee))
         .or_else(|| swift_library_api_contract_provenance_ids(lang, id, callee))
+        .or_else(|| ruby_library_api_contract_provenance_ids(lang, id, callee))
         .or_else(|| rust_library_api_contract_provenance_ids(lang, id, callee))
         .or_else(|| java_library_api_contract_provenance_ids(id, callee))
         .or_else(|| go_library_api_contract_provenance_ids(id, callee))
         .or_else(|| protocol_library_api_contract_provenance_ids(id, callee))
+}
+
+fn ruby_library_api_contract_provenance_ids(
+    lang: Lang,
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+) -> Option<(&'static str, &'static str)> {
+    match id {
+        LibraryApiContractId::MethodCall(_)
+            if lang == Lang::Ruby && ruby_sequence_hof_method_callee(id, callee) =>
+        {
+            Some((
+                SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+                SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn ruby_sequence_hof_method_callee(
+    id: LibraryApiContractId,
+    callee: LibraryApiCalleeContract,
+) -> bool {
+    matches!(
+        (id, callee),
+        (
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map)),
+            LibraryApiCalleeContract::Method {
+                method: "map" | "collect",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+        ) | (
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Filter)),
+            LibraryApiCalleeContract::Method {
+                method: "select" | "filter",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+        ) | (
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Reject)),
+            LibraryApiCalleeContract::Method {
+                method: "reject",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+        )
+    )
 }
 
 fn python_library_api_contract_provenance_ids(

--- a/crates/nose-semantics/src/library_api/registry.rs
+++ b/crates/nose-semantics/src/library_api/registry.rs
@@ -12,7 +12,7 @@ pub(super) fn library_api_contract_result_domain_for_arity(
 ) -> Option<DomainEvidence> {
     library_api_materialized_result_domain_for_arity(id, callee, arity).or(match id {
         LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(
-            HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap,
+            HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap | HoFKind::Reject,
         )) if matches!(
             callee,
             LibraryApiCalleeContract::Method {
@@ -472,6 +472,7 @@ fn method_call_contract_callees_for_semantic(
         "unwrap_or_else",
         "map_or",
         "reduce",
+        "reject",
         "Min",
         "Max",
         "abs",

--- a/crates/nose-semantics/src/library_api/registry/contract_ids.rs
+++ b/crates/nose-semantics/src/library_api/registry/contract_ids.rs
@@ -142,6 +142,7 @@ fn push_method_call_library_api_contract_ids(ids: &mut Vec<LibraryApiContractId>
             MethodSemanticContract::HoF(HoFKind::Filter),
             MethodSemanticContract::HoF(HoFKind::FlatMap),
             MethodSemanticContract::HoF(HoFKind::FilterMap),
+            MethodSemanticContract::HoF(HoFKind::Reject),
         ]
         .into_iter()
         .map(LibraryApiContractId::MethodCall),

--- a/crates/nose-semantics/src/library_api/rows/methods.rs
+++ b/crates/nose-semantics/src/library_api/rows/methods.rs
@@ -439,6 +439,7 @@ fn method_call_contract_provenance(
 ) -> (&'static str, &'static str) {
     if rust_sequence_hof_method_call(lang, contract)
         || swift_sequence_hof_method_call(lang, contract)
+        || ruby_sequence_hof_method_call(lang, contract)
     {
         (
             SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
@@ -567,6 +568,7 @@ mod classification;
 mod receiver;
 mod selectors;
 pub(in crate::library_api) use classification::js_like_array_hof_method_call;
+pub(in crate::library_api) use classification::ruby_sequence_hof_method_call;
 use classification::rust_sequence_hof_method_call;
 pub(in crate::library_api) use classification::swift_sequence_hof_method_call;
 pub use receiver::{library_receiver_method_api_contract, library_receiver_method_api_contracts};

--- a/crates/nose-semantics/src/library_api/rows/methods/classification.rs
+++ b/crates/nose-semantics/src/library_api/rows/methods/classification.rs
@@ -55,3 +55,18 @@ pub(in crate::library_api) fn swift_sequence_hof_method_call(
             )
         )
 }
+
+pub(in crate::library_api) fn ruby_sequence_hof_method_call(
+    lang: Lang,
+    contract: MethodCallContract,
+) -> bool {
+    lang == Lang::Ruby
+        && matches!(
+            (contract.semantic, contract.receiver, contract.args),
+            (
+                MethodSemanticContract::HoF(HoFKind::Map | HoFKind::Filter | HoFKind::Reject),
+                MethodReceiverContract::ExactArrayOrCollection,
+                MethodBuiltinArgs::Hof,
+            )
+        )
+}

--- a/crates/nose-semantics/src/library_api/rows/methods/selectors.rs
+++ b/crates/nose-semantics/src/library_api/rows/methods/selectors.rs
@@ -68,6 +68,7 @@ pub(crate) fn library_method_selector_name(name: &str) -> Option<&'static str> {
         "nil?" => "nil?",
         "push" => "push",
         "reduce" => "reduce",
+        "reject" => "reject",
         "select" => "select",
         "size" => "size",
         "some" => "some",

--- a/crates/nose-semantics/src/method_contracts.rs
+++ b/crates/nose-semantics/src/method_contracts.rs
@@ -213,19 +213,27 @@ pub(super) fn method_call_contract_shapes(
             receiver: Receiver::ExactArray,
             args: Args::Hof,
         }];
-    } else if lang == Lang::Swift
-        && matches!(
-            method_hof_contract(lang, name),
+    } else if matches!(
+        (lang, method_hof_contract(lang, name)),
+        (
+            Lang::Swift,
             Some(HoFKind::Map | HoFKind::Filter | HoFKind::FlatMap)
+        ) | (
+            Lang::Ruby,
+            Some(HoFKind::Map | HoFKind::Filter | HoFKind::Reject)
         )
-        && arg_count == 1
+    ) && arg_count == 1
     {
         return vec![MethodCallContract {
             semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
             receiver: Receiver::ExactArrayOrCollection,
             args: Args::Hof,
         }];
-    } else if !js_like_lang(lang) && method_hof_contract(lang, name).is_some() && arg_count > 0 {
+    } else if !js_like_lang(lang)
+        && !matches!(lang, Lang::Swift | Lang::Ruby)
+        && method_hof_contract(lang, name).is_some()
+        && arg_count > 0
+    {
         return vec![MethodCallContract {
             semantic: Semantic::HoF(method_hof_contract(lang, name).unwrap()),
             receiver: Receiver::ExactProtocol,

--- a/crates/nose-semantics/src/method_families.rs
+++ b/crates/nose-semantics/src/method_families.rs
@@ -48,6 +48,7 @@ pub fn method_hof_contract(lang: Lang, name: &str) -> Option<HoFKind> {
         | (Lang::Java, "filter")
         | (Lang::Swift, "filter")
         | (Lang::Ruby, "filter" | "select") => HoFKind::Filter,
+        (Lang::Ruby, "reject") => HoFKind::Reject,
         _ => return None,
     })
 }

--- a/crates/nose-semantics/src/packs/compiled/constants/sequence_hof.rs
+++ b/crates/nose-semantics/src/packs/compiled/constants/sequence_hof.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_LANGUAGES: &[&str] =
-    &["rust", "swift"];
+    &["rust", "swift", "ruby"];
 pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PACKAGES: &[&str] =
-    &["core::iter", "Swift.Collection"];
+    &["core::iter", "Swift.Collection", "Enumerable"];
 pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_IDS: &[&str] =
     &[SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID];
 pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONTRACT_IDS: &[&str] =
@@ -33,4 +33,17 @@ pub(in crate::packs::compiled) const SEQUENCE_HOF_ADAPTER_PROTOCOL_CONFORMANCE_R
     "swift-sequence-hof-mutating-closure-hard-negative",
     "swift-sequence-hof-any-sequence-reuse-hard-negative",
     "swift-sequence-hof-compact-map-unsupported-hard-negative",
+    "ruby-enumerable-hof-map-positive",
+    "ruby-enumerable-hof-collect-positive",
+    "ruby-enumerable-hof-select-positive",
+    "ruby-enumerable-hof-filter-positive",
+    "ruby-enumerable-hof-reject-positive",
+    "ruby-enumerable-hof-no-block-hard-negative",
+    "ruby-enumerable-hof-lazy-enumerator-hard-negative",
+    "ruby-enumerable-hof-framework-relation-hard-negative",
+    "ruby-enumerable-hof-custom-method-hard-negative",
+    "ruby-enumerable-hof-hash-order-hard-negative",
+    "ruby-enumerable-hof-set-order-hard-negative",
+    "ruby-enumerable-hof-mutating-block-hard-negative",
+    "ruby-enumerable-hof-flat-map-unsupported-hard-negative",
 ];

--- a/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
+++ b/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
@@ -349,10 +349,13 @@ pub(super) fn assert_group() {
     let sequence_hof_adapter = builtin_pack_descriptor(SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID)
         .expect("sequence HOF adapter protocol descriptor");
     assert_eq!(sequence_hof_adapter.kind, SemanticPackKind::ProtocolPack);
-    assert_eq!(sequence_hof_adapter.supported_languages, &["rust", "swift"]);
+    assert_eq!(
+        sequence_hof_adapter.supported_languages,
+        &["rust", "swift", "ruby"]
+    );
     assert_eq!(
         sequence_hof_adapter.supported_packages,
-        &["core::iter", "Swift.Collection"]
+        &["core::iter", "Swift.Collection", "Enumerable"]
     );
     assert_eq!(
         sequence_hof_adapter.evidence_producer_ids,
@@ -365,8 +368,8 @@ pub(super) fn assert_group() {
     );
     assert_eq!(sequence_hof_adapter.counts().evidence_producers, 1);
     assert_eq!(sequence_hof_adapter.counts().contracts, 1);
-    assert_eq!(sequence_hof_adapter.counts().positive_fixtures, 10);
-    assert_eq!(sequence_hof_adapter.counts().hard_negatives, 14);
+    assert_eq!(sequence_hof_adapter.counts().positive_fixtures, 15);
+    assert_eq!(sequence_hof_adapter.counts().hard_negatives, 22);
     assert!(sequence_hof_adapter
         .conformance_refs()
         .contains(&"rust-iterator-hof-missing-terminal-proof-hard-negative"));
@@ -379,6 +382,12 @@ pub(super) fn assert_group() {
     assert!(sequence_hof_adapter
         .conformance_refs()
         .contains(&"swift-sequence-hof-any-sequence-reuse-hard-negative"));
+    assert!(sequence_hof_adapter
+        .conformance_refs()
+        .contains(&"ruby-enumerable-hof-reject-positive"));
+    assert!(sequence_hof_adapter
+        .conformance_refs()
+        .contains(&"ruby-enumerable-hof-no-block-hard-negative"));
 
     let go_namespace_call = builtin_pack_descriptor(GO_STDLIB_NAMESPACE_CALL_PACK_ID)
         .expect("Go stdlib namespace-call descriptor");

--- a/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
@@ -199,6 +199,11 @@ fn hof_demand_effect_profiles_split_eager_and_pull_lazy_timing() {
             .proves_eager_per_element_callback_demand()
     );
     assert!(
+        library_hof_demand_effect_profile(Lang::Ruby, HoFKind::Reject)
+            .unwrap()
+            .proves_eager_per_element_callback_demand()
+    );
+    assert!(
         library_hof_demand_effect_profile(Lang::Swift, HoFKind::FlatMap)
             .unwrap()
             .proves_eager_per_element_callback_demand()

--- a/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
@@ -33,6 +33,10 @@ fn method_protocol_contracts_are_language_constrained() {
         Some(HoFKind::Filter)
     );
     assert_eq!(
+        method_hof_contract(Lang::Ruby, "reject"),
+        Some(HoFKind::Reject)
+    );
+    assert_eq!(
         method_hof_contract(Lang::Swift, "filter"),
         Some(HoFKind::Filter)
     );
@@ -168,6 +172,26 @@ fn method_call_contracts_carry_receiver_and_resolution_obligations() {
             args: MethodBuiltinArgs::Hof,
         })
     );
+    assert_eq!(method_call_contract(Lang::Swift, "map", 2), None);
+    assert_eq!(
+        method_call_contract(Lang::Ruby, "map", 1),
+        Some(MethodCallContract {
+            semantic: MethodSemanticContract::HoF(HoFKind::Map),
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
+            args: MethodBuiltinArgs::Hof,
+        })
+    );
+    assert_eq!(
+        method_call_contract(Lang::Ruby, "reject", 1),
+        Some(MethodCallContract {
+            semantic: MethodSemanticContract::HoF(HoFKind::Reject),
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
+            args: MethodBuiltinArgs::Hof,
+        })
+    );
+    assert_eq!(method_call_contract(Lang::Ruby, "map", 0), None);
+    assert_eq!(method_call_contract(Lang::Ruby, "map", 2), None);
+    assert_eq!(method_call_contract(Lang::Ruby, "flat_map", 1), None);
     assert_eq!(
         method_call_contract(Lang::TypeScript, "map", 1),
         Some(MethodCallContract {

--- a/crates/nose-semantics/src/tests/library_api_contracts/method_protocols/sequence_hof_rows.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/method_protocols/sequence_hof_rows.rs
@@ -71,6 +71,39 @@ fn rust_iterator_hof_rows_use_sequence_hof_protocol_pack() {
         library_method_call_contract(Lang::Swift, "compactMap", 1).is_none(),
         "Swift compactMap stays closed until optional-channel semantics are represented"
     );
+    assert!(
+        library_method_call_contract(Lang::Swift, "map", 2).is_none(),
+        "Swift Sequence HOF rows stay closed outside the single-callback shape"
+    );
+
+    for method in ["map", "collect", "select", "filter", "reject"] {
+        let contract =
+            library_method_call_contract(Lang::Ruby, method, 1).expect("Ruby Enumerable HOF row");
+        assert_eq!(contract.pack_id, SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID);
+        assert_eq!(
+            contract.producer_id,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID
+        );
+        assert_eq!(
+            contract.callee,
+            LibraryApiCalleeContract::Method {
+                method,
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            }
+        );
+    }
+    assert!(
+        library_method_call_contract(Lang::Ruby, "map", 0).is_none(),
+        "Ruby Enumerable HOF rows require an explicit block"
+    );
+    assert!(
+        library_method_call_contract(Lang::Ruby, "map", 2).is_none(),
+        "Ruby Enumerable HOF rows stay closed for block-plus-argument shapes"
+    );
+    assert!(
+        library_method_call_contract(Lang::Ruby, "flat_map", 1).is_none(),
+        "Ruby flat_map stays closed until nested flattening semantics are represented"
+    );
 
     assert!(
         library_method_call_contract(Lang::Rust, "find", 1).is_none(),

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod ruby;
 mod swift;
 
 fn sequence_hof_call_il(method: &str, arg_count: usize) -> (Il, Interner, NodeId, NodeId) {
@@ -62,6 +63,126 @@ fn sequence_hof_record(
         SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
         SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
     )
+}
+
+struct OrderedHofPackRequirementMessages {
+    raw_shape: &'static str,
+    missing_dependency: &'static str,
+    wrong_pack: &'static str,
+    wrong_producer: &'static str,
+    admitted: &'static str,
+}
+
+fn assert_sequence_hof_requires_pack_and_ordered_receiver(
+    lang: Lang,
+    method: &'static str,
+    expected: MethodSemanticContract,
+    make_call: impl Fn() -> (Il, Interner, NodeId, NodeId),
+    rejected_domains: &[(DomainEvidence, &'static str)],
+    messages: OrderedHofPackRequirementMessages,
+) {
+    let (mut raw_shape, interner, call, receiver) = make_call();
+    push_receiver_domain_dependency(&mut raw_shape, 0, receiver, DomainEvidence::Collection);
+    assert!(
+        admitted_library_method_call_at_call(&raw_shape, &interner, call).is_none(),
+        "{}",
+        messages.raw_shape
+    );
+
+    let contract = library_method_call_contract(lang, method, 1).expect("sequence HOF row");
+    assert_eq!(
+        contract.callee,
+        LibraryApiCalleeContract::Method {
+            method,
+            receiver: MethodReceiverContract::ExactArrayOrCollection,
+        }
+    );
+
+    let (mut missing_dependency, interner, call, _receiver) = make_call();
+    missing_dependency.evidence.push(sequence_hof_record(
+        1,
+        &missing_dependency,
+        call,
+        contract,
+        1,
+        &[],
+    ));
+    assert!(
+        admitted_library_method_call_at_call(&missing_dependency, &interner, call).is_none(),
+        "{}",
+        messages.missing_dependency
+    );
+
+    let (mut wrong_pack, interner, call, receiver) = make_call();
+    push_receiver_domain_dependency(&mut wrong_pack, 0, receiver, DomainEvidence::Collection);
+    wrong_pack
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            wrong_pack.node(call).span,
+            contract.id,
+            contract.callee,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            BUILTIN_METHOD_CALL_PROTOCOL_PACK_ID,
+            BUILTIN_METHOD_CALL_PROTOCOL_PRODUCER_ID,
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_pack, &interner, call).is_none(),
+        "{}",
+        messages.wrong_pack
+    );
+
+    let (mut wrong_producer, interner, call, receiver) = make_call();
+    push_receiver_domain_dependency(&mut wrong_producer, 0, receiver, DomainEvidence::Collection);
+    wrong_producer
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            wrong_producer.node(call).span,
+            contract.id,
+            contract.callee,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+            "wrong.protocols.sequence-hof-adapter-api",
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_producer, &interner, call).is_none(),
+        "{}",
+        messages.wrong_producer
+    );
+
+    for &(domain, message) in rejected_domains {
+        let (mut il, interner, call, receiver) = make_call();
+        push_receiver_domain_dependency(&mut il, 0, receiver, domain);
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        assert!(
+            admitted_library_method_call_at_call(&il, &interner, call).is_none(),
+            "{message}"
+        );
+    }
+
+    let (mut admitted, interner, call, receiver) = make_call();
+    push_receiver_domain_dependency(&mut admitted, 0, receiver, DomainEvidence::Collection);
+    admitted
+        .evidence
+        .push(sequence_hof_record(1, &admitted, call, contract, 1, &[0]));
+    let occurrence =
+        admitted_library_method_call_at_call(&admitted, &interner, call).expect(messages.admitted);
+    assert_eq!(
+        occurrence.contract.id,
+        LibraryApiContractId::MethodCall(expected)
+    );
+    assert_eq!(
+        occurrence.contract.pack_id,
+        SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID
+    );
+    assert_eq!(occurrence.receiver, Some(receiver));
+    assert_eq!(occurrence.arg_count, 1);
 }
 
 #[test]

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/ruby.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/ruby.rs
@@ -1,0 +1,339 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum RubyCallbackShape {
+    Inline,
+    Reference,
+    EffectfulCall,
+    MutatingAssign,
+    Throwing,
+}
+
+impl RubyCallbackShape {
+    fn fixture(self) -> CallbackFixtureShape {
+        match self {
+            Self::Inline => CallbackFixtureShape::InlineFunc { cid: 1 },
+            Self::Reference => CallbackFixtureShape::Reference { name: "transform" },
+            Self::EffectfulCall => CallbackFixtureShape::EffectfulCall {
+                callee: "side_effect",
+                arg_cid: 1,
+            },
+            Self::MutatingAssign => CallbackFixtureShape::MutatingAssign {
+                lhs_cid: 2,
+                rhs_cid: 1,
+            },
+            Self::Throwing => CallbackFixtureShape::Throwing { err_cid: 1 },
+        }
+    }
+}
+
+fn ruby_enumerable_hof_call_il(
+    method: &str,
+    shape: RubyCallbackShape,
+) -> (Il, Interner, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(400), &[]);
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(401),
+        &[receiver],
+    );
+    let callback = callback_fixture_node(&mut b, &interner, shape.fixture(), 402);
+    let call = b.add(NodeKind::Call, Payload::None, sp(410), &[callee, callback]);
+    let root = b.add(NodeKind::Func, Payload::None, sp(411), &[call]);
+    (finish_il(b, root, Lang::Ruby), interner, call, receiver)
+}
+
+fn ruby_enumerable_no_block_call_il(method: &str) -> (Il, Interner, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(420), &[]);
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(421),
+        &[receiver],
+    );
+    let call = b.add(NodeKind::Call, Payload::None, sp(422), &[callee]);
+    let root = b.add(NodeKind::Func, Payload::None, sp(423), &[call]);
+    (finish_il(b, root, Lang::Ruby), interner, call, receiver)
+}
+
+fn ruby_lazy_enumerator_hof_call_il(method: &str) -> (Il, Interner, NodeId, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(430), &[]);
+    let lazy = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("lazy")),
+        sp(431),
+        &[receiver],
+    );
+    let callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern(method)),
+        sp(432),
+        &[lazy],
+    );
+    let callback =
+        callback_fixture_node(&mut b, &interner, RubyCallbackShape::Inline.fixture(), 433);
+    let call = b.add(NodeKind::Call, Payload::None, sp(434), &[callee, callback]);
+    let root = b.add(NodeKind::Func, Payload::None, sp(435), &[call]);
+    (
+        finish_il(b, root, Lang::Ruby),
+        interner,
+        call,
+        receiver,
+        lazy,
+    )
+}
+
+fn ruby_enumerable_hof_chain_il() -> (Il, Interner, NodeId, NodeId, NodeId) {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let receiver = b.add(NodeKind::Var, Payload::Cid(0), sp(440), &[]);
+    let reject_callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("reject")),
+        sp(441),
+        &[receiver],
+    );
+    let reject_fn = b.add(NodeKind::Func, Payload::Cid(1), sp(442), &[]);
+    let reject_call = b.add(
+        NodeKind::Call,
+        Payload::None,
+        sp(443),
+        &[reject_callee, reject_fn],
+    );
+    let map_callee = b.add(
+        NodeKind::Field,
+        Payload::Name(interner.intern("map")),
+        sp(444),
+        &[reject_call],
+    );
+    let map_fn = b.add(NodeKind::Func, Payload::Cid(2), sp(445), &[]);
+    let map_call = b.add(
+        NodeKind::Call,
+        Payload::None,
+        sp(446),
+        &[map_callee, map_fn],
+    );
+    let root = b.add(NodeKind::Func, Payload::None, sp(447), &[map_call]);
+    (
+        finish_il(b, root, Lang::Ruby),
+        interner,
+        map_call,
+        reject_call,
+        receiver,
+    )
+}
+
+#[test]
+fn admitted_ruby_enumerable_hof_requires_sequence_hof_pack_block_and_ordered_collection_receiver() {
+    assert_sequence_hof_requires_pack_and_ordered_receiver(
+        Lang::Ruby,
+        "map",
+        MethodSemanticContract::HoF(HoFKind::Map),
+        || ruby_enumerable_hof_call_il("map", RubyCallbackShape::Inline),
+        &[
+            (
+                DomainEvidence::Set,
+                "Ruby Set receiver proof stays closed because order is not represented",
+            ),
+            (
+                DomainEvidence::Map,
+                "Ruby Hash receiver proof stays closed because key/value iteration shape is not represented",
+            ),
+            (
+                DomainEvidence::Iterable,
+                "Ruby lazy/framework Enumerable receiver proof stays closed",
+            ),
+        ],
+        OrderedHofPackRequirementMessages {
+            raw_shape: "raw Ruby map shape plus collection receiver proof is not enough",
+            missing_dependency:
+                "same-span Ruby Enumerable HOF evidence without collection proof is rejected",
+            wrong_pack: "Ruby Enumerable HOF evidence under the generic method-call pack is rejected",
+            wrong_producer: "Ruby Enumerable HOF evidence with the wrong producer is rejected",
+            admitted: "Ruby map with collection proof and inline block admits",
+        },
+    );
+}
+
+#[test]
+fn admitted_ruby_enumerable_hof_pack_covers_supported_eager_hofs() {
+    for (method, semantic) in [
+        ("map", MethodSemanticContract::HoF(HoFKind::Map)),
+        ("collect", MethodSemanticContract::HoF(HoFKind::Map)),
+        ("select", MethodSemanticContract::HoF(HoFKind::Filter)),
+        ("filter", MethodSemanticContract::HoF(HoFKind::Filter)),
+        ("reject", MethodSemanticContract::HoF(HoFKind::Reject)),
+    ] {
+        let (mut il, interner, call, receiver) =
+            ruby_enumerable_hof_call_il(method, RubyCallbackShape::Inline);
+        push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+        let contract = library_method_call_contract(Lang::Ruby, method, 1).expect("Ruby HOF row");
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        let occurrence = admitted_library_method_call_at_call(&il, &interner, call)
+            .expect("supported Ruby Enumerable HOF admits");
+        assert_eq!(
+            occurrence.contract.id,
+            LibraryApiContractId::MethodCall(semantic)
+        );
+        assert_eq!(
+            occurrence.contract.pack_id,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID
+        );
+    }
+}
+
+#[test]
+fn ruby_enumerable_hof_rejects_no_block_lazy_custom_and_unsupported_surfaces() {
+    let contract = library_method_call_contract(Lang::Ruby, "map", 1).expect("Ruby map row");
+
+    let (mut no_block, interner, call, receiver) = ruby_enumerable_no_block_call_il("map");
+    push_receiver_domain_dependency(&mut no_block, 0, receiver, DomainEvidence::Collection);
+    no_block
+        .evidence
+        .push(sequence_hof_record(1, &no_block, call, contract, 0, &[0]));
+    assert!(
+        admitted_library_method_call_at_call(&no_block, &interner, call).is_none(),
+        "Ruby Enumerable methods without blocks return Enumerator and stay closed"
+    );
+
+    let (mut base_proof, interner, call, receiver, _lazy) = ruby_lazy_enumerator_hof_call_il("map");
+    push_receiver_domain_dependency(&mut base_proof, 0, receiver, DomainEvidence::Collection);
+    base_proof
+        .evidence
+        .push(sequence_hof_record(1, &base_proof, call, contract, 1, &[0]));
+    assert!(
+        admitted_library_method_call_at_call(&base_proof, &interner, call).is_none(),
+        "Ruby lazy.map does not inherit eager collection proof from the base receiver"
+    );
+
+    let (mut lazy_iterable, interner, call, _receiver, lazy) =
+        ruby_lazy_enumerator_hof_call_il("map");
+    push_receiver_domain_dependency(&mut lazy_iterable, 0, lazy, DomainEvidence::Iterable);
+    lazy_iterable.evidence.push(sequence_hof_record(
+        1,
+        &lazy_iterable,
+        call,
+        contract,
+        1,
+        &[0],
+    ));
+    assert!(
+        admitted_library_method_call_at_call(&lazy_iterable, &interner, call).is_none(),
+        "Ruby Enumerator::Lazy stays closed until delayed demand is modeled"
+    );
+
+    let (mut custom_map, interner, call, receiver) =
+        ruby_enumerable_hof_call_il("map", RubyCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut custom_map, 0, receiver, DomainEvidence::Collection);
+    custom_map
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            custom_map.node(call).span,
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map)),
+            LibraryApiCalleeContract::Method {
+                method: "map",
+                receiver: MethodReceiverContract::ExactProtocol,
+            },
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&custom_map, &interner, call).is_none(),
+        "Ruby same-name custom methods do not become Enumerable HOFs"
+    );
+
+    let (mut flat_map, interner, call, receiver) =
+        ruby_enumerable_hof_call_il("flat_map", RubyCallbackShape::Inline);
+    push_receiver_domain_dependency(&mut flat_map, 0, receiver, DomainEvidence::Collection);
+    flat_map
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            flat_map.node(call).span,
+            LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::FlatMap)),
+            LibraryApiCalleeContract::Method {
+                method: "flat_map",
+                receiver: MethodReceiverContract::ExactArrayOrCollection,
+            },
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
+            SEQUENCE_HOF_ADAPTER_PROTOCOL_PRODUCER_ID,
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&flat_map, &interner, call).is_none(),
+        "Ruby flat_map stays closed until nested flattening semantics are represented"
+    );
+}
+
+#[test]
+fn ruby_enumerable_hof_rejects_non_inline_or_effectful_blocks() {
+    let contract = library_method_call_contract(Lang::Ruby, "map", 1).expect("Ruby map row");
+    for (shape, message) in [
+        (
+            RubyCallbackShape::Reference,
+            "callback references stay closed until callable effects are proven",
+        ),
+        (
+            RubyCallbackShape::EffectfulCall,
+            "unknown calls inside Ruby blocks stay closed",
+        ),
+        (
+            RubyCallbackShape::MutatingAssign,
+            "receiver or captured mutation inside Ruby blocks stays closed",
+        ),
+        (
+            RubyCallbackShape::Throwing,
+            "raising Ruby blocks stay closed",
+        ),
+    ] {
+        let (mut il, interner, call, receiver) = ruby_enumerable_hof_call_il("map", shape);
+        push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+        il.evidence
+            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
+        assert!(
+            admitted_library_method_call_at_call(&il, &interner, call).is_none(),
+            "{message}"
+        );
+    }
+}
+
+#[test]
+fn ruby_enumerable_hof_result_domain_can_prove_follow_on_ordered_receiver() {
+    let (mut il, interner, map_call, reject_call, receiver) = ruby_enumerable_hof_chain_il();
+    push_receiver_domain_dependency(&mut il, 0, receiver, DomainEvidence::Collection);
+    let reject_contract =
+        library_method_call_contract(Lang::Ruby, "reject", 1).expect("Ruby reject row");
+    il.evidence.push(sequence_hof_record(
+        1,
+        &il,
+        reject_call,
+        reject_contract,
+        1,
+        &[0],
+    ));
+    let map_contract = library_method_call_contract(Lang::Ruby, "map", 1).expect("Ruby map row");
+    il.evidence
+        .push(sequence_hof_record(2, &il, map_call, map_contract, 1, &[1]));
+
+    let occurrence = admitted_library_method_call_at_call(&il, &interner, map_call)
+        .expect("Ruby reject result proves follow-on Ruby map receiver");
+    assert_eq!(
+        occurrence.contract.id,
+        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map))
+    );
+    assert_eq!(occurrence.receiver, Some(reject_call));
+}

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/swift.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/sequence_hof/swift.rs
@@ -148,123 +148,34 @@ fn swift_sequence_hof_pack_rejects_lazy_adapter_receiver() {
 
 #[test]
 fn admitted_swift_sequence_hof_requires_sequence_hof_pack_and_ordered_collection_receiver() {
-    let (mut raw_shape, interner, call, receiver) =
-        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-    push_receiver_domain_dependency(&mut raw_shape, 0, receiver, DomainEvidence::Collection);
-    assert!(
-        admitted_library_method_call_at_call(&raw_shape, &interner, call).is_none(),
-        "raw Swift map shape plus collection receiver proof is not enough"
+    assert_sequence_hof_requires_pack_and_ordered_receiver(
+        Lang::Swift,
+        "map",
+        MethodSemanticContract::HoF(HoFKind::Map),
+        || swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline),
+        &[
+            (
+                DomainEvidence::Set,
+                "Swift Set receiver proof stays closed because order is not represented",
+            ),
+            (
+                DomainEvidence::Map,
+                "Swift Dictionary receiver proof stays closed for Sequence HOF admission",
+            ),
+            (
+                DomainEvidence::Iterable,
+                "Swift AnySequence/one-shot receiver proof stays closed",
+            ),
+        ],
+        OrderedHofPackRequirementMessages {
+            raw_shape: "raw Swift map shape plus collection receiver proof is not enough",
+            missing_dependency:
+                "same-span Swift HOF evidence without ordered collection proof is rejected",
+            wrong_pack: "Swift HOF evidence under the generic method-call pack is rejected",
+            wrong_producer: "Swift HOF evidence with the wrong producer is rejected",
+            admitted: "Swift map with ordered collection proof admits",
+        },
     );
-
-    let contract = library_method_call_contract(Lang::Swift, "map", 1).expect("Swift map row");
-    assert_eq!(
-        contract.callee,
-        LibraryApiCalleeContract::Method {
-            method: "map",
-            receiver: MethodReceiverContract::ExactArrayOrCollection,
-        }
-    );
-
-    let (mut missing_dependency, interner, call, _receiver) =
-        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-    missing_dependency.evidence.push(sequence_hof_record(
-        1,
-        &missing_dependency,
-        call,
-        contract,
-        1,
-        &[],
-    ));
-    assert!(
-        admitted_library_method_call_at_call(&missing_dependency, &interner, call).is_none(),
-        "same-span Swift HOF evidence without ordered collection proof is rejected"
-    );
-
-    let (mut wrong_pack, interner, call, receiver) =
-        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-    push_receiver_domain_dependency(&mut wrong_pack, 0, receiver, DomainEvidence::Collection);
-    wrong_pack
-        .evidence
-        .push(library_api_record_with_provenance_and_arity(
-            1,
-            wrong_pack.node(call).span,
-            contract.id,
-            contract.callee,
-            1,
-            EvidenceStatus::Asserted,
-            &[0],
-            BUILTIN_METHOD_CALL_PROTOCOL_PACK_ID,
-            BUILTIN_METHOD_CALL_PROTOCOL_PRODUCER_ID,
-        ));
-    assert!(
-        admitted_library_method_call_at_call(&wrong_pack, &interner, call).is_none(),
-        "Swift HOF evidence under the generic method-call pack is rejected"
-    );
-
-    let (mut wrong_producer, interner, call, receiver) =
-        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-    push_receiver_domain_dependency(&mut wrong_producer, 0, receiver, DomainEvidence::Collection);
-    wrong_producer
-        .evidence
-        .push(library_api_record_with_provenance_and_arity(
-            1,
-            wrong_producer.node(call).span,
-            contract.id,
-            contract.callee,
-            1,
-            EvidenceStatus::Asserted,
-            &[0],
-            SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID,
-            "wrong.protocols.sequence-hof-adapter-api",
-        ));
-    assert!(
-        admitted_library_method_call_at_call(&wrong_producer, &interner, call).is_none(),
-        "Swift HOF evidence with the wrong producer is rejected"
-    );
-
-    for (domain, message) in [
-        (
-            DomainEvidence::Set,
-            "Swift Set receiver proof stays closed because order is not represented",
-        ),
-        (
-            DomainEvidence::Map,
-            "Swift Dictionary receiver proof stays closed for Sequence HOF admission",
-        ),
-        (
-            DomainEvidence::Iterable,
-            "Swift AnySequence/one-shot receiver proof stays closed",
-        ),
-    ] {
-        let (mut il, interner, call, receiver) =
-            swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-        push_receiver_domain_dependency(&mut il, 0, receiver, domain);
-        il.evidence
-            .push(sequence_hof_record(1, &il, call, contract, 1, &[0]));
-        assert!(
-            admitted_library_method_call_at_call(&il, &interner, call).is_none(),
-            "{message}"
-        );
-    }
-
-    let (mut admitted, interner, call, receiver) =
-        swift_sequence_hof_call_il("map", SwiftCallbackShape::Inline);
-    push_receiver_domain_dependency(&mut admitted, 0, receiver, DomainEvidence::Collection);
-    admitted
-        .evidence
-        .push(sequence_hof_record(1, &admitted, call, contract, 1, &[0]));
-    let occurrence = admitted_library_method_call_at_call(&admitted, &interner, call)
-        .expect("Swift map with ordered collection proof admits");
-    assert_eq!(
-        occurrence.contract.id,
-        LibraryApiContractId::MethodCall(MethodSemanticContract::HoF(HoFKind::Map))
-    );
-    assert_eq!(
-        occurrence.contract.pack_id,
-        SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID
-    );
-    assert_eq!(occurrence.receiver, Some(receiver));
-    assert_eq!(occurrence.arg_count, 1);
 }
 
 #[test]

--- a/docs/demand-effect-semantics.md
+++ b/docs/demand-effect-semantics.md
@@ -48,22 +48,25 @@ list/dict-comprehension surfaces use eager per-element demand where modeled.
 Python generator-expression surfaces use pull-lazy demand: callback errors and
 effects are delayed until a terminal consumer pulls an element. First-party
 library/API HOF rows now carry explicit timing for the supported surfaces:
-JS-like, Ruby, and Swift `map`/`flatMap`/`filter` rows are eager per element
-where available, while Rust iterator and Java Stream `map`/`flatMap`/`filter`
-rows are pull-lazy. Python builtin `map`/`filter` rows are also pull-lazy, but only when
-they are admitted through `nose.protocols.iterator_builtins` with unshadowed
-builtin proof, iterable-source proof, and a lambda callback shape. Rust
+JS-like and Swift `map`/`flatMap`/`filter` rows are eager per element where
+available; Ruby Enumerable `map`/`collect`/`select`/`filter`/`reject` rows are
+eager per element only when an inline effect-closed block is present. Rust
+iterator and Java Stream `map`/`flatMap`/`filter` rows are pull-lazy. Python
+builtin `map`/`filter` rows are also pull-lazy, but only when they are admitted
+through `nose.protocols.iterator_builtins` with unshadowed builtin proof,
+iterable-source proof, and a lambda callback shape. Rust
 iterator HOF rows require
 `nose.protocols.sequence_hof_adapters` occurrence provenance on a proven
 protocol receiver; `any`/`all` and `count` terminal rows use the same provenance
 boundary, while Swift `map`/`filter`/`flatMap` rows use the same pack only on
-proven Array/Collection receivers with inline effect-closed callbacks.
-`Sequence`/`AnySequence`, `Set`, `Dictionary`, `compactMap`, and `.lazy`
-surfaces remain closed until their one-shot, ordering, optional-channel, or
-deferred-demand semantics are represented. `collect` remains in the iterator
-identity/materialization adapter slice. Admitted HOF identity alone is still not
-enough; consumers resolve the node-level demand/effect profile before opening
-exact behavior.
+proven Array/Collection receivers with inline effect-closed callbacks. Ruby
+Enumerable rows use the same pack only on proven Array/Collection receivers with
+inline effect-closed blocks; no-block Enumerator returns, lazy enumerators,
+framework relations, Hash/Set receivers, and `flat_map` remain closed until
+their demand, receiver, ordering, or flattening semantics are represented.
+`collect` remains in the Rust iterator identity/materialization adapter slice.
+Admitted HOF identity alone is still not enough; consumers resolve the
+node-level demand/effect profile before opening exact behavior.
 
 Promise `.then` now carries an async-continuation demand/effect profile in its
 contract row. That does not open exact beta-reduction by itself. The value-graph

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -424,3 +424,12 @@ sharing a callback fixture node helper in the admission resolver support module 
 cid-param/receiver fixture in receiver-domain tests. After that cleanup, accepted representative
 `1096a4a828c21a80` no longer reports and no new family appears, so the baseline budget is tightened
 again.
+
+The #538 Ruby Enumerable HOF capability PR keeps the count at 53. The first draft surfaced
+avoidable test-scope families while adding Ruby `map`/`collect`/`select`/`filter`/`reject`
+admission: Ruby/Swift sequence-HOF pack requirement tests and HOF demand fixture setup. Those were
+deduped by sharing the ordered sequence-HOF pack requirement helper and the map/predicate HOF
+fixture builders. The remaining drift is representative-ID churn: `4e655a7c9a3d22dd` disappears
+and `d836cac640ba27ba` appears. The new representative covers the same reviewed HOF
+demand/materialization negative scaffolding, now anchored on the shared `map_len_il_with_lambda`
+helper plus the strict-exact pull-lazy `len` boundary test. No new budget is accepted.

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -596,7 +596,9 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   `nose.protocols.sequence_hof_adapters` provenance when protocol receiver proof
   is present, and Swift `map`/`filter`/`flatMap` HOFs with the same provenance
   when Array/Collection receiver proof and inline effect-closed callback proof
-  are present, generic method-call and namespace-call builtin semantics with
+  are present, and Ruby Enumerable `map`/`collect`/`select`/`filter`/`reject`
+  HOFs with the same provenance when Array/Collection receiver proof and inline
+  effect-closed block proof are present, generic method-call and namespace-call builtin semantics with
   `nose.protocols.builtin_method_calls` provenance when no narrower pack owns
   the row, Go `fmt.Print*`, `strings.HasPrefix`/`HasSuffix`,
   `strings.Contains`, and `slices.Contains` namespace calls with
@@ -782,7 +784,7 @@ callers:
   pack-proven map get-default, pack-proven map-key
   views, iterator identity adapters with
   `nose.protocols.iterator_identity_adapters` provenance, Rust sequence-HOF
-  adapters and Swift Array/Collection HOFs with
+  adapters, Swift Array/Collection HOFs, and Ruby Enumerable HOFs with
   `nose.protocols.sequence_hof_adapters` provenance, Java
   `Arrays.stream`, Java map entries, Rust `Some(...)`, Rust map factory receiver
   proof, and HOF receiver proof instead of locally recombining selector strings
@@ -817,8 +819,11 @@ callers:
   receiver evidence. Downstream calls such as Rust `.collect()` can therefore
   depend on the admitted `filter_map`/`map`/`filter` occurrence after IL
   canonicalization, without reopening selector-only proof. For Rust iterator
-  chains, that same-span HOF record must carry
-  `nose.protocols.sequence_hof_adapters` provenance. Value-graph filter
+  chains, Swift Array/Collection chains, and Ruby Enumerable chains, that
+  same-span HOF record must carry `nose.protocols.sequence_hof_adapters`
+  provenance. Ruby `reject` records carry the distinct negated-filter HOF kind,
+  so `reject { p }` does not reuse the positive `filter { p }` predicate.
+  Value-graph filter
   consumers such as `len(filter(...))`, explicit reductions over a filter, and
   static literal membership shortcuts reuse the same HOF admission; a raw
   `HoF(Filter)` payload no longer enters those paths by shape alone;

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -153,7 +153,8 @@ The next code slices are intentionally incremental:
    `nose.protocols.sequence_hof_adapters` for Rust iterator
    `map`/`filter`/`filter_map`/`flat_map` HOF adapter occurrence provenance plus
    `any`/`all`/`count` terminal proof and Swift Array/Collection
-   `map`/`filter`/`flatMap` HOF occurrence provenance,
+   `map`/`filter`/`flatMap` HOF occurrence provenance plus Ruby Enumerable
+   `map`/`collect`/`select`/`filter`/`reject` HOF occurrence provenance,
    then
    `nose.protocols.iterator_identity_adapters` for Rust
    `iter`/`into_iter`/`iter_mut`/`collect`/`to_vec`/`copied`/`cloned` and Java
@@ -1546,6 +1547,33 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   budget on the final compare rerun (`features` 9.94 ms, semantic query
   7.81 ms; deep chain 592 tokens / 152 value-fingerprint nodes, wide chain 1455
   / 324).
+- The Ruby Enumerable HOF slice moved safe Ruby `map`/`collect` and
+  `select`/`filter`/`reject` rows from the broad non-JS method-HOF path into
+  `nose.protocols.sequence_hof_adapters` for proven Array/Collection receivers.
+  Admission now requires sequence-HOF pack provenance, exact ordered collection
+  receiver proof, and an inline effect-closed block before Ruby HOF callback
+  demand, result-domain reuse, or follow-on HOF receiver proof can open. Ruby
+  `reject` is represented as a distinct HOF kind whose value-graph predicate is
+  `Not(predicate)`, so `reject { p }` does not collapse into `select { p }`.
+  Calls without blocks, `Enumerator::Lazy`, framework-style relation receivers,
+  custom same-name methods, Hash key/value iteration, Set ordering, mutating or
+  raising blocks, and `flat_map` remain hard negatives or unsupported
+  boundaries. Inventory before/after against `main@0a42dc57`: builtin packs
+  48 -> 48, exact-capable packs 38 -> 38, positive fixtures 172 -> 177, hard
+  negatives 131 -> 139, conformance refs 303 -> 316. The sequence-HOF pack
+  metadata changed from Rust+Swift to Rust+Swift+Ruby, positives 10 -> 15, and
+  hard negatives 14 -> 22. Focused Ruby HOF admission coverage moved from 0/5
+  sequence-HOF rows to 5/5, while adjacent false merges from no-block Enumerator
+  returns, lazy enumerators, framework relations, custom methods, Hash/Set
+  receivers, and effectful blocks remain 0. 2026-06-26 product
+  query-regression compared clean `origin/main@0a42dc57` with the
+  `issue-538-ruby-enumerable-hof` working-tree binary on the standard Ruby
+  `liquid` representative, repeats=5: 1 repo compared, 0 investigation
+  triggers, result JSON bytes 28431 -> 28438, distinct location sets 4 -> 4,
+  median wall time 50.27 ms -> 49.61 ms, and `normalize+extract` median 16.5
+  ms -> 16.1 ms. The corpus-free HoF budget smoke stayed under budget
+  (`features` 9.83 ms, semantic query 9.65 ms; deep chain 592 tokens / 152
+  value-fingerprint nodes, wide chain 1455 / 324).
 - The static API occurrence slice moved Java empty collection constructors and
   JS-like static `indexOf`/`findIndex` membership behind the same
   dependency-backed occurrence boundary. `new ArrayList<>()`/

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -212,6 +212,13 @@ still being migrated toward it.
   Array/Collection receivers with inline effect-closed callbacks, while Swift
   `Set`, `Dictionary`, `Sequence`/`AnySequence`, `.lazy`, throwing or mutating
   callbacks, and `compactMap` remain hard negatives or unsupported boundaries.
+  It also owns Ruby Enumerable `map`/`collect`/`select`/`filter`/`reject` HOF
+  occurrence provenance on proven Array/Collection receivers with inline
+  effect-closed blocks. Ruby calls without blocks, `Enumerator::Lazy`,
+  framework relation receivers, custom same-name methods, Hash key/value
+  iteration, Set ordering, mutating or raising blocks, and `flat_map` remain
+  hard negatives or unsupported boundaries; `reject` carries a negated predicate
+  instead of reusing the positive filter predicate.
   Rust custom methods, missing receiver proof, eager callback assumptions,
   missing terminal proof, one-shot iterator reuse, `collect_vec`, and `find`
   remain hard negatives or unsupported boundaries. The
@@ -722,7 +729,12 @@ migrated.
   `map`/`filter`/`flatMap` same-span occurrences use the same pack only when
   their receiver proof is Array/Collection rather than arbitrary `Sequence`,
   `Set`, or `Dictionary`, so chained Swift HOFs can reuse pack-backed receiver
-  proof without opening one-shot or ordering assumptions. Value-graph filter
+  proof without opening one-shot or ordering assumptions. Ruby
+  `map`/`collect`/`select`/`filter`/`reject` same-span occurrences use the same
+  pack only when their receiver proof is Array/Collection rather than Hash,
+  Set, lazy Enumerator, or framework relation; chained Ruby HOFs can reuse
+  pack-backed receiver proof, and `reject` carries `Not(predicate)` in the value
+  graph. Value-graph filter
   consumers such as `len(filter(...))`, explicit reductions over a filter, and
   static literal membership shortcuts reuse HOF admission as well, so raw
   `HoF(Filter)` cannot bypass the source/API HOF gate by appearing under another

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -155,6 +155,12 @@ Trust is separate from channel eligibility.
   `nose.protocols.builtin_method_calls` owns generic method-call and
   namespace-call builtin semantics that have not moved to a narrower protocol
   pack;
+  `nose.protocols.sequence_hof_adapters` owns Rust iterator
+  `map`/`filter`/`filter_map`/`flat_map` HOF adapter occurrence provenance plus
+  `any`/`all`/`count` terminal proof, Swift Array/Collection
+  `map`/`filter`/`flatMap` HOF occurrence provenance, and Ruby Enumerable
+  `map`/`collect`/`select`/`filter`/`reject` HOF occurrence provenance under
+  receiver and callback/block proof;
   `nose.go.stdlib.namespace_calls` owns Go `fmt.Print*`,
   `strings.HasPrefix`/`HasSuffix`, `strings.Contains`, and `slices.Contains`
   API occurrence provenance under imported-namespace proof;

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -49,7 +49,7 @@
     "e6d039006310127f",
     "e88e8f81d527af19",
     "ea0bb003c4b01bf8",
-    "4e655a7c9a3d22dd",
+    "d836cac640ba27ba",
     "f010e9908081b902",
     "f57a5ee0ebbdf114",
     "f88aeebdec4f2c68"


### PR DESCRIPTION
## Summary

- Moves safe Ruby Enumerable `map`/`collect`/`select`/`filter`/`reject` method-HOF rows behind `nose.protocols.sequence_hof_adapters` with exact Array/Collection receiver proof and inline effect-closed block proof.
- Adds `HoFKind::Reject` so Ruby `reject { p }` carries `Not(predicate)` and does not collapse into `select`/`filter`.
- Keeps no-block Enumerator returns, `Enumerator::Lazy`, framework relations, custom same-name methods, Hash/Set receiver assumptions, effectful blocks, and `flat_map` closed.
- Updates pack inventory, roadmap/snapshot/evidence docs, and dogfooding duplication baseline after deduping avoidable test fixture duplication.

## Quantified Change

- Builtin packs: 48 -> 48; exact-capable packs: 38 -> 38.
- Positive fixtures: 172 -> 177; hard negatives: 131 -> 139; conformance refs: 303 -> 316.
- Sequence-HOF pack metadata: Rust+Swift -> Rust+Swift+Ruby; positives 10 -> 15; hard negatives 14 -> 22.
- Focused Ruby HOF admission coverage: 0/5 -> 5/5 rows.
- Adjacent false merges for no-block/lazy/framework/custom/Hash/Set/effectful block boundaries remain 0.
- Product query-regression on Ruby `liquid`, repeats=5: 1 repo compared, 0 investigation triggers; result JSON bytes 28431 -> 28438; distinct location sets 4 -> 4; median wall 50.27ms -> 49.61ms; normalize+extract 16.5ms -> 16.1ms.

## Validation

- `cargo test -p nose-semantics -p nose-normalize -p nose-frontend --lib`
- `cargo test -p nose-cli --test cli`
- `cargo test -p nose-cli --test equivalence`
- `cargo test -p nose-detect --lib`
- `cargo test -p nose-semantics library_api_evidence::admission_resolvers::sequence_hof --lib`
- `cargo test -p nose-normalize value_graph::tests::source_evidence::hof_demand --lib`
- `cargo clippy -p nose-semantics -p nose-normalize -p nose-frontend -p nose-cli --all-targets -- -D warnings`
- `cargo build --release --bin nose`
- `cargo llvm-cov --workspace --summary-only --fail-under-lines 83`
- `python3 bench/type4/query_regression/query_regression.py selftest`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `scripts/check-duplication.sh`
- `awiki lint --root docs`
- `git diff --check`

Closes #538
