### PR TITLE
docs: backfill #533 closeout evidence

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -90,6 +90,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-kernel-external-authorability-511](semantic-kernel-external-authorability-511.md) — issue #511 R4: external-pack authorability matrix, Guava fixed-domain dry run, and transition-to-R5 assessment.
 - [semantic-kernel-hof-demand-511](semantic-kernel-hof-demand-511.md) — issue #511 R5: HOF, demand, and materialization boundary matrix.
 - [semantic-kernel-expansion-closeout-511](semantic-kernel-expansion-closeout-511.md) — issue #511 R6 closeout: minimal capability set, builtin expansion, external authorability, remaining blockers, and validation gates.
+- [semantic-kernel-closeout-533](semantic-kernel-closeout-533.md) — closeout for the #533 sequence-HOF and iterator materialization tranche, including product metrics and process-evidence gaps.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/semantic-kernel-closeout-533.md
+++ b/docs/semantic-kernel-closeout-533.md
@@ -45,8 +45,9 @@ investigation triggers:
 | #537 | standard 9-repo subset, plus Swift `swift-metrics` | 5 | rerun reported 9 repos compared, 0 triggers; `swift-metrics` JSON 31489 -> 31499 bytes, locations 3 -> 3, median wall 37.72 ms -> 29.08 ms. |
 | #538 | Ruby `liquid` | 5 | 1 repo compared, 0 triggers; JSON 28431 -> 28438 bytes, locations 4 -> 4, median wall 50.27 ms -> 49.61 ms, `normalize+extract` 16.5 ms -> 16.1 ms. |
 
-Durability note: the roadmap and GitHub comments preserve the command shape,
-refs, metrics, and trigger counts. Some raw compare files were generated under
+Durability note: the roadmap and GitHub records preserve summaries, refs,
+metrics, and trigger counts where available. They do not uniformly preserve raw
+compare artifacts for every leaf. Some raw compare files were generated under
 `/tmp`; those scratch files are not durable closeout artifacts. Future
 behavior-changing semantic-pack leaf PRs must follow the closeout gate in
 [semantic-pack-adoption](semantic-pack-adoption.md), including durable binary
@@ -56,11 +57,11 @@ identity and query-regression artifact records.
 
 | issue | PR | durable review evidence | status |
 |---|---|---|---|
-| #534 | #542 | PR comments record two independent pre-merge reviews: semantic/provenance and coverage/docs closeout. | Satisfies the #533 closeout gate. |
-| #535 | #543 | PR comments record review-fix and final verification summaries, including accepted changes and local verification. Reviewer identity and artifact links are weaker than the later closeout gate. | Process gap recorded. |
+| #534 | #542 | PR comments record two independent pre-merge reviews: [semantic/provenance](https://github.com/corca-ai/nose/pull/542#issuecomment-4801999583) and [coverage/docs closeout](https://github.com/corca-ai/nose/pull/542#issuecomment-4801999717). | Satisfies the #533 closeout gate. |
+| #535 | #543 | PR comments record [review-fix](https://github.com/corca-ai/nose/pull/543#issuecomment-4803151095) and [final verification](https://github.com/corca-ai/nose/pull/543#issuecomment-4803556204) summaries, including accepted changes and local verification. Reviewer identity and artifact links are weaker than the later closeout gate. | Process gap recorded. |
 | #536 | #544 | No durable PR review comments or GitHub review artifacts found after merge. | Process gap recorded. |
-| #537 | #545 | Issue closeout comment names two reviews and one fixed `.lazy` hard-negative gap. The PR does not link durable review artifacts. | Process gap recorded. |
-| #538 | #546 | Post-merge semantic review found no blockers and listed non-blocking Ruby follow-ups. No durable pre-merge PR review comments were found. | Process gap recorded. |
+| #537 | #545 | Issue closeout comment [names two reviews](https://github.com/corca-ai/nose/issues/537#issuecomment-4805173961) and one fixed `.lazy` hard-negative gap. The PR does not link durable review artifacts. | Process gap recorded. |
+| #538 | #546 | [Post-merge semantic review](https://github.com/corca-ai/nose/pull/546#issuecomment-4805593486) found no blockers and listed non-blocking Ruby follow-ups. No durable pre-merge PR review comments were found. | Process gap recorded. |
 
 The post-merge semantic review found no blocking issue in the merged tranche.
 It did identify non-blocking follow-ups:
