### PR TITLE
Report Rust nested brace runtime provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,10 @@ break.
   `Runtime::new().unwrap()/expect`, `Runtime::new()?`, or
   `Builder::new_*().build().unwrap()/expect/?` now receive the same reporting;
   nominal parameter receivers proven as scope-visible `tokio::runtime::Runtime`
-  or `tokio::runtime::Handle` now do too. Selector-only `.block_on`, struct
-  fields, nested brace-import parameter types, type aliases, wrapped
-  constructors, and `map_err(...)?` runtime construction remain closed.
+  or `tokio::runtime::Handle` now do too, including nested static brace imports
+  such as `use tokio::{runtime::{Runtime}}`. Selector-only `.block_on`, struct
+  fields, wildcard or relative imports, type aliases, wrapped constructors, and
+  `map_err(...)?` runtime construction remain closed.
 - Added Go channel/goroutine/defer obligation refinement. Go source-backed
   protocol boundaries now report channel send synchronization, receive value,
   comma-ok receive status, select readiness/case/default, goroutine scheduling

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -465,9 +465,16 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   `tokio::runtime::Runtime` and `tokio::runtime::Handle` parameters now receive
   the same future-drive and future-settled obligations when the type is fully
   qualified or backed by scope-visible exact imported-binding evidence. Exact
-  admission stays closed; struct fields, nested brace-import parameter types,
-  child-module parameters with only parent-module imports, type aliases, wrapper
-  calls, and `map_err(...)?` construction remain closed.
+  admission stays closed. In that slice, struct fields, nested brace-import
+  parameter types, child-module parameters with only parent-module imports, type
+  aliases, wrapper calls, and `map_err(...)?` construction remained closed.
+- [rust-nested-brace-runtime-provenance-2026-07-01.v1.json](rust-nested-brace-runtime-provenance-2026-07-01.v1.json)
+  records the follow-up Rust nested static brace-import expansion. Nested items
+  such as `use tokio::{runtime::{Runtime}}` now emit per-item import evidence,
+  allowing those `Runtime` parameters to receive the same future-drive and
+  future-settled obligations. Exact admission stays closed; struct fields,
+  wildcard/relative imports, type aliases, wrapper calls, and `map_err(...)?`
+  construction remain closed.
 - [scheduling-lifecycle-boundary-audit-swift-structured-concurrency-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-swift-structured-concurrency-2026-06-30.v1.json)
   records the matching 120-repo source-prevalence pricing. It raises total
   source prevalence from `142,847` to `143,178`: `Task.sleep` contributes
@@ -735,7 +742,7 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
 - [issue-576-cycle.v1.json](issue-576-cycle.v1.json) records the first recovery
   slice after the census: Rust brace `use` imports now feed dependency-backed
   imported call-target evidence while wildcard/nested/relative brace imports
-  stay closed.
+  stayed closed in that slice.
 - [issue-578-cycle.v1.json](issue-578-cycle.v1.json) records the next Rust
   scoped-path recovery slice: imported roots such as `Span::new` now feed
   dependency-backed imported member call-target evidence while raw `crate`,

