### PR TITLE
Classify aggregate import snapshot boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ break.
   binding-import miss reasons such as missing provider modules/exports,
   importer mutation, provider mutation/escape, missing provider `LibraryApi`
   proof, and provider aggregate shapes that are not export-safe.
+- Refined import-snapshot census aggregate miss attribution without widening
+  imported snapshot admission. Provider aggregates that are proven exact
+  surfaces but not import-literal surfaces now report separately from aggregates
+  whose children are binding references or import-coordinate placeholders.
 - Split recall-loss exact-admission rejections into capability-oriented buckets
   for callee identity, receiver domain, library API occurrence, HOF
   demand/effect, source surface, mutation/effect, unsupported runtime

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -83,3 +83,7 @@ slice.
 - [issue-567-phase3-import-snapshot-census.v1.json](issue-567-phase3-import-snapshot-census.v1.json)
   records the report-infrastructure closeout: recall-loss artifacts now include
   import snapshot success counts and binding-import miss reasons.
+- [issue-567-phase4-aggregate-boundary-triage.v1.json](issue-567-phase4-aggregate-boundary-triage.v1.json)
+  records the first census-driven triage pass: the broad provider-aggregate
+  miss bucket is split into non-import-literal sequence surfaces and child
+  reference boundaries without admitting new snapshots.

--- a/bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json
+++ b/bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": 1,
+  "report_kind": "recall-loss-cycle",
+  "issue": 567,
+  "phase": 4,
+  "generated_on": "2026-06-27",
+  "selected_reason": "provider-aggregate-children-not-exact-safe",
+  "what_changed": [
+    "The imported literal export rejection reporter now separates root sequence surfaces that are exact-tree-safe but not import-literal-safe.",
+    "The reporter now separates importable aggregate children that are binding references, field paths, or index expressions from ordinary child export-safety failures.",
+    "The reporter now has a pinned reason for aggregate children that are import-coordinate placeholders.",
+    "Imported snapshot admission is unchanged; this phase only improves miss attribution."
+  ],
+  "product_fixture_delta": {
+    "import_snapshot_aggregate_reason_precision": {
+      "before_supported": 0,
+      "after_supported": 1,
+      "total": 1,
+      "fixtures": [
+        "crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs::imported_literal_export_rejection_reports_reference_children",
+        "crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs::imported_literal_export_safety_rejects_import_coordinate_children"
+      ],
+      "pinned_reasons": [
+        "provider-sequence-surface-not-import-literal-safe",
+        "provider-aggregate-child-reference-boundary",
+        "provider-aggregate-child-import-coordinate-boundary"
+      ]
+    }
+  },
+  "before_report": {
+    "artifact": "target/recall-loss.aggregate-before.json",
+    "summary": {
+      "total_units": 6237,
+      "interpretable_units": 862,
+      "excluded_units": 5375,
+      "canon_checked": 72,
+      "canon_preservation_violations": 0,
+      "admission_rejections": 716
+    },
+    "import_snapshot_census": {
+      "snapshot_records": 0,
+      "unresolved_binding_imports": 384,
+      "reported_misses": 384,
+      "misses_by_reason": {
+        "provider-module-missing": 255,
+        "provider-export-missing": 123,
+        "importer-binding-mutated": 3,
+        "provider-aggregate-children-not-exact-safe": 3
+      }
+    }
+  },
+  "after_report": {
+    "artifact": "target/recall-loss.aggregate-after.json",
+    "summary": {
+      "total_units": 6240,
+      "interpretable_units": 863,
+      "excluded_units": 5377,
+      "canon_checked": 72,
+      "canon_preservation_violations": 0,
+      "admission_rejections": 717
+    },
+    "completeness": {
+      "behavior_equal_pairs": 83,
+      "fingerprint_equal_pairs": 39,
+      "completeness_percent": 46.98795180722892,
+      "under_merged_behavior_groups": 2
+    },
+    "import_snapshot_census": {
+      "snapshot_records": 0,
+      "unresolved_binding_imports": 384,
+      "reported_misses": 384,
+      "misses_by_reason": {
+        "provider-module-missing": 255,
+        "provider-export-missing": 123,
+        "importer-binding-mutated": 3,
+        "provider-sequence-surface-not-import-literal-safe": 2,
+        "provider-aggregate-child-reference-boundary": 1
+      }
+    }
+  },
+  "bucket_delta": {
+    "provider-aggregate-children-not-exact-safe": -3,
+    "provider-sequence-surface-not-import-literal-safe": 2,
+    "provider-aggregate-child-reference-boundary": 1,
+    "admission_rejections": 1,
+    "import-symbol-callee-identity-proof-missing": 1
+  },
+  "hard_gate": {
+    "false_merges_before": 0,
+    "false_merges_after": 0,
+    "canon_preservation_violations_before": 0,
+    "canon_preservation_violations_after": 0,
+    "gate_passed": true
+  },
+  "decision": {
+    "notes": [
+      "The phase-3 provider-aggregate bucket did not contain a safe imported literal export opportunity.",
+      "Two cases are Rust re-export paths (`pub use context::...`), where the provider RHS has a sequence surface but that surface is not an imported literal value surface.",
+      "One case is the compiled semantic-pack descriptor table assembled from indexed references into grouped descriptor arrays.",
+      "Admitting these as imported immutable snapshots would treat references as literal provider values, so the strict semantic-kernel decision is to keep them closed and report them explicitly."
+    ],
+    "follow_up": "Do not continue #567 by widening aggregate child export safety. The remaining large buckets are module/export resolution scope; if import snapshots stay the priority, start a separate module-resolution milestone rather than broadening imported literal admission."
+  },
+  "fixture_refs": [
+    "crates/nose-semantics/src/module_exports.rs",
+    "crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs",
+    "docs/recall-loss-diagnostics.md"
+  ]
+}

