### PR TITLE
Close relative super import resolution tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ break.
   `provider-module-missing` moves `90 -> 11`, generic module/export target rows
   move `92 -> 13`, imported snapshot records stay `1`, and hard gates remain at
   zero false merges and zero canon-preservation violations.
+- Added the #587 relative-super closeout. Rust provider lookup now treats
+  `super` and repeated `super` aliases as the parent module itself when an
+  import names a parent or grandparent module export directly. On `crates`,
+  `provider-module-missing` moves `11 -> 0`, generic module/export target rows
+  move `13 -> 2`, imported snapshot records stay `1`, and the moved rows close
+  as callable/type/re-export type boundaries with zero false merges and zero
+  canon-preservation violations.
 
 ### Fixed
 - Hardened JS/TS string-affix receiver proof so TypeScript `String` object

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -110,3 +110,7 @@ slice.
   records the #587 residual boundary split: external crate, residual stdlib, and
   residual workspace-crate imports are priced as explicit closed boundaries
   instead of generic provider-module misses.
+- [issue-587-relative-super-closeout.v1.json](issue-587-relative-super-closeout.v1.json)
+  records the #587 relative-super closeout: imports that name the parent module
+  itself now resolve to callable/type boundaries, moving
+  `provider-module-missing` `11 -> 0` without admitting new snapshots.

--- a/bench/recall_loss/issue-587-relative-super-closeout.v1.json
+++ b/bench/recall_loss/issue-587-relative-super-closeout.v1.json
@@ -1,0 +1,75 @@
+{
+  "schema": "nose.recall_loss.issue_587.relative_super_closeout.v1",
+  "issue": 587,
+  "slice": "relative super parent-module closeout",
+  "date": "2026-06-28",
+  "command": "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-relative-super-after.json",
+  "baseline_artifact": "bench/recall_loss/issue-587-residual-boundary-split.v1.json",
+  "goal": "Resolve the remaining relative-super Rust provider-module misses by matching imports that name the parent or grandparent module itself.",
+  "hard_gates": {
+    "false_merges": 0,
+    "canon_preservation_violations": 0,
+    "completeness": "39/83"
+  },
+  "before": {
+    "source": "target/recall-loss.issue-587-relative-super-before.json",
+    "snapshot_records": 1,
+    "unresolved_binding_imports": 388,
+    "generic_module_export_target_rows": 13,
+    "residual_rows_including_reexport_target": 14,
+    "misses_by_reason": {
+      "provider-module-missing": 11,
+      "provider-export-missing": 2,
+      "provider-reexport-target-export-missing": 1,
+      "provider-callable-export-boundary": 107,
+      "provider-type-export-boundary": 62,
+      "provider-reexport-type-boundary": 4
+    }
+  },
+  "after": {
+    "source": "target/recall-loss.issue-587-relative-super-after.json",
+    "snapshot_records": 1,
+    "unresolved_binding_imports": 388,
+    "generic_module_export_target_rows": 2,
+    "residual_rows_including_reexport_target": 3,
+    "misses_by_reason": {
+      "provider-module-missing": 0,
+      "provider-export-missing": 2,
+      "provider-reexport-target-export-missing": 1,
+      "provider-callable-export-boundary": 110,
+      "provider-type-export-boundary": 69,
+      "provider-reexport-type-boundary": 5
+    }
+  },
+  "deltas": {
+    "snapshot_records": 0,
+    "provider-module-missing": -11,
+    "generic_module_export_target_rows": -11,
+    "residual_rows_including_reexport_target": -11,
+    "provider-callable-export-boundary": 3,
+    "provider-type-export-boundary": 7,
+    "provider-reexport-type-boundary": 1
+  },
+  "implemented_capabilities": [
+    "Rust importer-relative provider lookup now treats super and repeated super aliases as the parent module itself when the provider module is exactly that ancestor.",
+    "Imports such as use super::Item and use super::super::Item now find same-crate parent or grandparent module providers.",
+    "Literal-safe parent-module exports can be snapshotted through those aliases; the current crates corpus has no new literal snapshot records in this slice.",
+    "Non-value parent-module exports now close under callable, type, or re-export type boundary reasons instead of generic provider-module-missing."
+  ],
+  "remaining_same_repo_tail": {
+    "provider-module-missing": 0,
+    "provider-export-missing": 2,
+    "provider-reexport-target-export-missing": 1,
+    "representatives": [
+      "crates/nose-il/src/unit.rs:2 use crate::node::NodeId;",
+      "crates/nose-semantics/src/library_api/imported_occurrences.rs:2 use crate::evidence::span_contains;",
+      "crates/nose-semantics/src/packs/tests/descriptor_enumeration/group_2.rs:2 use crate::PYTHON_STDLIB_TYPE_DOMAIN_PRODUCER_ID;"
+    ]
+  },
+  "validation": [
+    "cargo fmt --all -- --check",
+    "cargo test -p nose-frontend module_imports --lib",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-relative-super-after.json",
+    "python3 scripts/recall-loss-diff.py target/recall-loss.issue-587-relative-super-before.json target/recall-loss.issue-587-relative-super-after.json"
+  ]
+}