--- a/bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json
+++ b/bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json
@@ -1,0 +1,174 @@
+{
+  "report_kind": "rust-nested-brace-runtime-provenance",
+  "schema_version": 1,
+  "generated_on": "2026-07-01",
+  "scope": {
+    "kind": "reporting-only-rust-nested-brace-import-runtime-provenance",
+    "summary": "Rust nested static brace imports now emit per-item import evidence, allowing nested-brace tokio Runtime parameters to feed block_on future-drive reporting.",
+    "semantic_admission_delta": 0,
+    "exact_admission_opened": false
+  },
+  "capability_alignment": {
+    "principle": "Capabilities over features",
+    "capability": "static import binding provenance for receiver type evidence",
+    "not_a_feature_list": [
+      "No exact admission path was opened for Rust block_on or async/sync equivalence.",
+      "No new public semantic-pack API was added.",
+      "The slice strengthens existing Import/Symbol evidence production instead of adding a block_on-specific parser.",
+      "Wildcard imports and self/super-relative brace prefixes stay closed.",
+      "Struct-field receivers, type aliases, and unknown local receivers remain closed."
+    ],
+    "reused_capabilities": [
+      "Rust imported binding evidence",
+      "Rust parameter domain evidence",
+      "runtime-boundary-model",
+      "AdmissionContext Rust local-runtime-root guard",
+      "recall-loss oracle_exclusions.by_obligation",
+      "shared future-drive scheduling and future-settled value-channel obligations"
+    ]
+  },
+  "new_reporting_surfaces": [
+    {
+      "language": "rust",
+      "surface": "use tokio::{runtime::{Builder, Runtime}}; fn run(rt: Runtime) { rt.block_on(...) }",
+      "guard": "The nested brace item must resolve to a static imported binding in the same module scope as the parameter."
+    },
+    {
+      "language": "rust",
+      "surface": "use std::{io::{self, Read}, path::Path as StdPath}",
+      "guard": "Nested static brace imports emit the same per-item Import/Symbol evidence as direct and one-level brace imports; self imports become namespace evidence."
+    },
+    {
+      "language": "rust",
+      "surface": "pub use crate::{constants::{LIMIT}}",
+      "guard": "Nested public static brace imports emit re-export binding evidence for exact module/export coordinates."
+    }
+  ],
+  "focused_fixture": {
+    "tests": [
+      {
+        "test": "rust::tests::imports::nested_brace_use_emits_imported_symbol_evidence_for_static_items",
+        "command": "cargo test -p nose-frontend rust::tests::imports -- --nocapture",
+        "assertions": [
+          "Nested std::{io::{self, Read}} emits namespace evidence for std::io and imported binding evidence for std::io::Read.",
+          "Nested tokio::{runtime::{Builder, Runtime}} emits imported binding evidence for tokio::runtime::Builder and Runtime.",
+          "Wildcard brace imports still emit no static import symbol evidence."
+        ]
+      },
+      {
+        "test": "param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses",
+        "command": "cargo test -p nose-frontend lower::tests::param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture",
+        "assertions": [
+          "Nested-brace tokio Runtime parameter domain evidence depends on nested brace imported-binding symbol evidence.",
+          "Parent-module nested brace imports do not prove child-module Runtime parameter evidence."
+        ]
+      },
+      {
+        "test": "rust_block_on::reports_future_drive_obligations_when_parameter_runtime_identity_is_proven",
+        "command": "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture",
+        "assertions": [
+          "Nested-brace tokio Runtime parameter receivers report future-drive and future-settled obligations.",
+          "Parent-module nested brace imports remain closed for child-module Runtime parameter receivers."
+        ]
+      }
+    ]
+  },
+  "current_crates_gate": {
+    "report": "target/recall-loss.rust-nested-brace-block-on.crates.json",
+    "total_units": 6785,
+    "interpretable_units": 940,
+    "excluded_units": 5845,
+    "admission_rejections": 785,
+    "false_merges": 0,
+    "lossy_fingerprint_collisions": 0,
+    "advisory_disagreements": 4,
+    "canon_checked": 96,
+    "canon_preservation_violations": 0,
+    "gate_passed": true,
+    "future_drive_admission_rejections": 0,
+    "future_drive_oracle_exclusions": 0,
+    "elapsed_real_seconds": 1.7
+  },
+  "real_corpus_spot_checks": [
+    {
+      "repo": "tokio",
+      "path": "tokio/tests/fs_uring.rs",
+      "command": "target/release/nose verify bench/repos/tokio/tokio/tests/fs_uring.rs --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.fs-uring.json",
+      "elapsed_real_seconds": 0.61,
+      "summary": {
+        "total_units": 9,
+        "interpretable_units": 0,
+        "excluded_units": 9,
+        "false_merges": 0,
+        "future_drive_evidence_units": 2,
+        "future_drive_primary_units": 0,
+        "primary_reason_note": "The matching block_on units also carry async-await evidence, which remains the primary scheduling subreason by rule order."
+      },
+      "future_drive_lines": [
+        {
+          "line": 88,
+          "primary_obligation_subreason": "async-await-scheduling-contract-missing"
+        },
+        {
+          "line": 89,
+          "primary_obligation_subreason": "async-await-scheduling-contract-missing"
+        }
+      ]
+    },
+    {
+      "repo": "tokio",
+      "path": "tokio/tests/fs_uring_read.rs",
+      "command": "target/release/nose verify bench/repos/tokio/tokio/tests/fs_uring_read.rs --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.fs-uring-read.json",
+      "elapsed_real_seconds": 0.6,
+      "summary": {
+        "total_units": 13,
+        "interpretable_units": 3,
+        "excluded_units": 10,
+        "admission_rejections": 3,
+        "false_merges": 0,
+        "future_drive_evidence_units": 2,
+        "future_drive_primary_units": 0,
+        "primary_reason_note": "This direct one-level brace import case remains covered after the nested-brace parser change."
+      }
+    }
+  ],
+  "closed_surfaces": [
+    {
+      "surface": "self.rt.block_on(...) or other field-backed runtime receivers",
+      "reason": "The reporter still does not infer struct-field tokio runtime types."
+    },
+    {
+      "surface": "use tokio::{runtime::*} or other wildcard imports",
+      "reason": "Wildcard imports do not provide a unique static exported symbol coordinate."
+    },
+    {
+      "surface": "self/super-relative brace prefixes",
+      "reason": "Relative module resolution is still not modeled by this import-evidence producer."
+    },
+    {
+      "surface": "type Rt = tokio::runtime::Runtime; fn run(rt: Rt) { rt.block_on(...) }",
+      "reason": "Rust type aliases are not converted into nominal receiver domain evidence in this slice."
+    },
+    {
+      "surface": "Exact convergence between block_on, await, and synchronous payload values",
+      "reason": "Future drive scheduling, wake/poll behavior, cancellation/liveness, result-channel, and receiver/type identity contracts remain missing evidence."
+    }
+  ],
+  "validation_commands": [
+    "cargo fmt --all --check",
+    "cargo test -p nose-frontend rust::tests::imports -- --nocapture",
+    "cargo test -p nose-frontend lower::tests::param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture",
+    "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture",
+    "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime -- --nocapture",
+    "cargo test -p nose-cli --test cli recall_loss_report_oracle_exclusions::recall_loss_report_attributes_non_js_async_runtime_api_exclusions -- --nocapture",
+    "cargo clippy -p nose-cli -p nose-frontend --all-targets -- -D warnings",
+    "cargo build --release -p nose-cli",
+    "/usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.crates.json",
+    "/usr/bin/time -p target/release/nose verify bench/repos/tokio/tokio/tests/fs_uring.rs --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.fs-uring.json",
+    "/usr/bin/time -p target/release/nose verify bench/repos/tokio/tokio/tests/fs_uring_read.rs --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.fs-uring-read.json"
+  ],
+  "next_followups": [
+    "Add struct-field type provenance for self.rt.block_on only after field declarations, constructor assignment, and receiver aliasing can be proven fail-closed.",
+    "Consider self/super-relative brace import proof as a separate import-resolution slice."
+  ]
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on.rs
@@ -129,6 +129,12 @@ fn reports_future_drive_obligations_when_parameter_runtime_identity_is_proven() 
         Lang::Rust,
         ".block_on",
     );
