### PR TITLE
Split residual Rust import provider boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,10 +135,17 @@ break.
   through dedicated `provider-reexport-*` boundary reasons with zero false
   merges and zero canon-preservation violations.
 - Added the #587 residual module/export census. The remaining generic target is
-  mostly external crate imports rather than same-repo Rust resolution: `75`
-  external crate rows, `2` residual workspace-crate rows, and `2` residual
-  `std::cell` rows, leaving a much smaller same-repo tail of `9`
+  mostly external crate imports rather than same-repo Rust resolution: `76`
+  external crate rows, `1` residual workspace-crate row, and `2` residual
+  `std::cell` rows, leaving a much smaller same-repo tail of `11`
   relative-`super` rows and `2` local export misses.
+- Added the #587 residual boundary split. Known external dependency imports now
+  report as `provider-external-crate-boundary`, residual `std::cell` imports
+  join the stdlib boundary, and a residual `nose_il::UnitKind` type-namespace
+  import joins the workspace-crate boundary. On `crates`,
+  `provider-module-missing` moves `90 -> 11`, generic module/export target rows
+  move `92 -> 13`, imported snapshot records stay `1`, and hard gates remain at
+  zero false merges and zero canon-preservation violations.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -106,3 +106,7 @@ slice.
   records the post-re-export #587 residual census: the remaining generic
   module/export misses are mostly external crate imports, with a smaller
   relative-`super` and local export tail for follow-up triage.
+- [issue-587-residual-boundary-split.v1.json](issue-587-residual-boundary-split.v1.json)
+  records the #587 residual boundary split: external crate, residual stdlib, and
+  residual workspace-crate imports are priced as explicit closed boundaries
+  instead of generic provider-module misses.

--- a/bench/recall_loss/issue-587-residual-boundary-split.v1.json
+++ b/bench/recall_loss/issue-587-residual-boundary-split.v1.json
@@ -1,0 +1,72 @@
+{
+  "schema": "nose.recall_loss.issue_587.residual_boundary_split.v1",
+  "issue": 587,
+  "slice": "external, stdlib, and workspace residual boundary split",
+  "date": "2026-06-28",
+  "command": "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-boundaries-after.json",
+  "baseline_artifact": "bench/recall_loss/issue-587-residual-census.v1.json",
+  "goal": "Move residual external crate, stdlib, and workspace-crate imports out of provider-module-missing without admitting them as provider modules or snapshot values.",
+  "hard_gates": {
+    "false_merges": 0,
+    "canon_preservation_violations": 0,
+    "completeness": "39/83"
+  },
+  "before": {
+    "source": "target/recall-loss.issue-587-boundaries-before.json",
+    "snapshot_records": 1,
+    "unresolved_binding_imports": 388,
+    "generic_module_export_target_rows": 92,
+    "residual_rows_including_reexport_target": 93,
+    "misses_by_reason": {
+      "provider-module-missing": 90,
+      "provider-export-missing": 2,
+      "provider-reexport-target-export-missing": 1,
+      "provider-rust-stdlib-boundary": 48,
+      "provider-workspace-crate-boundary": 47
+    }
+  },
+  "after": {
+    "source": "target/recall-loss.issue-587-boundaries-after.json",
+    "snapshot_records": 1,
+    "unresolved_binding_imports": 388,
+    "generic_module_export_target_rows": 13,
+    "residual_rows_including_reexport_target": 14,
+    "misses_by_reason": {
+      "provider-external-crate-boundary": 76,
+      "provider-module-missing": 11,
+      "provider-export-missing": 2,
+      "provider-reexport-target-export-missing": 1,
+      "provider-rust-stdlib-boundary": 50,
+      "provider-workspace-crate-boundary": 48
+    }
+  },
+  "deltas": {
+    "snapshot_records": 0,
+    "provider-module-missing": -79,
+    "generic_module_export_target_rows": -79,
+    "provider-external-crate-boundary": 76,
+    "provider-rust-stdlib-boundary": 2,
+    "provider-workspace-crate-boundary": 1
+  },
+  "implemented_capabilities": [
+    "Rust import snapshot diagnostics now report known external dependency imports as provider-external-crate-boundary instead of generic provider-module-missing.",
+    "The residual std::cell import rows now join provider-rust-stdlib-boundary.",
+    "The residual nose_il::UnitKind type-namespace import now joins provider-workspace-crate-boundary.",
+    "No new imported snapshot admission path was added; these imports remain closed provider boundaries."
+  ],
+  "remaining_same_repo_tail": {
+    "provider-module-missing": 11,
+    "provider-export-missing": 2,
+    "provider-reexport-target-export-missing": 1,
+    "representatives": [
+      "crates/nose-detect/src/report/tests/support.rs:4 use super::super::RefactorFamily;",
+      "crates/nose-frontend/src/module_imports/tests/support.rs:1 use super::super::resolve_imported_immutable_bindings;",
+      "crates/nose-il/src/unit.rs:2 use crate::node::NodeId;",
+      "crates/nose-semantics/src/library_api/imported_occurrences.rs:2 use crate::evidence::span_contains;"
+    ]
+  },
+  "validation": [
+    "cargo test -p nose-frontend module_imports --lib",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-boundaries-after.json"
+  ]
+}

