### PR TITLE
Refine recall-loss callee attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ break.
   boundaries, and value-fingerprint floor; added deterministic report diff
   tooling plus checked-in `crates` and mixed-language corpus-slice baselines for
   the semantic-kernel recovery loop.
+- Refined recall-loss attribution for expression-statement effect boundaries
+  and unmodeled Rust macro invocations: discarded call results now land in the
+  effect boundary bucket, while `format!`/other uncontracted macros land in the
+  source-surface bucket instead of broad callee-identity loss.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -40,3 +40,7 @@ python3 scripts/recall-loss-diff.py before.json after.json
   and Swift.
 - [issue-570-cycles.v1.json](issue-570-cycles.v1.json) records the five focused
   top-bucket cycles and the explicit unsupported/fail-closed boundary decision.
+- [issue-572-cycle.v1.json](issue-572-cycle.v1.json) records the first
+  post-#570 refinement cycle: expression-statement effect boundaries and Rust
+  macro surfaces are split out of the callee-identity bucket while preserving
+  the hard gate.

--- a/bench/recall_loss/corpus-slice.baseline.v1.json
+++ b/bench/recall_loss/corpus-slice.baseline.v1.json
@@ -46,9 +46,10 @@
       "path-bail": 7
     },
     "admission_rejections_by_reason": {
-      "import-symbol-callee-identity-proof-missing": 26,
+      "import-symbol-callee-identity-proof-missing": 23,
       "unsupported-runtime-boundary": 18,
       "value-fingerprint-too-small": 5,
+      "mutation-effect-boundary": 3,
       "library-api-occurrence-proof-missing": 1,
       "source-surface-proof-missing": 1,
       "unattributed-strict-exact-unsafe": 0
@@ -57,7 +58,7 @@
   "representative_buckets": [
     {
       "reason": "import-symbol-callee-identity-proof-missing",
-      "count": 26,
+      "count": 23,
       "examples": [
         "bench/repos/boltons/boltons/iterutils.py:193",
         "bench/repos/boltons/boltons/iterutils.py:223",
@@ -71,6 +72,15 @@
         "bench/repos/boltons/boltons/iterutils.py:61",
         "bench/repos/boltons/boltons/iterutils.py:205",
         "bench/repos/swift-metrics/Sources/CoreMetrics/Metrics.swift:89"
+      ]
+    },
+    {
+      "reason": "mutation-effect-boundary",
+      "count": 3,
+      "examples": [
+        "bench/repos/boltons/boltons/iterutils.py:1487",
+        "bench/repos/boltons/boltons/iterutils.py:1530",
+        "bench/repos/thor/lib/thor/actions.rb:48"
       ]
     },
     {

--- a/bench/recall_loss/crates.baseline.v1.json
+++ b/bench/recall_loss/crates.baseline.v1.json
@@ -19,9 +19,9 @@
   },
   "current": {
     "summary": {
-      "total_units": 6108,
+      "total_units": 6111,
       "interpretable_units": 847,
-      "excluded_units": 5261,
+      "excluded_units": 5264,
       "canon_checked": 69,
       "canon_preservation_violations": 0,
       "admission_rejections": 764
@@ -47,20 +47,33 @@
       "core-missing": 0,
       "battery-bail": 1,
       "empty-fingerprint": 1,
-      "uninterpretable": 5258,
+      "uninterpretable": 5261,
       "path-bail": 1
     },
     "admission_rejections_by_reason": {
-      "import-symbol-callee-identity-proof-missing": 385,
-      "receiver-domain-proof-missing": 276,
+      "import-symbol-callee-identity-proof-missing": 264,
+      "receiver-domain-proof-missing": 238,
+      "mutation-effect-boundary": 134,
+      "source-surface-proof-missing": 73,
       "hof-demand-effect-proof-missing": 28,
-      "mutation-effect-boundary": 22,
-      "source-surface-proof-missing": 21,
       "unsupported-runtime-boundary": 14,
-      "library-api-occurrence-proof-missing": 12,
+      "library-api-occurrence-proof-missing": 7,
       "value-fingerprint-too-small": 6,
       "unattributed-strict-exact-unsafe": 0
     }
+  },
+  "cycle_572_attribution_refinement": {
+    "source": "issue-572",
+    "selected_reason": "import-symbol-callee-identity-proof-missing",
+    "before_count": 385,
+    "after_count": 264,
+    "delta": -121,
+    "moved_to": {
+      "mutation-effect-boundary": 112,
+      "source-surface-proof-missing": 52
+    },
+    "hard_gate_preserved": true,
+    "follow_up": "Recover the remaining pure scoped/path callee identity cases with reusable symbol evidence instead of reopening expression-statement effect or macro surfaces."
   },
   "attribution_improvement": {
     "opaque_strict_exact_unsafe_before": 758,
@@ -72,20 +85,38 @@
   "representative_buckets": [
     {
       "reason": "import-symbol-callee-identity-proof-missing",
-      "count": 385,
+      "count": 264,
       "examples": [
-        "crates/nose-cli/src/baseline.rs:42",
-        "crates/nose-cli/src/baseline_comparison.rs:81",
-        "crates/nose-cli/src/command_dispatch.rs:89"
+        "crates/nose-cli/src/command_dispatch.rs:89",
+        "crates/nose-cli/src/divergence.rs:32",
+        "crates/nose-cli/src/divergence/git.rs:5"
       ]
     },
     {
       "reason": "receiver-domain-proof-missing",
-      "count": 276,
+      "count": 238,
       "examples": [
         "crates/nose-cli/src/baseline.rs:158",
         "crates/nose-cli/src/falsify.rs:42",
         "crates/nose-cli/src/family_display.rs:9"
+      ]
+    },
+    {
+      "reason": "mutation-effect-boundary",
+      "count": 134,
+      "examples": [
+        "crates/nose-cli/src/baseline_comparison.rs:81",
+        "crates/nose-cli/src/detect_command.rs:152",
+        "crates/nose-cli/src/ignores.rs:416"
+      ]
+    },
+    {
+      "reason": "source-surface-proof-missing",
+      "count": 73,
+      "examples": [
+        "crates/nose-cli/src/baseline.rs:42",
+        "crates/nose-cli/src/divergence/detect.rs:201",
+        "crates/nose-cli/src/markdown.rs:93"
       ]
     },
     {
@@ -95,24 +126,6 @@
         "crates/nose-cli/src/divergence/git.rs:97",
         "crates/nose-cli/src/divergence/git.rs:110",
         "crates/nose-cli/src/path_utils.rs:8"
-      ]
-    },
-    {
-      "reason": "mutation-effect-boundary",
-      "count": 22,
-      "examples": [
-        "crates/nose-cli/src/oracle_gate.rs:412",
-        "crates/nose-cli/src/oracle_gate.rs:528",
-        "crates/nose-cli/src/query_opportunities.rs:30"
-      ]
-    },
-    {
-      "reason": "source-surface-proof-missing",
-      "count": 21,
-      "examples": [
-        "crates/nose-cli/src/divergence/detect.rs:201",
-        "crates/nose-cli/src/oracle_gate.rs:392",
-        "crates/nose-detect/src/fragment/conditional_guard.rs:51"
       ]
     },
     {

--- a/bench/recall_loss/issue-572-cycle.v1.json
+++ b/bench/recall_loss/issue-572-cycle.v1.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "report_kind": "recall-loss-cycle-log",
+  "issue": 572,
+  "generated_on": "2026-06-27",
+  "baseline_summary": "bench/recall_loss/crates.baseline.v1.json",
+  "selected_reason": "import-symbol-callee-identity-proof-missing",
+  "decision": "precision-hardened-attribution",
+  "before_report": "target/recall-loss.before.json",
+  "after_report": "target/recall-loss.after.json",
+  "hard_gate": {
+    "surface": "crates",
+    "false_merges_before": 0,
+    "false_merges_after": 0,
+    "canon_preservation_violations_before": 0,
+    "canon_preservation_violations_after": 0
+  },
+  "bucket_delta": {
+    "import-symbol-callee-identity-proof-missing": {
+      "before": 385,
+      "after": 264,
+      "delta": -121
+    },
+    "mutation-effect-boundary": {
+      "before": 22,
+      "after": 134,
+      "delta": 112
+    },
+    "source-surface-proof-missing": {
+      "before": 21,
+      "after": 73,
+      "delta": 52
+    },
+    "unattributed-strict-exact-unsafe": {
+      "before": 0,
+      "after": 0,
+      "delta": 0
+    }
+  },
+  "what_changed": [
+    "Expression-statement calls that need an effect contract are attributed to mutation-effect-boundary instead of callee-identity proof loss.",
+    "Rust macro invocations without admitted macro/library semantics are attributed to source-surface-proof-missing with rust-macro-expansion-contract as missing evidence.",
+    "Exact admission behavior remains unchanged; this cycle narrows the next recoverable callee-identity target."
+  ],
+  "fixture_refs": [
+    "crates/nose-cli/tests/cli/commands/recall_loss_report.rs:recall_loss_report_splits_rust_effect_and_macro_boundaries_from_callee_identity",
+    "crates/nose-cli/tests/cli/semantic_idioms/literal_membership/fixture.rs:4",
+    "crates/nose-cli/src/baseline.rs:42"
+  ],
+  "follow_up": {
+    "issue": 567,
+    "target": "remaining pure scoped/path callee identity cases",
+    "policy": "Recover with reusable symbol/callee evidence and hard negatives for shadowed paths, local overrides, expression-statement effects, and unmodeled macros."
+  }
+}

--- a/crates/nose-cli/src/verify_admission.rs
+++ b/crates/nose-cli/src/verify_admission.rs
@@ -97,6 +97,16 @@ fn strict_exact_rejection_reason(
         };
     }
 
+    if subtree_has(il, root, rust_macro_invocation_call) {
+        return ExactAdmissionRejectionDiagnostic {
+            reason: "source-surface-proof-missing",
+            admission_gate: "strict-exact-source-surface",
+            capability_id: "source-surface-evidence",
+            pack_id: None,
+            missing_evidence: vec!["rust-macro-expansion-contract"],
+        };
+    }
+
     if subtree_has(il, root, |il, node| {
         il.kind(node) == nose_il::NodeKind::Call
     }) {
@@ -154,6 +164,7 @@ fn effect_boundary_node(il: &nose_il::Il, node: NodeId) -> bool {
                         nose_il::NodeKind::Field | nose_il::NodeKind::Index
                     )
                 })
+                || expression_statement_call(il, node)
         }
     }
 }