--- a/crates/nose-semantics/src/module_exports.rs
+++ b/crates/nose-semantics/src/module_exports.rs
@@ -63,13 +63,16 @@ fn imported_literal_seq_rejection_reason(
     interner: &Interner,
     seq: NodeId,
 ) -> &'static str {
-    if go_zero_map_literal_contract_for_node(il, interner, seq).is_some()
-        || seq_surface_contract_for_node(il, interner, seq).is_some()
-    {
-        "provider-aggregate-children-not-exact-safe"
-    } else {
-        "provider-sequence-surface-proof-missing"
+    if go_zero_map_literal_contract_for_node(il, interner, seq).is_some() {
+        return literal_export_children_rejection_reason(il, interner, il.children(seq));
     }
+    let Some(contract) = seq_surface_contract_for_node(il, interner, seq) else {
+        return "provider-sequence-surface-proof-missing";
+    };
+    if !contract.imported_literal {
+        return "provider-sequence-surface-not-import-literal-safe";
+    }
+    literal_export_children_rejection_reason(il, interner, il.children(seq))
 }
 
 fn go_zero_map_literal_export_safe(il: &Il, interner: &Interner, seq: NodeId) -> bool {
@@ -127,6 +130,54 @@ fn literal_export_value_safe(il: &Il, interner: &Interner, node: NodeId) -> bool
             .all(|&child| literal_export_value_safe(il, interner, child)),
         NodeKind::Call => java_map_entry_call_safe(il, interner, node),
         _ => false,
+    }
+}
+
+fn literal_export_children_rejection_reason(
+    il: &Il,
+    interner: &Interner,
+    children: &[NodeId],
+) -> &'static str {
+    children
+        .iter()
+        .find_map(|&child| literal_export_value_rejection_reason(il, interner, child))
+        .unwrap_or("provider-aggregate-children-not-exact-safe")
+}
+
+fn literal_export_value_rejection_reason(
+    il: &Il,
+    interner: &Interner,
+    node: NodeId,
+) -> Option<&'static str> {
+    match il.kind(node) {
+        NodeKind::Lit => None,
+        NodeKind::Seq => {
+            if import_fact_evidence_rhs(il, node).is_some() {
+                return Some("provider-aggregate-child-import-coordinate-boundary");
+            }
+            let contract = seq_surface_contract_for_node(il, interner, node)?;
+            if !contract.exact_tree_safe {
+                return Some("provider-aggregate-child-surface-not-exact-safe");
+            }
+            il.children(node)
+                .iter()
+                .find_map(|&child| literal_export_value_rejection_reason(il, interner, child))
+        }
+        NodeKind::UnOp => il
+            .children(node)
+            .iter()
+            .find_map(|&child| literal_export_value_rejection_reason(il, interner, child)),
+        NodeKind::Var | NodeKind::Field | NodeKind::Index => {
+            Some("provider-aggregate-child-reference-boundary")
+        }
+        NodeKind::Call => {
+            if java_map_entry_call_safe(il, interner, node) {
+                None
+            } else {
+                Some("provider-aggregate-child-call-boundary")
+            }
+        }
+        _ => Some("provider-aggregate-children-not-exact-safe"),
     }
 }
 

