### PR TITLE
Expand string affix conformance boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ break.
   case-sensitive receiver-method prefix/suffix predicates, moving those rows out
   of the broad builtin-method provenance path while preserving exact string
   receiver and prefix/suffix direction boundaries.
+- Expanded the string-affix protocol pack's conformance inventory across
+  Python, Java, Rust, Swift, JavaScript, and TypeScript receiver-method positives,
+  with hard negatives for non-string receivers, wrong producer provenance, and
+  unsupported offset forms.
 
 ## [0.16.0] - 2026-06-26
 

--- a/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/builtin_report/group_1.rs
@@ -327,8 +327,8 @@ pub(super) fn assert_group(json: &serde_json::Value) {
     assert_eq!(string_affix["counts"]["evidence_producers"], 1);
     assert_eq!(string_affix["counts"]["contracts"], 1);
     assert_eq!(string_affix["counts"]["value_laws"], 0);
-    assert_eq!(string_affix["counts"]["positive_fixtures"], 2);
-    assert_eq!(string_affix["counts"]["hard_negatives"], 4);
+    assert_eq!(string_affix["counts"]["positive_fixtures"], 12);
+    assert_eq!(string_affix["counts"]["hard_negatives"], 7);
 
     let sequence_hof_adapter = semantic_pack_by_id(&json, "nose.protocols.sequence_hof_adapters");
     assert_eq!(sequence_hof_adapter["hash"], "2c6344624cc74477");

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs
@@ -10,9 +10,9 @@ fn semantic_pack_inventory_json_reports_builtin_coverage() {
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["packs"], 49);
     assert_eq!(json["totals"]["builtin_packs"], 49);
-    assert_eq!(json["totals"]["positive_fixtures"], 178);
-    assert_eq!(json["totals"]["hard_negatives"], 143);
-    assert_eq!(json["totals"]["conformance_refs"], 321);
+    assert_eq!(json["totals"]["positive_fixtures"], 188);
+    assert_eq!(json["totals"]["hard_negatives"], 146);
+    assert_eq!(json["totals"]["conformance_refs"], 334);
     assert_eq!(json["totals"]["packs_needing_coverage"], 0);
     assert_eq!(
         json["evidence_policy"]["product_output"],
@@ -49,7 +49,17 @@ fn assert_string_affix_predicate_pack(packs: &[serde_json::Value]) {
         json_array_strings(&string_affix["conformance"], "positive_refs"),
         vec![
             "string-affix-predicate-python-startswith-positive",
-            "string-affix-predicate-python-endswith-positive"
+            "string-affix-predicate-python-endswith-positive",
+            "string-affix-predicate-java-startswith-positive",
+            "string-affix-predicate-java-endswith-positive",
+            "string-affix-predicate-rust-starts-with-positive",
+            "string-affix-predicate-rust-ends-with-positive",
+            "string-affix-predicate-swift-has-prefix-positive",
+            "string-affix-predicate-swift-has-suffix-positive",
+            "string-affix-predicate-typescript-startswith-positive",
+            "string-affix-predicate-typescript-endswith-positive",
+            "string-affix-predicate-javascript-startswith-positive",
+            "string-affix-predicate-javascript-endswith-positive"
         ]
     );
     assert_eq!(
@@ -57,13 +67,19 @@ fn assert_string_affix_predicate_pack(packs: &[serde_json::Value]) {
         vec![
             "string-affix-predicate-direction-mismatch-hard-negative",
             "string-affix-predicate-missing-receiver-proof-hard-negative",
+            "string-affix-predicate-non-string-receiver-hard-negative",
             "string-affix-predicate-wrong-pack-hard-negative",
-            "string-affix-predicate-unsupported-arity-hard-negative"
+            "string-affix-predicate-wrong-producer-hard-negative",
+            "string-affix-predicate-unsupported-arity-hard-negative",
+            "string-affix-predicate-unsupported-offset-hard-negative"
         ]
     );
     assert_eq!(
         json_array_strings(&string_affix["conformance"], "unsupported_refs"),
-        vec!["string-affix-predicate-unsupported-arity-hard-negative"]
+        vec![
+            "string-affix-predicate-unsupported-arity-hard-negative",
+            "string-affix-predicate-unsupported-offset-hard-negative"
+        ]
     );
 }
 

--- a/crates/nose-semantics/src/packs/compiled/constants.rs
+++ b/crates/nose-semantics/src/packs/compiled/constants.rs
@@ -2,10 +2,12 @@ use super::*;
 
 mod rust;
 mod sequence_hof;
+mod string_affix;
 mod swift;
 mod type_domains;
 pub(super) use rust::*;
 pub(super) use sequence_hof::*;
+pub(super) use string_affix::*;
 pub(super) use swift::*;
 pub(super) use type_domains::*;
 
@@ -473,18 +475,6 @@ pub(super) const BUILTIN_METHOD_CALL_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
     "builtin-method-call-missing-receiver-proof-hard-negative",
     "builtin-method-call-wrong-pack-hard-negative",
     "builtin-method-call-unsupported-arity-hard-negative",
-];
-pub(super) const STRING_AFFIX_PREDICATE_PROTOCOL_PRODUCER_IDS: &[&str] =
-    &[STRING_AFFIX_PREDICATE_PROTOCOL_PRODUCER_ID];
-pub(super) const STRING_AFFIX_PREDICATE_PROTOCOL_CONTRACT_IDS: &[&str] =
-    &[STRING_AFFIX_PREDICATE_CONTRACT_ID];
-pub(super) const STRING_AFFIX_PREDICATE_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
-    "string-affix-predicate-python-startswith-positive",
-    "string-affix-predicate-python-endswith-positive",
-    "string-affix-predicate-direction-mismatch-hard-negative",
-    "string-affix-predicate-missing-receiver-proof-hard-negative",
-    "string-affix-predicate-wrong-pack-hard-negative",
-    "string-affix-predicate-unsupported-arity-hard-negative",
 ];
 pub(super) const GO_STDLIB_NAMESPACE_CALL_PRODUCER_IDS: &[&str] =
     &[GO_STDLIB_NAMESPACE_CALL_PRODUCER_ID];

