### PR TITLE
Close out import-backed immutable provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ break.
   proof, provider-local shadows, provider/importer mutations, wrong contents,
   and ambiguous single-argument `Arrays.asList(...)` provider snapshots stay
   closed.
+- Added the #567 imported immutable provenance closeout artifact and narrative
+  closeout, tying the phase logs to the epic requirements, admitted coordinate
+  families, hard-negative inventory, import-snapshot census boundaries, and
+  runtime evidence.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object
@@ -120,11 +124,16 @@ break.
 
 ### Performance
 - Compared the #567 import-backed immutable provenance change against
-  `origin/main` (`dbb688e7`) with release `nose query crates all top=0 --mode
-  semantic --format json` and `NOSE_TIME` over five paired runs. Median wall
-  time stayed in budget at `0.92s -> 0.95s` (+3.3%), `import-resolve` stayed in
-  budget at `145.4ms -> 151.7ms` (+4.3%), and the rendered JSON size stayed
-  identical at 54,288 bytes.
+  the pre-#567 baseline `dbb688e7` with release `nose query crates all top=0
+  --mode semantic --format json` and `NOSE_TIME` over five paired runs. Median
+  wall time stayed in budget at `0.92s -> 0.95s` (+3.3%), `import-resolve`
+  stayed in budget at `145.4ms -> 151.7ms` (+4.3%), and the rendered JSON size
+  stayed identical at 54,288 bytes.
+- Rechecked the #584/#585 closeout delta against `37027b54` with the same
+  release query over five paired runs on the current `crates` input. Product
+  output stayed stable (`31 -> 31` families, 67,200 JSON bytes unchanged) and
+  median wall time improved `488.03ms -> 445.77ms` (-8.7%); `import-resolve`
+  remained within budget at `69.6ms -> 72.0ms` (+3.4%).
 
 ## [0.16.0] - 2026-06-26
 

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -87,3 +87,6 @@ slice.
   records the first census-driven triage pass: the broad provider-aggregate
   miss bucket is split into non-import-literal sequence surfaces and child
   reference boundaries without admitting new snapshots.
+- [issue-567-closeout.v1.json](issue-567-closeout.v1.json) records the epic
+  closeout audit: requirement coverage, admitted imported-coordinate families,
+  hard-negative inventory, false-merge hard gates, and product/runtime evidence.

--- a/bench/recall_loss/issue-567-closeout.v1.json
+++ b/bench/recall_loss/issue-567-closeout.v1.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": 1,
+  "report_kind": "epic-closeout",
+  "issue": 567,
+  "generated_on": "2026-06-28",
+  "title": "Import-backed immutable value provenance",
+  "goal": "Represent immutable value provenance for imported and cross-file bindings so exact semantic admission can safely use collection, map, string, and value coordinates beyond same-file literals and locals.",
+  "requirement_audit": [
+    {
+      "requirement": "Census: refresh corpus signal for membership_contains and map_default_lookup imported/cross-file binding cases.",
+      "status": "complete",
+      "evidence": [
+        "bench/recall_loss/issue-567-phase3-import-snapshot-census.v1.json",
+        "bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json",
+        "docs/recall-loss-diagnostics.md",
+        "docs/recall-loss-recovery-loop.md"
+      ],
+      "result": "Local recall-loss reports now include import_snapshot_census. On crates after phase 4, unresolved binding imports remain 384: provider-module-missing 255, provider-export-missing 123, importer-binding-mutated 3, provider-sequence-surface-not-import-literal-safe 2, and provider-aggregate-child-reference-boundary 1."
+    },
+    {
+      "requirement": "Evidence substrate: define the minimal Source/Symbol/Domain/LibraryApi dependency shape for immutable exported values.",
+      "status": "complete",
+      "evidence": [
+        "crates/nose-il/src/node/evidence.rs",
+        "crates/nose-semantics/src/import_facts.rs",
+        "crates/nose-semantics/src/module_exports.rs",
+        "crates/nose-frontend/src/module_imports/snapshot.rs",
+        "docs/evidence-records.md",
+        "docs/semantic-kernel-snapshot.md"
+      ],
+      "result": "ImportedLiteralSnapshot records imported immutable provenance, provider export safety is shared in nose-semantics, and frontend snapshot copy preserves provider source-origin spans while rewiring dependency ids through imported binding evidence."
+    },
+    {
+      "requirement": "Positive slice: same-repo Python/TS/Java/Rust/Go imported immutable collection/map bindings where coordinates are static and mutation-free.",
+      "status": "complete",
+      "evidence": [
+        "crates/nose-cli/tests/cli/semantic_idioms/imported_immutable.rs",
+        "crates/nose-cli/tests/equivalence/literal_map_defaults.rs",
+        "crates/nose-cli/tests/equivalence/imported_js_ts_map_defaults.rs",
+        "crates/nose-cli/tests/equivalence/imported_js_ts_collection_membership.rs",
+        "crates/nose-cli/tests/equivalence/imported_collection_membership.rs"
+      ],
+      "result": "Focused product fixtures now cover imported map-default coordinates for Python, Java, Go, Rust, and JS/TS Map constructors; imported collection membership for TypeScript/Rust literals, JS/TS Set constructors, Python set/deque factories, and Java List.of/Set.of factories; and imported string-affix coordinates for TypeScript, Java, Rust, and Go."
+    },
+    {
+      "requirement": "Hard negatives: mutated provider binding, consumer rebinding, wildcard/ambiguous imports, dynamic export/import, cross-file side effects, map-key/value confusion.",
+      "status": "complete",
+      "evidence": [
+        "crates/nose-cli/tests/cli/semantic_idioms/imported_immutable.rs",
+        "crates/nose-cli/tests/equivalence/literal_map_defaults.rs",
+        "crates/nose-cli/tests/equivalence/imported_js_ts_map_defaults.rs",
+        "crates/nose-cli/tests/equivalence/imported_js_ts_collection_membership.rs",
+        "crates/nose-cli/tests/equivalence/imported_collection_membership.rs",
+        "crates/nose-frontend/src/module_imports/tests/go_namespace.rs",
+        "crates/nose-frontend/src/module_imports/tests/js_ts_snapshots.rs",
+        "crates/nose-frontend/src/module_imports/tests/collection_snapshots.rs",
+        "crates/nose-semantics/src/tests/semantic_evidence/sequence_surfaces.rs"
+      ],
+      "result": "The closeout inventory records 32 focused guard assertions/groups: 4 initial product hard negatives, 16 phase-1/2 product equivalence hard negatives, 9 frontend snapshot gate groups, and 3 aggregate-boundary diagnostic reason pins. False merges remain zero on every checked recall-loss phase."
+    },
+    {
+      "requirement": "Product metrics: before/after focused query families, false-merge count, hard-negative count, and runtime delta.",
+      "status": "complete",
+      "evidence": [
+        "bench/recall_loss/issue-567-phase1-js-ts-constructors.v1.json",
+        "bench/recall_loss/issue-567-phase2-collection-factories.v1.json",
+        "bench/recall_loss/issue-567-phase3-import-snapshot-census.v1.json",
+        "bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json",
+        "bench/recall_loss/issue-567-closeout.v1.json"
+      ],
+      "result": "Focused positive fixtures moved from 0/2 to 2/2 for JS/TS imported Map defaults, JS/TS imported Set membership, Python imported collection factories, and Java imported collection factories. Hard gates remained false_merges 0 -> 0 and canon_preservation_violations 0 -> 0 in phases 1-4. Closeout runtime on the #584/#585 delta has stable product output and median wall time 488.03ms -> 445.77ms."
+    }
+  ],
+  "capability_result": {
+    "newly_admitted_exact_safe_families": [
+      {
+        "family": "map_default_lookup",
+        "languages_and_coordinates": [
+          "Python imported literal dict binding",
+          "Java imported Map.of binding",
+          "Go imported namespace map member",
+          "Rust use-imported const entry array consumed by HashMap::from",
+          "JavaScript/TypeScript imported new Map(...) provider binding"
+        ]
+      },
+      {
+        "family": "membership_contains",
+        "languages_and_coordinates": [
+          "TypeScript imported immutable literal array binding",
+          "Rust use-imported const array binding",
+          "JavaScript/TypeScript imported new Set(...) provider binding",
+          "Python imported set([...]) and collections.deque([...]) provider bindings",
+          "Java static-imported List.of(...) and Set.of(...) provider bindings"
+        ]
+      },
+      {
+        "family": "string_affix",
+        "languages_and_coordinates": [
+          "TypeScript imported string affix binding",
+          "Java static-imported string affix binding",
+          "Rust use-imported string affix binding",
+          "Go imported namespace string affix member"
+        ]
+      }
+    ],
+    "closed_boundaries": [
+      "No broad cross-file constant propagation.",
+      "No package ecosystem semantics.",
+      "No dynamic import, eval, reflection, or side-effecting re-export admission.",
+      "No exact admission without dependency-backed import, binding, domain or LibraryApi, and mutation evidence.",
+      "No raw import-coordinate sequence as value proof."
+    ]
+  },
+  "phase_metrics": [
+    {
+      "phase": 1,
+      "artifact": "bench/recall_loss/issue-567-phase1-js-ts-constructors.v1.json",
+      "focused_positive_delta": {
+        "imported_js_ts_map_default_positive": "0/2 -> 2/2",
+        "imported_js_ts_set_membership_positive": "0/2 -> 2/2"
+      },
+      "hard_negative_delta": "frontend constructor snapshot hard negatives 0/4 -> 4/4",
+      "hard_gate": "false_merges 0 -> 0; canon_preservation_violations 0 -> 0"
+    },
+    {
+      "phase": 2,
+      "artifact": "bench/recall_loss/issue-567-phase2-collection-factories.v1.json",
+      "focused_positive_delta": {
+        "imported_python_collection_membership_positive": "0/2 -> 2/2",
+        "imported_java_collection_membership_positive": "0/2 -> 2/2"
+      },
+      "hard_negative_delta": "frontend collection snapshot hard negatives 0/5 -> 5/5",
+      "hard_gate": "false_merges 0 -> 0; canon_preservation_violations 0 -> 0"
+    },
+    {
+      "phase": 3,
+      "artifact": "bench/recall_loss/issue-567-phase3-import-snapshot-census.v1.json",
+      "focused_positive_delta": {
+        "recall_loss_import_snapshot_census_section": "0/1 -> 1/1"
+      },
+      "hard_negative_delta": "pinned miss reasons include provider-library-api-proof-missing, provider-binding-unsafe, and importer-binding-mutated",
+      "hard_gate": "false_merges 0 -> 0; canon_preservation_violations 0 -> 0"
+    },
+    {
+      "phase": 4,
+      "artifact": "bench/recall_loss/issue-567-phase4-aggregate-boundary-triage.v1.json",
+      "focused_positive_delta": {
+        "import_snapshot_aggregate_reason_precision": "0/1 -> 1/1"
+      },
+      "hard_negative_delta": "provider-aggregate-children-not-exact-safe 3 -> 0, split into closed boundary reasons",
+      "hard_gate": "false_merges 0 -> 0; canon_preservation_violations 0 -> 0"
+    }
+  ],
+  "runtime_delta": {
+    "initial_imported_provenance_measurement": {
+      "scope": "dbb688e7 -> 14d5d248 initial imported immutable provenance product slice",
+      "source": "CHANGELOG.md Performance entry introduced with 14d5d248",
+      "command": "release nose query crates all top=0 --mode semantic --format json with NOSE_TIME over five paired runs",
+      "median_wall_time": "0.92s -> 0.95s (+3.3%)",
+      "median_import_resolve": "145.4ms -> 151.7ms (+4.3%)",
+      "rendered_json_bytes": "54288 -> 54288 (0.0%)"
+    },
+    "closeout_incremental_measurement": {
+      "scope": "37027b543db4ab7dd91ae15c820a5420e018f329 -> 00fa35f0b66e394f76d6a918d7611fd70111276d (#584/#585 closeout phases)",
+      "command": "release nose query crates all top=0 --mode semantic --format json with NOSE_TIME over five paired runs",
+      "input": "current crates worktree at 00fa35f0b66e394f76d6a918d7611fd70111276d",
+      "pre_closeout_binary_sha256": "1c98ac80f5baca244a3ef909f3e4153c2038a60af9a8b0db9a39c314d3d943e3",
+      "current_binary_sha256": "455e1c576fadf2386a78e5b6972c477c84df255ec64f6949b95fff632a6e6f89",
+      "median_wall_ms": "488.03 -> 445.77 (-8.7%)",
+      "median_import_resolve_ms": "69.6 -> 72.0 (+3.4%)",
+      "median_normalize_extract_ms": "194.4 -> 177.4 (-8.7%)",
+      "family_count": "31 -> 31",
+      "rendered_json_bytes": "67200 -> 67200 (0.0%)",
+      "result": "No product-output drift and no runtime degradation on the closeout delta."
+    },
+    "repository_self_gates": {
+      "local_gate_commands": [
+        "cargo test -p nose-cli --test cli imported_immutable -- --nocapture",
+        "cargo test -p nose-cli --test equivalence imported_ -- --nocapture",
+        "cargo test -p nose-semantics semantic_evidence::sequence_surfaces -- --nocapture",
+        "cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect",
+        "cargo test -p nose-cli --test cli recall_loss_report -- --nocapture",
+        "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.closeout.json",
+        "cargo clippy --all-targets --all-features -- -D warnings",
+        "./scripts/check-duplication.sh",
+        "awiki lint --root docs",
+        "cargo fmt --all -- --check",
+        "git diff --check"
+      ],
+      "github_ci_reference": {
+        "pre_epic_reference_pr": "https://github.com/corca-ai/nose/pull/568",
+        "latest_closeout_pr": "https://github.com/corca-ai/nose/pull/585",
+        "latest_closeout_ci": "All required CI checks passed before merge: build/test/lint/dup-gate, llvm-cov coverage, MSRV, awiki, Lean proofs, unused-deps/advisories/licenses."
+      }
+    }
+  },
+  "closeout_decision": {
+    "status": "complete",
+    "reason": "The semantic-kernel capability is dependency-backed and reusable, focused product fixtures recover the imported immutable coordinate families, hard negatives and recall-loss hard gates stay closed, import-snapshot misses are now measured for future prioritization, and runtime evidence shows the #584/#585 closeout phases did not degrade the product query path."
+  }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -99,6 +99,7 @@ fundamentals; the rest is grouped by area.
 - [js-ts-string-affix-hardening-closeout-550](js-ts-string-affix-hardening-closeout-550.md) — closeout for the #550 JavaScript/TypeScript string-affix receiver proof hardening, including false-open and runtime evidence.
 - [ruby-string-affix-closeout-551](ruby-string-affix-closeout-551.md) — closeout for the #551 Ruby `String#start_with?`/`String#end_with?` proof slice, including product-output, inventory, and runtime evidence.
 - [string-affix-coordinate-closeout-552](string-affix-coordinate-closeout-552.md) — closeout for the #552 string-affix coordinate boundary hardening, including parameter/binding coordinates and deferred multi/offset forms.