--- a/crates/nose-frontend/src/module_imports/modules.rs
+++ b/crates/nose-frontend/src/module_imports/modules.rs
@@ -82,9 +82,6 @@ pub(super) fn rust_importable_module_hashes(
         let Some(remaining) = provider.parts.strip_prefix(base) else {
             continue;
         };
-        if remaining.is_empty() {
-            continue;
-        }
         let mut alias_parts = vec!["super"; levels_up];
         let remaining = remaining.iter().map(String::as_str);
         alias_parts.extend(remaining);

--- a/crates/nose-frontend/src/module_imports/tests/rust_module_resolution.rs
+++ b/crates/nose-frontend/src/module_imports/tests/rust_module_resolution.rs
@@ -5,102 +5,62 @@ use nose_il::{Corpus, FileId, Interner, Lang, NodeKind};
 
 #[test]
 fn rust_crate_import_resolves_mod_rs_literal_export() {
-    let interner = Interner::new();
-    let provider = lower_rust_file(
-        FileId(0),
+    assert_rust_literal_import_snapshot(
         "crates/demo/src/constants/mod.rs",
         "pub(crate) const LIMIT: i64 = 7;\n",
-        &interner,
-    );
-    let importer = lower_rust_file(
-        FileId(1),
         "crates/demo/src/consumer.rs",
         "use crate::constants::LIMIT;\nfn read() -> i64 { LIMIT }\n",
-        &interner,
+        "LIMIT",
+        NodeKind::Lit,
     );
-
-    let mut files = vec![provider, importer];
-    resolve_imported_immutable_bindings(&mut files, &interner);
-
-    assert_eq!(snapshot_count(&files[1]), 1);
-    let rhs = imported_binding_rhs(&files[1], &interner, "LIMIT");
-    assert_eq!(files[1].kind(rhs), NodeKind::Lit);
-    assert_eq!(files[1].node(rhs).span.file, FileId(0));
 }
 
 #[test]
 fn rust_super_import_resolves_parent_relative_literal_export() {
-    let interner = Interner::new();
-    let provider = lower_rust_file(
-        FileId(0),
+    assert_rust_literal_import_snapshot(
         "crates/demo/src/parent/constants.rs",
         "pub(crate) const LIMIT: i64 = 7;\n",
-        &interner,
-    );
-    let importer = lower_rust_file(
-        FileId(1),
         "crates/demo/src/parent/child.rs",
         "use super::constants::LIMIT;\nfn read() -> i64 { LIMIT }\n",
-        &interner,
+        "LIMIT",
+        NodeKind::Lit,
     );
+}
 
-    let mut files = vec![provider, importer];
-    resolve_imported_immutable_bindings(&mut files, &interner);
-
-    assert_eq!(snapshot_count(&files[1]), 1);
-    let rhs = imported_binding_rhs(&files[1], &interner, "LIMIT");
-    assert_eq!(files[1].kind(rhs), NodeKind::Lit);
-    assert_eq!(files[1].node(rhs).span.file, FileId(0));
+#[test]
+fn rust_super_import_resolves_parent_module_literal_export() {
+    assert_rust_literal_import_snapshot(
+        "crates/demo/src/units.rs",
+        "pub(crate) const LIMIT: i64 = 7;\n",
+        "crates/demo/src/units/features.rs",
+        "use super::LIMIT;\nfn read() -> i64 { LIMIT }\n",
+        "LIMIT",
+        NodeKind::Lit,
+    );
 }
 
 #[test]
 fn rust_bare_child_import_resolves_nested_module_literal_export() {
-    let interner = Interner::new();
-    let provider = lower_rust_file(
-        FileId(0),
+    assert_rust_literal_import_snapshot(
         "crates/demo/src/units/fragments/context.rs",
         "pub(crate) const LIMIT: i64 = 7;\n",
-        &interner,
-    );
-    let importer = lower_rust_file(
-        FileId(1),
         "crates/demo/src/units/fragments.rs",
         "use context::LIMIT;\nfn read() -> i64 { LIMIT }\n",
-        &interner,
+        "LIMIT",
+        NodeKind::Lit,
     );
-
-    let mut files = vec![provider, importer];
-    resolve_imported_immutable_bindings(&mut files, &interner);
-
-    assert_eq!(snapshot_count(&files[1]), 1);
-    let rhs = imported_binding_rhs(&files[1], &interner, "LIMIT");
-    assert_eq!(files[1].kind(rhs), NodeKind::Lit);
-    assert_eq!(files[1].node(rhs).span.file, FileId(0));
 }
 
 #[test]
 fn rust_bare_sibling_import_resolves_literal_export_without_src_root() {
-    let interner = Interner::new();
-    let provider = lower_rust_file(
-        FileId(0),
+    assert_rust_literal_import_snapshot(
         "fixtures/demo/rust_values.rs",
         "pub const VALUES: [&str; 2] = [\"red\", \"blue\"];\n",
-        &interner,
-    );
-    let importer = lower_rust_file(
-        FileId(1),
         "fixtures/demo/rust_imported_membership.rs",
         "use rust_values::VALUES;\n\npub fn membership(value: &str) -> bool {\n    VALUES.contains(&value)\n}\n",
-        &interner,
+        "VALUES",
+        NodeKind::Seq,
     );
-
-    let mut files = vec![provider, importer];
-    resolve_imported_immutable_bindings(&mut files, &interner);
-
-    assert_eq!(snapshot_count(&files[1]), 1);
-    let rhs = imported_binding_rhs(&files[1], &interner, "VALUES");
-    assert_eq!(files[1].kind(rhs), NodeKind::Seq);
-    assert_eq!(files[1].node(rhs).span.file, FileId(0));
 }
 
 #[test]
@@ -227,6 +187,43 @@ fn rust_reexport_to_callable_stays_non_value_boundary() {
 }
 
 #[test]
+fn rust_census_resolves_parent_module_relative_non_value_boundaries() {
+    let interner = Interner::new();
+    let files = vec![
+        lower_rust_file(
+            FileId(0),
+            "crates/demo/src/units.rs",
+            "pub(crate) struct UnitExtractCtx;\npub(crate) fn lower() {}\n",
+            &interner,
+        ),
+        lower_rust_file(
+            FileId(1),
+            "crates/demo/src/units/features.rs",
+            "use super::UnitExtractCtx;\nuse super::lower;\nfn f() {}\n",
+            &interner,
+        ),
+        lower_rust_file(
+            FileId(2),
+            "crates/demo/src/report.rs",
+            "pub(crate) struct RefactorFamily;\n",
+            &interner,
+        ),
+        lower_rust_file(
+            FileId(3),
+            "crates/demo/src/report/tests/support.rs",
+            "use super::super::RefactorFamily;\nfn f() {}\n",
+            &interner,
+        ),
+    ];
+    let corpus = Corpus::new(interner, files);
+    let census = imported_immutable_snapshot_census(&corpus);
+
+    assert_reason_count(&census, "provider-callable-export-boundary", 1);
+    assert_reason_count(&census, "provider-module-missing", 0);
+    assert_reason_count(&census, "provider-type-export-boundary", 2);
+}
+
+#[test]
 fn rust_census_splits_non_value_and_unsupported_provider_boundaries() {
     let interner = Interner::new();
     let files = vec![
@@ -294,6 +291,27 @@ fn f() {}\n",
 fn lower_rust_file(file: FileId, path: &str, src: &str, interner: &Interner) -> nose_il::Il {
     crate::lower_source(file, path, src.as_bytes(), Lang::Rust, interner)
         .expect("lower Rust test file")
+}
+
+fn assert_rust_literal_import_snapshot(
+    provider_path: &str,
+    provider_src: &str,
+    importer_path: &str,
+    importer_src: &str,
+    local: &str,
+    expected_kind: NodeKind,
+) {
+    let interner = Interner::new();
+    let provider = lower_rust_file(FileId(0), provider_path, provider_src, &interner);
+    let importer = lower_rust_file(FileId(1), importer_path, importer_src, &interner);
+
+    let mut files = vec![provider, importer];
+    resolve_imported_immutable_bindings(&mut files, &interner);
+
+    assert_eq!(snapshot_count(&files[1]), 1);
+    let rhs = imported_binding_rhs(&files[1], &interner, local);
+    assert_eq!(files[1].kind(rhs), expected_kind);
+    assert_eq!(files[1].node(rhs).span.file, FileId(0));
 }
 
 fn imported_binding_rhs(il: &nose_il::Il, interner: &Interner, name: &str) -> nose_il::NodeId {

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -339,6 +339,22 @@ remain at `false_merges == 0` and `canon_preservation_violations == 0`. The
 checked-in measurement is
 [`issue-587-residual-boundary-split.v1.json`](../bench/recall_loss/issue-587-residual-boundary-split.v1.json).
 
+The #587 relative-`super` closeout handles the last generic Rust
+`provider-module-missing` rows. Importer-relative provider lookup already knew
+how to build aliases such as `super::child`; the missing case was when the
+import names the parent module itself, such as `use super::Item` or
+`use super::super::Item`. That alias now resolves to the same-crate parent or
+grandparent module provider. On `crates`, `provider-module-missing` moves
+`11 -> 0`, generic module/export target rows move `13 -> 2`, and the residual
+set including the re-export target-export tail moves `14 -> 3`. The moved rows
+remain closed as non-value boundaries (`provider-callable-export-boundary`,
+`provider-type-export-boundary`, or `provider-reexport-type-boundary`) rather
+than becoming snapshot values; successful imported snapshot records stay `1`,
+with `false_merges == 0` and `canon_preservation_violations == 0`. The remaining
+tail is export-only (`2` local export misses and `1` re-export target export
+miss), so #587's module-missing work is complete. The checked-in measurement is
+[`issue-587-relative-super-closeout.v1.json`](../bench/recall_loss/issue-587-relative-super-closeout.v1.json).
+
 ## See Also
 
 - [recall-loss-diagnostics](recall-loss-diagnostics.md)


### PR DESCRIPTION
## Summary

Close the remaining #587 relative-super provider-module-missing tail. Rust importer-relative provider lookup now keeps `super` / repeated `super` aliases when the provider module is exactly the parent or grandparent module, so imports like `use super::Item` and `use super::super::Item` can find same-crate providers.

This does not widen package semantics or raw coordinate admission. In the current crates corpus the moved rows are non-value exports, so they close as callable/type/re-export type boundaries rather than becoming imported literal snapshots.

## Quantified effect

From `target/recall-loss.issue-587-relative-super-before.json` to `target/recall-loss.issue-587-relative-super-after.json`:

- `provider-module-missing`: 11 -> 0
- generic module/export target rows: 13 -> 2
- residual rows including re-export target-export tail: 14 -> 3
- `provider-callable-export-boundary`: 107 -> 110
- `provider-type-export-boundary`: 62 -> 69
- `provider-reexport-type-boundary`: 4 -> 5
- `ImportedLiteralSnapshot` records: 1 -> 1
- false merges: 0 -> 0
- canon preservation violations: 0 -> 0
- completeness: 39/83 -> 39/83

Checked in: `bench/recall_loss/issue-587-relative-super-closeout.v1.json`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nose-frontend module_imports --lib`
- `cargo test -p nose-frontend --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-587-relative-super-after.json`
- `python3 scripts/recall-loss-diff.py target/recall-loss.issue-587-relative-super-before.json target/recall-loss.issue-587-relative-super-after.json`
- `jq empty bench/recall_loss/issue-587-relative-super-closeout.v1.json`
- `awiki lint --root docs`
- `python3 scripts/check-file-lengths.py --self-test && python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `./scripts/check-duplication.sh`
- `git diff --check`