### PR TITLE
Expand non-JS async imported binding proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,14 @@ break.
   `use tokio::join; join!(...)`, and `use futures::select; select!(...)` now
   receive the same reporting-only task/timer/aggregate obligations when their
   import identity is proven. Exact admission remains closed.
+- Expanded the same proof path to Python `from asyncio import ...` bindings
+  and Rust brace imports such as `use tokio::{spawn}` or
+  `use futures::{select as fut_select}`. The slice reuses existing
+  `ImportedBinding` evidence, keeps nested Python imports and local
+  shadow/module cases plus Rust block-scoped and other-module imports closed
+  at the imported-occurrence producer, adds `2` newly priced Python imported `sleep`
+  occurrences in the pinned 120-repo corpus, and keeps the release
+  `verify crates` gate at `0` false merges.
 - Refined import-snapshot census reporting to separate missing provider modules,
   missing exports, re-export boundaries, external/stdlib/workspace boundaries,
   provider/importer mutation, missing provider API proof, and aggregate shapes

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -396,6 +396,22 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   `join!`/`try_join!` (`8` / `1` repo). Python `asyncio` alias and Rust
   imported `select!` support are exercised by fixtures but have `0` occurrences
   in the pinned corpus.
+- [non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json](non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json)
+  records the next reporting-only imported-binding expansion. Python
+  `from asyncio import create_task`/`sleep`/`gather`/`wait` bindings and Rust
+  brace imports such as `use tokio::{spawn}` or
+  `use futures::{select as fut_select}` now reuse existing `ImportedBinding`
+  proof before receiving shared task/timer/aggregate obligations. Imported
+  occurrence evidence is scoped at the producer, so Rust block-scoped or
+  parent-module `use` bindings do not prove out-of-scope unqualified calls.
+  Exact admission stays closed.
+- [scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json)
+  records the matching 120-repo source-prevalence pricing. It raises total
+  source prevalence from `142,845` to `142,847` by adding `2` Python
+  `from asyncio import sleep` occurrences in `1` repo. Rust imported rows remain
+  `11` priced occurrences because the prior audit already counted direct and
+  brace `use` spellings; this slice makes brace evidence-only imports
+  actionable in admission.
 - [promise-protocol-hard-negatives-2026-06-28.v1.json](promise-protocol-hard-negatives-2026-06-28.v1.json)
   records the follow-up Promise hard-negative slice. It keeps exact admission
   closed while pinning async-function/sync, Promise executor/sync,