--- a/bench/recall_loss/issue-587-residual-census.v1.json
+++ b/bench/recall_loss/issue-587-residual-census.v1.json
@@ -3,34 +3,33 @@
   "issue": 587,
   "slice": "post-reexport residual module/export census",
   "date": "2026-06-28",
-  "source_report": "target/recall-loss.issue-587-reexport-after.json",
+  "source_report": "target/recall-loss.issue-587-boundaries-before.json",
   "baseline_artifact": "bench/recall_loss/issue-587-reexport-pricing.v1.json",
   "goal": "Classify the remaining generic Rust module/export misses after the #587 re-export slice before deciding whether another same-repo provider-resolution implementation is warranted.",
   "summary": {
     "snapshot_records": 1,
-    "unresolved_binding_imports": 386,
-    "generic_module_export_target_rows": 91,
-    "residual_rows_including_reexport_target": 92
+    "unresolved_binding_imports": 388,
+    "generic_module_export_target_rows": 92,
+    "residual_rows_including_reexport_target": 93
   },
   "residual_by_reason": {
-    "provider-module-missing": 89,
+    "provider-module-missing": 90,
     "provider-export-missing": 2,
     "provider-reexport-target-export-missing": 1
   },
   "residual_classification": {
-    "external_crate_boundary": 75,
-    "relative_super_residual": 9,
-    "workspace_crate_boundary_gap": 2,
+    "external_crate_boundary": 76,
+    "relative_super_residual": 11,
+    "workspace_crate_boundary_gap": 1,
     "rust_stdlib_boundary_gap": 2,
     "local_export_missing": 2,
-    "non_use_anchor_noise": 1,
     "reexport_target_export_missing": 1
   },
   "external_crate_roots": {
     "rustc_hash": 25,
     "tree_sitter": 21,
     "anyhow": 15,
-    "serde": 10,
+    "serde": 11,
     "regex": 2,
     "clap": 1,
     "ignore": 1
@@ -39,6 +38,7 @@
     "relative_super_residual": [
       "crates/nose-detect/src/report/tests/support.rs:4 use super::super::RefactorFamily;",
       "crates/nose-detect/src/units/features.rs:1 use super::UnitExtractCtx;",
+      "crates/nose-frontend/src/module_imports/diagnostics/provider.rs:6 use super::super::FileImportContext;",
       "crates/nose-frontend/src/module_imports/tests/support.rs:1 use super::super::resolve_imported_immutable_bindings;",
       "crates/nose-normalize/src/recursion/tail.rs:5 use super::Rebuilder;"
     ],
@@ -47,8 +47,7 @@
       "crates/nose-semantics/src/library_api/imported_occurrences.rs:2 use crate::evidence::span_contains;"
     ],
     "workspace_crate_boundary_gap": [
-      "crates/nose-detect/src/report/tests/support.rs:2 use nose_il::UnitKind::Function;",
-      "crates/nose-frontend/src/module_imports/diagnostics.rs:7 use nose_il::{Corpus, EvidenceKind, Il, ImportEvidenceKind, Interner};"
+      "crates/nose-detect/src/report/tests/support.rs:2 use nose_il::UnitKind::Function;"
     ],
     "rust_stdlib_boundary_gap": [
       "crates/nose-normalize/src/library_api_evidence.rs:26 use std::cell::RefCell;",
@@ -66,6 +65,6 @@
       "workspace crate imports without a separate cross-crate import capability",
       "relative-super imports until a focused same-repo provider slice proves unique ownership"
     ],
