### PR TITLE
Census residual Rust import snapshot misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ break.
   `provider-export-missing` moves `9 -> 2`, and re-export targets are reported
   through dedicated `provider-reexport-*` boundary reasons with zero false
   merges and zero canon-preservation violations.
+- Added the #587 residual module/export census. The remaining generic target is
+  mostly external crate imports rather than same-repo Rust resolution: `75`
+  external crate rows, `2` residual workspace-crate rows, and `2` residual
+  `std::cell` rows, leaving a much smaller same-repo tail of `9`
+  relative-`super` rows and `2` local export misses.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -102,3 +102,7 @@ slice.
   records the direct Rust public re-export slice: one-hop `pub use` lookup for
   already literal-safe provider exports, bare child module aliases, and
   re-export-specific boundary reasons.
+- [issue-587-residual-census.v1.json](issue-587-residual-census.v1.json)
+  records the post-re-export #587 residual census: the remaining generic
+  module/export misses are mostly external crate imports, with a smaller
+  relative-`super` and local export tail for follow-up triage.

--- a/bench/recall_loss/issue-587-residual-census.v1.json
+++ b/bench/recall_loss/issue-587-residual-census.v1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "nose.recall_loss.issue_587.residual_census.v1",
+  "issue": 587,
+  "slice": "post-reexport residual module/export census",
+  "date": "2026-06-28",
+  "source_report": "target/recall-loss.issue-587-reexport-after.json",
+  "baseline_artifact": "bench/recall_loss/issue-587-reexport-pricing.v1.json",
+  "goal": "Classify the remaining generic Rust module/export misses after the #587 re-export slice before deciding whether another same-repo provider-resolution implementation is warranted.",
+  "summary": {
+    "snapshot_records": 1,
+    "unresolved_binding_imports": 386,
+    "generic_module_export_target_rows": 91,
+    "residual_rows_including_reexport_target": 92
+  },
+  "residual_by_reason": {
+    "provider-module-missing": 89,
+    "provider-export-missing": 2,
+    "provider-reexport-target-export-missing": 1
+  },
+  "residual_classification": {
+    "external_crate_boundary": 75,
+    "relative_super_residual": 9,
+    "workspace_crate_boundary_gap": 2,
+    "rust_stdlib_boundary_gap": 2,
+    "local_export_missing": 2,
+    "non_use_anchor_noise": 1,
+    "reexport_target_export_missing": 1
+  },
+  "external_crate_roots": {
+    "rustc_hash": 25,
+    "tree_sitter": 21,
+    "anyhow": 15,
+    "serde": 10,
+    "regex": 2,
+    "clap": 1,
+    "ignore": 1
+  },
+  "representatives": {
+    "relative_super_residual": [
+      "crates/nose-detect/src/report/tests/support.rs:4 use super::super::RefactorFamily;",
+      "crates/nose-detect/src/units/features.rs:1 use super::UnitExtractCtx;",
+      "crates/nose-frontend/src/module_imports/tests/support.rs:1 use super::super::resolve_imported_immutable_bindings;",
+      "crates/nose-normalize/src/recursion/tail.rs:5 use super::Rebuilder;"
+    ],
+    "local_export_missing": [
+      "crates/nose-il/src/unit.rs:2 use crate::node::NodeId;",
+      "crates/nose-semantics/src/library_api/imported_occurrences.rs:2 use crate::evidence::span_contains;"
+    ],
+    "workspace_crate_boundary_gap": [
+      "crates/nose-detect/src/report/tests/support.rs:2 use nose_il::UnitKind::Function;",
+      "crates/nose-frontend/src/module_imports/diagnostics.rs:7 use nose_il::{Corpus, EvidenceKind, Il, ImportEvidenceKind, Interner};"
+    ],
+    "rust_stdlib_boundary_gap": [
+      "crates/nose-normalize/src/library_api_evidence.rs:26 use std::cell::RefCell;",
+      "crates/nose-semantics/src/evidence/domain.rs:3 use std::cell::RefCell;"
+    ],
+    "reexport_target_export_missing": [
+      "crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_2.rs:2 use crate::PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID;"
+    ]
+  },
+  "decision": {
+    "next_pr": "Split external crate, residual workspace-crate, and residual stdlib imports out of provider-module-missing as explicit closed boundaries.",
+    "do_not_admit": [
+      "external crates as provider modules",
+      "stdlib modules as provider files",
+      "workspace crate imports without a separate cross-crate import capability",
+      "relative-super imports until a focused same-repo provider slice proves unique ownership"
+    ],
+    "expected_effect": "provider-module-missing should drop from 89 to roughly 10 without changing snapshot_records, false_merges, or canon_preservation_violations."
+  }
+}

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -311,6 +311,20 @@ as `provider-reexport-*` boundary reasons. Hard gates remain at
 measurement is
 [`issue-587-reexport-pricing.v1.json`](../bench/recall_loss/issue-587-reexport-pricing.v1.json).
 
+The #587 residual census checks whether another same-repo provider-resolution
+slice is warranted before widening implementation. After the re-export slice,
+the remaining generic module/export target is `91` rows, or `92` if the
+re-export target-export tail is included. Most of that is not same-repo module
+resolution: `75` rows are external crate imports (`rustc_hash`, `tree_sitter`,
+`anyhow`, `serde`, `regex`, `clap`, `ignore`), `2` are residual workspace-crate
+boundary gaps, and `2` are residual `std::cell` rows. The same-repo tail is much
+smaller: `9` relative-`super` rows and `2` local export misses. The next
+implementation slice should therefore split external/std/workspace residuals
+out of `provider-module-missing` as explicit closed boundaries before deciding
+whether the relative-`super` tail is worth opening. The checked-in measurement
+is
+[`issue-587-residual-census.v1.json`](../bench/recall_loss/issue-587-residual-census.v1.json).
+
 ## See Also
 
 - [recall-loss-diagnostics](recall-loss-diagnostics.md)


### PR DESCRIPTION
## Summary
- add the #587 post-re-export residual census artifact
- document that the remaining generic module/export target is mostly external crate imports, not same-repo Rust provider lookup
- point the next implementation slice at explicit external/std/workspace boundary splitting

Refs #587.

## Quantified Signal
- generic module/export target rows after #590: `91` (`92` including the re-export target-export tail)
- residual classes: `75` external crate rows, `9` relative-super rows, `2` residual workspace-crate rows, `2` residual `std::cell` rows, `2` local export misses, `1` non-use anchor, `1` re-export target-export tail
- largest external roots: `rustc_hash = 25`, `tree_sitter = 21`, `anyhow = 15`, `serde = 10`

## Validation
- `jq empty bench/recall_loss/issue-587-residual-census.v1.json`
- `awiki lint --root docs`
- `git diff --check`