--- a/bench/recall_loss/non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json
+++ b/bench/recall_loss/non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json
@@ -1,0 +1,146 @@
+{
+  "report_kind": "non-js-async-runtime-imported-binding-proof",
+  "schema_version": 1,
+  "generated_on": "2026-06-30",
+  "scope": {
+    "kind": "reporting-only-imported-binding-proof-expansion",
+    "summary": "Non-JS async runtime obligation attribution now consumes Python asyncio imported bindings and Rust brace-use evidence-only imported bindings before attaching shared task and async aggregate obligation labels.",
+    "semantic_admission_delta": 0,
+    "exact_admission_opened": false
+  },
+  "capability_alignment": {
+    "principle": "Capabilities over features",
+    "capability": "compose existing ImportedBinding proof with shared async runtime obligations",
+      "not_a_feature_list": [
+        "No new SourceProtocolKind, SourceCallKind, semantic-pack row, or public kernel API was added.",
+        "No exact admission path was opened for Python or Rust async runtime APIs.",
+        "Python from-import support requires import-backed asyncio binding proof plus local module and same-file shadow guards.",
+        "Rust brace-use support requires builtin ImportedBinding evidence in the same module scope, local runtime-root guards, and macro-invocation evidence for join/select aggregates.",
+        "Nested Python function-local imports stay closed until scope proof is available."
+      ],
+    "reused_capabilities": [
+      "Python ImportedBinding symbol evidence",
+      "Rust ImportedBinding symbol evidence, including evidence-only brace-use imports",
+      "AdmissionContext local Python module and Rust runtime-root guards",
+      "Rust SourceCallKind::MacroInvocation evidence",
+      "shared task, timer, and async aggregate missing-evidence labels",
+      "recall-loss oracle_exclusions.by_obligation"
+    ]
+  },
+  "new_reporting_surfaces": [
+    {
+      "language": "python",
+      "surface": "from asyncio import create_task/ensure_future/sleep/gather/wait [as local]; local(...)",
+      "guard": "The callee must resolve to an import-backed asyncio binding, with no path-visible local asyncio module and no same-file parameter or assignment shadow for that binding.",
+      "blocked_false_open_examples": [
+        "from asyncio import gather as all_done; async def main(all_done, task): return await all_done(task)",
+        "from asyncio import sleep as delay; async def main(): delay = local_sleep; return await delay(1)",
+        "async def helper(): from asyncio import sleep as delay; async def main(): return await delay(1)",
+        "asyncio.py plus from asyncio import create_task as spawn_task in a path-visible sibling or child module"
+      ]
+    },
+    {
+      "language": "rust",
+      "surface": "use runtime::{spawn/join/select [as local]}; local(...) or local!(...)",
+      "guard": "The callee must have builtin ImportedBinding evidence for the runtime module/export in the same module scope, the binding must not be block-scoped, the runtime root must not be locally defined in the same file, and join/select aggregates must be macro invocations.",
+      "blocked_false_open_examples": [
+        "mod tokio { ... } use tokio::{spawn}; spawn(work())",
+        "use tokio::{spawn}; fn run<F>(spawn: F) { spawn(work()) }",
+        "use tokio::{spawn}; let spawn = local; spawn(work())",
+        "use tokio::{join}; macro_rules! join { ... } join!(a, b)",
+        "fn helper() { use tokio::{spawn}; } fn run() { spawn(work()) }",
+        "fn run() { spawn(work()) } mod helper { use tokio::{spawn}; fn helper() { spawn(work()) } }",
+        "const INIT: () = { use tokio::{spawn}; }; fn run() { spawn(work()) }"
+      ]
+    }
+  ],
+  "focused_fixture": {
+    "test": "non_js_async_runtime_imported_bindings_report_shared_obligations",
+    "command": "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime -- --nocapture",
+    "assertions": [
+      "from asyncio import create_task as spawn_task; spawn_task(...) reports task spawn, handle lifecycle, and cancellation/liveness obligations",
+      "from asyncio import sleep as delay; delay(...) reports timer scheduling obligations",
+      "from asyncio import gather as all_done; all_done(...) reports all-completion aggregate obligations",
+      "from asyncio import wait; wait(...) reports completion, cancellation/liveness, and result-channel obligations",
+      "use tokio::{spawn}; spawn(...) reports task spawn, handle lifecycle, and cancellation/liveness obligations",
+      "use tokio::{join as tokio_join}; tokio_join!(...) reports all-completion aggregate obligations",
+      "use futures::{select as fut_select}; fut_select!(...) reports first-completion, cancellation/liveness, and result-channel obligations"
+    ]
+  },
+  "focused_hard_negative_fixtures": [
+    {
+      "test": "non_js_async_runtime_imported_bindings_reject_local_shadows",
+      "assertions": [
+        "Python imported asyncio bindings shadowed by parameters or assignments do not report runtime obligations",
+        "Python asyncio bindings imported only in another local scope do not report runtime obligations"
+      ]
+    },
+    {
+      "test": "non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes",
+      "assertions": [
+        "Rust brace-imported runtime names shadowed by parameters, let bindings, or local macros do not report runtime obligations",
+        "Rust direct or brace runtime imports in another function, block, or module do not report runtime obligations outside that scope"
+      ]
+    },
+    {
+      "test": "non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "assertions": [
+        "path-visible local asyncio.py blocks from-import backed asyncio task reporting",
+        "same-file local mod tokio blocks brace-imported spawn reporting"
+      ]
+    }
+  ],
+  "current_crates_gate": {
+    "report": "target/recall-loss.non-js-async-runtime-imported-binding-proof.crates.json",
+    "total_units": 6693,
+    "interpretable_units": 920,
+    "excluded_units": 5773,
+    "admission_rejections": 768,
+    "false_merges": 0,
+    "lossy_fingerprint_collisions": 0,
+    "advisory_disagreements": 4,
+    "canon_checked": 87,
+    "canon_preservation_violations": 0,
+    "gate_passed": true
+  },
+  "corpus_pricing_delta": {
+    "source": "bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json",
+    "previous_source": "bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-import-proof-2026-06-30.v1.json",
+    "total_source_prevalence_before": 142845,
+    "total_source_prevalence_after": 142847,
+    "newly_priced_occurrences": 2,
+    "python_asyncio_imported_task_occurrences": 0,
+    "python_asyncio_imported_sleep_occurrences": 2,
+    "python_asyncio_imported_gather_occurrences": 0,
+    "python_asyncio_imported_wait_occurrences": 0,
+    "rust_imported_spawn_occurrences": 3,
+    "rust_imported_join_try_join_occurrences": 8,
+    "rust_imported_select_occurrences": 0,
+    "reason": "The pricing script now counts Python asyncio from-import bindings in addition to the prior alias/import rows. The pinned 120-repo corpus contributes 2 new Python imported sleep occurrences. Rust brace-use imports were already priced by the imported Rust rows; this slice makes their evidence-only bindings actionable in admission."
+  },
+  "validation_commands": [
+    "cargo fmt",
+    "cargo test -p nose-normalize call_target_evidence::tests::imported -- --nocapture",
+    "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime -- --nocapture",
+    "cargo run -q -p nose-cli -- verify /tmp/nose-rust-block-import.XXXXXX --recall-loss-report target/recall-loss.rust-block-import-repro.json # verified task-spawn-scheduling-contract count = 0 for const-block use repro",
+    "python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --generated-on 2026-06-30 --output bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.non-js-async-runtime-imported-binding-proof.crates.json",
+    "./scripts/check-duplication.sh",
+    "./scripts/check-ci-local.sh --fast"
+  ],
+  "local_gate_commands": [
+    "cargo build --release",
+    "/usr/bin/time -p ./target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.non-js-async-runtime-imported-binding-proof.release7.crates.json"
+  ],
+  "release_verify_timing": {
+    "command": "/usr/bin/time -p ./target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.non-js-async-runtime-imported-binding-proof.release7.crates.json",
+    "real_seconds": 0.96,
+    "user_seconds": 5.62,
+    "sys_seconds": 0.06
+  },
+  "next_exact_work_policy": {
+    "status": "closed_until_evidence",
+    "summary": "The reporter can now attribute more imported runtime API spellings, but exact recovery still requires dependency-closed scheduling, cancellation, lifecycle, aggregate result-channel, exception, and callback/effect contracts."
+  }
+}

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json
@@ -1,0 +1,3123 @@
+{
+  "current_recall_loss": null,
+  "generated_on": "2026-06-30",
+  "hard_negative_inventory": [
+    {
+      "class": "thenable assimilation and custom Promise-like receivers",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "first-settled versus all-settled aggregate semantics",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "executor callback timing and thrown executor errors",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::promise_constructor_missing_evidence_splits_executor_obligations",
+      "status": "reporting-only-this-slice"
+    },
+    {
+      "class": "scheduler/microtask ordering versus synchronous evaluation",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::scheduler_and_interval_calls_report_timing_and_lifecycle_obligations",
+      "status": "reporting-only-this-slice"
+    },
+    {
+      "class": "interval stream liveness/cardinality",
+      "evidence": "crates/nose-cli/tests/cli/commands/recall_loss_report.rs::recall_loss_report_splits_promise_protocol_boundaries",
+      "status": "reporting-only-this-slice"
+    },
+    {
+      "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
+      "evidence": "docs/scheduling-channel-callback-obligations-594.md",
+      "status": "mapped-doc-policy"
+    },
+    {
+      "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "expanded-this-slice"
+    }
+  ],
+  "policy": {
+    "note": "Counts price boundary surfaces; they do not prove exact semantics.",
+    "raw_source_snippets_included": false,
+    "semantic_admission_delta": 0,
+    "source_prevalence_only": true
+  },
+  "recommended_order": [
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "rank": 1,
+      "repos": 17,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "rank": 2,
+      "repos": 8,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "rank": 3,
+      "repos": 18,
+      "why": "new Promise is high-risk because timing, resolve/reject callback, and throw-to-rejection behavior interact."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "rank": 4,
+      "repos": 7,
+      "why": "Cancellation appears across JS/TS scheduling APIs and must stay separate from fulfillment/rejection recovery."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "rank": 5,
+      "repos": 11,
+      "why": "Repeated emission/liveness needs lifecycle proof before interval streams can be compared exactly."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "rank": 6,
+      "repos": 14,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "rust",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "rank": 7,
+      "repos": 3,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "swift",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 210,
+      "operation": "Task",
+      "rank": 8,
+      "repos": 12,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "python",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "rank": 9,
+      "repos": 3,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "rust",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "rank": 10,
+      "repos": 1,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    }
+  ],
+  "regenerate": [
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --output bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json --generated-on 2026-06-30"
+  ],
+  "report_kind": "scheduling-lifecycle-boundary-audit",
+  "schema_version": 1,
+  "summary": {
+    "languages": {
+      "c": 81,
+      "go": 27808,
+      "java": 5599,
+      "javascript-typescript": 45382,
+      "python": 6405,
+      "ruby": 4884,
+      "rust": 13228,
+      "swift": 39460
+    },
+    "obligation_families": {
+      "callback-demand-effect": 801,
+      "cancellation-liveness-boundary": 297,
+      "channel-boundary": 8338,
+      "exception-channel": 30631,
+      "executor-callback": 795,
+      "lifecycle-materialization-boundary": 22469,
+      "scheduling-boundary": 78698,
+      "success-error-result-channel": 818
+    },
+    "repos_in_manifest": 120,
+    "total_source_prevalence": 142847
+  },
+  "surfaces": [
+    {
+      "boundary": "await scheduling",
+      "language": "javascript-typescript",
+      "note": "await is scheduling and thenable assimilation, not sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 29305,
+      "operation": "await",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.await",
+      "top_files": [
+        {
+          "occurrences": 1058,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 689,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 673,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 635,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 615,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 615,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 487,
+          "path": "drizzle-orm/integration-tests/tests/sqlite/sqlite-common.ts"
+        },
+        {
+          "occurrences": 484,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12136,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3321,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 2666,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2413,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1604,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 1592,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 1171,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 1164,
+          "repo": "swr"
+        }
+      ]
+    },
+    {
+      "boundary": "throws channel",
+      "language": "swift",
+      "note": "Swift throws/try is an explicit error channel",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "swift-throws-exception-channel-contract-missing",
+      "occurrences": 26608,
+      "operation": "throws/try",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "swift.error.throws",
+      "top_files": [
+        {
+          "occurrences": 664,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 489,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 450,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 406,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 396,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 364,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 344,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 304,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14760,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2508,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1466,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 1356,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 1107,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 914,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 805,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "defer lifecycle",
+      "language": "go",
+      "note": "defer has scope-exit ordering and panic interaction semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "defer-lifecycle-ordering-contract-missing",
+      "occurrences": 17521,
+      "operation": "defer statement",
+      "repos": 16,
+      "status": "closed-boundary",
+      "surface": "go.concurrent.defer",
+      "top_files": [
+        {
+          "occurrences": 1001,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 560,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 494,
+          "path": "nats-server/server/jetstream_consumer_test.go"
+        },
+        {
+          "occurrences": 461,
+          "path": "nats-server/server/filestore_test.go"
+        },
+        {
+          "occurrences": 420,
+          "path": "nats-server/server/mqtt_test.go"
+        },
+        {
+          "occurrences": 396,
+          "path": "nats-server/server/jetstream_cluster_3_test.go"
+        },
+        {
+          "occurrences": 394,
+          "path": "nats-server/server/jetstream_cluster_1_test.go"
+        },
+        {
+          "occurrences": 379,
+          "path": "nats-server/server/gateway_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10073,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 2461,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1797,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 1151,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 581,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 449,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 422,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 161,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "javascript-typescript",
+      "note": "async functions have scheduling and rejection boundaries even without explicit await",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 14491,
+      "operation": "async function",
+      "repos": 22,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.function",
+      "top_files": [
+        {
+          "occurrences": 352,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 314,
+          "path": "ky/test/hooks.ts"
+        },
+        {
+          "occurrences": 278,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 278,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 210,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 207,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 198,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 192,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4595,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 1621,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1607,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 1079,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 883,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 814,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 688,
+          "repo": "axios"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "swift",
+      "note": "Swift await has task scheduling and actor/lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8689,
+      "operation": "await",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "swift.async.await",
+      "top_files": [
+        {
+          "occurrences": 612,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 556,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 263,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 257,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 251,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 221,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 153,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 150,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3169,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2261,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 969,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 944,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 724,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 155,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 139,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 96,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "future await",
+      "language": "rust",
+      "note": "Rust .await polls a Future and must keep wake/scheduling effects explicit",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8647,
+      "operation": ".await",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.await",
+      "top_files": [
+        {
+          "occurrences": 545,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/proxy.rs"
+        },
+        {
+          "occurrences": 255,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 227,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 221,
+          "path": "meilisearch/crates/meilisearch/tests/dumps/mod.rs"
+        },
+        {
+          "occurrences": 193,
+          "path": "meilisearch/crates/meilisearch/tests/search/mod.rs"
+        },
+        {
+          "occurrences": 147,
+          "path": "meilisearch/crates/meilisearch/tests/tasks/mod.rs"
+        },
+        {
+          "occurrences": 141,
+          "path": "meilisearch/crates/meilisearch/tests/batches/mod.rs"
+        },
+        {
+          "occurrences": 138,
+          "path": "meilisearch/crates/meilisearch/tests/documents/get_documents.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5632,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 2942,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 39,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 34,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "channel protocol",
+      "language": "go",
+      "note": "channel send/receive has blocking and synchronization semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-receive-protocol-contract-missing",
+      "occurrences": 6418,
+      "operation": "channel send/receive",
+      "repos": 13,
+      "status": "closed-boundary",
+      "surface": "go.channel.send_receive",
+      "top_files": [
+        {
+          "occurrences": 155,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 119,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 111,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 89,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "delve/service/test/integration2_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 83,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 82,
+          "path": "nats-server/server/filestore.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2038,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1998,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 998,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 805,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 230,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 125,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 93,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 34,
+          "repo": "fzf"
+        }
+      ]
+    },
+    {
+      "boundary": "exception channel",
+      "language": "ruby",
+      "note": "raise/rescue changes error channels and non-local control",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 4010,
+      "operation": "raise/rescue",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "ruby.exception",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 71,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 67,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 53,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 50,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1334,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 699,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 343,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 264,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 226,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 155,
+          "repo": "sinatra"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "swift",
+      "note": "Swift async surfaces create task/future-like protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 3953,
+      "operation": "async",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "swift.async.function",
+      "top_files": [
+        {
+          "occurrences": 134,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 71,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 62,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 54,
+          "path": "vapor/Tests/VaporMacroTests/HTTPMethodMacroTests.swift"
+        },
+        {
+          "occurrences": 53,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 50,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 47,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1379,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 680,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 670,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 334,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 226,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 179,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 131,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 115,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "executor scheduling",
+      "language": "java",
+      "note": "Executor/Future APIs introduce scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "java-executor-scheduling-contract-missing",
+      "occurrences": 3297,
+      "operation": "Executor/Future",
+      "repos": 16,
+      "status": "closed-boundary",
+      "surface": "java.future.executor",
+      "top_files": [
+        {
+          "occurrences": 59,
+          "path": "netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 33,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1338,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 1173,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 343,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 107,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 86,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 84,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 57,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 44,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "rust",
+      "note": "async fn creates a suspended async function boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2806,
+      "operation": "async fn",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 67,
+          "path": "meilisearch/crates/meilisearch/tests/common/index.rs"
+        },
+        {
+          "occurrences": 60,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 56,
+          "path": "meilisearch/crates/meilisearch/tests/common/server.rs"
+        },
+        {
+          "occurrences": 49,
+          "path": "meilisearch/crates/meilisearch/tests/search/errors.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 37,
+          "path": "meilisearch/crates/meilisearch/tests/auth/api_keys.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1405,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 1352,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 28,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 21,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "generator lifecycle",
+      "language": "python",
+      "note": "yield has suspension and iterator lifecycle semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "generator-yield-lifecycle-contract-missing",
+      "occurrences": 2404,
+      "operation": "yield",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "python.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 86,
+          "path": "sympy/sympy/utilities/iterables.py"
+        },
+        {
+          "occurrences": 83,
+          "path": "black/src/black/linegen.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "scrapy/tests/test_crawl.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sympy/sympy/core/facts.py"
+        },
+        {
+          "occurrences": 39,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 37,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 31,
+          "path": "packaging/src/packaging/tags.py"
+        },
+        {
+          "occurrences": 29,
+          "path": "rich/rich/segment.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 540,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 446,
+          "repo": "sympy"
+        },
+        {
+          "occurrences": 367,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 339,
+          "repo": "rich"
+        },
+        {
+          "occurrences": 172,
+          "repo": "black"
+        },
+        {
+          "occurrences": 139,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 76,
+          "repo": "poetry"
+        },
+        {
+          "occurrences": 64,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Java streams need lazy/eager lifecycle and terminal materialization proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 1996,
+      "operation": "stream/parallelStream",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "java.stream.lifecycle",
+      "top_files": [
+        {
+          "occurrences": 137,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/GeoPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 124,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java"
+        },
+        {
+          "occurrences": 80,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGeospatialCommandsTest.java"
+        },
+        {
+          "occurrences": 75,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 60,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "netty/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java"
+        },
+        {
+          "occurrences": 24,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 535,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 508,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 385,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 280,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 102,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 88,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 29,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 24,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "goroutine scheduling",
+      "language": "go",
+      "note": "go statements spawn concurrent execution",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "repos": 14,
+      "status": "closed-boundary",
+      "surface": "go.concurrent.goroutine",
+      "top_files": [
+        {
+          "occurrences": 52,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "prometheus/discovery/kubernetes/kubernetes.go"
+        },
+        {
+          "occurrences": 23,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 22,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 20,
+          "path": "nats-server/server/jwt_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 501,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 439,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 364,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 253,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 126,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 91,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 60,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 36,
+          "repo": "hugo"
+        }
+      ]
+    },
+    {
+      "boundary": "channel select",
+      "language": "go",
+      "note": "select has readiness, default, and scheduling semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-protocol-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "repos": 13,
+      "status": "closed-boundary",
+      "surface": "go.channel.select",
+      "top_files": [
+        {
+          "occurrences": 62,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 58,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 45,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 33,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 31,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "nats-server/server/routes_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "prometheus/scrape/scrape_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 706,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 574,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 279,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 250,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 47,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 25,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 21,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "python",
+      "note": "Python await has coroutine scheduling and exception channel semantics",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 1789,
+      "operation": "await",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "python.async.await",
+      "top_files": [
+        {
+          "occurrences": 145,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 122,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 78,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 72,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 62,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 54,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 50,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 716,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 661,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 200,
+          "repo": "black"
+        },
+        {
+          "occurrences": 196,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 5,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "python",
+      "note": "async def creates coroutine protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 1596,
+      "operation": "async def",
+      "repos": 9,
+      "status": "closed-boundary",
+      "surface": "python.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 75,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 57,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/result.py"
+        },
+        {
+          "occurrences": 53,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "scrapy/tests/test_spidermiddleware.py"
+        },
+        {
+          "occurrences": 40,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 790,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 424,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 209,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 144,
+          "repo": "black"
+        },
+        {
+          "occurrences": 19,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 3,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async block construction",
+      "language": "rust",
+      "note": "async blocks create suspended async boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-block-scheduling-contract-missing",
+      "occurrences": 1342,
+      "operation": "async block",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.block",
+      "top_files": [
+        {
+          "occurrences": 109,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 86,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 57,
+          "path": "tokio/tokio/tests/task_local_set.rs"
+        },
+        {
+          "occurrences": 43,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 42,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio-util/tests/task_join_map.rs"
+        },
+        {
+          "occurrences": 33,
+          "path": "tokio/tokio/tests/rt_basic.rs"
+        },
+        {
+          "occurrences": 31,
+          "path": "tokio/tokio/tests/task_join_set.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1273,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 5,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "block callback",
+      "language": "ruby",
+      "note": "Ruby yield invokes a block with demand/effect obligations",
+      "obligation_family": "callback-demand-effect",
+      "obligation_subreason": "ruby-yield-callback-demand-effect-contract-missing",
+      "occurrences": 801,
+      "operation": "yield",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "ruby.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 26,
+          "path": "rubocop/spec/rubocop/cop/style/explicit_block_argument_spec.rb"
+        },
+        {
+          "occurrences": 22,
+          "path": "rspec-core/benchmarks/capture_block_vs_yield.rb"
+        },
+        {
+          "occurrences": 18,
+          "path": "rack/test/spec_deflater.rb"
+        },
+        {
+          "occurrences": 16,
+          "path": "sinatra/lib/sinatra/base.rb"
+        },
+        {
+          "occurrences": 12,
+          "path": "rubocop/spec/rubocop/cop/layout/hash_alignment_spec.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "faraday/lib/faraday/connection.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "rack/test/spec_lint.rb"
+        },
+        {
+          "occurrences": 8,
+          "path": "rspec-core/lib/rspec/core/configuration.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 228,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 98,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 55,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 38,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 36,
+          "repo": "devise"
+        },
+        {
+          "occurrences": 34,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "executor timing",
+      "language": "javascript-typescript",
+      "note": "new Promise needs executor timing, resolve/reject callback, and throw-to-rejection contracts",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.executor",
+      "top_files": [
+        {
+          "occurrences": 46,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 28,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 20,
+          "path": "axios/tests/unit/prototypePollution.test.js"
+        },
+        {
+          "occurrences": 20,
+          "path": "trpc/packages/tests/server/websockets.test.ts"
+        },
+        {
+          "occurrences": 12,
+          "path": "esbuild/scripts/plugin-tests.js"
+        },
+        {
+          "occurrences": 12,
+          "path": "prettier/tests/format/flow/flow-repo/promises/promise.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 151,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 135,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 96,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 89,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 80,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 61,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 55,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 50,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "async iterator lifecycle",
+      "language": "python",
+      "note": "async for/with needs awaitable lifecycle and cleanup proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "python-async-iterator-lifecycle-contract-missing",
+      "occurrences": 475,
+      "operation": "async for/with",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "python.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 71,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 59,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 34,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 28,
+          "path": "httpx/tests/client/test_auth.py"
+        },
+        {
+          "occurrences": 26,
+          "path": "httpx/tests/client/test_async_client.py"
+        },
+        {
+          "occurrences": 20,
+          "path": "httpx/tests/test_content.py"
+        },
+        {
+          "occurrences": 16,
+          "path": "httpx/tests/models/test_responses.py"
+        },
+        {
+          "occurrences": 15,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 184,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 125,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 125,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 39,
+          "repo": "black"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "all-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.all needs ordered all-fulfilled value and first rejection semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "execa/test/convert/concurrent.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 12,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 11,
+          "path": "zod/packages/zod/src/v4/core/schemas.ts"
+        },
+        {
+          "occurrences": 9,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "date-fns/pkgs/docs/src/bin.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "execa/test/pipe/streaming.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 79,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 62,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 60,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 56,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 29,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 17,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 17,
+          "repo": "zod"
+        },
+        {
+          "occurrences": 16,
+          "repo": "date-fns"
+        }
+      ]
+    },
+    {
+      "boundary": "task spawn",
+      "language": "rust",
+      "note": "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "rust.async.spawn",
+      "top_files": [
+        {
+          "occurrences": 32,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 18,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 16,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 12,
+          "path": "tokio/tokio/tests/task_abort.rs"
+        },
+        {
+          "occurrences": 11,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "meilisearch/crates/meilisearch/src/routes/indexes/documents.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/net_named_pipe.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 284,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 62,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "future channel",
+      "language": "java",
+      "note": "CompletableFuture needs success/error channel and scheduling proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "java-completable-future-channel-contract-missing",
+      "occurrences": 306,
+      "operation": "CompletableFuture",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "java.future.completable",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "retrofit/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 130,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 64,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 55,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 33,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 12,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 9,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "cancellation signal",
+      "language": "javascript-typescript",
+      "note": "AbortSignal/AbortController can change scheduling and rejection outcomes",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "js-ts.cancellation.abort",
+      "top_files": [
+        {
+          "occurrences": 18,
+          "path": "execa/test/terminate/cancel.js"
+        },
+        {
+          "occurrences": 18,
+          "path": "execa/test/ipc/graceful.js"
+        },
+        {
+          "occurrences": 14,
+          "path": "execa/test/terminate/graceful.js"
+        },
+        {
+          "occurrences": 13,
+          "path": "trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test-d/arguments/options.test-d.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test/pipe/abort.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "trpc/packages/client/src/internals/signals.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 108,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 87,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 30,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 17,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 8,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 4,
+          "repo": "pixijs"
+        }
+      ]
+    },
+    {
+      "boundary": "task scheduling",
+      "language": "swift",
+      "note": "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 210,
+      "operation": "Task",
+      "repos": 12,
+      "status": "closed-boundary",
+      "surface": "swift.task.spawn",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift"
+        },
+        {
+          "occurrences": 21,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "rxswift/Sources/AllTestz/PrimitiveSequence+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 63,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 34,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 27,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 23,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 23,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 16,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 6,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timer",
+      "language": "python",
+      "note": "asyncio sleep creates a timer-backed scheduling boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 104,
+      "operation": "asyncio.sleep",
+      "repos": 6,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.sleep",
+      "top_files": [
+        {
+          "occurrences": 48,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 9,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "flask/tests/test_async.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_command_parse.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_utils_defer.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 3,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 59,
+          "repo": "black"
+        },
+        {
+          "occurrences": 32,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "interval lifecycle",
+      "language": "javascript-typescript",
+      "note": "setInterval and timers interval streams have repeated emission, cancellation, and liveness semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.interval",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjs/packages/rxjs/spec/Observable-spec.ts"
+        },
+        {
+          "occurrences": 4,
+          "path": "swr/test/use-swr-subscription.test.tsx"
+        },
+        {
+          "occurrences": 3,
+          "path": "drizzle-orm/drizzle-kit/src/cli/views.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/example/src/main/resources/io/netty/example/stomp/websocket/stomp.js"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/src/internal/scheduler/intervalProvider.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/spec/schedulers/TestScheduler-spec.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 16,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 7,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 7,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 6,
+          "repo": "swr"
+        },
+        {
+          "occurrences": 3,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "thread/fiber scheduling",
+      "language": "ruby",
+      "note": "Thread/Fiber APIs create scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "ruby-thread-fiber-scheduling-contract-missing",
+      "occurrences": 73,
+      "operation": "Thread/Fiber",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "ruby.thread.fiber",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "puma/test/test_cli.rb"
+        },
+        {
+          "occurrences": 6,
+          "path": "rack/test/spec_multipart.rb"
+        },
+        {
+          "occurrences": 4,
+          "path": "puma/test/test_pumactl.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/test/test_thread_pool.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/lib/puma/cluster/worker.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/benchmarks/local/response_time_wrk.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "fastlane/fastlane/lib/fastlane/swift_lane_manager.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "puma/test/test_puma_server_ssl.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 36,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 10,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 10,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jekyll"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 1,
+          "repo": "asciidoctor"
+        }
+      ]
+    },
+    {
+      "boundary": "thread scheduling",
+      "language": "c",
+      "note": "pthread_create introduces thread scheduling and lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "c-pthread-scheduling-contract-missing",
+      "occurrences": 68,
+      "operation": "pthread_create",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "c.thread.pthread",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "redis/tests/modules/blockedclient.c"
+        },
+        {
+          "occurrences": 3,
+          "path": "redis/tests/modules/blockonbackground.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/name-hash.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/transport-helper.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/read-cache.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/fsmonitor--daemon.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/pack-objects.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/helper/test-trace2.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 23,
+          "repo": "git"
+        },
+        {
+          "occurrences": 7,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 5,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 3,
+          "repo": "libuv"
+        },
+        {
+          "occurrences": 2,
+          "repo": "raylib"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jq"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nginx"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime join style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "repos": 2,
+      "status": "closed-boundary",
+      "surface": "rust.async.join",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_try_join.rs"
+        },
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_try_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_join.rs"
+        },
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "meilisearch/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 67,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 1,
+          "repo": "meilisearch"
+        }
+      ]
+    },
+    {
+      "boundary": "first-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.race needs first-settled ordering and liveness proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "execa/test/convert/iterable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/setup/server.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/convert/readable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "ky/source/core/Ky.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/client/src/links/localLink.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/mysql2/session.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/singlestore/session.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 15,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 4,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 3,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 3,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 2,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "all-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.allSettled needs settled-record channel and shape proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-settled-contract-missing",
+      "occurrences": 17,
+      "operation": "Promise.allSettled",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/lib/resolve/wait-subprocess.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "jest/packages/jest-haste-map/src/watchers/index.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/streaming.test.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/adapters/standalone.test.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/pipe/setup.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/resolve/exit-async.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/buffer-messages.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/convert/concurrent.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 5,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 2,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio all-completion aggregate",
+      "language": "python",
+      "note": "asyncio gather needs all-completion, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.gather",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/examples/asyncio/gather_orm_statements.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_downloadermiddleware_robotstxt.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/pipelines/media.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "black"
+        },
+        {
+          "occurrences": 6,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio task spawn",
+      "language": "python",
+      "note": "asyncio task APIs create scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.task",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/core/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/defer.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "black"
+        }
+      ]
+    },
+    {
+      "boundary": "non-local jump",
+      "language": "c",
+      "note": "setjmp/longjmp is non-local control flow, not ordinary return",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "c-nonlocal-jump-contract-missing",
+      "occurrences": 13,
+      "operation": "setjmp/longjmp",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "c.nonlocal_jump",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "sqlite/autosetup/jimsh0.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/unit-tests/clar/clar.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "lua/ltests.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "redis/modules/vector-sets/fastjson_test.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "vim/src/if_python3.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 2,
+          "repo": "git"
+        },
+        {
+          "occurrences": 2,
+          "repo": "lua"
+        },
+        {
+          "occurrences": 2,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vim"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduler yield",
+      "language": "javascript-typescript",
+      "note": "scheduler.yield needs microtask/order proof",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "scheduler-yield-microtask-order-contract-missing",
+      "occurrences": 11,
+      "operation": "scheduler.yield",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.scheduler",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/generator.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/web-transform.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/duplex.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/graceful.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/incoming.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/ipc/get-each.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/transform/generator-main.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/convert/writable.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 11,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "imported future all-completion aggregate",
+      "language": "rust",
+      "note": "import-backed tokio/futures/futures_util join-style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 8,
+      "operation": "use runtime::join; join!",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join.imported",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "tokio/tokio/tests/tcp_connect.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tests-integration/tests/process_stdio.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/tcp_stream.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "future first-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime select style macros need first-completion, cancellation, and result-channel proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 5,
+      "operation": "tokio/futures/futures_util select",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "rust.async.select",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/examples/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio completion aggregate",
+      "language": "python",
+      "note": "asyncio wait needs completion-selection, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "asyncio.wait",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.wait",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/extensions/feedexport.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "imported task spawn",
+      "language": "rust",
+      "note": "import-backed tokio/async-std spawn bindings introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn.imported",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_handle_block_on.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "imported asyncio timer",
+      "language": "python",
+      "note": "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "from asyncio import sleep; binding",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.imported.sleep",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spider_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "first-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.any needs first-fulfilled and AggregateError rejection proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-first-fulfilled-contract-missing",
+      "occurrences": 1,
+      "operation": "Promise.any",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "jest/packages/expect/src/__tests__/toThrowMatchers.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "jest"
+        }
+      ]
+    }
+  ],
+  "tracking_issue": {
+    "number": 602,
+    "url": "https://github.com/corca-ai/nose/issues/602"
+  }
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime.rs
@@ -5,6 +5,8 @@ use nose_il::{
     NodeId, NodeKind, SymbolEvidenceKind,
 };
 
+mod rust_imports;
+
 pub(super) fn push_async_runtime_call_missing_evidence(
     il: &nose_il::Il,
     interner: &Interner,
@@ -43,32 +45,54 @@ fn push_python_async_runtime_call_missing_evidence(
     if context.python_module_is_local_for_file("asyncio", &il.meta.path) {
         return false;
     }
-    let Some(receiver) = method_receiver(il, callee) else {
-        return false;
-    };
-    if !python_asyncio_namespace_receiver_proven(il, interner, receiver) {
-        return false;
+    if let Some(receiver) = method_receiver(il, callee) {
+        if python_asyncio_namespace_receiver_proven(il, interner, receiver) {
+            return callee_field_method(il, interner, callee)
+                .is_some_and(|method| push_python_asyncio_api_missing_evidence(method, labels));
+        }
     }
-    match callee_field_method(il, interner, callee) {
-        Some("create_task" | "ensure_future") => {
+    for exported in ["create_task", "ensure_future", "sleep", "gather", "wait"] {
+        if python_asyncio_imported_binding_proven(il, interner, callee, exported) {
+            return push_python_asyncio_api_missing_evidence(exported, labels);
+        }
+    }
+    false
+}
+
+fn push_python_asyncio_api_missing_evidence(
+    exported: &str,
+    labels: &mut Vec<&'static str>,
+) -> bool {
+    match exported {
+        "create_task" | "ensure_future" => {
             push_task_spawn_missing_evidence(labels);
             true
         }
-        Some("sleep") => {
+        "sleep" => {
             super::super::push_unique(labels, "timer-scheduling-contract");
             true
         }
-        Some("gather") => {
+        "gather" => {
             push_async_aggregate_all_missing_evidence(labels);
             true
         }
-        Some("wait") => {
+        "wait" => {
             push_async_aggregate_completion_missing_evidence(labels);
             super::super::push_unique(labels, "async-aggregate-cancellation-liveness-contract");
             true
         }
         _ => false,
     }
+}
+
+fn python_asyncio_imported_binding_proven(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+    exported: &str,
+) -> bool {
+    nose_semantics::imported_binding_symbol(il, interner, callee, "asyncio", exported)
+        && !python_imported_binding_shadowed(il, interner, callee, "asyncio", exported)
 }
 
 fn python_asyncio_namespace_receiver_proven(
@@ -133,6 +157,55 @@ fn python_asyncio_namespace_receiver_proven(
     import_bindings > 0 && shadow_definitions == 0
 }
 
+fn python_imported_binding_shadowed(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let Some(local_name) = super::super::node_exact_name(il, interner, callee) else {
+        return false;
+    };
+    let occurrence_span = il.node(callee).span;
+    let top_level_statements = top_level_statements(il);
+    for unit in &il.units {
+        if il.node(unit.root).span.file == occurrence_span.file
+            && unit
+                .name
+                .is_some_and(|symbol| interner.resolve(symbol) == local_name)
+        {
+            return true;
+        }
+    }
+    for (idx, node) in il.nodes.iter().enumerate() {
+        if node.span.file != occurrence_span.file {
+            continue;
+        }
+        let node_id = NodeId(idx as u32);
+        match node.kind {
+            NodeKind::Assign => {
+                let Some(lhs) = il.children(node_id).first().copied() else {
+                    continue;
+                };
+                if !node_defines_name(il, interner, lhs, local_name) {
+                    continue;
+                }
+                if !top_level_statements.contains(&node_id)
+                    || !python_import_binding_at_span(il, node.span, local_name, module, exported)
+                {
+                    return true;
+                }
+            }
+            NodeKind::Param if node_defines_name(il, interner, node_id, local_name) => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 fn python_import_namespace_binding_at_span(
     il: &nose_il::Il,
     span: nose_il::Span,
@@ -145,6 +218,29 @@ fn python_import_namespace_binding_at_span(
         record.anchor == EvidenceAnchor::binding(span, local_hash)
             && record.kind
                 == EvidenceKind::Symbol(SymbolEvidenceKind::ImportedNamespace { module_hash })
+            && record.provenance.emitter == EvidenceEmitter::Builtin
+            && record.status == EvidenceStatus::Asserted
+            && il.evidence_dependencies_asserted(record)
+    })
+}
+
+fn python_import_binding_at_span(
+    il: &nose_il::Il,
+    span: nose_il::Span,
+    local: &str,
+    module: &str,
+    exported: &str,
+) -> bool {
+    let local_hash = stable_symbol_hash(local);
+    let module_hash = stable_symbol_hash(module);
+    let exported_hash = stable_symbol_hash(exported);
+    il.evidence_anchored_at(span).any(|record| {
+        record.anchor == EvidenceAnchor::binding(span, local_hash)
+            && record.kind
+                == EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+                    module_hash,
+                    exported_hash,
+                })
             && record.provenance.emitter == EvidenceEmitter::Builtin
             && record.status == EvidenceStatus::Asserted
             && il.evidence_dependencies_asserted(record)
@@ -332,7 +428,10 @@ fn rust_imported_runtime_member(
     if context.rust_runtime_root_is_local_for_file(module_root(module), &il.meta.path) {
         return false;
     }
-    nose_semantics::imported_member_symbol(il, interner, callee, module, exported)
+    (nose_semantics::imported_member_symbol(il, interner, callee, module, exported)
+        || rust_imports::rust_imported_binding_evidence_only_symbol(
+            il, interner, callee, module, exported,
+        ))
         && !rust_imported_member_shadowed(il, interner, callee, module, exported)
 }
 

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/rust_imports.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/rust_imports.rs
@@ -1,0 +1,102 @@
+use nose_il::{
+    stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceKind, EvidenceStatus, Interner,
+    NodeId, NodeKind, SymbolEvidenceKind,
+};
+
+pub(super) fn rust_imported_binding_evidence_only_symbol(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+    module: &str,
+    exported: &str,
+) -> bool {
+    if il.kind(callee) != NodeKind::Var {
+        return false;
+    }
+    let Some(local_name) = super::super::super::node_exact_name(il, interner, callee) else {
+        return false;
+    };
+    let local_hash = stable_symbol_hash(local_name);
+    let module_hash = stable_symbol_hash(module);
+    let exported_hash = stable_symbol_hash(exported);
+    let occurrence_span = il.node(callee).span;
+    let mut found_matching = false;
+    for record in il.evidence_binding_anchored(local_hash) {
+        let EvidenceAnchor::Binding {
+            span,
+            local_hash: anchor_hash,
+        } = record.anchor
+        else {
+            continue;
+        };
+        if span.file != occurrence_span.file || anchor_hash != local_hash {
+            continue;
+        }
+        if !rust_import_binding_span_visible_at_call(il, span, occurrence_span) {
+            continue;
+        }
+        let EvidenceKind::Symbol(SymbolEvidenceKind::ImportedBinding {
+            module_hash: actual_module,
+            exported_hash: actual_exported,
+        }) = record.kind
+        else {
+            continue;
+        };
+        if record.provenance.emitter != EvidenceEmitter::Builtin
+            || record.status != EvidenceStatus::Asserted
+            || !il.evidence_dependencies_asserted(record)
+        {
+            return false;
+        }
+        if actual_module == module_hash && actual_exported == exported_hash {
+            found_matching = true;
+        } else {
+            return false;
+        }
+    }
+    found_matching
+}
+
+fn rust_import_binding_span_visible_at_call(
+    il: &nose_il::Il,
+    binding_span: nose_il::Span,
+    occurrence_span: nose_il::Span,
+) -> bool {
+    if binding_span.file != occurrence_span.file {
+        return false;
+    }
+    if rust_span_inside_non_module_block_scope(il, binding_span) {
+        return false;
+    }
+    rust_nearest_module_scope_containing_span(il, binding_span)
+        == rust_nearest_module_scope_containing_span(il, occurrence_span)
+}
+
+fn rust_span_inside_non_module_block_scope(il: &nose_il::Il, span: nose_il::Span) -> bool {
+    il.nodes.iter().any(|node| {
+        matches!(
+            node.kind,
+            NodeKind::Block | NodeKind::Func | NodeKind::Lambda
+        ) && node.span.file == span.file
+            && node.span.start_byte <= span.start_byte
+            && span.end_byte <= node.span.end_byte
+            && (node.span.start_byte < span.start_byte || span.end_byte < node.span.end_byte)
+    })
+}
+
+fn rust_nearest_module_scope_containing_span(
+    il: &nose_il::Il,
+    span: nose_il::Span,
+) -> Option<NodeId> {
+    il.nodes
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| {
+            node.kind == NodeKind::Module
+                && node.span.file == span.file
+                && node.span.start_byte <= span.start_byte
+                && span.end_byte <= node.span.end_byte
+        })
+        .min_by_key(|(_, node)| node.span.end_byte.saturating_sub(node.span.start_byte))
+        .map(|(idx, _)| NodeId(idx as u32))
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
@@ -7,6 +7,8 @@ use nose_il::{FileId, Interner, Lang, NodeId, NodeKind};
 
 use super::super::runtime_boundary_missing_evidence_with_context;
 
+mod imported_bindings;
+
 fn runtime_boundary_evidence_for_corpus_call(
     sources: &[(&str, &str, Lang)],
     target_path: &str,
@@ -36,6 +38,36 @@ fn runtime_boundary_evidence_for_corpus_call(
         })
         .unwrap_or_else(|| panic!("expected call ending in {callee_suffix}"));
     runtime_boundary_missing_evidence_with_context(il, &corpus.interner, call, &context)
+}
+
+fn python_runtime_with_path_visible_local_asyncio(
+    runtime_src: &str,
+    callee_suffix: &str,
+) -> Option<Vec<&'static str>> {
+    runtime_boundary_evidence_for_corpus_call(
+        &[
+            (
+                "asyncio.py",
+                "def create_task(x):\n    return x\n",
+                Lang::Python,
+            ),
+            ("runtime.py", runtime_src, Lang::Python),
+        ],
+        "runtime.py",
+        callee_suffix,
+    )
+}
+
+fn rust_runtime_with_same_file_local_tokio(
+    runtime_src: &str,
+    callee_suffix: &str,
+) -> Option<Vec<&'static str>> {
+    let src = format!("mod tokio {{ pub fn spawn<T>(task: T) -> T {{ task }} }}\n{runtime_src}");
+    runtime_boundary_evidence_for_corpus_call(
+        &[("runtime.rs", &src, Lang::Rust)],
+        "runtime.rs",
+        callee_suffix,
+    )
 }
 
 #[test]
@@ -427,29 +459,12 @@ fn non_js_async_runtime_context_keeps_unrelated_runtime_names_open() {
 
 #[test]
 fn non_js_async_runtime_context_rejects_project_local_import_aliases() {
-    let py_local_asyncio_alias = runtime_boundary_evidence_for_corpus_call(
-        &[
-            (
-                "asyncio.py",
-                "def create_task(x):\n    return x\n",
-                Lang::Python,
-            ),
-            (
-                "runtime.py",
-                "import asyncio as aio\nasync def main():\n    return aio.create_task(work())\n",
-                Lang::Python,
-            ),
-        ],
-        "runtime.py",
+    let py_local_asyncio_alias = python_runtime_with_path_visible_local_asyncio(
+        "import asyncio as aio\nasync def main():\n    return aio.create_task(work())\n",
         "aio.create_task",
     );
-    let rust_local_tokio_imported_spawn = runtime_boundary_evidence_for_corpus_call(
-        &[(
-            "runtime.rs",
-            "mod tokio { pub fn spawn<T>(task: T) -> T { task } }\nuse tokio::spawn;\nfn run() { spawn(work()); }\n",
-            Lang::Rust,
-        )],
-        "runtime.rs",
+    let rust_local_tokio_imported_spawn = rust_runtime_with_same_file_local_tokio(
+        "use tokio::spawn;\nfn run() { spawn(work()); }\n",
         "spawn",
     );
 

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs
@@ -1,0 +1,212 @@
+use super::{
+    assert_missing_evidence_not_contains, missing_evidence_for_lang_call,
+    python_runtime_with_path_visible_local_asyncio, runtime_boundary_evidence_for_lang_call,
+    rust_runtime_with_same_file_local_tokio,
+};
+use nose_il::Lang;
+
+#[test]
+fn non_js_async_runtime_imported_bindings_report_shared_obligations() {
+    let py_imported_task = missing_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import create_task as spawn_task\nasync def main():\n    return spawn_task(work())\n",
+        Lang::Python,
+        "spawn_task",
+    );
+    let py_imported_sleep = missing_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import sleep as delay\nasync def main():\n    return await delay(1)\n",
+        Lang::Python,
+        "delay",
+    );
+    let py_imported_gather = missing_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import gather as all_done\nasync def main(task):\n    return await all_done(task)\n",
+        Lang::Python,
+        "all_done",
+    );
+    let py_imported_wait = missing_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import wait\nasync def main(task):\n    return await wait([task])\n",
+        Lang::Python,
+        "wait",
+    );
+    let rust_brace_spawn = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{spawn};\nfn run() { spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_brace_join_alias = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{join as tokio_join};\nasync fn run() { tokio_join!(work(), other()); }\n",
+        Lang::Rust,
+        "tokio_join",
+    );
+    let rust_brace_select_alias = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use futures::{select as fut_select};\nasync fn run() { fut_select!(a = work() => a); }\n",
+        Lang::Rust,
+        "fut_select",
+    );
+
+    assert!(py_imported_task.contains(&"task-spawn-scheduling-contract"));
+    assert!(py_imported_task.contains(&"task-handle-lifecycle-contract"));
+    assert!(py_imported_task.contains(&"task-cancellation-liveness-contract"));
+    assert!(py_imported_sleep.contains(&"timer-scheduling-contract"));
+    assert!(py_imported_gather.contains(&"async-aggregate-all-completion-contract"));
+    assert!(py_imported_gather.contains(&"async-aggregate-result-channel-contract"));
+    assert!(py_imported_wait.contains(&"async-aggregate-completion-contract"));
+    assert!(py_imported_wait.contains(&"async-aggregate-cancellation-liveness-contract"));
+    assert!(py_imported_wait.contains(&"async-aggregate-result-channel-contract"));
+    assert!(rust_brace_spawn.contains(&"task-spawn-scheduling-contract"));
+    assert!(rust_brace_spawn.contains(&"task-handle-lifecycle-contract"));
+    assert!(rust_brace_spawn.contains(&"task-cancellation-liveness-contract"));
+    assert!(rust_brace_join_alias.contains(&"async-aggregate-all-completion-contract"));
+    assert!(rust_brace_join_alias.contains(&"async-aggregate-result-channel-contract"));
+    assert!(rust_brace_select_alias.contains(&"async-aggregate-first-completion-contract"));
+    assert!(rust_brace_select_alias.contains(&"async-aggregate-cancellation-liveness-contract"));
+    assert!(rust_brace_select_alias.contains(&"async-aggregate-result-channel-contract"));
+}
+
+#[test]
+fn non_js_async_runtime_imported_bindings_reject_local_shadows() {
+    let py_imported_gather_param_shadow = runtime_boundary_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import gather as all_done\nasync def main(all_done, task):\n    return await all_done(task)\n",
+        Lang::Python,
+        "all_done",
+    );
+    let py_imported_sleep_assign_shadow = runtime_boundary_evidence_for_lang_call(
+        "runtime.py",
+        "from asyncio import sleep as delay\nasync def main():\n    delay = local_sleep\n    return await delay(1)\n",
+        Lang::Python,
+        "delay",
+    );
+    let py_nested_imported_binding = runtime_boundary_evidence_for_lang_call(
+        "runtime.py",
+        "async def helper():\n    from asyncio import sleep as delay\nasync def main():\n    return await delay(1)\n",
+        Lang::Python,
+        "delay",
+    );
+
+    assert_missing_evidence_not_contains(
+        py_imported_gather_param_shadow,
+        "async-aggregate-all-completion-contract",
+        "Python imported asyncio binding shadowed by parameter",
+    );
+    assert_missing_evidence_not_contains(
+        py_imported_sleep_assign_shadow,
+        "timer-scheduling-contract",
+        "Python imported asyncio binding shadowed by assignment",
+    );
+    assert_missing_evidence_not_contains(
+        py_nested_imported_binding,
+        "timer-scheduling-contract",
+        "Python imported asyncio binding imported only in another local scope",
+    );
+}
+
+#[test]
+fn non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes() {
+    let rust_brace_spawn_param_shadow = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{spawn};\nfn run<F>(spawn: F) { spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_brace_spawn_let_shadow = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{spawn};\nfn run() { let spawn = local; spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_brace_join_macro_shadow = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{join};\nmacro_rules! join { ($a:expr, $b:expr) => { ($a, $b) }; }\nasync fn run() { join!(work(), other()); }\n",
+        Lang::Rust,
+        "join",
+    );
+    let rust_brace_spawn_nested_use = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn helper() { use tokio::{spawn}; }\nfn run() { spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_direct_spawn_nested_use = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn helper() { use tokio::spawn; }\nfn run() { spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_brace_spawn_other_module = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn run() { spawn(work()); }\nmod helper { use tokio::{spawn}; fn helper() { spawn(work()); } }\n",
+        Lang::Rust,
+        "spawn",
+    );
+    let rust_brace_spawn_const_block_use = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "const INIT: () = { use tokio::{spawn}; };\nfn run() { spawn(work()); }\n",
+        Lang::Rust,
+        "spawn",
+    );
+
+    for (labels, surface) in [
+        (
+            rust_brace_spawn_param_shadow,
+            "Rust brace spawn parameter shadow",
+        ),
+        (rust_brace_spawn_let_shadow, "Rust brace spawn let shadow"),
+    ] {
+        assert_missing_evidence_not_contains(labels, "task-spawn-scheduling-contract", surface);
+    }
+    assert_missing_evidence_not_contains(
+        rust_brace_join_macro_shadow,
+        "async-aggregate-all-completion-contract",
+        "Rust brace join shadowed by local macro",
+    );
+    for (labels, surface) in [
+        (
+            rust_brace_spawn_nested_use,
+            "Rust brace spawn imported only in another function",
+        ),
+        (
+            rust_direct_spawn_nested_use,
+            "Rust direct spawn imported only in another function",
+        ),
+        (
+            rust_brace_spawn_other_module,
+            "Rust brace spawn imported only in another module",
+        ),
+        (
+            rust_brace_spawn_const_block_use,
+            "Rust brace spawn imported only in a const initializer block",
+        ),
+    ] {
+        assert_missing_evidence_not_contains(labels, "task-spawn-scheduling-contract", surface);
+    }
+}
+
+#[test]
+fn non_js_async_runtime_context_rejects_project_local_imported_bindings() {
+    let py_local_asyncio_imported_task = python_runtime_with_path_visible_local_asyncio(
+        "from asyncio import create_task as spawn_task\nasync def main():\n    return spawn_task(work())\n",
+        "spawn_task",
+    );
+    let rust_local_tokio_brace_spawn = rust_runtime_with_same_file_local_tokio(
+        "use tokio::{spawn};\nfn run() { spawn(work()); }\n",
+        "spawn",
+    );
+
+    assert_missing_evidence_not_contains(
+        py_local_asyncio_imported_task,
+        "task-spawn-scheduling-contract",
+        "project-local Python asyncio module through imported binding",
+    );
+    assert_missing_evidence_not_contains(
+        rust_local_tokio_brace_spawn,
+        "task-spawn-scheduling-contract",
+        "project-local Rust tokio root for brace imported spawn",
+    );
+}

--- a/crates/nose-normalize/src/call_target_evidence/imported.rs
+++ b/crates/nose-normalize/src/call_target_evidence/imported.rs
@@ -119,8 +119,12 @@ fn imported_scoped_member_target(
 ) -> Option<ImportedMemberTarget> {
     let (root, suffix) = scoped_var_root_and_suffix(il, interner, callee)?;
     let root_hash = stable_symbol_hash(root);
-    let (symbol, binding_dependency) =
-        unique_binding_symbol_for_hash(il, root_hash, ImportedBindingUse::MemberReceiver)?;
+    let (symbol, binding_dependency) = unique_binding_symbol_for_hash(
+        il,
+        root_hash,
+        il.node(callee).span,
+        ImportedBindingUse::MemberReceiver,
+    )?;
     let dependency = upsert_valid_imported_symbol_occurrence(
         il,
         interner,
@@ -204,16 +208,23 @@ fn unique_binding_symbol_for_var(
     imported_use: ImportedBindingUse,
 ) -> Option<(SymbolEvidenceKind, EvidenceId)> {
     let local_hash = node_name_hash(il, interner, node)?;
-    unique_binding_symbol_for_hash(il, local_hash, imported_use)
+    unique_binding_symbol_for_hash(il, local_hash, il.node(node).span, imported_use)
 }
 
 fn unique_binding_symbol_for_hash(
     il: &Il,
     local_hash: u64,
+    occurrence_span: Span,
     imported_use: ImportedBindingUse,
 ) -> Option<(SymbolEvidenceKind, EvidenceId)> {
     let mut found = None;
     for record in il.evidence_binding_anchored(local_hash) {
+        let EvidenceAnchor::Binding { span, .. } = record.anchor else {
+            continue;
+        };
+        if !imported_binding_span_visible_at_occurrence(il, span, occurrence_span) {
+            continue;
+        }
         let EvidenceKind::Symbol(symbol) = record.kind else {
             continue;
         };
@@ -230,6 +241,50 @@ fn unique_binding_symbol_for_hash(
         }
     }
     found
+}
+
+fn imported_binding_span_visible_at_occurrence(
+    il: &Il,
+    binding_span: Span,
+    occurrence_span: Span,
+) -> bool {
+    if binding_span.file != occurrence_span.file {
+        return false;
+    }
+    if binding_span_inside_local_scope(il, binding_span) {
+        return false;
+    }
+    if il.meta.lang == Lang::Rust {
+        return nearest_module_scope_containing_span(il, binding_span)
+            == nearest_module_scope_containing_span(il, occurrence_span);
+    }
+    true
+}
+
+fn binding_span_inside_local_scope(il: &Il, span: Span) -> bool {
+    il.nodes.iter().any(|node| {
+        matches!(
+            node.kind,
+            NodeKind::Block | NodeKind::Func | NodeKind::Lambda
+        ) && node.span.file == span.file
+            && node.span.start_byte <= span.start_byte
+            && span.end_byte <= node.span.end_byte
+            && (node.span.start_byte < span.start_byte || span.end_byte < node.span.end_byte)
+    })
+}
+
+fn nearest_module_scope_containing_span(il: &Il, span: Span) -> Option<NodeId> {
+    il.nodes
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| {
+            node.kind == NodeKind::Module
+                && node.span.file == span.file
+                && node.span.start_byte <= span.start_byte
+                && span.end_byte <= node.span.end_byte
+        })
+        .min_by_key(|(_, node)| node.span.end_byte.saturating_sub(node.span.start_byte))
+        .map(|(idx, _)| NodeId(idx as u32))
 }
 
 fn scoped_var_root_and_suffix<'a>(

--- a/crates/nose-normalize/src/call_target_evidence/tests/imported.rs
+++ b/crates/nose-normalize/src/call_target_evidence/tests/imported.rs
@@ -276,6 +276,92 @@ fn scoped_imported_member_call_target_uses_full_suffix_for_nested_paths() {
 }
 
 #[test]
+fn rust_block_scoped_imported_binding_does_not_emit_call_target() {
+    let interner = Interner::new();
+    let spawn = interner.intern("spawn");
+    let mut b = IlBuilder::new(FileId(0));
+    let block = b.add(NodeKind::Block, Payload::None, wide_sp(15, 30), &[]);
+    let callee = b.add(NodeKind::Var, Payload::Name(spawn), sp(42), &[]);
+    let call = b.add(NodeKind::Call, Payload::None, sp(43), &[callee]);
+    let ret = b.add(NodeKind::Return, Payload::None, sp(44), &[call]);
+    let body = b.add(NodeKind::Block, Payload::None, wide_sp(40, 50), &[ret]);
+    let func = b.add(NodeKind::Func, Payload::None, wide_sp(35, 55), &[body]);
+    let module = b.add(
+        NodeKind::Module,
+        Payload::None,
+        wide_sp(0, 60),
+        &[block, func],
+    );
+    let mut il = b.finish(
+        module,
+        FileMeta {
+            path: "t".into(),
+            lang: Lang::Rust,
+        },
+        Vec::new(),
+        Vec::new(),
+    );
+    il.evidence.push(binding_symbol(
+        0,
+        sp(20),
+        "spawn",
+        SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("tokio"),
+            exported_hash: stable_symbol_hash("spawn"),
+        },
+        EvidenceStatus::Asserted,
+    ));
+
+    run(&mut il, &interner);
+
+    assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+    assert!(!imported_function_call_target_at_call(&il, &interner, call));
+}
+
+#[test]
+fn rust_parent_module_imported_binding_does_not_emit_nested_module_call_target() {
+    let interner = Interner::new();
+    let spawn = interner.intern("spawn");
+    let mut b = IlBuilder::new(FileId(0));
+    let callee = b.add(NodeKind::Var, Payload::Name(spawn), sp(52), &[]);
+    let call = b.add(NodeKind::Call, Payload::None, sp(53), &[callee]);
+    let ret = b.add(NodeKind::Return, Payload::None, sp(54), &[call]);
+    let body = b.add(NodeKind::Block, Payload::None, wide_sp(50, 60), &[ret]);
+    let func = b.add(NodeKind::Func, Payload::None, wide_sp(45, 65), &[body]);
+    let nested_module = b.add(NodeKind::Module, Payload::None, wide_sp(40, 70), &[func]);
+    let root_module = b.add(
+        NodeKind::Module,
+        Payload::None,
+        wide_sp(0, 80),
+        &[nested_module],
+    );
+    let mut il = b.finish(
+        root_module,
+        FileMeta {
+            path: "t".into(),
+            lang: Lang::Rust,
+        },
+        Vec::new(),
+        Vec::new(),
+    );
+    il.evidence.push(binding_symbol(
+        0,
+        sp(1),
+        "spawn",
+        SymbolEvidenceKind::ImportedBinding {
+            module_hash: stable_symbol_hash("tokio"),
+            exported_hash: stable_symbol_hash("spawn"),
+        },
+        EvidenceStatus::Asserted,
+    ));
+
+    run(&mut il, &interner);
+
+    assert_eq!(call_target_evidence_at_call(&il, &interner, call), None);
+    assert!(!imported_function_call_target_at_call(&il, &interner, call));
+}
+
+#[test]
 fn updates_legacy_first_party_imported_function_records() {
     let interner = Interner::new();
     let p = interner.intern("p");

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -144,10 +144,10 @@ matching `nose.lang.*` pack provenance for the lowered file language:
   raw-name path stays closed instead of overriding that proof.
 - `ImportedFunction` for variable callees whose local binding has a unique
   asserted `Symbol(ImportedBinding)` proof and whose call-site occurrence can be
-  materialized as dependency-backed imported-symbol evidence. Alias rebinding,
-  local shadowing, ambiguous/conflicting symbol evidence, dependency-broken
-  import proof, and locally visible same-name function units keep the call
-  target closed.
+  materialized as dependency-backed imported-symbol evidence visible at that
+  occurrence. Alias rebinding, local shadowing, ambiguous/conflicting symbol
+  evidence, dependency-broken import proof, locally visible same-name function
+  units, and out-of-scope imported bindings keep the call target closed.
 - `ImportedMember` for field callees whose receiver has a unique asserted
   `Symbol(ImportedNamespace)` or `Symbol(ImportedBinding)` proof. Imported
   namespace receivers use the module/member coordinate; imported binding
@@ -548,9 +548,12 @@ Imported API occurrence evidence is not a broad name guess. A call-site
 `Symbol(ImportedBinding)` or `Symbol(ImportedNamespace)` dependency must itself
 depend on the matching binding-anchor symbol, pass rebinding and local/parameter
 shadow checks, and match the current receiver/callee span when that span is
-available. If normalization erases an import occurrence into a seeded import
-value, consumers pass no occurrence span and rely on that validated dependency
-instead of accepting an unrelated imported symbol elsewhere in the file.
+available. The occurrence producer also requires the binding anchor to be
+visible at the occurrence; Rust `use` bindings in block scopes or parent
+modules do not prove unqualified calls outside that module scope. If
+normalization erases an import occurrence into a seeded import value, consumers
+pass no occurrence span and rely on that validated dependency instead of
+accepting an unrelated imported symbol elsewhere in the file.
 Recall-loss reports use these same evidence boundaries when attributing
 fail-closed exact admission to callee identity, receiver domain, library API
 occurrence, HOF demand/effect, source surface, mutation/effect, and unsupported

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -83,6 +83,13 @@ bindings receive the same reporting-only obligations. Its matching [120-repo
 pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-import-proof-2026-06-30.v1.json)
 adds `11` Rust imported-binding occurrences over the qualified-only pricing and
 records `0` Python `asyncio` alias occurrences in the pinned corpus.
+The next [imported-binding proof artifact](../bench/recall_loss/non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json)
+keeps exact admission closed while extending that same capability to Python
+`from asyncio import ...` bindings and Rust brace imports backed only by
+binding evidence. Its matching [120-repo pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json)
+adds `2` Python imported `asyncio.sleep` occurrences over the prior artifact;
+Rust direct and brace imported runtime rows stay at `11` priced occurrences,
+but brace evidence-only imports are now actionable by the reporter.
 The follow-up [promise-protocol-hard-negatives-2026-06-28.v1.json](../bench/recall_loss/promise-protocol-hard-negatives-2026-06-28.v1.json)
 pins the Promise-specific hard negatives before any recovery slice opens:
 async-function/sync, Promise executor/sync, Promise.resolve/sync,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2118,11 +2118,14 @@ different APIs.
   obligations.
 - The non-JS async runtime follow-ups keep using that vocabulary instead of
   adding API-by-API kernel features. Python `asyncio` namespace aliases and
-  Rust imported `tokio`/`async_std`/`futures` runtime bindings now compose
-  existing import/symbol identity proof with shared task and async aggregate
-  obligations, while exact admission remains closed until scheduling,
-  cancellation, lifecycle, result-channel, exception, and callback/effect
-  contracts are dependency-closed.
+  `from asyncio import ...` bindings plus Rust imported and brace-imported
+  `tokio`/`async_std`/`futures` runtime bindings now compose existing
+  import/symbol identity proof with shared task and async aggregate obligations.
+  The latest pricing artifact adds `2` Python imported `asyncio.sleep`
+  occurrences over the previous `142,845` source-prevalence baseline, while
+  exact admission remains closed until scheduling, cancellation, lifecycle,
+  result-channel, exception, and callback/effect contracts are
+  dependency-closed.
 - Keep expanding lazy iterator/generator/channel hard negatives before enabling
   new exact laws. The first Python generator/list/set and Go channel/goroutine
   hard negatives are now in place, along with hard negatives for pull-lazy

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -132,6 +132,11 @@ widens that reporting to Python `asyncio` namespace aliases and Rust imported
 runtime bindings by composing existing `ImportedNamespace`/`ImportedMember`
 symbol proof with the same obligations instead of adding a selector-specific
 kernel feature.
+The next [imported-binding proof artifact](../bench/recall_loss/non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json)
+uses the same capability boundary for Python `from asyncio import ...`
+bindings and Rust brace-use `ImportedBinding` evidence, adding `2` newly priced
+Python imported `asyncio.sleep` occurrences while keeping exact admission
+closed and preserving the release `verify crates` gate at `0` false merges.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, selected property/non-factory method/view surfaces,
 and selected non-call sentinels, with occurrence evidence covering selected
@@ -1381,9 +1386,13 @@ this worktree because the required evidence is not yet modeled:
   Swift `Task` creation report scheduler, lifecycle, cancellation, and
   result-channel obligations but do not yet converge with synchronous calls,
   direct payload values, or each other. These reports require import-backed
-  Python `asyncio` with no path-visible local module, qualified Rust
-  spawn/aggregate paths whose root is not locally defined in the same file, and
-  unshadowed Swift `Task` roots with no corpus-visible Swift `Task` definition.
+  Python `asyncio` namespace or binding proof with no path-visible local module,
+  qualified or imported Rust runtime proof whose root is not locally defined in
+  the same file, and unshadowed Swift `Task` roots with no corpus-visible Swift
+  `Task` definition. Python function-local `asyncio` imports remain closed
+  until scope proof exists, and the imported-occurrence producer keeps Rust
+  block-scoped or other-module runtime imports from proving calls outside that
+  module scope.
 - Go `go f(x)`, `defer f(x)`, `<-ch`, `ch <- x`, and `select` do not converge
   with ordinary calls, values, sends, or sequential control-flow variants until
   channel/goroutine/defer/select contracts can prove scheduling, blocking,

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -170,6 +170,50 @@ PYTHON_ASYNCIO_ALIAS_WAIT = Pattern(
     re.compile(r"(?!x)x"),
     "reporting-supported-closed-boundary",
 )
+PYTHON_ASYNCIO_IMPORTED_TASK = Pattern(
+    "python",
+    "python.asyncio.imported.task",
+    "from asyncio import create_task/ensure_future; binding",
+    "scheduling-boundary",
+    "task-spawn-scheduling-contract-missing",
+    "imported asyncio task spawn",
+    "import-backed asyncio task bindings create the same scheduler, cancellation, and handle lifecycle boundaries as asyncio.*",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
+PYTHON_ASYNCIO_IMPORTED_SLEEP = Pattern(
+    "python",
+    "python.asyncio.imported.sleep",
+    "from asyncio import sleep; binding",
+    "scheduling-boundary",
+    "timer-scheduling-contract-missing",
+    "imported asyncio timer",
+    "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
+PYTHON_ASYNCIO_IMPORTED_GATHER = Pattern(
+    "python",
+    "python.asyncio.imported.gather",
+    "from asyncio import gather; binding",
+    "success-error-result-channel",
+    "async-aggregate-all-completion-contract-missing",
+    "imported asyncio all-completion aggregate",
+    "import-backed asyncio gather bindings need all-completion, result-channel, cancellation, and exception semantics",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
+PYTHON_ASYNCIO_IMPORTED_WAIT = Pattern(
+    "python",
+    "python.asyncio.imported.wait",
+    "from asyncio import wait; binding",
+    "success-error-result-channel",
+    "async-aggregate-completion-contract-missing",
+    "imported asyncio completion aggregate",
+    "import-backed asyncio wait bindings need completion-selection, result-channel, cancellation, and exception semantics",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
 RUST_IMPORTED_ASYNC_SPAWN = Pattern(
     "rust",
     "rust.async.spawn.imported",
@@ -297,6 +341,7 @@ def count_file(text: str, language: str) -> dict[Pattern, int]:
             counts[pattern] = count
     if language == "python":
         counts.update(python_asyncio_alias_counts(masked))
+        counts.update(python_asyncio_imported_counts(masked))
     elif language == "rust":
         counts.update(rust_imported_async_runtime_counts(masked))
     return counts
@@ -331,6 +376,79 @@ def python_asyncio_aliases(text: str) -> set[str]:
                 if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", alias) and alias != "asyncio":
                     aliases.add(alias)
     return aliases
+
+
+def python_asyncio_imported_counts(text: str) -> dict[Pattern, int]:
+    bindings = python_asyncio_imported_bindings(text)
+    if not bindings:
+        return {}
+    counts: dict[Pattern, int] = {}
+    count_bindings(
+        counts,
+        PYTHON_ASYNCIO_IMPORTED_TASK,
+        text,
+        bindings_for_python(bindings, ("create_task", "ensure_future")),
+        "(",
+    )
+    count_bindings(
+        counts,
+        PYTHON_ASYNCIO_IMPORTED_SLEEP,
+        text,
+        bindings_for_python(bindings, ("sleep",)),
+        "(",
+    )
+    count_bindings(
+        counts,
+        PYTHON_ASYNCIO_IMPORTED_GATHER,
+        text,
+        bindings_for_python(bindings, ("gather",)),
+        "(",
+    )
+    count_bindings(
+        counts,
+        PYTHON_ASYNCIO_IMPORTED_WAIT,
+        text,
+        bindings_for_python(bindings, ("wait",)),
+        "(",
+    )
+    return counts
+
+
+def python_asyncio_imported_bindings(text: str) -> dict[str, set[str]]:
+    bindings: dict[str, set[str]] = defaultdict(set)
+    for match in re.finditer(r"(?m)^\s*from\s+asyncio\s+import\s+([^\n]+)", text):
+        for part in match.group(1).split(","):
+            parsed = python_imported_name(part)
+            if not parsed:
+                continue
+            exported, local = parsed
+            if exported in {"create_task", "ensure_future", "sleep", "gather", "wait"}:
+                bindings[exported].add(local)
+    return bindings
+
+
+def python_imported_name(part: str) -> tuple[str, str] | None:
+    pieces = part.strip().split()
+    if len(pieces) == 1:
+        exported = local = pieces[0]
+    elif len(pieces) == 3 and pieces[1] == "as":
+        exported = pieces[0]
+        local = pieces[2]
+    else:
+        return None
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", exported) and re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*",
+        local,
+    ):
+        return exported, local
+    return None
+
+
+def bindings_for_python(bindings: dict[str, set[str]], targets: tuple[str, ...]) -> set[str]:
+    out: set[str] = set()
+    for target in targets:
+        out.update(bindings.get(target, set()))
+    return out
 
 
 def rust_imported_async_runtime_counts(text: str) -> dict[Pattern, int]:
@@ -727,6 +845,16 @@ def hard_negative_inventory() -> list[dict[str, Any]]:
             "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
             "evidence": "docs/scheduling-channel-callback-obligations-594.md",
             "status": "mapped-doc-policy",
+        },
+        {
+            "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+            "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+            "status": "expanded-this-slice",
+        },
+        {
+            "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+            "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+            "status": "expanded-this-slice",
         },
     ]
 


### PR DESCRIPTION
## Summary
- reuse existing `ImportedBinding` evidence so Python `from asyncio import create_task/sleep/gather/wait` bindings report shared task/timer/aggregate obligations
- make Rust brace-use runtime imports such as `use tokio::{spawn}` and `use futures::{select as fut_select}` actionable without adding a new kernel API
- harden imported occurrence production so Rust block-scoped or parent-module `use` bindings do not prove out-of-scope unqualified calls
- keep exact admission closed and refresh recall-loss/audit artifacts, changelog, and semantic-kernel/evidence docs

## Quantitative impact
- 120-repo source prevalence rises from `142,845` to `142,847` by adding `2` Python imported `asyncio.sleep` occurrences in `1` repo
- Rust imported rows remain `11` priced occurrences (`3` spawn, `8` join/try_join) because prior pricing already counted direct and brace spellings; this PR makes brace evidence-only imports actionable under the stricter visibility guard
- `nose verify crates`: `6693` total units, `920` interpretable, `5773` excluded, `768` admission rejections, `0` false merges, `0` canon preservation violations
- stable release timed run: `real 0.96s`, `user 5.62s`, `sys 0.06s`

## Review
- docs/artifact subagent review: no blocking findings
- runtime/admission subagent review found block-scope and normalized occurrence bypass risks; both were fixed and final re-review reported no blocking findings

## Validation
- `cargo fmt --check`
- `cargo test -p nose-normalize call_target_evidence::tests::imported -- --nocapture`
- `cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime -- --nocapture`
- full `nose verify` repro for `const INIT: () = { use tokio::{spawn}; }; fn run(){ spawn(work()); } fn run2(){ spawn(work()); }`: `task-spawn-scheduling-contract = 0`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --generated-on 2026-06-30 --output bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-imported-binding-proof-2026-06-30.v1.json`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.non-js-async-runtime-imported-binding-proof.crates.json`
- `cargo build --release`
- `/usr/bin/time -p ./target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.non-js-async-runtime-imported-binding-proof.release7.crates.json`
- `./scripts/check-duplication.sh`
- `./scripts/check-ci-local.sh --fast`
- `awiki format` and `awiki lint` from `docs/`
