### PR TITLE
Census import snapshot module resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@ break.
   closeout, tying the phase logs to the epic requirements, admitted coordinate
   families, hard-negative inventory, import-snapshot census boundaries, and
   runtime evidence.
+- Added the #587 import-snapshot module/export resolution tracker and starting
+  census artifact. The census selects the remaining module/export miss rows
+  after #567, splits them by reason, crate, import surface, and top files, and
+  points the first implementation slice at same-crate `crate::...` export lookup
+  after unsupported stdlib/external/workspace imports are separated.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -90,3 +90,7 @@ slice.
 - [issue-567-closeout.v1.json](issue-567-closeout.v1.json) records the epic
   closeout audit: requirement coverage, admitted imported-coordinate families,
   hard-negative inventory, false-merge hard gates, and product/runtime evidence.
+- [issue-587-module-export-census.v1.json](issue-587-module-export-census.v1.json)
+  records the #587 starting census for the next import-snapshot milestone:
+  module/export miss counts by reason, crate, import surface, top files, and
+  recommended implementation order.

--- a/bench/recall_loss/issue-587-module-export-census.v1.json
+++ b/bench/recall_loss/issue-587-module-export-census.v1.json
@@ -1,0 +1,323 @@
+{
+  "schema_version": 1,
+  "report_kind": "recall-loss-census",
+  "issue": 587,
+  "issue_url": "https://github.com/corca-ai/nose/issues/587",
+  "generated_on": "2026-06-28",
+  "source_report": "target/recall-loss.closeout.json",
+  "source_command": "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.closeout.json",
+  "selected_scope": "import_snapshot_census misses where reason is provider-module-missing or provider-export-missing",
+  "summary": {
+    "selected_misses": 378,
+    "language": "rust",
+    "total_unresolved_binding_imports": 384,
+    "excluded_from_this_census": {
+      "importer-binding-mutated": 3,
+      "provider-sequence-surface-not-import-literal-safe": 2,
+      "provider-aggregate-child-reference-boundary": 1
+    }
+  },
+  "by_reason": [
+    {
+      "key": "provider-module-missing",
+      "count": 255
+    },
+    {
+      "key": "provider-export-missing",
+      "count": 123
+    }
+  ],
+  "by_crate": [
+    {
+      "key": "crates/nose-frontend",
+      "count": 91
+    },
+    {
+      "key": "crates/nose-cli",
+      "count": 88
+    },
+    {
+      "key": "crates/nose-detect",
+      "count": 76
+    },
+    {
+      "key": "crates/nose-semantics",
+      "count": 45
+    },
+    {
+      "key": "crates/nose-normalize",
+      "count": 37
+    },
+    {
+      "key": "crates/nose-il",
+      "count": 20
+    },
+    {
+      "key": "crates/nose-markdown",
+      "count": 19
+    },
+    {
+      "key": "crates/nose-eval",
+      "count": 2
+    }
+  ],
+  "by_import_surface": [
+    {
+      "key": "external-or-local-use",
+      "count": 127
+    },
+    {
+      "key": "crate-root-use",
+      "count": 98
+    },
+    {
+      "key": "super-use",
+      "count": 54
+    },
+    {
+      "key": "rust-stdlib-use",
+      "count": 50
+    },
+    {
+      "key": "workspace-crate-use",
+      "count": 48
+    },
+    {
+      "key": "self-use",
+      "count": 1
+    }
+  ],
+  "reason_by_import_surface": {
+    "provider-export-missing": {
+      "crate-root-use": 68,
+      "external-or-local-use": 54,
+      "self-use": 1
+    },
+    "provider-module-missing": {
+      "rust-stdlib-use": 50,
+      "external-or-local-use": 73,
+      "super-use": 54,
+      "crate-root-use": 30,
+      "workspace-crate-use": 48
+    }
+  },
+  "reason_by_crate": {
+    "provider-export-missing": {
+      "crates/nose-cli": 26,
+      "crates/nose-detect": 21,
+      "crates/nose-frontend": 25,
+      "crates/nose-il": 16,
+      "crates/nose-markdown": 11,
+      "crates/nose-normalize": 6,
+      "crates/nose-semantics": 18
+    },
+    "provider-module-missing": {
+      "crates/nose-cli": 62,
+      "crates/nose-detect": 55,
+      "crates/nose-eval": 2,
+      "crates/nose-frontend": 66,
+      "crates/nose-il": 4,
+      "crates/nose-markdown": 8,
+      "crates/nose-normalize": 31,
+      "crates/nose-semantics": 27
+    }
+  },
+  "top_files": [
+    {
+      "file": "crates/nose-cli/src/legacy_prelude.rs",
+      "count": 10
+    },
+    {
+      "file": "crates/nose-detect/src/units/fragments.rs",
+      "count": 8
+    },
+    {
+      "file": "crates/nose-detect/src/units.rs",
+      "count": 7
+    },
+    {
+      "file": "crates/nose-normalize/src/value_graph.rs",
+      "count": 7
+    },
+    {
+      "file": "crates/nose-cli/src/command_dispatch.rs",
+      "count": 6
+    },
+    {
+      "file": "crates/nose-cli/src/query_model.rs",
+      "count": 6
+    },
+    {
+      "file": "crates/nose-frontend/src/js_ts/expressions.rs",
+      "count": 6
+    },
+    {
+      "file": "crates/nose-cli/src/ignores.rs",
+      "count": 5
+    },
+    {
+      "file": "crates/nose-frontend/src/js_ts/control.rs",
+      "count": 5
+    },
+    {
+      "file": "crates/nose-frontend/src/lower/library_api_post_lower.rs",
+      "count": 5
+    },
+    {
+      "file": "crates/nose-semantics/src/library_api/rows/methods.rs",
+      "count": 5
+    },
+    {
+      "file": "crates/nose-semantics/src/packs.rs",
+      "count": 5
+    }
+  ],
+  "top_roots_by_reason": {
+    "provider-module-missing": [
+      {
+        "key": "super",
+        "count": 54
+      },
+      {
+        "key": "std",
+        "count": 50
+      },
+      {
+        "key": "crate",
+        "count": 30
+      },
+      {
+        "key": "nose_il",
+        "count": 24
+      },
+      {
+        "key": "rustc_hash",
+        "count": 24
+      },
+      {
+        "key": "tree_sitter",
+        "count": 21
+      },
+      {
+        "key": "nose_semantics",
+        "count": 18
+      },
+      {
+        "key": "anyhow",
+        "count": 15
+      },
+      {
+        "key": "serde",
+        "count": 11
+      },
+      {
+        "key": "nose_normalize",
+        "count": 5
+      }
+    ],
+    "provider-export-missing": [
+      {
+        "key": "crate",
+        "count": 68
+      },
+      {
+        "key": "classification",
+        "count": 4
+      },
+      {
+        "key": "context",
+        "count": 3
+      },
+      {
+        "key": "model",
+        "count": 3
+      },
+      {
+        "key": "canonical",
+        "count": 2
+      },
+      {
+        "key": "regex",
+        "count": 2
+      }
+    ]
+  },
+  "representative_imports": {
+    "provider-export-missing_crate_root_use": [
+      {
+        "importer_file": "crates/nose-cli/src/command_dispatch.rs",
+        "importer_line": 10,
+        "import_line_text": "use crate::il_command::cmd_il;"
+      },
+      {
+        "importer_file": "crates/nose-cli/src/query_model.rs",
+        "importer_line": 2,
+        "import_line_text": "use crate::divergence::{DivergenceItem, DivergenceJson};"
+      },
+      {
+        "importer_file": "crates/nose-detect/src/units.rs",
+        "importer_line": 17,
+        "import_line_text": "use crate::fragment::FragmentKind;"
+      }
+    ],
+    "provider-module-missing_super_use": [
+      {
+        "importer_file": "crates/nose-detect/src/units/fragments.rs",
+        "importer_line": 6,
+        "import_line_text": "use super::tree::subtree_spans_within;"
+      },
+      {
+        "importer_file": "crates/nose-frontend/src/js_ts/expressions.rs",
+        "importer_line": 1,
+        "import_line_text": "use super::control::{lower_aug_assignment, lower_update};"
+      }
+    ],
+    "unsupported_boundary_examples": [
+      {
+        "importer_file": "crates/nose-cli/src/baseline.rs",
+        "importer_line": 14,
+        "import_line_text": "use std::path::Path;",
+        "boundary": "rust-stdlib-use"
+      },
+      {
+        "importer_file": "crates/nose-cli/src/baseline_comparison.rs",
+        "importer_line": 2,
+        "import_line_text": "use anyhow::Result;",
+        "boundary": "external-crate-use"
+      },
+      {
+        "importer_file": "crates/nose-cli/src/legacy_prelude.rs",
+        "importer_line": 38,
+        "import_line_text": "pub(crate) use nose_il::{Corpus, FileId, Interner, Lang};",
+        "boundary": "workspace-crate-use"
+      }
+    ]
+  },
+  "recommended_order": [
+    {
+      "step": 1,
+      "target": "Boundary split for intentionally unsupported imports",
+      "why": "stdlib, external crate, and workspace-crate imports account for at least 98 provider-module-missing rows and should not inflate the same-repo module-resolution target."
+    },
+    {
+      "step": 2,
+      "target": "Same-crate crate-root provider-export lookup",
+      "why": "provider-export-missing + crate-root-use is the largest clearly same-repo actionable slice at 68 rows."
+    },
+    {
+      "step": 3,
+      "target": "Relative super-use module resolution",
+      "why": "super-use accounts for 54 provider-module-missing rows and needs parent-module ownership proof before provider lookup."
+    },
+    {
+      "step": 4,
+      "target": "Local sibling module and direct pub use pricing",
+      "why": "provider-export-missing external-or-local-use roots are mostly local module names; they need module-tree proof and hard negatives for ambiguous re-exports."
+    }
+  ],
+  "hard_gates": {
+    "false_merges": 0,
+    "canon_preservation_violations": 0,
+    "must_remain": "No exact admission without dependency-backed module, export, provider value, and mutation evidence."
+  }
+}