--- a/crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs
+++ b/crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs
@@ -183,7 +183,7 @@ fn imported_literal_export_safety_rejects_import_coordinate_children() {
         EvidenceStatus::Asserted,
         Lang::JavaScript,
     ));
-    il.evidence.push(evidence(
+    il.evidence.push(language_core_evidence(
         1,
         EvidenceAnchor::sequence(sp(7)),
         EvidenceKind::Import(ImportEvidenceKind::Binding {
@@ -191,9 +191,43 @@ fn imported_literal_export_safety_rejects_import_coordinate_children() {
             exported_hash: stable_symbol_hash("VALUE"),
         }),
         EvidenceStatus::Asserted,
+        Lang::JavaScript,
     ));
 
     assert!(!imported_literal_export_safe(&il, &interner, root_value));
+    assert_eq!(
+        imported_literal_export_rejection_reason(&il, &interner, root_value),
+        Some("provider-aggregate-child-import-coordinate-boundary")
+    );
+}
+
+#[test]
+fn imported_literal_export_rejection_reports_reference_children() {
+    let interner = Interner::new();
+    let mut b = IlBuilder::new(FileId(0));
+    let array = interner.intern("array");
+    let referenced = b.add(
+        NodeKind::Var,
+        Payload::Name(interner.intern("DESCRIPTOR")),
+        sp(9),
+        &[],
+    );
+    let root_value = b.add(NodeKind::Seq, Payload::Name(array), sp(9), &[referenced]);
+    let root = b.add(NodeKind::Block, Payload::None, sp(9), &[root_value]);
+    let mut il = finish_il(b, root, Lang::Rust);
+    il.evidence.push(language_core_evidence(
+        0,
+        EvidenceAnchor::sequence(sp(9)),
+        EvidenceKind::SequenceSurface(SequenceSurfaceKind::Collection),
+        EvidenceStatus::Asserted,
+        Lang::Rust,
+    ));
+
+    assert!(!imported_literal_export_safe(&il, &interner, root_value));
+    assert_eq!(
+        imported_literal_export_rejection_reason(&il, &interner, root_value),
+        Some("provider-aggregate-child-reference-boundary")
+    );
 }
 
 #[test]

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -523,3 +523,12 @@ already reviewed reporting/oracle representative from `6f1baed465ffcde9` to
 `report_falsify`/`soundness_gate` production overlap recorded for #570, so this
 is representative-ID churn rather than new extractable duplication. No new
 budget is accepted.
+
+The #567 aggregate-boundary triage keeps the count at 54. Adding focused
+semantic evidence tests shifts two already reviewed Guava/collection-factory
+test helper representatives: `070c8818af8421e9` becomes `678befa6db9e5c5d`
+for the repeated `eleven_entry_payloads` hard-negative fixture, and
+`d984ca7d5210611e` becomes `8a02be14d3980cd3` for the Guava map factory IL
+builder family across detect, normalize, and semantics tests. These remain
+test-scope fixture debt already accepted in the collection-factory capability
+work; no new budget is accepted.

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -97,6 +97,11 @@ include:
 | `provider-library-api-proof-missing` | The provider RHS is a factory call without admitted `LibraryApi` proof. |
 | `provider-factory-arguments-not-exact-safe` | The provider factory is proven, but its arguments are not export-safe. |
 | `provider-aggregate-children-not-exact-safe` | The provider aggregate has a surface proof, but its children are not export-safe imported literal values. |
+| `provider-sequence-surface-not-import-literal-safe` | The provider aggregate has a proven sequence surface, but that surface is not an imported-literal value surface. |
+| `provider-aggregate-child-reference-boundary` | The provider aggregate contains a child reference, field path, or index expression rather than a literal/export-safe value. |
+| `provider-aggregate-child-import-coordinate-boundary` | The provider aggregate contains an import-coordinate placeholder; coordinates are proof, not imported literal values. |
+| `provider-aggregate-child-surface-not-exact-safe` | A nested provider aggregate child has a sequence surface that is not exact-tree-safe. |
+| `provider-aggregate-child-call-boundary` | A provider aggregate child is a call expression without a supported imported-literal child contract. |
 | `provider-sequence-surface-proof-missing` | The provider aggregate lacks the sequence-surface proof required for imported literal export. |
 | `unsupported-provider-rhs-shape` | The provider RHS is not a literal, supported aggregate, or supported factory call. |
 

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -50,6 +50,10 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   records the reporting closeout: local recall-loss reports now expose
   successful snapshot counts plus unresolved binding-import miss reasons, so the
   next imported-value slice can be selected from corpus evidence.
+- [#567 phase 4 aggregate-boundary triage log](../bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json)
+  records the first census-driven triage pass: the broad provider-aggregate miss
+  bucket is split into non-import-literal sequence surfaces and child reference
+  boundaries without admitting new snapshots.
 
 Regenerate the full local reports with:
 
@@ -224,15 +228,27 @@ successful imported snapshot records and `384` unresolved binding imports:
 `importer-binding-mutated` `3`, and
 `provider-aggregate-children-not-exact-safe` `3`. That makes the next
 imported-value decision explicit: most `crates` misses are module/export
-resolution scope, while the provider-aggregate slice is the small actionable
-semantic export-safety surface.
+resolution scope, while the provider-aggregate slice is the small triage target.
 
-The current top `crates` buckets after #567 phase 3 are:
+The #567 phase 4 aggregate-boundary triage follows that target and keeps
+imported snapshot admission unchanged. The broad
+`provider-aggregate-children-not-exact-safe` bucket moves `3 -> 0`: two cases
+are Rust `pub use context::...` re-export paths reported as
+`provider-sequence-surface-not-import-literal-safe`, and one case is the
+compiled semantic-pack descriptor table assembled from indexed descriptor
+references, reported as `provider-aggregate-child-reference-boundary`. The full
+`crates` report remains at `false_merges == 0` and
+`canon_preservation_violations == 0`; completeness stays `39/83`, and
+admission rejections move `716 -> 717` because this diagnostics-only pass adds
+new Rust semantic tests. The decision is to keep these closed: admitting them as
+snapshots would treat references as literal provider values.
+
+The current top `crates` buckets after #567 phase 4 are:
 
 | reason | count | next capability |
 |---|---:|---|
 | `receiver-domain-proof-missing` | 240 | cross-file field/constant domain provenance |
-| `import-symbol-callee-identity-proof-missing` | 226 | reusable member/receiver callee identity evidence |
+| `import-symbol-callee-identity-proof-missing` | 227 | reusable member/receiver callee identity evidence |
 | `mutation-effect-boundary` | 133 | effect and place contracts |
 | `source-surface-proof-missing` | 52 | Rust macro/source-surface contracts and construct/operator/comprehension evidence |
 | `hof-demand-effect-proof-missing` | 30 | HOF demand/effect/materialization profile |

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -2,7 +2,7 @@
   "accepted_family_ids": [
     "04d39fd18168311f",
     "016becf550d84d34",
-    "070c8818af8421e9",
+    "678befa6db9e5c5d",
     "0a126db1cbf0faa6",
     "44bfd76822ddbe95",
     "1dfaba2582163d7c",
@@ -43,7 +43,7 @@
     "c9fe4dc9d9cd14f5",
     "1bcf5beffb5c2932",
     "42cc257ba613ae19",
-    "d984ca7d5210611e",
+    "8a02be14d3980cd3",
     "dbbb03b3c0fa93e8",
     "e3fa2e4c707e342a",
     "e633f3912604730d",


### PR DESCRIPTION
## Summary
- split the broad `provider-aggregate-children-not-exact-safe` import snapshot miss reason into stricter reporting-only boundaries
- keep imported snapshot admission unchanged for aggregate child references and non-import-literal sequence surfaces
- add phase 4 recall-loss artifact, diagnostics docs, changelog, and dogfooding baseline updates

## Result
- `provider-aggregate-children-not-exact-safe`: `3 -> 0`
- new census buckets:
  - `provider-sequence-surface-not-import-literal-safe`: `2`
  - `provider-aggregate-child-reference-boundary`: `1`
- hard gates remain closed:
  - false merges: `0 -> 0`
  - canon preservation violations: `0 -> 0`
- completeness unchanged: `39/83`

## Decision
The phase-3 aggregate bucket did not contain a safe imported literal export opportunity. The remaining cases are Rust re-export paths and a descriptor table assembled from indexed references, so widening snapshot admission would treat references as literal provider values. This PR keeps those closed and reports them explicitly.

## Verification
- `cargo test -p nose-semantics semantic_evidence::sequence_surfaces -- --nocapture`
- `cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect`
- `cargo test -p nose-cli --test cli recall_loss_report -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.aggregate-after.json`
- `./scripts/check-duplication.sh`
- `awiki lint --root docs`
- `cargo fmt --all -- --check`
- `git diff --check`