+- [import-backed-immutable-provenance-closeout-567](import-backed-immutable-provenance-closeout-567.md) — closeout for the #567 imported immutable value provenance capability, including admitted coordinate families, hard-negative boundaries, recall-loss census, and runtime evidence.
 - [semantic-pack-boundary-review-2026-06-22](semantic-pack-boundary-review-2026-06-22.md) — pre-release review of the semantic kernel vs builtin semantic-pack boundary after the #484 stabilization tracker.
 - [semantic-kernel-snapshot](semantic-kernel-snapshot.md) — current implementation snapshot for semantic knowledge and the first internal kernel facade.
 - [semantic-kernel-roadmap](semantic-kernel-roadmap.md) — decisions, history, phases, and open work for the semantic-kernel direction.

--- a/docs/import-backed-immutable-provenance-closeout-567.md
+++ b/docs/import-backed-immutable-provenance-closeout-567.md
@@ -1,0 +1,93 @@
+# Import-backed immutable provenance closeout
+
+Issue #567 turns imported immutable values into dependency-backed semantic
+evidence instead of another table of API exceptions. The capability is narrow:
+exact admission may use an imported value only when import/export identity,
+provider value shape, LibraryApi or domain proof, and provider/importer mutation
+exclusion are all proven.
+
+The durable metric artifact is
+[issue-567-closeout.v1.json](../bench/recall_loss/issue-567-closeout.v1.json).
+The phase artifacts are linked from
+[recall-loss-recovery-loop](recall-loss-recovery-loop.md).
+
+## What changed
+
+Imported immutable provider values can now feed existing exact semantic families:
+
+| family | imported coordinates now admitted |
+|---|---|
+| `map_default_lookup` | Python literal dict bindings, Java `Map.of` bindings, Go namespace map members, Rust imported const entry arrays consumed by `HashMap::from`, and JS/TS `new Map(...)` provider bindings |
+| `membership_contains` | TypeScript/Rust imported literal collection bindings, JS/TS `new Set(...)` provider bindings, Python `set([...])` and `collections.deque([...])` provider bindings, and Java `List.of(...)`/`Set.of(...)` provider bindings |
+| `string_affix` | TypeScript, Java, Rust, and Go imported string-affix coordinates |
+
+The evidence substrate is shared:
+
+- `ImportedLiteralSnapshot` provenance records that an importer consumed a
+  provider-owned immutable value snapshot.
+- Provider literal export safety lives in `nose-semantics`, not in per-consumer
+  frontend shortcuts.
+- Snapshot copy preserves provider source-origin spans and rewires dependency
+  ids into the importer.
+- Existing `LibraryApi`, `Domain`, `Import`, and `Symbol` evidence must already
+  prove supported provider calls or binding coordinates.
+
+This keeps the design aligned with capabilities over features: the new behavior
+is a reusable proof lane that existing semantic packs consume, not a growing
+selector allow-list.
+
+## Closed boundaries
+
+These remain intentionally closed:
+
+- broad cross-file constant propagation;
+- package ecosystem semantics;
+- dynamic import, `eval`, reflection, and side-effecting re-export paths;
+- raw import-coordinate sequences as value proof;
+- provider mutation, importer rebinding, namespace shadowing, missing
+  `LibraryApi` proof, and ambiguous factory/provider shapes.
+
+The focused closeout inventory records 32 guard assertions or groups across
+product fixtures, equivalence tests, frontend snapshot gates, and diagnostic
+reason pins. The recall-loss hard gate stayed closed in every phase:
+`false_merges == 0` and `canon_preservation_violations == 0`.
+
+## Metrics
+
+The phase deltas are:
+
+| slice | positive delta | hard-negative / diagnostic guard |
+|---|---:|---:|
+| JS/TS `new Map(...)` imported defaults | `0/2 -> 2/2` | constructor snapshot guards `0/4 -> 4/4` |
+| JS/TS `new Set(...)` imported membership | `0/2 -> 2/2` | included in constructor snapshot guards |
+| Python imported collection factories | `0/2 -> 2/2` | collection snapshot guards `0/5 -> 5/5` |
+| Java imported collection factories | `0/2 -> 2/2` | included in collection snapshot guards |
+| recall-loss import snapshot census | `0/1 -> 1/1` | mutation/API/provider miss reasons pinned |
+| aggregate boundary attribution | `0/1 -> 1/1` | broad aggregate miss bucket `3 -> 0` |
+
+Runtime has two relevant measurements:
+
+- The initial imported provenance slice was measured in the changelog at
+  `0.92s -> 0.95s` median wall time (+3.3%) and `145.4ms -> 151.7ms`
+  `import-resolve` (+4.3%) on `nose query crates all top=0 --mode semantic
+  --format json`, with JSON bytes unchanged.
+- The closeout phases after #583 through #585 were remeasured over five paired
+  release runs on the same current `crates` input: median wall time
+  `488.03ms -> 445.77ms` (-8.7%), `import-resolve` `69.6ms -> 72.0ms`
+  (+3.4%), family count `31 -> 31`, and JSON bytes `67200 -> 67200`.
+
+## Follow-up boundary
+
+Do not continue #567 by widening aggregate child export safety. The remaining
+large import-snapshot census buckets are module/export resolution scope:
+`provider-module-missing` and `provider-export-missing`. If imported snapshots
+stay the priority, start a separate module-resolution milestone rather than
+relaxing imported literal admission.
+
+## See also
+
+- [recall-loss-diagnostics](recall-loss-diagnostics.md)
+- [recall-loss-recovery-loop](recall-loss-recovery-loop.md)
+- [semantic-kernel-snapshot](semantic-kernel-snapshot.md)
+- [evidence-records](evidence-records.md)
+- [source-facts](source-facts.md)

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -105,6 +105,12 @@ include:
 | `provider-sequence-surface-proof-missing` | The provider aggregate lacks the sequence-surface proof required for imported literal export. |
 | `unsupported-provider-rhs-shape` | The provider RHS is not a literal, supported aggregate, or supported factory call. |
 