--- a/docs/import-backed-immutable-provenance-closeout-567.md
+++ b/docs/import-backed-immutable-provenance-closeout-567.md
@@ -84,6 +84,11 @@ large import-snapshot census buckets are module/export resolution scope:
 stay the priority, start a separate module-resolution milestone rather than
 relaxing imported literal admission.
 
+That milestone is
+[#587](https://github.com/corca-ai/nose/issues/587). Its checked-in starting
+census is
+[issue-587-module-export-census.v1.json](../bench/recall_loss/issue-587-module-export-census.v1.json).
+
 ## See also
 
 - [recall-loss-diagnostics](recall-loss-diagnostics.md)

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -59,6 +59,10 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   coordinate families, hard-negative inventory, hard-gate status, and runtime
   measurements. The narrative closeout is
   [import-backed immutable provenance closeout](import-backed-immutable-provenance-closeout-567.md).
+- [#587 module/export census](../bench/recall_loss/issue-587-module-export-census.v1.json)
+  records the starting point for the follow-up import-snapshot milestone:
+  provider module/export miss counts by reason, crate, import surface, top
+  files, and recommended implementation order.
 
 Regenerate the full local reports with:
 
@@ -268,6 +272,13 @@ remain closed; and import-snapshot misses are measurable. The follow-up is not
 to relax aggregate child export safety. The remaining large census buckets are
 module/export resolution scope and should be planned as a separate milestone if
 import snapshots remain the priority.
+
+Issue #587 is that separate milestone. Its starting census selects the
+`provider-module-missing` and `provider-export-missing` rows from the #567
+closeout report: `378` rows, all Rust. The largest clearly same-repo first slice
+is `provider-export-missing` on `crate::...` imports (`68` rows). Before opening
+that slice, split unsupported stdlib, external crate, and workspace-crate imports
+out of the actionable module-resolution bucket so package semantics stay closed.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- create #587 as the follow-up epic for import snapshot module/export resolution
- add the checked-in #587 starting census for provider-module/provider-export import snapshot misses
- link the census from recall-loss docs, the #567 closeout, and the changelog

## Key census
- selected module/export misses: 378 rows, all Rust
- provider-module-missing: 255
- provider-export-missing: 123
- largest clearly same-repo first slice: provider-export-missing on `crate::...` imports, 68 rows
- boundary split needed first: stdlib/external/workspace-crate imports should stay out of same-repo module-resolution admission

## Verification
- jq empty bench/recall_loss/issue-587-module-export-census.v1.json
- awiki lint --root docs
- git diff --check
- cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587.json
- cargo fmt --all -- --check

Refs #587.