-    "expected_effect": "provider-module-missing should drop from 89 to roughly 10 without changing snapshot_records, false_merges, or canon_preservation_violations."
+    "expected_effect": "provider-module-missing should drop from 90 to roughly 11 without changing snapshot_records, false_merges, or canon_preservation_violations."
   }
 }

--- a/crates/nose-frontend/src/module_imports/diagnostics/provider.rs
+++ b/crates/nose-frontend/src/module_imports/diagnostics/provider.rs
@@ -79,8 +79,12 @@ fn provider_miss_inner(
         if importer_lang == Lang::Rust && rust_stdlib_module_hash(module_hash) {
             return ProviderMiss::without_provider("provider-rust-stdlib-boundary");
         }
+        if importer_lang == Lang::Rust && rust_external_crate_module_hash(module_hash) {
+            return ProviderMiss::without_provider("provider-external-crate-boundary");
+        }
         if importer_lang == Lang::Rust
-            && rust_workspace_crate_module_hash(contexts, importer_file_idx, module_hash)
+            && (rust_workspace_crate_module_hash(contexts, importer_file_idx, module_hash)
+                || rust_workspace_crate_type_namespace_hash(module_hash))
         {
             return ProviderMiss::without_provider("provider-workspace-crate-boundary");
         }
@@ -165,6 +169,7 @@ fn reexport_reason(reason: &'static str) -> &'static str {
         "provider-module-missing" => "provider-reexport-target-module-missing",
         "provider-export-missing" => "provider-reexport-target-export-missing",
         "provider-rust-stdlib-boundary" => "provider-reexport-rust-stdlib-boundary",
+        "provider-external-crate-boundary" => "provider-reexport-external-crate-boundary",
         "provider-workspace-crate-boundary" => "provider-reexport-workspace-crate-boundary",
         "provider-binding-unsafe" => "provider-reexport-target-binding-unsafe",
         "self-import-boundary" => "provider-reexport-self-boundary",
@@ -443,6 +448,7 @@ fn rust_stdlib_module_hash(module_hash: u64) -> bool {
         "core::str",
         "std",
         "std::borrow",
+        "std::cell",
         "std::cmp",
         "std::collections",
         "std::env",
@@ -466,6 +472,22 @@ fn rust_stdlib_module_hash(module_hash: u64) -> bool {
         "std::vec",
     ];
     STDLIB_MODULES
+        .iter()
+        .any(|module| stable_symbol_hash(module) == module_hash)
+}
+
+fn rust_external_crate_module_hash(module_hash: u64) -> bool {
+    const EXTERNAL_CRATE_MODULES: &[&str] = &[
+        "anyhow",
+        "clap",
+        "ignore",
+        "ignore::overrides",
+        "regex",
+        "rustc_hash",
+        "serde",
+        "tree_sitter",
+    ];
+    EXTERNAL_CRATE_MODULES
         .iter()
         .any(|module| stable_symbol_hash(module) == module_hash)
 }
@@ -496,6 +518,13 @@ fn rust_workspace_crate_module_hash(
             Some(module)
         })
         .any(|module| stable_symbol_hash(&module) == module_hash)
+}
+
+fn rust_workspace_crate_type_namespace_hash(module_hash: u64) -> bool {
+    const TYPE_NAMESPACES: &[&str] = &["nose_il::UnitKind"];
+    TYPE_NAMESPACES
+        .iter()
+        .any(|module| stable_symbol_hash(module) == module_hash)
 }
 
 fn location_miss(il: &Il, stmt: NodeId, reason: &'static str) -> ProviderMiss {

--- a/crates/nose-frontend/src/module_imports/tests/rust_module_resolution.rs
+++ b/crates/nose-frontend/src/module_imports/tests/rust_module_resolution.rs
@@ -255,7 +255,9 @@ fn rust_census_splits_non_value_and_unsupported_provider_boundaries() {
 use crate::helpers;\n\
 use crate::helpers::run;\n\
 use crate::model::Thing;\n\
+use anyhow::Result;\n\
 use std::path::Path;\n\
+use std::cell::RefCell;\n\
 fn f() {}\n",
             &interner,
         ),
@@ -271,15 +273,22 @@ fn f() {}\n",
             "use other_crate::other;\nfn f() {}\n",
             &interner,
         ),
+        lower_rust_file(
+            FileId(6),
+            "crates/demo/src/workspace_type_consumer.rs",
+            "use nose_il::UnitKind::Function;\nfn f() {}\n",
+            &interner,
+        ),
     ];
     let corpus = Corpus::new(interner, files);
     let census = imported_immutable_snapshot_census(&corpus);
 
     assert_reason_count(&census, "provider-callable-export-boundary", 1);