+The #567 import-backed immutable provenance closeout is the reference example
+for using this census to end a capability slice without widening admission. See
+[import-backed immutable provenance closeout](import-backed-immutable-provenance-closeout-567.md)
+and the checked-in
+[closeout artifact](../bench/recall_loss/issue-567-closeout.v1.json).
+
 ## PR reporting
 
 For any PR that changes exact semantic admission, include this table or the same

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -54,6 +54,11 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   records the first census-driven triage pass: the broad provider-aggregate miss
   bucket is split into non-import-literal sequence surfaces and child reference
   boundaries without admitting new snapshots.
+- [#567 closeout log](../bench/recall_loss/issue-567-closeout.v1.json)
+  records the epic-level audit: requirement coverage, exact-safe imported
+  coordinate families, hard-negative inventory, hard-gate status, and runtime
+  measurements. The narrative closeout is
+  [import-backed immutable provenance closeout](import-backed-immutable-provenance-closeout-567.md).
 
 Regenerate the full local reports with:
 
@@ -256,9 +261,18 @@ The current top `crates` buckets after #567 phase 4 are:
 | `value-fingerprint-too-small` | 13 | explicit low-substance floor policy |
 | `library-api-occurrence-proof-missing` | 8 | missing occurrence evidence, not selector spelling |
 
+The #567 closeout keeps that phase-4 decision intact. The epic is complete as an
+imported immutable value capability: product fixtures now cover the supported
+map-default, membership, and string-affix coordinate families; hard negatives
+remain closed; and import-snapshot misses are measurable. The follow-up is not
+to relax aggregate child export safety. The remaining large census buckets are
+module/export resolution scope and should be planned as a separate milestone if
+import snapshots remain the priority.
+
 ## See Also
 
 - [recall-loss-diagnostics](recall-loss-diagnostics.md)
+- [import-backed immutable provenance closeout](import-backed-immutable-provenance-closeout-567.md)
 - [semantic-pack-architecture](semantic-pack-architecture.md)
 - [source-facts](source-facts.md)
 - [evidence-records](evidence-records.md)


### PR DESCRIPTION
## Summary
- add the #567 epic closeout artifact with requirement audit, admitted coordinate families, hard-negative inventory, recall-loss hard gates, and runtime evidence
- add a narrative closeout doc and link it from the recall-loss docs, docs home, and bench recall-loss index
- clarify the changelog performance baseline and add the #584/#585 closeout runtime delta

## Verification
- cargo test -p nose-cli --test cli imported_immutable -- --nocapture
- cargo test -p nose-cli --test equivalence imported_ -- --nocapture
- cargo test -p nose-cli --test cli recall_loss_report -- --nocapture
- cargo test -p nose-semantics semantic_evidence::sequence_surfaces -- --nocapture
- cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.closeout.json
- cargo test -p nose-semantics -p nose-frontend -p nose-normalize -p nose-detect
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/check-duplication.sh
- awiki lint --root docs
- cargo fmt --all -- --check
- git diff --check

Closes #567 after merge.