--- a/crates/nose-semantics/src/packs/compiled/constants/string_affix.rs
+++ b/crates/nose-semantics/src/packs/compiled/constants/string_affix.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+pub(in crate::packs::compiled) const STRING_AFFIX_PREDICATE_PROTOCOL_PRODUCER_IDS: &[&str] =
+    &[STRING_AFFIX_PREDICATE_PROTOCOL_PRODUCER_ID];
+pub(in crate::packs::compiled) const STRING_AFFIX_PREDICATE_PROTOCOL_CONTRACT_IDS: &[&str] =
+    &[STRING_AFFIX_PREDICATE_CONTRACT_ID];
+pub(in crate::packs::compiled) const STRING_AFFIX_PREDICATE_PROTOCOL_CONFORMANCE_REFS: &[&str] = &[
+    "string-affix-predicate-python-startswith-positive",
+    "string-affix-predicate-python-endswith-positive",
+    "string-affix-predicate-java-startswith-positive",
+    "string-affix-predicate-java-endswith-positive",
+    "string-affix-predicate-rust-starts-with-positive",
+    "string-affix-predicate-rust-ends-with-positive",
+    "string-affix-predicate-swift-has-prefix-positive",
+    "string-affix-predicate-swift-has-suffix-positive",
+    "string-affix-predicate-typescript-startswith-positive",
+    "string-affix-predicate-typescript-endswith-positive",
+    "string-affix-predicate-javascript-startswith-positive",
+    "string-affix-predicate-javascript-endswith-positive",
+    "string-affix-predicate-direction-mismatch-hard-negative",
+    "string-affix-predicate-missing-receiver-proof-hard-negative",
+    "string-affix-predicate-non-string-receiver-hard-negative",
+    "string-affix-predicate-wrong-pack-hard-negative",
+    "string-affix-predicate-wrong-producer-hard-negative",
+    "string-affix-predicate-unsupported-arity-hard-negative",
+    "string-affix-predicate-unsupported-offset-hard-negative",
+];