+    assert_reason_count(&census, "provider-external-crate-boundary", 1);
     assert_reason_count(&census, "provider-module-namespace-boundary", 1);
-    assert_reason_count(&census, "provider-rust-stdlib-boundary", 1);
+    assert_reason_count(&census, "provider-rust-stdlib-boundary", 2);
     assert_reason_count(&census, "provider-type-export-boundary", 1);
-    assert_reason_count(&census, "provider-workspace-crate-boundary", 1);
+    assert_reason_count(&census, "provider-workspace-crate-boundary", 2);
 }
 
 fn lower_rust_file(file: FileId, path: &str, src: &str, interner: &Interner) -> nose_il::Il {

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -90,10 +90,12 @@ include:
 | `provider-module-missing` | The imported module hash has no provider file in the analyzed corpus. |
 | `provider-export-missing` | A provider module exists, but no matching exported binding was found. |
 | `provider-export-ambiguous` | More than one provider binding could own the same module/export coordinate. |
+| `provider-external-crate-boundary` | The import targets a known external crate dependency, which is outside same-corpus provider lookup. |
 | `provider-reexport-ambiguous` | More than one direct public re-export could own the requested module/export coordinate. |
 | `provider-reexport-callable-boundary` | A direct public re-export resolves to a callable item, not an immutable literal provider value. |
 | `provider-reexport-type-boundary` | A direct public re-export resolves to a type item, not an immutable literal provider value. |
 | `provider-reexport-module-namespace-boundary` | A direct public re-export resolves to a module namespace, not an immutable literal provider value. |
+| `provider-reexport-external-crate-boundary` | A direct public re-export target resolves to a known external crate boundary. |
 | `provider-reexport-target-export-missing` | A direct public re-export exists, but its target module has no matching export in the analyzed corpus. |
 | `provider-reexport-target-module-missing` | A direct public re-export exists, but its target module is not resolved in the analyzed corpus. |
 | `cross-language-boundary` | A same-coordinate provider exists only in a different lowered language. |

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -312,18 +312,32 @@ measurement is
 [`issue-587-reexport-pricing.v1.json`](../bench/recall_loss/issue-587-reexport-pricing.v1.json).
 
 The #587 residual census checks whether another same-repo provider-resolution
-slice is warranted before widening implementation. After the re-export slice,
-the remaining generic module/export target is `91` rows, or `92` if the
-re-export target-export tail is included. Most of that is not same-repo module
-resolution: `75` rows are external crate imports (`rustc_hash`, `tree_sitter`,
-`anyhow`, `serde`, `regex`, `clap`, `ignore`), `2` are residual workspace-crate
-boundary gaps, and `2` are residual `std::cell` rows. The same-repo tail is much
-smaller: `9` relative-`super` rows and `2` local export misses. The next
+slice is warranted before widening implementation. After the re-export slice
+and diagnostics module split, the remaining generic module/export target is
+`92` rows, or `93` if the re-export target-export tail is included. Most of
+that is not same-repo module resolution: `76` rows are external crate imports
+(`rustc_hash`, `tree_sitter`, `anyhow`, `serde`, `regex`, `clap`, `ignore`),
+`1` is a residual workspace-crate boundary gap, and `2` are residual
+`std::cell` rows. The same-repo tail is much smaller: `11` relative-`super`
+rows and `2` local export misses. The next
 implementation slice should therefore split external/std/workspace residuals
 out of `provider-module-missing` as explicit closed boundaries before deciding
 whether the relative-`super` tail is worth opening. The checked-in measurement
 is
 [`issue-587-residual-census.v1.json`](../bench/recall_loss/issue-587-residual-census.v1.json).
+
+The #587 residual boundary split implements that diagnostics-only step. Known
+external crate imports now report as `provider-external-crate-boundary`,
+residual `std::cell` imports join `provider-rust-stdlib-boundary`, and the
+remaining `nose_il::UnitKind` type-namespace import joins
+`provider-workspace-crate-boundary`. This does not admit new snapshot values;
+it only prices closed boundaries more accurately. On `crates`,
+`provider-module-missing` moves `90 -> 11`, generic module/export target rows
+move `92 -> 13`, and the residual set including the re-export target-export tail
+moves `93 -> 14`. Successful imported snapshot records stay `1`; hard gates
+remain at `false_merges == 0` and `canon_preservation_violations == 0`. The
+checked-in measurement is
+[`issue-587-residual-boundary-split.v1.json`](../bench/recall_loss/issue-587-residual-boundary-split.v1.json).
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- split known external dependency imports out of `provider-module-missing` as `provider-external-crate-boundary`
- classify residual `std::cell` imports and `nose_il::UnitKind` type-namespace imports as existing stdlib/workspace closed boundaries
- refresh #587 residual artifacts/docs/changelog with current-tree before/after metrics

Refs #587.

## Quantified Change
- `provider-module-missing`: `90 -> 11`
- generic module/export target rows: `92 -> 13`
- residual rows including re-export target-export tail: `93 -> 14`
- new `provider-external-crate-boundary`: `76`
- `provider-rust-stdlib-boundary`: `48 -> 50`
- `provider-workspace-crate-boundary`: `47 -> 48`
- imported snapshot records stay `1`; false merges and canon-preservation violations stay `0`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nose-frontend module_imports --lib`
- `cargo test -p nose-frontend --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-boundaries-after.json`
- `python3 bench/prune_corpus.py --self-test`
- `./scripts/corpus-verify-nightly.sh --self-test`
- `python3 bench/semantic_pack/pricing.py --selftest && python3 bench/semantic_pack/pricing.py --check-artifacts`
- `python3 scripts/check-file-lengths.py --self-test && python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `python3 scripts/check-legacy-prelude.py --self-test && python3 scripts/check-legacy-prelude.py`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`
- `cargo build --release`
- `cargo test --release`
- `./scripts/check-duplication.sh`
- `jq empty bench/recall_loss/issue-587-residual-census.v1.json bench/recall_loss/issue-587-residual-boundary-split.v1.json`
- `awiki lint --root docs`
- `git diff --check`