+    let nested_brace_imported_runtime_param = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{runtime::{Builder, Runtime}};\nfn run(rt: Runtime) { rt.block_on(work()); }\n",
+        Lang::Rust,
+        ".block_on",
+    );
     let aliased_handle_param = missing_evidence_for_lang_call(
         "runtime.rs",
         "use tokio::runtime::Handle as TokioHandle;\nfn run(handle: TokioHandle) { handle.block_on(work()); }\n",
@@ -151,6 +157,7 @@ fn reports_future_drive_obligations_when_parameter_runtime_identity_is_proven() 
     for labels in [
         imported_runtime_param,
         imported_runtime_ref_param,
+        nested_brace_imported_runtime_param,
         aliased_handle_param,
         qualified_runtime_param,
         scoped_imported_runtime_param,
@@ -280,6 +287,12 @@ fn requires_proven_parameter_runtime_identity() {
         Lang::Rust,
         ".block_on",
     );
+    let parent_nested_brace_import_not_visible = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{runtime::{Runtime}};\nmod local { fn run(rt: Runtime) { rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
     let parameter_reassigned_to_local = runtime_boundary_evidence_for_lang_call(
         "runtime.rs",
         "use tokio::runtime::Runtime;\nfn run(rt: Runtime) { let rt = make_local(rt); rt.block_on(work()); }\n",
@@ -304,6 +317,10 @@ fn requires_proven_parameter_runtime_identity() {
         (
             parent_module_import_not_visible,
             "parent-module import for child-module Runtime parameter type",
+        ),
+        (
+            parent_nested_brace_import_not_visible,
+            "parent-module nested brace import for child-module Runtime parameter type",
         ),
         (
             parameter_reassigned_to_local,

--- a/crates/nose-frontend/src/lower/tests/param_domains.rs
+++ b/crates/nose-frontend/src/lower/tests/param_domains.rs
@@ -350,6 +350,26 @@ fn assert_rust_tokio_runtime_param_domains(interner: &Interner) {
         "Rust tokio Runtime parameter domain evidence should be import-backed"
     );
 
+    let nested_brace_imported_runtime = lower_fixture(
+        "tokio_nested_brace_runtime_param.rs",
+        b"use tokio::{runtime::{Builder, Runtime}};\npub fn run(rt: Runtime) { rt.block_on(work()); }\n",
+        Lang::Rust,
+        interner,
+    );
+    let nested_runtime_import_ids = imported_binding_symbol_ids(
+        &nested_brace_imported_runtime.evidence,
+        "tokio::runtime",
+        "Runtime",
+    );
+    assert_eq!(nested_runtime_import_ids.len(), 1);
+    let nested_runtime_domains =
+        param_domain_records(&nested_brace_imported_runtime.evidence, runtime_domain);
+    assert_eq!(nested_runtime_domains.len(), 1);
+    assert_eq!(
+        nested_runtime_domains[0].dependencies, nested_runtime_import_ids,
+        "Rust tokio Runtime parameter evidence should use nested brace import evidence"
+    );
+
     let scoped_imported_runtime = lower_fixture(
         "tokio_scoped_runtime_param.rs",
         b"mod local { use tokio::runtime::Runtime; pub fn run(rt: Runtime) { rt.block_on(work()); } }\n",
@@ -433,6 +453,21 @@ fn assert_rust_tokio_runtime_param_domains(interner: &Interner) {
         param_domain_record_count(&parent_module_import_not_visible.evidence, runtime_domain),
         0,
         "parent-module imports must not prove child-module Runtime parameter evidence"
+    );
+
+    let parent_nested_brace_import_not_visible = lower_fixture(
+        "tokio_parent_nested_brace_import_param.rs",
+        b"use tokio::{runtime::{Runtime}};\nmod local { pub fn run(rt: Runtime) { rt.block_on(work()); } }\n",
+        Lang::Rust,
+        interner,
+    );
+    assert_eq!(
+        param_domain_record_count(
+            &parent_nested_brace_import_not_visible.evidence,
+            runtime_domain
+        ),
+        0,
+        "parent-module nested brace imports must not prove child-module Runtime parameter evidence"
     );
 
     let wrong_runtime = lower_fixture(

--- a/crates/nose-frontend/src/rust/items.rs
+++ b/crates/nose-frontend/src/rust/items.rs
@@ -142,8 +142,10 @@ fn rust_public_use(text: &str) -> bool {
     let Some(rest) = trimmed.strip_prefix("pub(") else {
         return false;
     };
-    rest.split_once(')')
-        .is_some_and(|(_, after)| after.trim_start().starts_with("use "))
+    let Some((visibility, after)) = rest.split_once(')') else {
+        return false;
+    };
+    visibility.trim() == "crate" && after.trim_start().starts_with("use ")
 }
 
 fn rust_single_static_import(
@@ -175,12 +177,8 @@ fn rust_brace_static_imports(
     body_offset: usize,
 ) -> Option<Vec<RustStaticImport>> {
     let open = body.find('{')?;
-    let close = body.rfind('}')?;
-    if open >= close
-        || body[open + 1..close].contains('{')
-        || body[open + 1..close].contains('}')
-        || !body[close + 1..].trim().is_empty()
-    {
+    let close = matching_brace(body, open)?;
+    if open >= close || !body[close + 1..].trim().is_empty() {
         return None;
     }
     let prefix = body[..open].trim().trim_end_matches("::").trim();
@@ -190,7 +188,46 @@ fn rust_brace_static_imports(
     let items = &body[open + 1..close];
     let items_offset = body_offset + open + 1;
     let mut imports = Vec::new();
-    for (item, item_offset) in comma_separated_use_items(items, items_offset) {
+    collect_rust_brace_static_imports(
+        full_text,
+        declaration_span,
+        prefix,
+        items,
+        items_offset,
+        &mut imports,
+    )?;
+    (!imports.is_empty()).then_some(imports)
+}
+
+fn collect_rust_brace_static_imports(
+    full_text: &str,
+    declaration_span: Span,
+    prefix: &str,
+    items: &str,
+    items_offset: usize,
+    imports: &mut Vec<RustStaticImport>,
+) -> Option<()> {
+    for (item, item_offset) in comma_separated_use_items(items, items_offset)? {
+        if let Some(open) = item.find('{') {
+            let close = matching_brace(item, open)?;
+            if !item[close + 1..].trim().is_empty() {
+                return None;
+            }
+            let nested_prefix = item[..open].trim().trim_end_matches("::").trim();
+            if nested_prefix.is_empty() || relative_rust_use_prefix(nested_prefix) {
+                return None;
+            }
+            let nested = format!("{prefix}::{nested_prefix}");
+            collect_rust_brace_static_imports(
+                full_text,
+                declaration_span,
+                &nested,
+                &item[open + 1..close],
+                item_offset + open + 1,
+                imports,
+            )?;
+            continue;
+        }
         let parsed = parse_rust_use_item(item)?;
         let item_span = span_for_text_range(
             declaration_span,
@@ -222,7 +259,7 @@ fn rust_brace_static_imports(
             kind: RustStaticImportKind::Binding { exported },
         });
     }
-    (!imports.is_empty()).then_some(imports)
+    Some(())
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -276,17 +313,59 @@ fn relative_rust_use_prefix(prefix: &str) -> bool {
         || prefix.starts_with("super::")
 }
 
-fn comma_separated_use_items<'a>(
+fn comma_separated_use_items(items: &str, items_offset: usize) -> Option<Vec<(&str, usize)>> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (index, byte) in items.bytes().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => depth = depth.checked_sub(1)?,
+            b',' if depth == 0 => {
+                push_trimmed_use_item(items, items_offset, start, index, &mut parts);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    push_trimmed_use_item(items, items_offset, start, items.len(), &mut parts);
+    Some(parts)
+}
+
+fn push_trimmed_use_item<'a>(
     items: &'a str,
     items_offset: usize,
-) -> impl Iterator<Item = (&'a str, usize)> + 'a {
-    items.split(',').scan(0usize, move |cursor, part| {
-        let raw_start = *cursor;
-        *cursor += part.len() + 1;
+    start: usize,
+    end: usize,
+    parts: &mut Vec<(&'a str, usize)>,
+) {
+    if let Some(part) = items.get(start..end) {
         let (trimmed, leading) = trim_with_offset(part);
         let (trimmed, _) = trim_end_with_len(trimmed);
-        (!trimmed.is_empty()).then_some((trimmed, items_offset + raw_start + leading))
-    })
+        if !trimmed.is_empty() {
+            parts.push((trimmed, items_offset + start + leading));
+        }
+    }
+}
+
+fn matching_brace(text: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, byte) in text.bytes().enumerate().skip(open) {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn trim_with_offset(value: &str) -> (&str, usize) {

--- a/crates/nose-frontend/src/rust/tests/imports.rs
+++ b/crates/nose-frontend/src/rust/tests/imports.rs
@@ -24,6 +24,26 @@ fn imported_binding_symbol_count(il: &Il, local: &str, module: &str, exported: &
         .count()
 }
 
+fn imported_namespace_symbol_count(il: &Il, local: &str, module: &str) -> usize {
+    il.evidence
+        .iter()
+        .filter(|record| {
+            record.status == nose_il::EvidenceStatus::Asserted
+                && matches!(
+                    record.anchor,
+                    nose_il::EvidenceAnchor::Binding { local_hash, .. }
+                        if local_hash == nose_il::stable_symbol_hash(local)
+                )
+                && matches!(
+                    record.kind,
+                    nose_il::EvidenceKind::Symbol(
+                        nose_il::SymbolEvidenceKind::ImportedNamespace { module_hash },
+                    ) if module_hash == nose_il::stable_symbol_hash(module)
+                )
+        })
+        .count()
+}
+
 fn reexport_binding_count(il: &Il, local: &str, module: &str, exported: &str) -> usize {
     il.evidence
         .iter()
@@ -70,6 +90,31 @@ fn brace_use_emits_imported_binding_symbol_for_each_static_item() {
 }
 
 #[test]
+fn nested_brace_use_emits_imported_symbol_evidence_for_static_items() {
+    let (_, il) = lower_rust(
+        "use std::{io::{self, Read}, path::Path as StdPath};\nuse tokio::{runtime::{Builder, Runtime}};\nfn f() {}",
+    );
+
+    assert_eq!(imported_namespace_symbol_count(&il, "io", "std::io"), 1);
+    assert_eq!(
+        imported_binding_symbol_count(&il, "Read", "std::io", "Read"),
+        1
+    );
+    assert_eq!(
+        imported_binding_symbol_count(&il, "StdPath", "std::path", "Path"),
+        1
+    );
+    assert_eq!(
+        imported_binding_symbol_count(&il, "Builder", "tokio::runtime", "Builder"),
+        1
+    );
+    assert_eq!(
+        imported_binding_symbol_count(&il, "Runtime", "tokio::runtime", "Runtime"),
+        1
+    );
+}
+
+#[test]
 fn public_use_emits_reexport_binding_evidence_for_direct_static_items() {
     let (_, il) = lower_rust(
         "pub use crate::constants::LIMIT;\npub(crate) use crate::constants::VALUES as PUBLIC_VALUES;\npub use crate::constants::{NAME, OTHER as RENAMED};\nfn f() {}",
@@ -94,7 +139,16 @@ fn public_use_emits_reexport_binding_evidence_for_direct_static_items() {
 }
 
 #[test]
-fn private_wildcard_and_nested_use_do_not_emit_reexport_binding_evidence() {
+fn public_use_emits_reexport_binding_evidence_for_nested_static_items() {
+    let (_, nested) = lower_rust("pub use crate::{constants::{LIMIT}};\nfn f() {}");
+    assert_eq!(
+        reexport_binding_count(&nested, "LIMIT", "crate::constants", "LIMIT"),
+        1
+    );
+}
+
+#[test]
+fn private_and_wildcard_use_do_not_emit_reexport_binding_evidence() {
     let (_, private_use) = lower_rust("use crate::constants::LIMIT;\nfn f() {}");
     assert_eq!(
         reexport_binding_count(&private_use, "LIMIT", "crate::constants", "LIMIT"),
@@ -107,24 +161,31 @@ fn private_wildcard_and_nested_use_do_not_emit_reexport_binding_evidence() {
         0
     );
 
-    let (_, nested) = lower_rust("pub use crate::{constants::{LIMIT}};\nfn f() {}");
+    let (_, private_direct) = lower_rust("pub(self) use crate::constants::LIMIT;\nfn f() {}");
     assert_eq!(
-        reexport_binding_count(&nested, "LIMIT", "crate::constants", "LIMIT"),
+        reexport_binding_count(&private_direct, "LIMIT", "crate::constants", "LIMIT"),
+        0
+    );
+
+    let (_, private_nested) =
+        lower_rust("pub(in crate::private) use crate::{constants::{LIMIT}};\nfn f() {}");
+    assert_eq!(
+        reexport_binding_count(&private_nested, "LIMIT", "crate::constants", "LIMIT"),
         0
     );
 }
 
 #[test]
-fn wildcard_and_nested_brace_use_stay_without_static_import_symbol_evidence() {
+fn wildcard_brace_use_stays_without_static_import_symbol_evidence() {
     let (_, wildcard) = lower_rust("use crate::items::*;\nfn f() {}");
     assert_eq!(
         imported_binding_symbol_count(&wildcard, "items", "crate::items", "items"),
         0
     );
 
-    let (_, nested) = lower_rust("use std::{io::{self, Read}};\nfn f() {}");
+    let (_, nested_wildcard) = lower_rust("use std::{io::*};\nfn f() {}");
     assert_eq!(
-        imported_binding_symbol_count(&nested, "Read", "std::io", "Read"),
+        imported_binding_symbol_count(&nested_wildcard, "Read", "std::io", "Read"),
         0
     );
 }

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -75,11 +75,11 @@ The current implemented kinds are:
 Rust `use` producers use the same `Import`/`Symbol` vocabulary as other static
 imports. Simple static imports such as `use m::f;` keep their existing
 assignment-shaped import proof. Static brace imports such as `use m::{f, T};`
-emit per-item evidence-only binding proofs so the import syntax remains a
-low-signal token sequence while call-target and library-api consumers can still
-depend on a precise local binding. Wildcard imports, nested brace imports, and
-`self`/`super`-relative brace prefixes stay closed until a producer can prove a
-non-ambiguous coordinate.
+and nested static brace imports such as `use m::{n::{f, T}};` emit per-item
+evidence-only binding proofs so the import syntax remains a low-signal token
+sequence while call-target and library-api consumers can still depend on a
+precise local binding. Wildcard imports and `self`/`super`-relative brace
+prefixes stay closed until a producer can prove a non-ambiguous coordinate.
 
 `LibraryApi` evidence is an occurrence fact, not the whole contract. It records
 the contract id, callee coordinate, arity, and dependencies for a specific
@@ -274,12 +274,14 @@ stays closed instead of falling back to the raw sequence shape. Value-graph
 import identity likewise consumes only sequence `Import` evidence and
 materializes dedicated internal import values, never raw `ValOp::Seq` proof
 objects.
-Rust public re-export proof follows the same rule. A direct `pub use` may emit
-`Import(ReExportBinding)` evidence for the alias and its target coordinate, but
-that evidence is only a module/export alias proof. Imported immutable snapshots
-may follow one same-corpus re-export hop only when the target binding is already
-literal-safe under the normal provider checks. Private `use`, wildcard/nested
-brace re-exports, ambiguous aliases, and non-value targets remain closed.
+Rust re-export proof follows the same rule. Unrestricted `pub use` and
+crate-visible `pub(crate) use` may emit `Import(ReExportBinding)` evidence for
+direct or nested static brace aliases and their target coordinates, but that
+evidence is only a module/export alias proof. Imported immutable snapshots may
+follow one same-corpus re-export hop only when the target binding is already
+literal-safe under the normal provider checks. Private or restricted
+`pub(self)`/`pub(in ...)` use, wildcard re-exports, ambiguous aliases, and
+non-value targets remain closed.
 
 Imported immutable provider snapshots follow the same rule. A provider binding
 whose RHS is a collection or map factory call is exportable only when the call

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -206,7 +206,12 @@ provenance artifact](../bench/recall_loss/rust-block-on-parameter-runtime-proven
 then adds nominal `tokio::runtime::Runtime`/`Handle` parameter receivers backed
 by fully qualified type text or scope-visible exact imported-binding evidence;
 struct fields, nested brace imports such as `use tokio::{ runtime::{Runtime}, ... }`, type
-aliases, wrappers, and `map_err(...)?` construction remain closed. The
+aliases, wrappers, and `map_err(...)?` construction remained closed in that
+slice. The [Rust nested brace runtime provenance artifact](../bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json)
+then adds per-item evidence for nested static brace imports, allowing those
+`Runtime` parameter receivers to reuse the same `block_on` reporting. Struct
+fields, wildcard/relative imports, type aliases, wrappers, and `map_err(...)?`
+construction remain closed. The
 follow-up [Go channel protocol pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-channel-protocol-2026-06-30.v1.json)
 keeps exact admission closed while refining Go protocol-boundary reporting into
 channel send synchronization, receive value, comma-ok receive status, select
@@ -344,13 +349,13 @@ include:
 | `provider-export-missing` | A provider module exists, but no matching exported binding was found. |
 | `provider-export-ambiguous` | More than one provider binding could own the same module/export coordinate. |
 | `provider-external-crate-boundary` | The import targets a known external crate dependency, which is outside same-corpus provider lookup. |
-| `provider-reexport-ambiguous` | More than one direct public re-export could own the requested module/export coordinate. |
-| `provider-reexport-callable-boundary` | A direct public re-export resolves to a callable item, not an immutable literal provider value. |
-| `provider-reexport-type-boundary` | A direct public re-export resolves to a type item, not an immutable literal provider value. |
-| `provider-reexport-module-namespace-boundary` | A direct public re-export resolves to a module namespace, not an immutable literal provider value. |
-| `provider-reexport-external-crate-boundary` | A direct public re-export target resolves to a known external crate boundary. |
-| `provider-reexport-target-export-missing` | A direct public re-export exists, but its target module has no matching export in the analyzed corpus. |
-| `provider-reexport-target-module-missing` | A direct public re-export exists, but its target module is not resolved in the analyzed corpus. |
+| `provider-reexport-ambiguous` | More than one public or crate-visible static re-export could own the requested module/export coordinate. |
+| `provider-reexport-callable-boundary` | A public or crate-visible static re-export resolves to a callable item, not an immutable literal provider value. |
+| `provider-reexport-type-boundary` | A public or crate-visible static re-export resolves to a type item, not an immutable literal provider value. |
+| `provider-reexport-module-namespace-boundary` | A public or crate-visible static re-export resolves to a module namespace, not an immutable literal provider value. |
+| `provider-reexport-external-crate-boundary` | A public or crate-visible static re-export target resolves to a known external crate boundary. |
+| `provider-reexport-target-export-missing` | A public or crate-visible static re-export exists, but its target module has no matching export in the analyzed corpus. |
+| `provider-reexport-target-module-missing` | A public or crate-visible static re-export exists, but its target module is not resolved in the analyzed corpus. |
 | `cross-language-boundary` | A same-coordinate provider exists only in a different lowered language. |
 | `self-import-boundary` | The only matching provider is the importer file itself. |
 | `importer-binding-mutated` | The importer mutates the imported binding before it could be snapshotted. |

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -105,7 +105,8 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
 - [Java CompletableFuture obligation reporting](../bench/recall_loss/java-completablefuture-obligation-reporting-2026-06-30.v1.json) records the Java Future follow-up: proof-backed `CompletableFuture` static calls and exact-import-backed CompletionStage-style receiver continuations now report reusable future, task, aggregate, callback, and exception obligations. Exact admission remains closed, while the 120-repo lexical audit splits `40` Java future reporting candidates out of the broad `CompletableFuture` bucket and leaves `276` broad mentions closed.
 - [Rust block_on future-drive obligation reporting](../bench/recall_loss/rust-block-on-future-drive-obligation-reporting-2026-07-01.v1.json) records the Rust Future bridge follow-up: qualified/import-backed `tokio_test::block_on` plus proof-backed `Handle::current().block_on` and inline `Runtime`/`Builder` receiver chains now report `future-drive-scheduling-contract` plus `future-settled-value-channel-contract`. Exact admission remains closed.
 - [Rust local runtime provenance](../bench/recall_loss/rust-block-on-local-runtime-provenance-2026-07-01.v1.json) extends that reporting to local variables whose last visible assignment is proof-backed `Handle::current()`, `Runtime::new().unwrap()/expect/?`, or `Builder::new_*().build().unwrap()/expect/?`, while selector-only receivers, parameters, fields, wrappers, and `map_err(...)?` construction remain closed.
-- [Rust parameter runtime provenance](../bench/recall_loss/rust-block-on-parameter-runtime-provenance-2026-07-01.v1.json) extends the same reporting to nominal `tokio::runtime::Runtime` and `tokio::runtime::Handle` parameter receivers when the type is fully qualified or backed by scope-visible exact imported-binding evidence. Exact admission remains closed; struct fields, nested brace-import parameter types, child-module parameters with only parent-module imports, type aliases, wrappers, and `map_err(...)?` construction remain closed.
+- [Rust parameter runtime provenance](../bench/recall_loss/rust-block-on-parameter-runtime-provenance-2026-07-01.v1.json) extends the same reporting to nominal `tokio::runtime::Runtime` and `tokio::runtime::Handle` parameter receivers when the type is fully qualified or backed by scope-visible exact imported-binding evidence. Exact admission remains closed; in that slice, struct fields, nested brace-import parameter types, child-module parameters with only parent-module imports, type aliases, wrappers, and `map_err(...)?` construction remained closed.
+- [Rust nested brace runtime provenance](../bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json) extends Rust static import evidence to nested brace groups such as `use tokio::{runtime::{Runtime}}`, allowing those parameter receivers to report the same future-drive and future-settled obligations. Exact admission remains closed; struct fields, wildcard/relative imports, type aliases, wrappers, and `map_err(...)?` construction remain closed.
 
 Regenerate the full local reports with:
 
@@ -191,7 +192,9 @@ without changing the hard gate (`false_merges == 0`,
 `canon_preservation_violations == 0`). It does this by proving Rust brace import
 bindings such as `use crate::m::{f, T};` as per-item `Import`/`Symbol` evidence
 while leaving wildcard imports, nested brace imports, and `self`/`super`-relative
-brace prefixes closed. This shrinks the local-or-parameter primary surface from
+brace prefixes closed at that time. A later nested-brace runtime-provenance
+follow-up opens static nested brace groups while keeping wildcard and relative
+forms closed. This shrinks the local-or-parameter primary surface from
 `115` to `71`; the next dominant targets are scoped paths and member calls.
 
 The #578 recovery slice reduces the callee-identity bucket from `251` to `235`

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -113,8 +113,12 @@ proof-backed `Handle::current()`, `Runtime::new().unwrap()/expect/?`, or
 parameter runtime provenance artifact](../bench/recall_loss/rust-block-on-parameter-runtime-provenance-2026-07-01.v1.json)
 reuses the same capability for nominal `tokio::runtime::Runtime`/`Handle`
 parameter receivers backed by fully qualified type text or exact
-scope-visible imported-binding evidence. Fields, nested brace imports, type
-aliases, wrappers, and `map_err(...)?` construction remain closed.
+scope-visible imported-binding evidence. The follow-up [Rust nested brace
+runtime provenance artifact](../bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json)
+extends the import-evidence side of that capability to nested static brace
+imports such as `use tokio::{runtime::{Runtime}}`. Fields, wildcard/relative
+imports, type aliases, wrappers, and `map_err(...)?` construction remain
+closed.
 The follow-up [Java CompletableFuture artifact](../bench/recall_loss/java-completablefuture-obligation-reporting-2026-06-30.v1.json)
 keeps exact admission closed and maps proof-backed Java
 `CompletableFuture.supplyAsync`/`runAsync`, settled factories, `allOf`/`anyOf`,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -178,9 +178,14 @@ keeps exact admission closed while following nominal
 qualified type text or scope-visible exact imported-binding evidence. Tokio
 spot checks show `2` future-drive evidence units in
 `tokio/tests/fs_uring_read.rs` and `1` in
-`tokio/tests/rt_unstable_eager_driver_handoff.rs`; field receivers, nested brace
-imports, child-module parameters with only parent-module imports, type aliases,
-wrappers, and `map_err(...)?` construction remain closed.
+`tokio/tests/rt_unstable_eager_driver_handoff.rs`. The follow-up [Rust nested
+brace runtime provenance artifact](../bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json)
+adds per-item evidence for nested static brace imports such as
+`use tokio::{runtime::{Runtime}}`; Tokio `fs_uring.rs` then shows `2`
+future-drive evidence units for nested-brace `Runtime` parameter receivers.
+Field receivers, wildcard/relative imports, child-module parameters with only
+parent-module imports, type aliases, wrappers, and `map_err(...)?` construction
+remain closed.
 The follow-up [Go channel protocol pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-channel-protocol-2026-06-30.v1.json)
 keeps exact admission closed while pricing `4,294` channel receives, `1,525`
 sends, `155` comma-ok receives, `1,920` select parents, `3,590` select cases,
@@ -1274,7 +1279,8 @@ migrated.
   import coordinate sequences can no longer become proof-bearing value nodes by
   tag shape. Imported literal replacement also consumes evidence-only import
   facts; missing or ambiguous `Import` evidence no longer proves a cross-file
-  replacement. Rust direct public re-exports now emit
+  replacement. Rust unrestricted `pub use` and crate-visible `pub(crate) use`
+  re-exports, including nested static brace aliases, now emit
   `Import(ReExportBinding)` as alias proof, not value proof; imported literal
   replacement may follow one such same-corpus hop only to an already
   literal-safe provider export.
@@ -1458,8 +1464,8 @@ this worktree because the required evidence is not yet modeled:
   corpus-visible Swift `Task` definition. Python function-local `asyncio`
   imports remain closed until scope proof exists, the imported-occurrence
   producer keeps Rust block-scoped or other-module runtime imports from proving
-  calls outside that module scope, and `self.rt.block_on(...)`, nested brace
-  import parameter types, and type aliases stay closed until stronger
+  calls outside that module scope, and `self.rt.block_on(...)`,
+  wildcard/relative imports, and type aliases stay closed until stronger
   receiver/type evidence exists.
 - Java `CompletableFuture.supplyAsync`/`runAsync`, settled factories,
   `allOf`/`anyOf`, and exact-import-backed CompletionStage-style receiver


### PR DESCRIPTION
## Summary
- emit Rust static import evidence for nested brace use trees such as `use tokio::{runtime::{Runtime}}`
- let nested-brace tokio `Runtime` parameter receivers report the same `block_on` future-drive obligations as direct imports
- keep exact admission closed and keep wildcard/relative imports, restricted `pub(self)`/`pub(in ...)` re-exports, parent-module-only imports, fields, aliases, wrappers, and `map_err(...)?` construction closed

## Validation
- `cargo fmt --all --check`
- `cargo test -p nose-frontend rust::tests::imports -- --nocapture`
- `cargo test -p nose-frontend module_imports::tests::rust_module_resolution -- --nocapture`
- `cargo test -p nose-frontend lower::tests::param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture`
- `cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture`
- `cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime -- --nocapture`
- `cargo clippy -p nose-cli -p nose-frontend --all-targets -- -D warnings`
- `./scripts/check-docs.sh`
- `./scripts/check-duplication.sh`
- `python3 scripts/check-file-lengths.py --self-test && python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `jq empty bench/recall_loss/rust-nested-brace-runtime-provenance-2026-07-01.v1.json`
- `/usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.rust-nested-brace-block-on.crates.json` -> `false_merges=0`, `real=1.70s`
