### PR TITLE
docs: require semantic-pack closeout evidence

### DIFF
--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -53,7 +53,7 @@ and pack ecosystem.
 10. **Pack-boundary migrations must preserve product behavior and performance.**
     Descriptor, registry, naming, and reporting changes should not change family
     output except intentional metadata. Implementation PRs should run product
-    query-regression output/runtime comparison and follow the gates in
+    query-regression output/runtime comparison and must follow the gates in
     [semantic-pack-architecture](semantic-pack-architecture.md) and the
     closeout requirements in
     [semantic-pack-adoption](semantic-pack-adoption.md).

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -54,7 +54,9 @@ and pack ecosystem.
     Descriptor, registry, naming, and reporting changes should not change family
     output except intentional metadata. Implementation PRs should run product
     query-regression output/runtime comparison and follow the gates in
-    [semantic-pack-architecture](semantic-pack-architecture.md).
+    [semantic-pack-architecture](semantic-pack-architecture.md) and the
+    closeout requirements in
+    [semantic-pack-adoption](semantic-pack-adoption.md).
 
 ## Active migration tranche
 

--- a/docs/semantic-pack-adoption.md
+++ b/docs/semantic-pack-adoption.md
@@ -75,6 +75,27 @@ Implementation PR checklist:
 - State the rollback action: demote pack, disable row, tighten admission, or
   revert.
 
+Implementation PR closeout gate:
+
+- Link two independent review artifacts before merge. Each artifact must name
+  the reviewer, the reviewed commit or PR state, blocking findings,
+  non-blocking follow-ups, accepted changes, and rejected feedback with reason.
+  Chat-only review summaries are not durable enough unless they are copied into
+  the PR, a linked issue, or a committed closeout artifact.
+- Attach durable product query-regression evidence for behavior-changing
+  support. The PR or linked artifact must name the baseline/current refs,
+  command shape, repo subset, repeat count, investigation-trigger count, output
+  drift, and runtime medians. Files under `/tmp` are scratch space, not
+  closeout evidence.
+- Record focused before/after counts for exact-capable rows, positive fixtures,
+  hard negatives, conformance refs, unsupported refs, and any pack/protocol
+  metadata that changed.
+- Convert unresolved review findings into linked follow-up issues before merge.
+  If required pre-merge evidence is missing, record it as a process gap instead
+  of presenting post-merge review as pre-merge review.
+- Do not close a leaf issue until the PR links the closeout evidence above and
+  the issue records any intentionally deferred semantic boundary.
+
 ## Builtin Optional To Builtin Default
 
 Promote `builtin-optional` to `builtin-default` only after corpus evidence shows
@@ -109,6 +130,8 @@ Implementation PR checklist:
   default behavior.
 - Name the smallest rollback path if false merges, noise, or runtime regression
   appears after release.
+- Satisfy the implementation PR closeout gate above if default enablement lands
+  in the same PR as behavior-changing pack rows.
 
 ## Rollback
 

--- a/docs/semantic-pack-adoption.md
+++ b/docs/semantic-pack-adoption.md
@@ -77,22 +77,31 @@ Implementation PR checklist:
 
 Implementation PR closeout gate:
 
+This gate applies to every behavior-changing semantic-pack leaf or migration PR,
+even when the work is not an ownership-lane promotion.
+
 - Link two independent review artifacts before merge. Each artifact must name
-  the reviewer, the reviewed commit or PR state, blocking findings,
-  non-blocking follow-ups, accepted changes, and rejected feedback with reason.
-  Chat-only review summaries are not durable enough unless they are copied into
-  the PR, a linked issue, or a committed closeout artifact.
+  a distinct reviewer, the reviewed commit or PR state, the review run or prompt
+  boundary, blocking findings, non-blocking follow-ups, accepted changes, and
+  rejected feedback with reason. Chat-only review summaries are not durable
+  enough unless they are copied into the PR, a linked issue, or a committed
+  closeout artifact.
 - Attach durable product query-regression evidence for behavior-changing
   support. The PR or linked artifact must name the baseline/current refs,
-  command shape, repo subset, repeat count, investigation-trigger count, output
-  drift, and runtime medians. Files under `/tmp` are scratch space, not
-  closeout evidence.
+  binary SHA-256s or build refs, command shape, repo subset, repeat count,
+  investigation-trigger count, output drift, and runtime medians. Files under
+  `/tmp` are scratch space, not
+  closeout evidence. Descriptor-only or reporting-only PRs may record an
+  explicit no-product-drift exception, but semantic-pack leaf rows that change
+  analysis behavior need durable evidence even when family output is unchanged.
 - Record focused before/after counts for exact-capable rows, positive fixtures,
   hard negatives, conformance refs, unsupported refs, and any pack/protocol
   metadata that changed.
-- Convert unresolved review findings into linked follow-up issues before merge.
-  If required pre-merge evidence is missing, record it as a process gap instead
-  of presenting post-merge review as pre-merge review.
+- Resolve every blocking review finding before merge, either by changing the PR
+  or by recording why the finding was downgraded to non-blocking. Convert only
+  non-blocking or intentionally deferred review findings into linked follow-up
+  issues before merge. If required pre-merge evidence is missing, record it as a
+  process gap instead of presenting post-merge review as pre-merge review.
 - Do not close a leaf issue until the PR links the closeout evidence above and
   the issue records any intentionally deferred semantic boundary.
 

--- a/docs/semantic-pack-candidate-pricing.md
+++ b/docs/semantic-pack-candidate-pricing.md
@@ -151,6 +151,8 @@ implementation still needs the normal semantic-pack adoption gates:
 - `nose semantic-pack inventory`, `adoption-gates`, and `compatibility` checks;
 - product query-regression output and runtime notes;
 - docs and rollback path.
+- the implementation PR closeout gate in
+  [semantic-pack-adoption](semantic-pack-adoption.md).
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add a semantic-pack implementation PR closeout gate to `docs/semantic-pack-adoption.md`.
- Require two durable independent review artifacts before merge for behavior-changing semantic-pack support.
- Require durable query-regression evidence, focused before/after counts, linked follow-ups, and leaf issue closeout evidence.
- Link the roadmap's pack-boundary migration decision to the closeout gate.

## Scope

This addresses the future-gate hardening part of #553. It does not pretend to backfill missing pre-merge evidence for #544/#546; #553 should continue tracking those historical gaps and durable artifact preservation.

## Validation

- `awiki lint --root docs`
- `git diff --check`

Refs #553.