--- a/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
+++ b/crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_1.rs
@@ -382,8 +382,8 @@ pub(super) fn assert_group() {
     );
     assert_eq!(string_affix.counts().evidence_producers, 1);
     assert_eq!(string_affix.counts().contracts, 1);
-    assert_eq!(string_affix.counts().positive_fixtures, 2);
-    assert_eq!(string_affix.counts().hard_negatives, 4);
+    assert_eq!(string_affix.counts().positive_fixtures, 12);
+    assert_eq!(string_affix.counts().hard_negatives, 7);
     assert!(string_affix
         .conformance_refs()
         .contains(&"string-affix-predicate-python-startswith-positive"));
@@ -392,7 +392,31 @@ pub(super) fn assert_group() {
         .contains(&"string-affix-predicate-python-endswith-positive"));
     assert!(string_affix
         .conformance_refs()
+        .contains(&"string-affix-predicate-java-startswith-positive"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-rust-starts-with-positive"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-swift-has-prefix-positive"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-typescript-startswith-positive"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-javascript-endswith-positive"));
+    assert!(string_affix
+        .conformance_refs()
         .contains(&"string-affix-predicate-direction-mismatch-hard-negative"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-non-string-receiver-hard-negative"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-wrong-producer-hard-negative"));
+    assert!(string_affix
+        .conformance_refs()
+        .contains(&"string-affix-predicate-unsupported-offset-hard-negative"));
 
     let sequence_hof_adapter = builtin_pack_descriptor(SEQUENCE_HOF_ADAPTER_PROTOCOL_PACK_ID)
         .expect("sequence HOF adapter protocol descriptor");