@@ -161,6 +172,15 @@ fn effect_boundary_node(il: &nose_il::Il, node: NodeId) -> bool {
 fn builtin_call_node(il: &nose_il::Il, node: NodeId) -> bool {
     il.kind(node) == nose_il::NodeKind::Call
         && matches!(il.node(node).payload, nose_il::Payload::Builtin(_))
+}
+
+fn expression_statement_call(il: &nose_il::Il, node: NodeId) -> bool {
+    il.kind(node) == nose_il::NodeKind::ExprStmt
+        && il.children(node).first().is_some_and(|&expr| {
+            subtree_has(il, expr, |il, node| {
+                il.kind(node) == nose_il::NodeKind::Call
+            })
+        })
 }
 
 fn receiver_method_call(il: &nose_il::Il, interner: &Interner, node: NodeId) -> bool {
@@ -206,6 +226,9 @@ fn receiver_method_call(il: &nose_il::Il, interner: &Interner, node: NodeId) -> 
 }
 
 fn source_surface_boundary_node(il: &nose_il::Il, node: NodeId) -> bool {
+    if rust_macro_invocation_call(il, node) {
+        return true;
+    }
     matches!(
         il.kind(node),
         nose_il::NodeKind::Seq
@@ -214,4 +237,17 @@ fn source_surface_boundary_node(il: &nose_il::Il, node: NodeId) -> bool {
             | nose_il::NodeKind::BinOp
             | nose_il::NodeKind::UnOp
     )
+}
+
+fn rust_macro_invocation_call(il: &nose_il::Il, node: NodeId) -> bool {
+    il.meta.lang == nose_il::Lang::Rust
+        && il.kind(node) == nose_il::NodeKind::Call
+        && il.evidence_anchored_at(il.node(node).span).any(|record| {
+            matches!(
+                record.kind,
+                nose_il::EvidenceKind::Source(nose_il::SourceFactKind::Call(
+                    nose_il::SourceCallKind::MacroInvocation
+                ))
+            )
+        })
 }

--- a/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
+++ b/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
@@ -122,3 +122,63 @@ fn recall_loss_report_ratchets_representative_admission_buckets() {
         "bucket ratchet should not leave opaque strict-exact rejections: {report}"
     );
 }
+
+#[test]
+fn recall_loss_report_splits_rust_effect_and_macro_boundaries_from_callee_identity() {
+    let project = TempProject::new("recall_loss_rust_callee_boundaries");
+    project.write(
+        "sample.rs",
+        "use std::fs;\n\
+use std::path::Path;\n\n\
+pub fn write_fixture(dir: &Path) {\n\
+    fs::write(dir.join(\"case.txt\"), \"value\").unwrap();\n\
+}\n\n\
+pub fn format_key(key: u64) -> String {\n\
+    format!(\"{key:016x}\")\n\
+}\n",
+    );
+    let report_path = project.path().join("recall-loss.json");
+    let out = run_raw(&[
+        "verify",
+        project.path().to_str().unwrap(),
+        "--max-violations",
+        "0",
+        "--recall-loss-report",
+        report_path.to_str().unwrap(),
+    ]);
+    assert!(out.contains("GATE: 0"));
+
+    let report_text = fs::read_to_string(&report_path).expect("recall-loss report");
+    let report: serde_json::Value =
+        serde_json::from_str(&report_text).expect("recall-loss report JSON");
+    let reasons = report["by_reason"]
+        .as_array()
+        .expect("by_reason should be an array");
+    assert!(
+        reasons
+            .iter()
+            .any(|item| item["reason"] == "mutation-effect-boundary"
+                && item["count"].as_u64().unwrap_or(0) >= 1),
+        "expected fs::write to be attributed to the effect boundary: {report}"
+    );
+    assert!(
+        reasons
+            .iter()
+            .any(|item| item["reason"] == "source-surface-proof-missing"
+                && item["count"].as_u64().unwrap_or(0) >= 1),
+        "expected format! to be attributed to the Rust macro source boundary: {report}"
+    );
+    assert!(
+        report["admission_rejections"]
+            .as_array()
+            .expect("admission_rejections should be an array")
+            .iter()
+            .any(|item| item["reason"] == "source-surface-proof-missing"
+                && item["missing_evidence"]
+                    .as_array()
+                    .is_some_and(|items| items
+                        .iter()
+                        .any(|value| value == "rust-macro-expansion-contract"))),
+        "expected macro-specific missing evidence: {report}"
+    );
+}

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -511,11 +511,14 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   expressions emit source-comprehension facts so exact consumers can distinguish
   eager materialized lists, lazy generators, set deduplication, and dict
   materialization even when the lowered HOF body shape is similar. Rust range
-  expressions emit half-open or inclusive range source facts, and Rust
-  tuple-struct single-wildcard patterns such as `Some(_)` emit pattern source
-  facts. These facts are syntax provenance only: the full-index range rewrite
-  also needs an admitted `len` contract, and Option pattern predicates also need
-  admitted `Some`/`None` API occurrence evidence and receiver-domain proof;
+  expressions emit half-open or inclusive range source facts, Rust macro
+  invocations emit call source facts, and Rust tuple-struct single-wildcard
+  patterns such as `Some(_)` emit pattern source facts. These facts are syntax
+  provenance only: the full-index range rewrite also needs an admitted `len`
+  contract, Option pattern predicates also need admitted `Some`/`None` API
+  occurrence evidence and receiver-domain proof, and unmodeled Rust macros stay
+  in recall-loss `source-surface-proof-missing` until a macro expansion or
+  library contract proves their behavior;
 - import binding and namespace lowering emits `Import` evidence for the proof RHS
   and `Symbol` evidence for the local alias identity;
 - selected top-level Ruby literal `require "module"` calls that occur before a

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -57,8 +57,8 @@ or narrow product admission by itself.
 | `receiver-domain-proof-missing` | A receiver method call needs receiver-domain evidence rather than selector-name inference. |
 | `library-api-occurrence-proof-missing` | A canonical builtin/API occurrence lacks admitted pack or producer evidence. |
 | `hof-demand-effect-proof-missing` | A higher-order surface lacks a demand, effect, and materialization profile. |
-| `source-surface-proof-missing` | A source construct, operator, comprehension, or syntax distinction is required but not proven. |
-| `mutation-effect-boundary` | Mutation, place, or effect obligations close exact admission until an effect-preserving contract exists. |
+| `source-surface-proof-missing` | A source construct, operator, comprehension, Rust macro invocation, or syntax distinction is required but not proven. |
+| `mutation-effect-boundary` | Mutation, place, side-effecting call, or effect obligations close exact admission until an effect-preserving contract exists. |
 | `unsupported-runtime-boundary` | Runtime/protocol boundaries such as raw lowered constructs, try/throw, splat, or keyword-argument surfaces intentionally fail closed. |
 | `value-fingerprint-too-small` | The unit is strict-exact-safe, but its value fingerprint is below the non-degenerate exact-claim floor. |
 | `unattributed-strict-exact-unsafe` | Fallback for unknown strict-exact rejection. This should stay visible and should trend toward zero. |
@@ -68,6 +68,10 @@ guess.
 
 The checked-in baseline summaries and the five-cycle recovery log are described
 in [recall-loss-recovery-loop](recall-loss-recovery-loop.md).
+The #572 cycle also records a diagnostics-only refinement: expression-statement
+calls that need an effect contract stay in the effect boundary bucket, and
+unmodeled Rust macros such as `format!` stay in the source-surface bucket until
+a macro expansion or library contract proves their behavior.
 
 ## PR reporting
 

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -17,6 +17,9 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   Rust, and Swift.
 - [#570 cycle log](../bench/recall_loss/issue-570-cycles.v1.json) records the
   first five top-bucket cycles and the unsupported runtime boundary decision.
+- [#572 cycle log](../bench/recall_loss/issue-572-cycle.v1.json) records the
+  first post-#570 refinement cycle, which splits expression-statement effect
+  boundaries and Rust macro source surfaces out of the callee-identity bucket.
 
 Regenerate the full local reports with:
 
@@ -70,15 +73,21 @@ The first coarse `crates` baseline had `758` units in the opaque
 `unattributed-strict-exact-unsafe` to `0` while preserving false merges `0` and
 canon-preservation violations `0`.
 
+The #572 refinement keeps the same hard gate while moving expression-statement
+effect boundaries and unmodeled Rust macro invocations out of the
+callee-identity bucket. That sharpens the remaining exact-recovery target: pure
+scoped/path callees still need reusable symbol/callee evidence, while discarded
+call results and unmodeled macro expansion stay closed.
+
 The current top `crates` buckets are:
 
 | reason | count | next capability |
 |---|---:|---|
-| `import-symbol-callee-identity-proof-missing` | 385 | reusable callee identity evidence |
-| `receiver-domain-proof-missing` | 276 | receiver-domain evidence instead of selector spelling |
+| `import-symbol-callee-identity-proof-missing` | 264 | reusable callee identity evidence |
+| `receiver-domain-proof-missing` | 238 | receiver-domain evidence instead of selector spelling |
+| `mutation-effect-boundary` | 134 | effect and place contracts |
+| `source-surface-proof-missing` | 73 | Rust macro/source-surface contracts and construct/operator/comprehension evidence |
 | `hof-demand-effect-proof-missing` | 28 | HOF demand/effect/materialization profile |
-| `mutation-effect-boundary` | 22 | effect and place contracts |
-| `source-surface-proof-missing` | 21 | construct/operator/comprehension/source-surface evidence |
 | `unsupported-runtime-boundary` | 14 | intentional fail-closed runtime/protocol boundary |
 
 These are capability gaps, not feature requests. A future PR should close a

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -118,7 +118,10 @@ fall back to a side-table mirror when source evidence is missing.
   provenance and the specialized `c.source.cast.unsigned32` producer id.
 - Rust lowering emits source facts for macro invocation syntax, half-open versus
   inclusive range expressions, tuple-struct single-wildcard patterns such as
-  `Some(_)`, `.await`, async blocks, and `?` error propagation.
+  `Some(_)`, `.await`, async blocks, and `?` error propagation. Macro facts are
+  syntax provenance only: recall-loss diagnostics attribute unmodeled Rust
+  macros such as `format!` to `source-surface-proof-missing` until a library or
+  macro-expansion contract proves their behavior.
 - JS/TS, Python, and Rust `await` lowering preserves `Raw("await", value)`
   instead of erasing the source operation. JS/TS and Python `yield` preserves
   `Raw("yield", value)`. Rust `async {}` and `?` are preserved as


### PR DESCRIPTION
## Summary

- Split expression-statement effect boundaries out of broad callee-identity recall loss.
- Attribute unmodeled Rust macro invocations to `source-surface-proof-missing` with `rust-macro-expansion-contract` missing evidence.
- Update checked-in recall-loss baselines, #572 cycle log, docs, and changelog.

## Quantitative report

`python3 scripts/recall-loss-diff.py target/recall-loss.before.json target/recall-loss.after.json` on `crates`:

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| false merges | 0 | 0 | 0 |
| canon-preservation violations | 0 | 0 | 0 |
| completeness percent | 53.52 | 53.52 | 0.00 |
| under-merged behavior groups | 2 | 2 | 0 |
| admission rejections | 764 | 764 | 0 |

| reason | before | after | delta |
| --- | ---: | ---: | ---: |
| `import-symbol-callee-identity-proof-missing` | 385 | 264 | -121 |
| `mutation-effect-boundary` | 22 | 134 | +112 |
| `source-surface-proof-missing` | 21 | 73 | +52 |
| `receiver-domain-proof-missing` | 276 | 238 | -38 |
| `library-api-occurrence-proof-missing` | 12 | 7 | -5 |
| `unattributed-strict-exact-unsafe` | 0 | 0 | 0 |

Mixed corpus slice also stays green: false merges 0, canon-preservation violations 0, completeness 100%; callee-identity moves 26 -> 23 with mutation-effect 0 -> 3.

## Verification

- `cargo test -p nose-cli --test cli commands::recall_loss_report -- --nocapture`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.after.json`
- `cargo run -q -p nose-cli -- verify bench/repos/chi/middleware/content_type.go bench/repos/boltons/boltons/iterutils.py bench/repos/thor/lib/thor/actions.rb bench/repos/radash/src/array.ts bench/repos/hyperfine/src/util/number.rs bench/repos/swift-metrics/Sources/CoreMetrics/Metrics.swift --max-violations 0 --recall-loss-report target/recall-loss.corpus-slice.after.json`
- `python3 scripts/recall-loss-diff.py --self-test`
- `jq empty bench/recall_loss/*.json`
- `awiki lint --root docs`
- `./scripts/check-duplication.sh`
- `./scripts/check-ci-local.sh --fast`

Closes #572. Refs #570. Refs #567.