@@ -86,7 +87,7 @@ The tranche should not be treated as process-complete under the stricter
 post-#554 gate. #553 remains open to preserve or backfill per-leaf evidence
 where possible and to label any missing pre-merge artifacts honestly.
 
-## See Also
+## See also
 
 Back to [semantic-kernel-roadmap](semantic-kernel-roadmap.md). Current behavior
 status is in [semantic-kernel-snapshot](semantic-kernel-snapshot.md). Adoption

--- a/docs/semantic-kernel-closeout-533.md
+++ b/docs/semantic-kernel-closeout-533.md
@@ -1,0 +1,93 @@
+# Semantic kernel #533 closeout, 2026-06-26
+
+This page records durable closeout evidence for GitHub issue #533, the
+sequence-HOF and iterator materialization capability tranche under #519.
+
+The tranche is functionally complete: #534-#538 are closed through merged PRs
+#542-#546. This page also records the process-evidence gaps found after merge.
+Missing pre-merge review artifacts are listed as gaps, not reconstructed as if
+they had existed.
+
+## Scope
+
+The tranche moved common higher-order-function and iterator/materialization
+surfaces behind pack-owned semantic capabilities:
+
+| issue | PR | merge commit | outcome |
+|---|---|---|---|
+| #534 | #542 | `76cc0e81` | Rust iterator HOFs require `nose.protocols.sequence_hof_adapters` provenance plus protocol receiver proof. |
+| #535 | #543 | `2613ec11` | Python `map`/`filter` HOFs and `zip`/`enumerate` source/materialization gates require `nose.protocols.iterator_builtins` provenance. |
+| #536 | #544 | `ca7acf38` | JS/TS Array HOFs require JS Array pack provenance plus exact Array receiver proof. |
+| #537 | #545 | `0a42dc57` | Swift `map`/`filter`/`flatMap` require sequence-HOF pack provenance, Array/Collection receiver proof, and effect-closed callbacks. |
+| #538 | #546 | `d90a6b44` | Ruby `map`/`collect`/`select`/`filter`/`reject` require sequence-HOF pack provenance, ordered collection receiver proof, and effect-closed blocks. |
+
+Aggregate inventory movement across the tranche:
+
+| metric | before | after | delta |
+|---|---:|---:|---:|
+| builtin packs | 46 | 48 | +2 |
+| exact-capable packs | 36 | 38 | +2 |
+| positive fixtures | 150 | 177 | +27 |
+| hard negatives | 102 | 139 | +37 |
+| conformance refs | 252 | 316 | +64 |
+| unsupported refs | 13 | 18 | +5 |
+
+## Product Evidence
+
+Each leaf recorded a representative product query-regression comparison with no
+investigation triggers:
+
+| issue | representative | repeats | result |
+|---|---|---:|---|
+| #534 | Rust `serde_json` | 3 | 1 repo compared, 0 triggers; HoF smoke under budget. |
+| #535 | Python `boltons` | 5 | 1 repo compared, 0 triggers; HoF smoke under budget. |
+| #536 | JS/TS `axios` | 5 | 1 repo compared, 0 triggers; JSON 46361 -> 46362 bytes, locations 14 -> 14, median wall 167.22 ms -> 171.97 ms. |
+| #537 | standard 9-repo subset, plus Swift `swift-metrics` | 5 | rerun reported 9 repos compared, 0 triggers; `swift-metrics` JSON 31489 -> 31499 bytes, locations 3 -> 3, median wall 37.72 ms -> 29.08 ms. |
+| #538 | Ruby `liquid` | 5 | 1 repo compared, 0 triggers; JSON 28431 -> 28438 bytes, locations 4 -> 4, median wall 50.27 ms -> 49.61 ms, `normalize+extract` 16.5 ms -> 16.1 ms. |
+
+Durability note: the roadmap and GitHub comments preserve the command shape,
+refs, metrics, and trigger counts. Some raw compare files were generated under
+`/tmp`; those scratch files are not durable closeout artifacts. Future
+behavior-changing semantic-pack leaf PRs must follow the closeout gate in
+[semantic-pack-adoption](semantic-pack-adoption.md), including durable binary
+identity and query-regression artifact records.
+
+## Review Evidence
+
+| issue | PR | durable review evidence | status |
+|---|---|---|---|
+| #534 | #542 | PR comments record two independent pre-merge reviews: semantic/provenance and coverage/docs closeout. | Satisfies the #533 closeout gate. |
+| #535 | #543 | PR comments record review-fix and final verification summaries, including accepted changes and local verification. Reviewer identity and artifact links are weaker than the later closeout gate. | Process gap recorded. |
+| #536 | #544 | No durable PR review comments or GitHub review artifacts found after merge. | Process gap recorded. |
+| #537 | #545 | Issue closeout comment names two reviews and one fixed `.lazy` hard-negative gap. The PR does not link durable review artifacts. | Process gap recorded. |
+| #538 | #546 | Post-merge semantic review found no blockers and listed non-blocking Ruby follow-ups. No durable pre-merge PR review comments were found. | Process gap recorded. |
+
+The post-merge semantic review found no blocking issue in the merged tranche.
+It did identify non-blocking follow-ups:
+
+- audit pre-existing generic Ruby terminal/fold rows such as `any?`, `all?`,
+  `reduce`, and `inject`;
+- add Ruby nominal/framework relation hard negatives if future receiver/type
+  provenance expands enough to make ActiveRecord-like receivers look like
+  ordered collection proof;
+- keep nested admitted HOFs inside callbacks tied to tight receiver/effect proof
+  as external or domain producers grow.
+
+Those process and semantic follow-ups are tracked by GitHub issue #553.
+
+## Closeout Decision
+
+#533 can remain closed as a functional capability tranche. It strengthened the
+semantic kernel by moving HOF and iterator semantics toward pack/protocol-owned
+evidence, receiver/source proof, callback demand/effect boundaries, and
+fail-closed hard negatives rather than adding selector-only API breadth.
+
+The tranche should not be treated as process-complete under the stricter
+post-#554 gate. #553 remains open to preserve or backfill per-leaf evidence
+where possible and to label any missing pre-merge artifacts honestly.
+
+## See Also
+
+Back to [semantic-kernel-roadmap](semantic-kernel-roadmap.md). Current behavior
+status is in [semantic-kernel-snapshot](semantic-kernel-snapshot.md). Adoption
+and closeout gates are in [semantic-pack-adoption](semantic-pack-adoption.md).

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1576,6 +1576,8 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   ms -> 16.1 ms. The corpus-free HoF budget smoke stayed under budget
   (`features` 9.83 ms, semantic query 9.65 ms; deep chain 592 tokens / 152
   value-fingerprint nodes, wide chain 1455 / 324).
+  Durable closeout evidence for the #533 sequence-HOF tranche is recorded in
+  [semantic-kernel-closeout-533](semantic-kernel-closeout-533.md).
 - The static API occurrence slice moved Java empty collection constructors and
   JS-like static `indexOf`/`findIndex` membership behind the same
   dependency-backed occurrence boundary. `new ArrayList<>()`/


### PR DESCRIPTION
## Summary

- Add `docs/semantic-kernel-closeout-533.md` as a durable closeout record for #533.
- Record leaf-to-PR mapping, merge commits, aggregate inventory movement, product query-regression summaries, review-evidence status, and process gaps for #534-#538.
- Link the new closeout page from `docs/semantic-kernel-roadmap.md` near the #533 tranche notes.

## Scope

This addresses the per-leaf closeout evidence backfill part of #553. It intentionally labels missing pre-merge review artifacts as process gaps and does not pretend to recreate them. Historical raw `/tmp` query-regression files are still not durable artifacts; #553 should remain open for any further raw artifact preservation policy/work.

## Validation

- `awiki lint --root docs`
- `git diff --check`

Refs #553.