--- a/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/method_protocols.rs
@@ -108,8 +108,10 @@ fn receiver_method_string_affix_rows_use_string_affix_protocol_pack() {
         (Lang::Rust, "ends_with", Builtin::EndsWith),
         (Lang::Swift, "hasPrefix", Builtin::StartsWith),
         (Lang::Swift, "hasSuffix", Builtin::EndsWith),
-        (Lang::TypeScript, "startsWith", Builtin::StartsWith),
+        (Lang::JavaScript, "startsWith", Builtin::StartsWith),
         (Lang::JavaScript, "endsWith", Builtin::EndsWith),
+        (Lang::TypeScript, "startsWith", Builtin::StartsWith),
+        (Lang::TypeScript, "endsWith", Builtin::EndsWith),
     ] {
         let contract =
             library_method_call_contract(lang, method, 1).expect("string affix method contract");

--- a/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/string_affix.rs
+++ b/crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/string_affix.rs
@@ -10,13 +10,17 @@ fn string_affix_call_il(
     (il, interner, call, receiver)
 }
 
-fn push_string_receiver_dependency(il: &mut Il, receiver: NodeId) {
+fn push_receiver_domain_dependency(il: &mut Il, receiver: NodeId, domain: DomainEvidence) {
     il.evidence.push(evidence(
         0,
         EvidenceAnchor::node(il.node(receiver).span, il.kind(receiver)),
-        EvidenceKind::Domain(DomainEvidence::String),
+        EvidenceKind::Domain(domain),
         EvidenceStatus::Asserted,
     ));
+}
+
+fn push_string_receiver_dependency(il: &mut Il, receiver: NodeId) {
+    push_receiver_domain_dependency(il, receiver, DomainEvidence::String);
 }
 
 fn assert_admitted_string_affix(lang: Lang, method: &str, builtin: Builtin) {
@@ -77,6 +81,26 @@ fn admitted_string_affix_requires_protocol_pack_and_string_receiver_proof() {
         "affix evidence without exact string receiver proof is rejected"
     );
 
+    let (mut wrong_domain, interner, call, receiver) =
+        string_affix_call_il(Lang::JavaScript, "startsWith", 1);
+    push_receiver_domain_dependency(&mut wrong_domain, receiver, DomainEvidence::Collection);
+    let js_prefix_contract = library_method_call_contract(Lang::JavaScript, "startsWith", 1)
+        .expect("JavaScript startsWith contract");
+    wrong_domain
+        .evidence
+        .push(builtin_method_call_protocol_record(
+            1,
+            wrong_domain.node(call).span,
+            js_prefix_contract,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_domain, &interner, call).is_none(),
+        "affix evidence with a non-string receiver domain is rejected"
+    );
+
     let (mut wrong_pack, interner, call, receiver) =
         string_affix_call_il(Lang::Python, "startswith", 1);
     push_string_receiver_dependency(&mut wrong_pack, receiver);
@@ -96,6 +120,27 @@ fn admitted_string_affix_requires_protocol_pack_and_string_receiver_proof() {
     assert!(
         admitted_library_method_call_at_call(&wrong_pack, &interner, call).is_none(),
         "string affix evidence under the broad builtin-method pack is rejected"
+    );
+
+    let (mut wrong_producer, interner, call, receiver) =
+        string_affix_call_il(Lang::Python, "startswith", 1);
+    push_string_receiver_dependency(&mut wrong_producer, receiver);
+    wrong_producer
+        .evidence
+        .push(library_api_record_with_provenance_and_arity(
+            1,
+            wrong_producer.node(call).span,
+            contract.id,
+            contract.callee,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+            STRING_AFFIX_PREDICATE_PROTOCOL_PACK_ID,
+            "wrong.protocols.string-affix-predicate-api",
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&wrong_producer, &interner, call).is_none(),
+        "string affix evidence with the wrong producer provenance is rejected"
     );
 
     let (mut wrong_direction, interner, call, receiver) =
@@ -136,8 +181,34 @@ fn admitted_string_affix_requires_protocol_pack_and_string_receiver_proof() {
         "forged affix evidence cannot open unsupported arity"
     );
 
+    let (mut unsupported_offset, interner, call, receiver) =
+        string_affix_call_il(Lang::JavaScript, "startsWith", 2);
+    push_string_receiver_dependency(&mut unsupported_offset, receiver);
+    unsupported_offset
+        .evidence
+        .push(builtin_method_call_protocol_record(
+            1,
+            unsupported_offset.node(call).span,
+            js_prefix_contract,
+            1,
+            EvidenceStatus::Asserted,
+            &[0],
+        ));
+    assert!(
+        admitted_library_method_call_at_call(&unsupported_offset, &interner, call).is_none(),
+        "forged affix evidence cannot open the JS offset argument form"
+    );
+
     assert_admitted_string_affix(Lang::Python, "startswith", Builtin::StartsWith);
     assert_admitted_string_affix(Lang::Python, "endswith", Builtin::EndsWith);
+    assert_admitted_string_affix(Lang::Java, "startsWith", Builtin::StartsWith);
+    assert_admitted_string_affix(Lang::Java, "endsWith", Builtin::EndsWith);
     assert_admitted_string_affix(Lang::Rust, "starts_with", Builtin::StartsWith);
+    assert_admitted_string_affix(Lang::Rust, "ends_with", Builtin::EndsWith);
+    assert_admitted_string_affix(Lang::Swift, "hasPrefix", Builtin::StartsWith);
     assert_admitted_string_affix(Lang::Swift, "hasSuffix", Builtin::EndsWith);
+    assert_admitted_string_affix(Lang::TypeScript, "startsWith", Builtin::StartsWith);
+    assert_admitted_string_affix(Lang::TypeScript, "endsWith", Builtin::EndsWith);
+    assert_admitted_string_affix(Lang::JavaScript, "startsWith", Builtin::StartsWith);
+    assert_admitted_string_affix(Lang::JavaScript, "endsWith", Builtin::EndsWith);
 }

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -207,8 +207,9 @@ still being migrated toward it.
   arities remain hard negatives. The
   `nose.protocols.string_affix_predicates` descriptor owns case-sensitive
   receiver-method prefix/suffix predicate contracts under exact string receiver
-  proof, while direction mismatches, missing receiver proof, wrong-pack
-  evidence, and unsupported arities remain hard negatives. The
+  proof, while direction mismatches, missing or non-string receiver proof,
+  wrong-pack or wrong-producer evidence, unsupported arities, and offset forms
+  remain hard negatives. The
   `nose.protocols.sequence_hof_adapters` descriptor owns Rust iterator
   `map`/`filter`/`filter_map`/`flat_map` HOF adapter occurrence provenance and
   `any`/`all`/`count` terminal proof on explicit protocol receivers. It also

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -376,7 +376,9 @@ previous semantic-kernel tranches.
    `nose.protocols.string_affix_predicates`, which owns case-sensitive
    receiver-method prefix/suffix API occurrence provenance under exact string
    receiver proof while preserving prefix/suffix direction and
-   receiver-vs-affix argument coordinates. The current Go stdlib namespace-call
+   receiver-vs-affix argument coordinates; conformance hard negatives keep
+   non-string receivers, wrong producer provenance, unsupported arities, and
+   offset argument forms closed. The current Go stdlib namespace-call
    slice is `nose.go.stdlib.namespace_calls`, which owns `fmt.Print*`,
    `strings.HasPrefix`/`HasSuffix`, `strings.Contains`, and `slices.Contains`
    API occurrence provenance under imported-namespace proof. `strings.Contains`

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -114,6 +114,14 @@ The inventory also records that product-output and performance evidence are
 `required-on-implementation-pr`. Those measurements live in the PR that changes
 behavior or pack ownership, not in a static descriptor table.
 
+The builtin `nose.protocols.string_affix_predicates` pack records
+case-sensitive receiver-method prefix/suffix positives across Python, Java,
+Rust, Swift, JavaScript, and TypeScript. Its hard negatives keep direction
+mismatches, missing or non-string receiver proof, wrong pack or producer
+provenance, unsupported arity, and unsupported offset argument forms closed.
+Go `strings.HasPrefix` and `strings.HasSuffix` stay under
+`nose.go.stdlib.namespace_calls` until the namespace-proof slice moves.
+
 ## Builtin Inventory JSON
 
 `nose semantic-pack inventory --format json` emits schema version 1:
@@ -127,10 +135,10 @@ behavior or pack ownership, not in a static descriptor table.
     "builtin_packs": 49,
     "exact_capable_packs": 39,
     "packs_needing_coverage": 0,
-    "positive_fixtures": 178,
-    "hard_negatives": 143,
-    "conformance_refs": 321,
-    "unsupported_refs": 19
+    "positive_fixtures": 188,
+    "hard_negatives": 146,
+    "conformance_refs": 334,
+    "unsupported_refs": 20
   },
   "evidence_policy": {
     "product_output": "required-on-implementation-pr",

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -121,6 +121,8 @@ mismatches, missing or non-string receiver proof, wrong pack or producer
 provenance, unsupported arity, and unsupported offset argument forms closed.
 Go `strings.HasPrefix` and `strings.HasSuffix` stay under
 `nose.go.stdlib.namespace_calls` until the namespace-proof slice moves.
+The focused #558 product comparison is recorded in
+[string-affix-conformance-closeout-558](string-affix-conformance-closeout-558.md).
 
 ## Builtin Inventory JSON
 

--- a/docs/string-affix-conformance-closeout-558.md
+++ b/docs/string-affix-conformance-closeout-558.md
@@ -1,0 +1,162 @@
+# String affix conformance closeout (#558)
+
+Status: #558 is a conformance/inventory hardening PR for
+`nose.protocols.string_affix_predicates`. It does not change runtime admission
+routes or widen exact matching.
+
+## Scope
+
+The PR expands descriptor-visible conformance refs for receiver-method string
+prefix/suffix predicates:
+
+- positives for Python, Java, Rust, Swift, JavaScript, and TypeScript prefix and
+  suffix methods already routed through the string-affix protocol pack;
+- hard negatives for non-string receiver proof, wrong producer provenance, and
+  unsupported JavaScript offset argument forms;
+- no movement for Go `strings.HasPrefix`/`strings.HasSuffix`, which stays in
+  `nose.go.stdlib.namespace_calls` for #549.
+
+## Product Comparison
+
+Baseline ref: `origin/main@def272b356e2062e0831ef88c62716adce93f158`.
+Measured current build ref: `66120cd530f46602b4249d181fa659bcc170d1dd`.
+
+Binary hashes:
+
+- baseline: `ae02d6525140aa309eef43553b07ea5f995f43db9df0468f9b6ad43f684fc0db`
+- current: `b7f7bd1838df7a32ba700584e95516e561b7d1df38f66b97b7e82bbf868d14d4`
+
+The focused corpus can be recreated in any scratch directory with these files:
+
+`prefix.ts`
+
+```ts
+export function hasPrefix(value: string): boolean {
+  return value.startsWith("pre")
+}
+```
+
+`prefix.js`
+
+```js
+function hasPrefix(value) {
+  return value.startsWith("pre");
+}
+```
+
+`Prefix.java`
+
+```java
+public class Prefix {
+  boolean hasPrefix(String value) {
+    return value.startsWith("pre");
+  }
+}
+```
+
+`prefix.rs`
+
+```rust
+pub fn has_prefix(value: &str) -> bool {
+    value.starts_with("pre")
+}
+```
+
+`prefix.swift`
+
+```swift
+func hasPrefix(_ value: String) -> Bool {
+    return value.hasPrefix("pre")
+}
+```
+
+`prefix.py`
+
+```python
+def has_prefix(value: str) -> bool:
+    return value.startswith("pre")
+```
+
+`suffix.py`
+
+```python
+def has_suffix(value: str) -> bool:
+    return value.endswith("pre")
+```
+
+`different_affix.py`
+
+```python
+def has_other_prefix(value: str) -> bool:
+    return value.startswith("alt")
+```
+
+`different_receiver.py`
+
+```python
+def has_prefix_other_receiver(value: str, other: str) -> bool:
+    return other.startswith("pre")
+```
+
+Comparison command:
+
+```sh
+nose query <focused-string-affix-corpus> all top=0 --mode semantic --format json
+```
+
+Result:
+
+| Metric | Baseline | Current |
+| --- | ---: | ---: |
+| family count | 1 | 1 |
+| families equal | true | true |
+| semantic pack count | 49 | 49 |
+| string-affix positive fixtures | 2 | 12 |
+| string-affix hard negatives | 4 | 7 |
+| investigation triggers | 0 | 0 |
+
+Drift classification: intentional conformance/inventory metadata drift only.
+Focused query families are unchanged.
+
+## Inventory Comparison
+
+Command:
+
+```sh
+nose semantic-pack inventory --format json
+```
+
+| Metric | Baseline | Current |
+| --- | ---: | ---: |
+| packs | 49 | 49 |
+| builtin packs | 49 | 49 |
+| exact-capable packs | 39 | 39 |
+| packs needing coverage | 0 | 0 |
+| positive fixtures | 178 | 188 |
+| hard negatives | 143 | 146 |
+| conformance refs | 321 | 334 |
+| unsupported refs | 19 | 20 |
+
+## Runtime
+
+Method: 2 warmups, then 9 alternating measured repeats over the focused corpus.
+
+Baseline times in milliseconds:
+
+```text
+7.196, 9.225, 8.758, 7.349, 9.585, 7.526, 9.653, 26.09, 12.987
+```
+
+Current times in milliseconds:
+
+```text
+7.291, 7.308, 8.863, 8.954, 8.802, 9.379, 12.909, 16.659, 10.125
+```
+
+Median: `9.225 ms -> 8.954 ms` (`-0.271 ms`).
+
+## Rollback
+
+Revert the #558 PR. No runtime admission route, pack id, producer id, or
+contract id change is required because the PR only changes conformance metadata,
+tests, and documentation.


### PR DESCRIPTION
## Summary

Closes #558. Parent: #548, tranche: #547, epic: #519.

This expands the builtin `nose.protocols.string_affix_predicates` conformance boundary without broadening runtime admission. The pack now records receiver-method positives across Python, Java, Rust, Swift, JavaScript, and TypeScript, plus hard negatives for non-string receiver proof, wrong producer provenance, and unsupported offset forms.

## Scope

- Adds explicit conformance refs for Java/Rust/Swift/JS/TS prefix and suffix receiver-method rows already routed through the string-affix protocol pack.
- Adds hard-negative refs for non-string receiver proof, wrong producer provenance, and unsupported JS offset argument forms.
- Extends admission tests so exact admission still requires the string-affix pack, exact string receiver proof, matching direction, matching producer provenance, and supported arity.
- Keeps Go `strings.HasPrefix`/`strings.HasSuffix` in `nose.go.stdlib.namespace_calls` for #549.
- Splits string-affix protocol constants into `constants/string_affix.rs` to keep the file-length ratchet below the default limit without adding a budget exception.

## Quantitative before/after

Baseline ref: `origin/main@def272b356e2062e0831ef88c62716adce93f158`  
Current PR head: `858d65a7`
Measured current build ref: `66120cd530f46602b4249d181fa659bcc170d1dd`

Durable closeout artifact: [docs/string-affix-conformance-closeout-558.md](docs/string-affix-conformance-closeout-558.md)

Focused corpus command:

```sh
nose query /tmp/nose-558-corpus all top=0 --mode semantic --format json
```

Focused product output comparison, baseline `/tmp/nose-558-main-target/release/nose` vs this branch release binary:

- Baseline binary SHA-256: `ae02d6525140aa309eef43553b07ea5f995f43db9df0468f9b6ad43f684fc0db`
- Current binary SHA-256: `b7f7bd1838df7a32ba700584e95516e561b7d1df38f66b97b7e82bbf868d14d4`
- Families equal: `true`
- Family count: `1 -> 1`
- Semantic pack count: `49 -> 49`
- Intentional string-affix pack metadata drift: positive fixtures `2 -> 12`, hard negatives `4 -> 7`
- Median wall time over 2 warmups + 9 repeats: `9.225 ms -> 8.954 ms` (`-0.271 ms`)

Builtin inventory before/after:

- Packs: `49 -> 49`
- Builtin packs: `49 -> 49`
- Exact-capable packs: `39 -> 39`
- Packs needing coverage: `0 -> 0`
- Positive fixtures: `178 -> 188`
- Hard negatives: `143 -> 146`
- Conformance refs: `321 -> 334`
- Unsupported refs: `19 -> 20`

Drift classification: intentional conformance/inventory metadata drift only. Focused query families are unchanged.

Rollback action: revert this PR; no runtime admission route or pack id change is required.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `cargo test -q -p nose-semantics string_affix -- --nocapture`
- `cargo test -q -p nose-semantics builtin_pack_descriptors_enumerate_declarations_and_conformance_refs -- --nocapture`
- `cargo test -q -p nose-semantics`
- `cargo test -q -p nose-cli semantic_pack_inventory_json_reports_builtin_coverage -- --nocapture`
- `cargo test -q -p nose-cli query_json_reports_builtin_semantic_packs -- --nocapture`
- `cargo check -q --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -q --release --bin nose`
- `cargo run -q -p nose-cli -- semantic-pack inventory --format json | jq '.totals'`
- `./scripts/check-docs.sh`
- `./scripts/check-duplication.sh`

## Independent reviews

- Huygens soundness/provenance review: https://github.com/corca-ai/nose/pull/561#issuecomment-4808642427
- Carson process/tests/evidence review: https://github.com/corca-ai/nose/pull/561#issuecomment-4808642446


