### PR TITLE
Census callee identity recall loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ break.
   and unmodeled Rust macro invocations: discarded call results now land in the
   effect boundary bucket, while `format!`/other uncontracted macros land in the
   source-surface bucket instead of broad callee-identity loss.
+- Added a recall-loss callee-identity census workflow that splits the remaining
+  callee bucket by call-target surface, including local/parameter calls,
+  member calls, scoped paths, imported/global target proof labels, and already
+  target-present call-contract proof labels.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -30,6 +30,14 @@ Compare two full reports with:
 python3 scripts/recall-loss-diff.py before.json after.json
 ```
 
+Build the #574 callee-identity census from a full report with:
+
+```sh
+python3 scripts/recall-loss-callee-census.py \
+  target/recall-loss.crates.json \
+  > bench/recall_loss/issue-574-callee-census.v1.json
+```
+
 ## Files
 
 - [crates.baseline.v1.json](crates.baseline.v1.json) records the current
@@ -44,3 +52,6 @@ python3 scripts/recall-loss-diff.py before.json after.json
   post-#570 refinement cycle: expression-statement effect boundaries and Rust
   macro surfaces are split out of the callee-identity bucket while preserving
   the hard gate.
+- [issue-574-callee-census.v1.json](issue-574-callee-census.v1.json) records
+  the #567/#574 census of the remaining callee-identity bucket by language and
+  call-target surface.

--- a/bench/recall_loss/crates.baseline.v1.json
+++ b/bench/recall_loss/crates.baseline.v1.json
@@ -19,9 +19,9 @@
   },
   "current": {
     "summary": {
-      "total_units": 6111,
+      "total_units": 6122,
       "interpretable_units": 847,
-      "excluded_units": 5264,
+      "excluded_units": 5275,
       "canon_checked": 69,
       "canon_preservation_violations": 0,
       "admission_rejections": 764
@@ -47,7 +47,7 @@
       "core-missing": 0,
       "battery-bail": 1,
       "empty-fingerprint": 1,
-      "uninterpretable": 5261,
+      "uninterpretable": 5272,
       "path-bail": 1
     },
     "admission_rejections_by_reason": {
@@ -74,6 +74,27 @@
     },
     "hard_gate_preserved": true,
     "follow_up": "Recover the remaining pure scoped/path callee identity cases with reusable symbol evidence instead of reopening expression-statement effect or macro surfaces."
+  },
+  "cycle_574_callee_census": {
+    "source": "issue-574",
+    "selected_reason": "import-symbol-callee-identity-proof-missing",
+    "total": 264,
+    "by_language": {
+      "rust": 261,
+      "typescript": 2,
+      "javascript": 1
+    },
+    "by_primary_surface": {
+      "local-or-parameter-call-target-proof": 115,
+      "member-call-target-proof": 92,
+      "scoped-path-call-target-proof": 45,
+      "direct-function-target-present-call-contract-proof": 9,
+      "unshadowed-global-call-target-proof": 2,
+      "imported-function-target-present-call-contract-proof": 1
+    },
+    "hard_gate_preserved": true,
+    "artifact": "bench/recall_loss/issue-574-callee-census.v1.json",
+    "follow_up": "Start with Rust local/scoped path call-target proof, then use the same evidence shape for import-backed immutable value provenance under #567."
   },
   "attribution_improvement": {
     "opaque_strict_exact_unsafe_before": 758,

--- a/bench/recall_loss/issue-574-callee-census.v1.json
+++ b/bench/recall_loss/issue-574-callee-census.v1.json
@@ -1,0 +1,292 @@
+{
+  "by_language": [
+    {
+      "count": 261,
+      "language": "rust"
+    },
+    {
+      "count": 2,
+      "language": "typescript"
+    },
+    {
+      "count": 1,
+      "language": "javascript"
+    }
+  ],
+  "by_language_and_surface": [
+    {
+      "count": 115,
+      "language": "rust",
+      "surface": "local-or-parameter-call-target-proof"
+    },
+    {
+      "count": 91,
+      "language": "rust",
+      "surface": "member-call-target-proof"
+    },
+    {
+      "count": 45,
+      "language": "rust",
+      "surface": "scoped-path-call-target-proof"
+    },
+    {
+      "count": 9,
+      "language": "rust",
+      "surface": "direct-function-target-present-call-contract-proof"
+    },
+    {
+      "count": 2,
+      "language": "typescript",
+      "surface": "unshadowed-global-call-target-proof"
+    },
+    {
+      "count": 1,
+      "language": "javascript",
+      "surface": "member-call-target-proof"
+    },
+    {
+      "count": 1,
+      "language": "rust",
+      "surface": "imported-function-target-present-call-contract-proof"
+    }
+  ],
+  "by_primary_surface": [
+    {
+      "count": 115,
+      "surface": "local-or-parameter-call-target-proof"
+    },
+    {
+      "count": 92,
+      "surface": "member-call-target-proof"
+    },
+    {
+      "count": 45,
+      "surface": "scoped-path-call-target-proof"
+    },
+    {
+      "count": 9,
+      "surface": "direct-function-target-present-call-contract-proof"
+    },
+    {
+      "count": 2,
+      "surface": "unshadowed-global-call-target-proof"
+    },
+    {
+      "count": 1,
+      "surface": "imported-function-target-present-call-contract-proof"
+    }
+  ],
+  "first_recovery_slice": {
+    "hard_negatives": [
+      "provider mutation",
+      "consumer rebinding",
+      "wildcard or ambiguous import",
+      "dynamic import or export",
+      "side-effecting module initialization",
+      "map key/value or coordinate confusion"
+    ],
+    "non_goals": [
+      "broad cross-file constant propagation",
+      "package ecosystem semantics",
+      "dynamic import/eval/reflection",
+      "exact admission without dependency-backed identity evidence"
+    ],
+    "rationale": "The current crates signal is overwhelmingly Rust, so the next implementation slice should prove reusable call-target identity before expanding import-backed immutable value provenance.",
+    "target": "Rust scoped-path and local-or-parameter call target proof census"
+  },
+  "generated_on": "2026-06-27",
+  "hard_gate": {
+    "canon_preservation_violations": 0,
+    "false_merges": 0,
+    "gate_passed": true
+  },
+  "issue": 574,
+  "parent_issue": 567,
+  "report_kind": "callee-identity-census",
+  "representative_units": {
+    "direct-function-target-present-call-contract-proof": [
+      {
+        "end_line": 26,
+        "file": "crates/nose-detect/src/orchestration.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "direct-function-target-present-call-contract-proof"
+        ],
+        "start_line": 24,
+        "tokens": 12
+      },
+      {
+        "end_line": 41,
+        "file": "crates/nose-detect/src/units/tests/extraction.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "direct-function-target-present-call-contract-proof"
+        ],
+        "start_line": 39,
+        "tokens": 15
+      },
+      {
+        "end_line": 123,
+        "file": "crates/nose-frontend/src/module_imports/tests/support.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "direct-function-target-present-call-contract-proof"
+        ],
+        "start_line": 121,
+        "tokens": 13
+      }
+    ],
+    "imported-function-target-present-call-contract-proof": [
+      {
+        "end_line": 201,
+        "file": "crates/nose-semantics/src/library_api/rows/methods/receiver.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "imported-function-target-present-call-contract-proof"
+        ],
+        "start_line": 188,
+        "tokens": 15
+      }
+    ],
+    "local-or-parameter-call-target-proof": [
+      {
+        "end_line": 127,
+        "file": "crates/nose-cli/src/command_dispatch.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "local-or-parameter-call-target-proof"
+        ],
+        "start_line": 89,
+        "tokens": 37
+      },
+      {
+        "end_line": 447,
+        "file": "crates/nose-cli/src/query_model.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "local-or-parameter-call-target-proof"
+        ],
+        "start_line": 445,
+        "tokens": 11
+      },
+      {
+        "end_line": 17,
+        "file": "crates/nose-cli/tests/equivalence.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "direct-function-target-present-call-contract-proof",
+          "local-or-parameter-call-target-proof",
+          "scoped-path-call-target-proof",
+          "member-call-target-proof"
+        ],
+        "start_line": 11,
+        "tokens": 44
+      }
+    ],
+    "member-call-target-proof": [
+      {
+        "end_line": 12,
+        "file": "crates/nose-cli/src/divergence/git.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "member-call-target-proof",
+          "direct-function-target-present-call-contract-proof"
+        ],
+        "start_line": 5,
+        "tokens": 21
+      },
+      {
+        "end_line": 123,
+        "file": "crates/nose-cli/src/query_terms.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "member-call-target-proof"
+        ],
+        "start_line": 116,
+        "tokens": 16
+      },
+      {
+        "end_line": 487,
+        "file": "crates/nose-cli/src/recall_loss_report.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "direct-function-target-present-call-contract-proof",
+          "member-call-target-proof"
+        ],
+        "start_line": 479,
+        "tokens": 19
+      }
+    ],
+    "scoped-path-call-target-proof": [
+      {
+        "end_line": 38,
+        "file": "crates/nose-cli/src/divergence.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "scoped-path-call-target-proof"
+        ],
+        "start_line": 32,
+        "tokens": 11
+      },
+      {
+        "end_line": 62,
+        "file": "crates/nose-cli/src/lib.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "scoped-path-call-target-proof"
+        ],
+        "start_line": 60,
+        "tokens": 5
+      },
+      {
+        "end_line": 84,
+        "file": "crates/nose-cli/src/query_opportunities.rs",
+        "language": "rust",
+        "missing_evidence": [
+          "member-call-target-proof",
+          "scoped-path-call-target-proof"
+        ],
+        "start_line": 82,
+        "tokens": 12
+      }
+    ],
+    "unshadowed-global-call-target-proof": [
+      {
+        "end_line": 3,
+        "file": "crates/nose-cli/tests/fixtures/string_affix_550/nested_param_object_define_property_patch.ts",
+        "language": "typescript",
+        "missing_evidence": [
+          "unshadowed-global-call-target-proof"
+        ],
+        "start_line": 1,
+        "tokens": 7
+      },
+      {
+        "end_line": 3,
+        "file": "crates/nose-cli/tests/fixtures/string_affix_550/nested_param_string_patch.ts",
+        "language": "typescript",
+        "missing_evidence": [
+          "unshadowed-global-call-target-proof"
+        ],
+        "start_line": 1,
+        "tokens": 7
+      }
+    ]
+  },
+  "schema_version": 1,
+  "selected_reason": "import-symbol-callee-identity-proof-missing",
+  "source_command": {
+    "command": "nose verify --recall-loss-report",
+    "max_violations": 0,
+    "no_cfg_norm": false,
+    "paths": [
+      "crates"
+    ]
+  },
+  "source_report_kind": "recall-loss-diagnostics",
+  "summary": {
+    "admission_rejections": 764,
+    "total_callee_identity_rejections": 264,
+    "unattributed_strict_exact_unsafe": 0
+  }
+}

--- a/crates/nose-cli/src/verify_admission.rs
+++ b/crates/nose-cli/src/verify_admission.rs
@@ -115,7 +115,7 @@ fn strict_exact_rejection_reason(
             admission_gate: "strict-exact-callee-identity",
             capability_id: "callee-identity-evidence",
             pack_id: None,
-            missing_evidence: vec!["import-or-call-target-proof"],
+            missing_evidence: callee_identity_missing_evidence(il, interner, root),
         };
     }
 
@@ -151,6 +151,158 @@ fn subtree_has(
         stack.extend(il.children(node).iter().copied());
     }
     false
+}
+
+fn callee_identity_missing_evidence(
+    il: &nose_il::Il,
+    interner: &Interner,
+    root: NodeId,
+) -> Vec<&'static str> {
+    let mut labels = Vec::new();
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if il.kind(node) == nose_il::NodeKind::Call
+            && !builtin_call_node(il, node)
+            && !rust_macro_invocation_call(il, node)
+        {
+            push_unique(
+                &mut labels,
+                callee_identity_call_evidence(il, interner, node),
+            );
+        }
+        stack.extend(il.children(node).iter().copied());
+    }
+    if labels.is_empty() {
+        labels.push("import-or-call-target-proof");
+    }
+    labels
+}
+
+fn push_unique(labels: &mut Vec<&'static str>, label: &'static str) {
+    if !labels.contains(&label) {
+        labels.push(label);
+    }
+}
+
+fn callee_identity_call_evidence(
+    il: &nose_il::Il,
+    interner: &Interner,
+    call: NodeId,
+) -> &'static str {
+    match nose_semantics::call_target_evidence_status_at_call(il, interner, call) {
+        nose_semantics::CallTargetEvidenceStatus::Rejected => "call-target-evidence-rejected",
+        nose_semantics::CallTargetEvidenceStatus::Admitted(target) => match target {
+            nose_il::CallTargetEvidenceKind::DirectFunction { .. } => {
+                "direct-function-target-present-call-contract-proof"
+            }
+            nose_il::CallTargetEvidenceKind::DirectMethod { .. } => {
+                "direct-method-target-present-call-contract-proof"
+            }
+            nose_il::CallTargetEvidenceKind::ImportedFunction { .. } => {
+                "imported-function-target-present-call-contract-proof"
+            }
+            nose_il::CallTargetEvidenceKind::ImportedMember { .. } => {
+                "imported-member-target-present-call-contract-proof"
+            }
+            nose_il::CallTargetEvidenceKind::DynamicDispatch { .. } => {
+                "dynamic-dispatch-target-present-concrete-target-proof"
+            }
+        },
+        nose_semantics::CallTargetEvidenceStatus::Missing => il
+            .children(call)
+            .first()
+            .map_or("unknown-call-target-proof", |&callee| {
+                missing_call_target_evidence(il, interner, callee)
+            }),
+    }
+}
+
+fn missing_call_target_evidence(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+) -> &'static str {
+    match il.kind(callee) {
+        nose_il::NodeKind::Var => var_call_target_evidence(il, interner, callee),
+        nose_il::NodeKind::Field => field_call_target_evidence(il, interner, callee),
+        _ => "unknown-call-target-proof",
+    }
+}
+
+fn var_call_target_evidence(il: &nose_il::Il, interner: &Interner, callee: NodeId) -> &'static str {
+    if var_name_contains_scope(il, interner, callee) {
+        return "scoped-path-call-target-proof";
+    }
+    symbol_call_target_evidence(il, callee).unwrap_or("local-or-parameter-call-target-proof")
+}
+
+fn field_call_target_evidence(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+) -> &'static str {
+    if let Some(label) = symbol_call_target_evidence(il, callee) {
+        return label;
+    }
+    if let Some(&receiver) = il.children(callee).first() {
+        if receiver_imported_member_evidence(il, receiver) {
+            return "imported-member-call-target-proof";
+        }
+        if receiver_contains_scoped_path(il, interner, receiver) {
+            return "scoped-path-call-target-proof";
+        }
+    }
+    "member-call-target-proof"
+}
+
+fn receiver_imported_member_evidence(il: &nose_il::Il, receiver: NodeId) -> bool {
+    il.evidence_anchored_at(il.node(receiver).span)
+        .any(|record| {
+            matches!(
+                record.kind,
+                nose_il::EvidenceKind::Symbol(
+                    nose_il::SymbolEvidenceKind::ImportedBinding { .. }
+                        | nose_il::SymbolEvidenceKind::ImportedNamespace { .. }
+                )
+            )
+        })
+}
+
+fn receiver_contains_scoped_path(il: &nose_il::Il, interner: &Interner, node: NodeId) -> bool {
+    match il.kind(node) {
+        nose_il::NodeKind::Var => var_name_contains_scope(il, interner, node),
+        nose_il::NodeKind::Field => il
+            .children(node)
+            .first()
+            .is_some_and(|&child| receiver_contains_scoped_path(il, interner, child)),
+        _ => false,
+    }
+}
+
+fn var_name_contains_scope(il: &nose_il::Il, interner: &Interner, node: NodeId) -> bool {
+    matches!(
+        il.node(node).payload,
+        nose_il::Payload::Name(name) if interner.resolve(name).contains("::")
+    )
+}
+
+fn symbol_call_target_evidence(il: &nose_il::Il, node: NodeId) -> Option<&'static str> {
+    il.evidence_anchored_at(il.node(node).span)
+        .find_map(|record| match record.kind {
+            nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::ImportedBinding {
+                ..
+            }) => Some("imported-binding-call-target-proof"),
+            nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::ImportedNamespace {
+                ..
+            }) => Some("imported-member-call-target-proof"),
+            nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::QualifiedGlobal {
+                ..
+            }) => Some("qualified-global-call-target-proof"),
+            nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::UnshadowedGlobal {
+                ..
+            }) => Some("unshadowed-global-call-target-proof"),
+            _ => None,
+        })
 }
 
 fn effect_boundary_node(il: &nose_il::Il, node: NodeId) -> bool {

--- a/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
+++ b/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
@@ -182,3 +182,47 @@ pub fn format_key(key: u64) -> String {\n\
         "expected macro-specific missing evidence: {report}"
     );
 }
+
+#[test]
+fn recall_loss_report_classifies_callee_identity_surfaces() {
+    let project = TempProject::new("recall_loss_callee_identity_surfaces");
+    project.write(
+        "sample.rs",
+        "pub fn call_local(x: u64) -> u64 {\n\
+    helper(x)\n\
+}\n\n\
+pub fn call_scoped(x: u64) -> u64 {\n\
+    helper_mod::value(x)\n\
+}\n",
+    );
+    let report_path = project.path().join("recall-loss.json");
+    let out = run_raw(&[
+        "verify",
+        project.path().to_str().unwrap(),
+        "--max-violations",
+        "0",
+        "--recall-loss-report",
+        report_path.to_str().unwrap(),
+    ]);
+    assert!(out.contains("GATE: 0"));
+
+    let report_text = fs::read_to_string(&report_path).expect("recall-loss report");
+    let report: serde_json::Value =
+        serde_json::from_str(&report_text).expect("recall-loss report JSON");
+    let rejections = report["admission_rejections"]
+        .as_array()
+        .expect("admission_rejections should be an array");
+    for expected in [
+        "local-or-parameter-call-target-proof",
+        "scoped-path-call-target-proof",
+    ] {
+        assert!(
+            rejections.iter().any(|item| item["reason"]
+                == "import-symbol-callee-identity-proof-missing"
+                && item["missing_evidence"]
+                    .as_array()
+                    .is_some_and(|items| items.iter().any(|value| value == expected))),
+            "expected callee identity evidence label {expected}: {report}"
+        );
+    }
+}

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -134,6 +134,15 @@ matching `nose.lang.*` pack provenance for the lowered file language:
   external, ambiguous, or dependency-broken occurrence rows do not prove public
   global/imported-namespace identity.
 
+Recall-loss #574 uses the same vocabulary to split the remaining
+`import-symbol-callee-identity-proof-missing` bucket by `missing_evidence`
+labels such as `local-or-parameter-call-target-proof`,
+`scoped-path-call-target-proof`, `member-call-target-proof`, imported/global
+target proof labels, and target-present call-contract proof labels. These
+labels are diagnostics only: they identify the next reusable evidence capability
+and do not admit a call without the corresponding dependency-closed
+`CallTarget` proof plus the required call contract.
+
 There is not yet a builtin producer for `DirectMethod` or `DynamicDispatch`.
 Duplicate function names, lexical shadowing, nested/non-top-level functions,
 methods without explicit target proof, computed callees, selector mismatches,

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -72,6 +72,12 @@ The #572 cycle also records a diagnostics-only refinement: expression-statement
 calls that need an effect contract stay in the effect boundary bucket, and
 unmodeled Rust macros such as `format!` stay in the source-surface bucket until
 a macro expansion or library contract proves their behavior.
+The #574 cycle keeps the same `import-symbol-callee-identity-proof-missing`
+reason but splits its `missing_evidence` labels by call-target surface, such as
+`local-or-parameter-call-target-proof`, `scoped-path-call-target-proof`,
+`member-call-target-proof`, imported/global target proof labels, and admitted
+target-present call-contract proof labels. Build the checked-in census with
+`scripts/recall-loss-callee-census.py`.
 
 ## PR reporting
 

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -20,6 +20,9 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
 - [#572 cycle log](../bench/recall_loss/issue-572-cycle.v1.json) records the
   first post-#570 refinement cycle, which splits expression-statement effect
   boundaries and Rust macro source surfaces out of the callee-identity bucket.
+- [#574 callee census](../bench/recall_loss/issue-574-callee-census.v1.json)
+  records the remaining callee-identity bucket by language and call-target
+  surface for the #567 import-backed immutable provenance epic.
 
 Regenerate the full local reports with:
 
@@ -78,6 +81,14 @@ effect boundaries and unmodeled Rust macro invocations out of the
 callee-identity bucket. That sharpens the remaining exact-recovery target: pure
 scoped/path callees still need reusable symbol/callee evidence, while discarded
 call results and unmodeled macro expansion stay closed.
+
+The #574 census keeps the `import-symbol-callee-identity-proof-missing` count at
+`264` but makes the inside of that bucket actionable. On `crates`, the remaining
+units are overwhelmingly Rust (`261/264`). The largest call-target surfaces are
+local-or-parameter calls (`115`), member calls (`92`), and scoped-path calls
+(`45`). That points the next implementation slice at Rust local/scoped path
+call-target proof before expanding the same evidence shape into broader
+import-backed immutable value provenance under #567.
 
 The current top `crates` buckets are:
 

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -182,7 +182,9 @@ diagnostics report is the soft gate that attributes under-merges, oracle
 exclusions, and exact-admission rejections to structured reason buckets.
 Use [`recall-loss-recovery-loop`](recall-loss-recovery-loop.md) for the
 checked-in baseline surfaces and `scripts/recall-loss-diff.py` for deterministic
-PR before/after tables.
+PR before/after tables. When the top bucket is callee identity, use
+`scripts/recall-loss-callee-census.py` to split it by call-target surface before
+adding semantic-pack or kernel capabilities.
 
 Behavior-change defaults:
 

--- a/scripts/recall-loss-callee-census.py
+++ b/scripts/recall-loss-callee-census.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Census the callee-identity bucket in a recall_loss_report.v1.json artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from copy import deepcopy
+from typing import Any
+
+
+CALLEE_REASON = "import-symbol-callee-identity-proof-missing"
+
+SURFACE_LABELS = [
+    "local-or-parameter-call-target-proof",
+    "scoped-path-call-target-proof",
+    "member-call-target-proof",
+    "imported-binding-call-target-proof",
+    "imported-member-call-target-proof",
+    "qualified-global-call-target-proof",
+    "unshadowed-global-call-target-proof",
+    "call-target-evidence-rejected",
+    "direct-function-target-present-call-contract-proof",
+    "direct-method-target-present-call-contract-proof",
+    "imported-function-target-present-call-contract-proof",
+    "imported-member-target-present-call-contract-proof",
+    "dynamic-dispatch-target-present-concrete-target-proof",
+    "unknown-call-target-proof",
+    "import-or-call-target-proof",
+]
+
+
+def load_report(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        report = json.load(handle)
+    if report.get("schema_version") != 1:
+        raise SystemExit(f"{path}: expected schema_version=1")
+    if report.get("report_kind") != "recall-loss-diagnostics":
+        raise SystemExit(f"{path}: expected recall-loss-diagnostics report")
+    return report
+
+
+def count_rows(counter: Counter[str], key_name: str) -> list[dict[str, Any]]:
+    rows = [{key_name: key, "count": count} for key, count in counter.items()]
+    rows.sort(key=lambda row: (-row["count"], row[key_name]))
+    return rows
+
+
+def primary_surface(rejection: dict[str, Any]) -> str:
+    evidence = rejection.get("missing_evidence", [])
+    for label in SURFACE_LABELS:
+        if label in evidence:
+            return label
+    return "unclassified-callee-identity"
+
+
+def loc_key(loc: dict[str, Any]) -> str:
+    return f"{loc.get('file', '')}:{loc.get('start_line', 0)}:{loc.get('end_line', 0)}"
+
+
+def representative_row(rejection: dict[str, Any]) -> dict[str, Any]:
+    loc = rejection.get("loc", {})
+    return {
+        "file": loc.get("file"),
+        "start_line": loc.get("start_line"),
+        "end_line": loc.get("end_line"),
+        "language": loc.get("language"),
+        "tokens": loc.get("tokens"),
+        "missing_evidence": rejection.get("missing_evidence", []),
+    }
+
+
+def build_census(
+    report: dict[str, Any],
+    *,
+    issue: int,
+    parent_issue: int,
+    generated_on: str,
+    representative_limit: int,
+) -> dict[str, Any]:
+    rejections = [
+        row
+        for row in report.get("admission_rejections", [])
+        if row.get("reason") == CALLEE_REASON
+    ]
+    by_language: Counter[str] = Counter()
+    by_surface: Counter[str] = Counter()
+    language_surface: Counter[tuple[str, str]] = Counter()
+    representatives: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for rejection in sorted(rejections, key=lambda row: loc_key(row.get("loc", {}))):
+        loc = rejection.get("loc", {})
+        language = str(loc.get("language", "unknown"))
+        surface = primary_surface(rejection)
+        by_language[language] += 1
+        by_surface[surface] += 1
+        language_surface[(language, surface)] += 1
+        if len(representatives[surface]) < representative_limit:
+            representatives[surface].append(representative_row(rejection))
+
+    return {
+        "schema_version": 1,
+        "report_kind": "callee-identity-census",
+        "issue": issue,
+        "parent_issue": parent_issue,
+        "generated_on": generated_on,
+        "source_report_kind": report.get("report_kind"),
+        "source_command": report.get("command"),
+        "selected_reason": CALLEE_REASON,
+        "hard_gate": {
+            "false_merges": report.get("soundness_gate", {}).get("false_merges", 0),
+            "canon_preservation_violations": report.get("soundness_gate", {}).get(
+                "canon_preservation_violations", 0
+            ),
+            "gate_passed": report.get("soundness_gate", {}).get("gate_passed"),
+        },
+        "summary": {
+            "total_callee_identity_rejections": len(rejections),
+            "admission_rejections": report.get("summary", {}).get(
+                "admission_rejections", 0
+            ),
+            "unattributed_strict_exact_unsafe": reason_count(
+                report, "unattributed-strict-exact-unsafe"
+            ),
+        },
+        "by_language": count_rows(by_language, "language"),
+        "by_primary_surface": count_rows(by_surface, "surface"),
+        "by_language_and_surface": [
+            {"language": language, "surface": surface, "count": count}
+            for (language, surface), count in sorted(
+                language_surface.items(), key=lambda item: (-item[1], item[0][0], item[0][1])
+            )
+        ],
+        "representative_units": dict(sorted(representatives.items())),
+        "first_recovery_slice": {
+            "target": "Rust scoped-path and local-or-parameter call target proof census",
+            "rationale": (
+                "The current crates signal is overwhelmingly Rust, so the next "
+                "implementation slice should prove reusable call-target identity "
+                "before expanding import-backed immutable value provenance."
+            ),
+            "hard_negatives": [
+                "provider mutation",
+                "consumer rebinding",
+                "wildcard or ambiguous import",
+                "dynamic import or export",
+                "side-effecting module initialization",
+                "map key/value or coordinate confusion",
+            ],
+            "non_goals": [
+                "broad cross-file constant propagation",
+                "package ecosystem semantics",
+                "dynamic import/eval/reflection",
+                "exact admission without dependency-backed identity evidence",
+            ],
+        },
+    }
+
+
+def reason_count(report: dict[str, Any], reason: str) -> int:
+    for row in report.get("by_reason", []):
+        if row.get("reason") == reason:
+            return int(row.get("count", 0))
+    return 0
+
+
+def markdown_table(headers: list[str], rows: list[list[str]]) -> str:
+    out = ["| " + " | ".join(headers) + " |"]
+    out.append("| " + " | ".join(["---"] * len(headers)) + " |")
+    out.extend("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(out)
+
+
+def render_markdown(census: dict[str, Any]) -> str:
+    language_rows = [
+        [row["language"], str(row["count"])] for row in census["by_language"]
+    ]
+    surface_rows = [
+        [row["surface"], str(row["count"])]
+        for row in census["by_primary_surface"]
+    ]
+    summary = census["summary"]
+    gate = census["hard_gate"]
+    sections = [
+        "## Callee-identity census",
+        "",
+        f"- selected reason: `{census['selected_reason']}`",
+        f"- total: `{summary['total_callee_identity_rejections']}`",
+        f"- false merges: `{gate['false_merges']}`",
+        f"- canon-preservation violations: `{gate['canon_preservation_violations']}`",
+        f"- unattributed strict-exact unsafe: `{summary['unattributed_strict_exact_unsafe']}`",
+        "",
+        "### By language",
+        markdown_table(["language", "count"], language_rows),
+        "",
+        "### By primary surface",
+        markdown_table(["surface", "count"], surface_rows),
+    ]
+    return "\n".join(sections) + "\n"
+
+
+def sample_report() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "report_kind": "recall-loss-diagnostics",
+        "command": {"paths": ["crates"]},
+        "summary": {"admission_rejections": 3},
+        "soundness_gate": {
+            "false_merges": 0,
+            "canon_preservation_violations": 0,
+            "gate_passed": True,
+        },
+        "by_reason": [
+            {"reason": CALLEE_REASON, "count": 2},
+            {"reason": "unattributed-strict-exact-unsafe", "count": 0},
+        ],
+        "admission_rejections": [
+            {
+                "reason": CALLEE_REASON,
+                "missing_evidence": ["local-or-parameter-call-target-proof"],
+                "loc": {
+                    "file": "a.rs",
+                    "start_line": 1,
+                    "end_line": 3,
+                    "tokens": 7,
+                    "language": "rust",
+                },
+            },
+            {
+                "reason": CALLEE_REASON,
+                "missing_evidence": ["scoped-path-call-target-proof"],
+                "loc": {
+                    "file": "b.ts",
+                    "start_line": 5,
+                    "end_line": 6,
+                    "tokens": 5,
+                    "language": "typescript",
+                },
+            },
+            {
+                "reason": "receiver-domain-proof-missing",
+                "missing_evidence": ["receiver-domain-proof"],
+                "loc": {
+                    "file": "c.rs",
+                    "start_line": 8,
+                    "end_line": 9,
+                    "tokens": 5,
+                    "language": "rust",
+                },
+            },
+        ],
+    }
+
+
+def self_test() -> None:
+    census = build_census(
+        deepcopy(sample_report()),
+        issue=574,
+        parent_issue=567,
+        generated_on="2026-06-27",
+        representative_limit=2,
+    )
+    assert census["summary"]["total_callee_identity_rejections"] == 2
+    by_language = {row["language"]: row["count"] for row in census["by_language"]}
+    assert by_language == {"rust": 1, "typescript": 1}
+    by_surface = {row["surface"]: row["count"] for row in census["by_primary_surface"]}
+    assert by_surface["local-or-parameter-call-target-proof"] == 1
+    assert by_surface["scoped-path-call-target-proof"] == 1
+    rendered = render_markdown(census)
+    assert "local-or-parameter-call-target-proof" in rendered
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Census import-symbol callee-identity recall-loss surfaces."
+    )
+    parser.add_argument("report", nargs="?")
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    parser.add_argument("--issue", type=int, default=574)
+    parser.add_argument("--parent-issue", type=int, default=567)
+    parser.add_argument("--generated-on", default="2026-06-27")
+    parser.add_argument("--representative-limit", type=int, default=3)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        self_test()
+        return 0
+    if not args.report:
+        parser.error("report is required unless --self-test is used")
+
+    census = build_census(
+        load_report(args.report),
+        issue=args.issue,
+        parent_issue=args.parent_issue,
+        generated_on=args.generated_on,
+        representative_limit=args.representative_limit,
+    )
+    if args.format == "json":
+        print(json.dumps(census, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(census), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Closes #574.

This turns the remaining `import-symbol-callee-identity-proof-missing` bucket into an actionable #567 census without changing exact admission behavior.

- Splits callee-identity `missing_evidence` by call-target surface.
- Adds `scripts/recall-loss-callee-census.py` for deterministic JSON/Markdown census output.
- Checks in `bench/recall_loss/issue-574-callee-census.v1.json` and links it from docs.
- Adds a CLI regression test for local/parameter and Rust scoped-path call target labels.

## Quantitative Result

`crates` report after this change:

| metric | value |
| --- | ---: |
| false merges | 0 |
| canon-preservation violations | 0 |
| admission rejections | 764 |
| `import-symbol-callee-identity-proof-missing` | 264 |
| `unattributed-strict-exact-unsafe` | 0 |

Callee-identity census:

| surface | count |
| --- | ---: |
| `local-or-parameter-call-target-proof` | 115 |
| `member-call-target-proof` | 92 |
| `scoped-path-call-target-proof` | 45 |
| `direct-function-target-present-call-contract-proof` | 9 |
| `unshadowed-global-call-target-proof` | 2 |
| `imported-function-target-present-call-contract-proof` | 1 |

By language: Rust `261`, TypeScript `2`, JavaScript `1`.

## Next Slice Named By Census

The safest next implementation slice is Rust local/scoped path call-target proof, with the same evidence shape later feeding #567 import-backed immutable value provenance. Hard negatives are provider mutation, consumer rebinding, wildcard/ambiguous import, dynamic import/export, side-effecting module initialization, and map key/value coordinate confusion.

## Verification

- `cargo test -p nose-cli --test cli commands::recall_loss_report -- --nocapture`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.callee-census.after.json`
- `python3 scripts/recall-loss-callee-census.py --self-test`
- `python3 scripts/recall-loss-diff.py --self-test`
- `jq empty bench/recall_loss/*.json`
- `awiki lint --root docs`
- `./scripts/check-duplication.sh`
- corpus-slice `nose verify --recall-loss-report target/recall-loss.corpus-slice.callee-census.json`
- `./scripts/check-ci-local.sh --fast`
