### PR TITLE
Report Rust local self-field runtime provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,11 +97,14 @@ break.
   nominal parameter receivers proven as scope-visible `tokio::runtime::Runtime`
   or `tokio::runtime::Handle` now do too, including nested static brace imports
   such as `use tokio::{runtime::{Runtime}}`; exact `self.<field>` receivers
-  whose same-scope struct field type proves `tokio::runtime::Runtime` or
-  `Handle` now receive the same reporting. Selector-only `.block_on`,
-  non-self fields, local struct fields, project-local `tokio` roots or aliases,
-  wildcard or relative imports, type aliases, wrapped constructors, and
-  `map_err(...)?` runtime construction remain closed.
+  whose module or local declaration-scope struct field type proves
+  `tokio::runtime::Runtime` or `Handle` now receive the same reporting, and
+  success-channel-preserving `Result::map_err` adapters over proven
+  `Runtime::new()`/`Builder::build()` results are followed before `unwrap`,
+  `expect`, or `?`. Selector-only `.block_on`, non-self fields, duplicate or
+  shadowed local structs, project-local `tokio` roots or aliases, wildcard or
+  relative imports, type aliases, wrapped constructors, and constructor-assigned
+  fields remain closed.
 - Added Go channel/goroutine/defer obligation refinement. Go source-backed
   protocol boundaries now report channel send synchronization, receive value,
   comma-ok receive status, select readiness/case/default, goroutine scheduling

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -484,7 +484,20 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   imported-binding type evidence. Exact admission stays closed; non-self
   fields, local struct fields, project-local `tokio` roots or aliases,
   wildcard/relative imports, type aliases, wrapper calls, constructor-assigned
-  fields, and `map_err(...)?` construction remain closed.
+  fields, and `map_err(...)?` construction remained closed in that slice.
+- [rust-local-self-field-runtime-provenance-2026-07-01.v1.json](rust-local-self-field-runtime-provenance-2026-07-01.v1.json)
+  records the follow-up Rust local self-field receiver-provenance expansion.
+  Function/block-local `struct Runner { rt: Runtime }` plus local
+  `impl Runner { fn run(&self) { self.rt.block_on(...) } }` now receive the
+  same future-drive and future-settled obligations when the local declaration
+  scope or enclosing module scope has exact tokio runtime import/type proof. The Tokio
+  `task_local_set.rs` spot check moves the `self.rt.block_on(...)` row from
+  `receiver-mutation/effect-preserving-contract-missing` to
+  `scheduling-boundary/future-drive-scheduling-contract-missing` with `0` false
+  merges. Exact admission stays closed; duplicate local structs, wrong local
+  `Runtime` imports, same-scope `Runtime` types, namespace aliases named
+  `tokio`, non-self fields, type aliases, wrapper calls, and
+  constructor-assigned fields remain closed.
 - [scheduling-lifecycle-boundary-audit-swift-structured-concurrency-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-swift-structured-concurrency-2026-06-30.v1.json)
   records the matching 120-repo source-prevalence pricing. It raises total
   source prevalence from `142,847` to `143,178`: `Task.sleep` contributes

--- a/bench/recall_loss/rust-local-self-field-runtime-provenance-2026-07-01.v1.json
+++ b/bench/recall_loss/rust-local-self-field-runtime-provenance-2026-07-01.v1.json
@@ -1,0 +1,154 @@
+{
+  "report_kind": "rust-local-self-field-runtime-provenance",
+  "schema_version": 1,
+  "generated_on": "2026-07-01",
+  "scope": {
+    "kind": "reporting-only-rust-future-drive-local-self-field-receiver-provenance",
+    "summary": "Rust block_on reporting now consumes nominal tokio runtime evidence for self-field receivers declared in local function/block scopes.",
+    "semantic_admission_delta": 0,
+    "exact_admission_opened": false
+  },
+  "capability_alignment": {
+    "principle": "Capabilities over features",
+    "capability": "scope-aware receiver type provenance for field-backed future-drive scheduling attribution",
+    "not_a_feature_list": [
+      "No exact admission path was opened for Rust block_on or async/sync equivalence.",
+      "No new semantic kernel API was added.",
+      "The slice reuses node-anchored DomainEvidence::Nominal, Import/Symbol evidence, and shared future-drive obligations.",
+      "Only exact self.field receiver nodes inside impl methods with a self parameter receive field-domain proof.",
+      "Duplicate local structs, same-scope non-tokio Runtime imports, same-scope local Runtime types, namespace aliases named tokio, non-self receivers, type aliases, wrapper fields, and constructor-assigned fields remain closed."
+    ],
+    "reused_capabilities": [
+      "runtime-boundary-model",
+      "Rust imported binding evidence",
+      "Rust nominal type-domain evidence",
+      "node-anchored receiver Domain evidence",
+      "declaration-scope import visibility",
+      "AdmissionContext Rust local-runtime-root guard",
+      "shared future-drive scheduling and future-settled value-channel obligations"
+    ]
+  },
+  "new_reporting_surfaces": [
+    {
+      "language": "rust",
+      "surface": "fn outer() { use tokio::runtime::Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(...) } } }",
+      "guard": "The self.field receiver must be inside a local impl method with a self parameter, and the impl's declaration scope must contain exactly one matching struct field whose type is backed by exact tokio::runtime::Runtime import evidence from the local declaration scope or an enclosing module scope."
+    },
+    {
+      "language": "rust",
+      "surface": "fn outer() { struct Runner { handle: tokio::runtime::Handle } impl Runner { fn run(&self) { self.handle.block_on(...) } } }",
+      "guard": "Fully qualified local tokio runtime field types are accepted only when visible scopes do not define or alias a local tokio root."
+    }
+  ],
+  "focused_fixture": {
+    "tests": [
+      {
+        "test": "rust_runtime_domains::rust_tokio_runtime_self_field_domains_are_dependency_backed",
+        "command": "cargo test -p nose-frontend lower::tests::rust_runtime_domains -- --nocapture",
+        "assertions": [
+          "Local function-scope Runtime self-field domain evidence depends on the local imported binding symbol evidence.",
+          "Module-scope Runtime imports remain visible to local function/block struct field types.",
+          "Existing module-scope Runtime and fully qualified Handle self-field evidence remain admitted."
+        ]
+      },
+      {
+        "test": "rust_runtime_domains::rust_tokio_runtime_self_field_domains_require_exact_receiver_and_type_proof",
+        "command": "cargo test -p nose-frontend lower::tests::rust_runtime_domains -- --nocapture",
+        "assertions": [
+          "A local-scope Runtime type closes unqualified local Runtime field evidence.",
+          "A local-scope same-name Runtime import from another module stays closed.",
+          "A local-scope namespace alias named tokio closes qualified tokio runtime field evidence.",
+          "Duplicate local struct declarations keep the field-domain proof closed."
+        ]
+      },
+      {
+        "test": "rust_block_on_self_field::reports_future_drive_obligations_when_self_field_runtime_identity_is_proven",
+        "command": "cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture",
+        "assertions": [
+          "Local function-scope Runtime self-field receivers report future-drive and future-settled obligations."
+        ]
+      },
+      {
+        "test": "rust_block_on_self_field::requires_proven_local_self_field_runtime_identity",
+        "command": "cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture",
+        "assertions": [
+          "Local wrong imports, local Runtime shadow types, namespace aliases named tokio, and duplicate local struct declarations do not report future-drive obligations."
+        ]
+      }
+    ]
+  },
+  "current_crates_gate": {
+    "report": "target/recall-loss-rust-local-self-field.crates.after.json",
+    "total_units": 6825,
+    "interpretable_units": 947,
+    "excluded_units": 5878,
+    "admission_rejections": 791,
+    "false_merges": 0,
+    "lossy_fingerprint_collisions": 0,
+    "advisory_disagreements": 4,
+    "canon_checked": 96,
+    "canon_preservation_violations": 0,
+    "gate_passed": true,
+    "origin_main_elapsed_real_seconds": 2.47,
+    "current_elapsed_real_seconds": 0.98,
+    "note": "The local crates surface has no proof-backed local Rust self-field block_on bridge rows; the gate is used for hard soundness and runtime comparison."
+  },
+  "real_corpus_spot_checks": [
+    {
+      "repo": "tokio",
+      "path": "tokio/tests/task_local_set.rs",
+      "origin_main_command": "/tmp/nose-origin-main-local-scope-target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/tokio/tokio/tests/task_local_set.rs --max-violations 0 --recall-loss-report /tmp/recall-loss-rust-local-self-field.task-local.origin-main.json",
+      "current_command": "target/release/nose verify bench/repos/tokio/tokio/tests/task_local_set.rs --max-violations 0 --recall-loss-report target/recall-loss-rust-local-self-field.task-local.after.json",
+      "origin_main_elapsed_real_seconds": 0.03,
+      "current_elapsed_real_seconds": 0.02,
+      "summary": {
+        "total_units": 38,
+        "interpretable_units": 3,
+        "excluded_units": 35,
+        "admission_rejections": 3,
+        "false_merges": 0,
+        "obligation_before": "receiver-mutation/effect-preserving-contract-missing",
+        "obligation_after": "scheduling-boundary/future-drive-scheduling-contract-missing",
+        "line_range": "720-722"
+      }
+    }
+  ],
+  "closed_surfaces": [
+    {
+      "surface": "runner.rt.block_on(...) or other non-self field receivers",
+      "reason": "The receiver identity is not tied to the current impl self receiver."
+    },
+    {
+      "surface": "type Rt = tokio::runtime::Runtime; struct Runner { rt: Rt }",
+      "reason": "Rust type aliases are not converted into nominal receiver domain evidence in this slice."
+    },
+    {
+      "surface": "fields assigned from runtime constructors rather than declared with a tokio runtime type",
+      "reason": "Constructor assignment and field lifecycle proof are separate capabilities."
+    },
+    {
+      "surface": "Runtime fields from project-local tokio roots, raw local r#tokio roots, namespace aliases, extern crate aliases, or non-tokio modules",
+      "reason": "Same-named local or third-party type and namespace roots do not prove tokio runtime receiver semantics."
+    },
+    {
+      "surface": "Exact convergence between block_on, await, and synchronous payload values",
+      "reason": "Future drive scheduling, wake/poll behavior, cancellation/liveness, result-channel, and complete receiver/type identity contracts remain missing evidence."
+    }
+  ],
+  "validation_commands": [
+    "cargo fmt --all",
+    "cargo test -p nose-frontend lower::tests::param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture",
+    "cargo test -p nose-frontend lower::tests::rust_runtime_domains -- --nocapture",
+    "cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture",
+    "cargo build --release",
+    "/usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss-rust-local-self-field.crates.after.json",
+    "/usr/bin/time -p /tmp/nose-origin-main-local-scope-target/release/nose verify /Users/ak/prjs/cc/nose/crates --max-violations 0 --recall-loss-report /tmp/recall-loss-rust-local-self-field.crates.origin-main.json",
+    "/usr/bin/time -p /tmp/nose-origin-main-local-scope-target/release/nose verify /Users/ak/prjs/cc/nose/bench/repos/tokio/tokio/tests/task_local_set.rs --max-violations 0 --recall-loss-report /tmp/recall-loss-rust-local-self-field.task-local.origin-main.json",
+    "/usr/bin/time -p target/release/nose verify bench/repos/tokio/tokio/tests/task_local_set.rs --max-violations 0 --recall-loss-report target/recall-loss-rust-local-self-field.task-local.after.json"
+  ],
+  "next_followups": [
+    "Consider type-alias to nominal-domain evidence as a separate producer slice.",
+    "Consider constructor-assigned runtime fields only after field lifecycle and mutation proof exist.",
+    "Continue balancing Rust block_on improvements with Python, Swift, Java, and Go async surfaces so shared kernel obligations remain cross-language rather than JS/TS-only."
+  ]
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
@@ -11,6 +11,7 @@ mod imported_bindings;
 mod java;
 mod rust_block_on;
 mod rust_block_on_root_shadow;
+mod rust_block_on_self_field;
 mod scope_shadowing;
 mod swift;
 

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on.rs
@@ -182,37 +182,6 @@ fn reports_future_drive_obligations_when_parameter_runtime_identity_is_proven() 
 }
 
 #[test]
-fn reports_future_drive_obligations_when_self_field_runtime_identity_is_proven() {
-    let imported_runtime_self_field = missing_evidence_for_lang_call(
-        "runtime.rs",
-        "use tokio::runtime::Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let nested_brace_runtime_self_field = missing_evidence_for_lang_call(
-        "runtime.rs",
-        "use tokio::{runtime::{Builder, Runtime}};\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let qualified_handle_self_field = missing_evidence_for_lang_call(
-        "runtime.rs",
-        "struct Runner { handle: tokio::runtime::Handle }\nimpl Runner { fn run(&self) { self.handle.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-
-    for labels in [
-        imported_runtime_self_field,
-        nested_brace_runtime_self_field,
-        qualified_handle_self_field,
-    ] {
-        assert!(labels.contains(&"future-drive-scheduling-contract"));
-        assert!(labels.contains(&"future-settled-value-channel-contract"));
-    }
-}
-
-#[test]
 fn requires_proven_runtime_identity() {
     let unproven_receiver = runtime_boundary_evidence_for_lang_call(
         "runtime.rs",
@@ -288,74 +257,6 @@ fn requires_proven_runtime_identity() {
         (
             extension_method_changes_receiver_type,
             "Rust extension method changes block_on receiver type",
-        ),
-    ] {
-        assert_missing_evidence_not_contains(labels, "future-drive-scheduling-contract", surface);
-    }
-}
-
-#[test]
-fn requires_proven_self_field_runtime_identity() {
-    let non_self_receiver = runtime_boundary_evidence_for_lang_call(
-        "runtime.rs",
-        "use tokio::runtime::Runtime;\nstruct Runner { rt: Runtime }\nfn run(runner: Runner) { runner.rt.block_on(work()); }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let wrong_runtime_import = runtime_boundary_evidence_for_lang_call(
-        "runtime.rs",
-        "use project::runtime::Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let local_runtime_type = runtime_boundary_evidence_for_lang_call(
-        "runtime.rs",
-        "struct Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let parent_import_not_visible = runtime_boundary_evidence_for_lang_call(
-        "runtime.rs",
-        "use tokio::runtime::Runtime;\nmod local { struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    let project_local_tokio_field = runtime_boundary_evidence_for_corpus_call(
-        &[(
-            "runtime.rs",
-            "mod tokio { pub mod runtime { pub struct Runtime; } }\nstruct Runner { rt: tokio::runtime::Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-            Lang::Rust,
-        )],
-        "runtime.rs",
-        ".block_on",
-    );
-    let type_alias_field = runtime_boundary_evidence_for_lang_call(
-        "runtime.rs",
-        "use tokio::runtime::Runtime;\ntype Rt = Runtime;\nstruct Runner { rt: Rt }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
-        Lang::Rust,
-        ".block_on",
-    );
-    for (labels, surface) in [
-        (non_self_receiver, "Rust non-self field receiver"),
-        (
-            wrong_runtime_import,
-            "Rust self field with non-tokio Runtime import",
-        ),
-        (
-            local_runtime_type,
-            "Rust self field with local Runtime type",
-        ),
-        (
-            parent_import_not_visible,
-            "Rust self field with parent-module Runtime import",
-        ),
-        (
-            project_local_tokio_field,
-            "project-local tokio Runtime self field type",
-        ),
-        (
-            type_alias_field,
-            "Rust self field through Runtime type alias",
         ),
     ] {
         assert_missing_evidence_not_contains(labels, "future-drive-scheduling-contract", surface);

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on_self_field.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/rust_block_on_self_field.rs
@@ -1,0 +1,161 @@
+use super::{
+    assert_missing_evidence_not_contains, missing_evidence_for_lang_call,
+    runtime_boundary_evidence_for_corpus_call, runtime_boundary_evidence_for_lang_call,
+};
+use nose_il::Lang;
+
+#[test]
+fn reports_future_drive_obligations_when_self_field_runtime_identity_is_proven() {
+    let imported_runtime_self_field = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::runtime::Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let nested_brace_runtime_self_field = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::{runtime::{Builder, Runtime}};\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let qualified_handle_self_field = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "struct Runner { handle: tokio::runtime::Handle }\nimpl Runner { fn run(&self) { self.handle.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let local_runtime_self_field = missing_evidence_for_lang_call(
+        "runtime.rs",
+        "fn outer() { use tokio::runtime::Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+
+    for labels in [
+        imported_runtime_self_field,
+        nested_brace_runtime_self_field,
+        qualified_handle_self_field,
+        local_runtime_self_field,
+    ] {
+        assert!(labels.contains(&"future-drive-scheduling-contract"));
+        assert!(labels.contains(&"future-settled-value-channel-contract"));
+    }
+}
+
+#[test]
+fn requires_proven_self_field_runtime_identity() {
+    let non_self_receiver = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::runtime::Runtime;\nstruct Runner { rt: Runtime }\nfn run(runner: Runner) { runner.rt.block_on(work()); }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let wrong_runtime_import = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use project::runtime::Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let local_runtime_type = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "struct Runtime;\nstruct Runner { rt: Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let parent_import_not_visible = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::runtime::Runtime;\nmod local { struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let project_local_tokio_field = runtime_boundary_evidence_for_corpus_call(
+        &[(
+            "runtime.rs",
+            "mod tokio { pub mod runtime { pub struct Runtime; } }\nstruct Runner { rt: tokio::runtime::Runtime }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+            Lang::Rust,
+        )],
+        "runtime.rs",
+        ".block_on",
+    );
+    let type_alias_field = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "use tokio::runtime::Runtime;\ntype Rt = Runtime;\nstruct Runner { rt: Rt }\nimpl Runner { fn run(&self) { self.rt.block_on(work()); } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+
+    for (labels, surface) in [
+        (non_self_receiver, "Rust non-self field receiver"),
+        (
+            wrong_runtime_import,
+            "Rust self field with non-tokio Runtime import",
+        ),
+        (
+            local_runtime_type,
+            "Rust self field with local Runtime type",
+        ),
+        (
+            parent_import_not_visible,
+            "Rust self field with parent-module Runtime import",
+        ),
+        (
+            project_local_tokio_field,
+            "project-local tokio Runtime self field type",
+        ),
+        (
+            type_alias_field,
+            "Rust self field through Runtime type alias",
+        ),
+    ] {
+        assert_missing_evidence_not_contains(labels, "future-drive-scheduling-contract", surface);
+    }
+}
+
+#[test]
+fn requires_proven_local_self_field_runtime_identity() {
+    let local_scope_wrong_import = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn outer() { use project::runtime::Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let local_scope_runtime_type = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn outer() { use tokio::runtime::Runtime; struct Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let local_scope_namespace_alias = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn outer() { mod project { pub mod runtime { pub struct Runtime; } } use project as tokio; struct Runner { rt: tokio::runtime::Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+    let duplicate_local_struct = runtime_boundary_evidence_for_lang_call(
+        "runtime.rs",
+        "fn outer() { use tokio::runtime::Runtime; struct Runner { rt: Runtime } struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        ".block_on",
+    );
+
+    for (labels, surface) in [
+        (
+            local_scope_wrong_import,
+            "Rust local self field with non-tokio Runtime import",
+        ),
+        (
+            local_scope_runtime_type,
+            "Rust local self field with local Runtime type",
+        ),
+        (
+            local_scope_namespace_alias,
+            "Rust local self field with namespace alias named tokio",
+        ),
+        (
+            duplicate_local_struct,
+            "Rust local self field with duplicate struct declarations",
+        ),
+    ] {
+        assert_missing_evidence_not_contains(labels, "future-drive-scheduling-contract", surface);
+    }
+}

--- a/crates/nose-frontend/src/lower/tests/rust_runtime_domains.rs
+++ b/crates/nose-frontend/src/lower/tests/rust_runtime_domains.rs
@@ -41,6 +41,44 @@ fn rust_tokio_runtime_self_field_domains_are_dependency_backed() {
         handle_fields[0].dependencies.is_empty(),
         "fully qualified tokio Handle field evidence does not need import dependencies"
     );
+
+    let local_runtime_field = lower_fixture(
+        "tokio_local_runtime_self_field.rs",
+        b"fn outer() { use tokio::runtime::Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    let local_runtime_import_ids =
+        imported_binding_symbol_ids(&local_runtime_field.evidence, "tokio::runtime", "Runtime");
+    assert_eq!(local_runtime_import_ids.len(), 1);
+    let local_runtime_fields = field_domain_records(&local_runtime_field.evidence, runtime_domain);
+    assert_eq!(local_runtime_fields.len(), 1);
+    assert_eq!(
+        local_runtime_fields[0].dependencies, local_runtime_import_ids,
+        "local Rust self field runtime domain evidence should use the local declaration-scope import"
+    );
+
+    let local_runtime_field_with_module_import = lower_fixture(
+        "tokio_local_runtime_self_field_module_import.rs",
+        b"use tokio::runtime::Runtime;\nfn outer() { struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    let module_runtime_import_ids = imported_binding_symbol_ids(
+        &local_runtime_field_with_module_import.evidence,
+        "tokio::runtime",
+        "Runtime",
+    );
+    assert_eq!(module_runtime_import_ids.len(), 1);
+    let module_import_fields = field_domain_records(
+        &local_runtime_field_with_module_import.evidence,
+        runtime_domain,
+    );
+    assert_eq!(module_import_fields.len(), 1);
+    assert_eq!(
+        module_import_fields[0].dependencies, module_runtime_import_ids,
+        "module-scope Rust runtime imports should remain visible to local function/block struct field types"
+    );
 }
 
 #[test]
@@ -96,6 +134,54 @@ fn rust_tokio_runtime_self_field_domains_require_exact_receiver_and_type_proof()
         field_domain_records(&raw_local_runtime_type.evidence, runtime_domain).len(),
         0,
         "a raw local Runtime type must close unqualified Rust runtime field evidence"
+    );
+
+    let local_scope_runtime_type = lower_fixture(
+        "tokio_runtime_local_scope_type_self_field.rs",
+        b"fn outer() { use tokio::runtime::Runtime; struct Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    assert_eq!(
+        field_domain_records(&local_scope_runtime_type.evidence, runtime_domain).len(),
+        0,
+        "a local-scope Runtime type must close unqualified local Rust runtime field evidence"
+    );
+
+    let local_scope_wrong_runtime_import = lower_fixture(
+        "tokio_runtime_local_scope_wrong_import_self_field.rs",
+        b"fn outer() { use project::runtime::Runtime; struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    assert_eq!(
+        field_domain_records(&local_scope_wrong_runtime_import.evidence, runtime_domain).len(),
+        0,
+        "a local-scope same-name Runtime import from another module must not prove tokio runtime field identity"
+    );
+
+    let local_scope_namespace_alias_shadow = lower_fixture(
+        "tokio_runtime_local_scope_namespace_alias_shadow_self_field.rs",
+        b"fn outer() { mod project { pub mod runtime { pub struct Runtime; } } use project as tokio; struct Runner { rt: tokio::runtime::Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    assert_eq!(
+        field_domain_records(&local_scope_namespace_alias_shadow.evidence, runtime_domain).len(),
+        0,
+        "a local-scope namespace alias named tokio must close qualified tokio runtime field evidence"
+    );
+
+    let local_scope_duplicate_struct = lower_fixture(
+        "tokio_runtime_local_scope_duplicate_struct_self_field.rs",
+        b"fn outer() { use tokio::runtime::Runtime; struct Runner { rt: Runtime } struct Runner { rt: Runtime } impl Runner { fn run(&self) { self.rt.block_on(work()); } } }\n",
+        Lang::Rust,
+        &interner,
+    );
+    assert_eq!(
+        field_domain_records(&local_scope_duplicate_struct.evidence, runtime_domain).len(),
+        0,
+        "duplicate local struct definitions must keep Rust self field runtime evidence closed"
     );
 
     let parent_import_not_visible = lower_fixture(

--- a/crates/nose-frontend/src/rust/expressions.rs
+++ b/crates/nose-frontend/src/rust/expressions.rs
@@ -391,7 +391,7 @@ fn rust_struct_field_type_in_same_scope<'tree>(
     struct_name: &str,
     field_name: &str,
 ) -> Option<TsNode<'tree>> {
-    let scope = rust_enclosing_module_scope(node)?;
+    let scope = rust_enclosing_impl_item(node)?.parent()?;
     let mut matches = Vec::new();
     for item in Lowering::named_children(scope) {
         if item.kind() != "struct_item" || rust_named_item_text(lo, item) != Some(struct_name) {
@@ -405,6 +405,15 @@ fn rust_struct_field_type_in_same_scope<'tree>(
         return None;
     };
     Some(*field_type)
+}
+fn rust_enclosing_impl_item(mut node: TsNode) -> Option<TsNode> {
+    while let Some(parent) = node.parent() {
+        if parent.kind() == "impl_item" {
+            return Some(parent);
+        }
+        node = parent;
+    }
+    None
 }
 fn rust_named_item_text<'a>(lo: &'a Lowering, node: TsNode) -> Option<&'a str> {
     node.child_by_field_name("name").map(|name| lo.text(name))

--- a/crates/nose-frontend/src/rust/functions.rs
+++ b/crates/nose-frontend/src/rust/functions.rs
@@ -82,19 +82,19 @@ pub(super) fn rust_tokio_runtime_nominal_type_domain(
     let head = rust_type_head_preserving_case(type_text)?;
     match head.as_str() {
         "tokio::runtime::Runtime" => {
-            if rust_module_scope_shadows_qualified_root(lo, node, "tokio") {
+            if rust_type_reference_scope_shadows_qualified_root(lo, node, "tokio") {
                 return None;
             }
             Some((rust_tokio_runtime_nominal_domain("Runtime"), Vec::new()))
         }
         "tokio::runtime::Handle" => {
-            if rust_module_scope_shadows_qualified_root(lo, node, "tokio") {
+            if rust_type_reference_scope_shadows_qualified_root(lo, node, "tokio") {
                 return None;
             }
             Some((rust_tokio_runtime_nominal_domain("Handle"), Vec::new()))
         }
         _ if !head.contains("::") => {
-            if rust_module_scope_defines_type_name(lo, node, &head) {
+            if rust_type_reference_scope_defines_type_name(lo, node, &head) {
                 return None;
             }
             let mut matches = Vec::new();
@@ -124,45 +124,52 @@ fn rust_imported_runtime_type_dependencies(
     local: &str,
     exported: &str,
 ) -> Option<Vec<nose_il::EvidenceId>> {
-    if rust_module_scope_shadows_qualified_root(lo, param, "tokio") {
+    if rust_type_reference_scope_shadows_qualified_root(lo, param, "tokio") {
         return None;
     }
-    let scope = rust_enclosing_module_scope(param)?;
     let local_hash = nose_il::stable_symbol_hash(local);
     let module_hash = nose_il::stable_symbol_hash("tokio::runtime");
     let exported_hash = nose_il::stable_symbol_hash(exported);
-    let mut dependencies = Vec::new();
-    for record in &lo.evidence {
-        let nose_il::EvidenceAnchor::Binding {
-            local_hash: anchor_hash,
-            span,
-            ..
-        } = record.anchor
-        else {
-            continue;
-        };
-        if anchor_hash != local_hash {
-            continue;
+
+    for scope in rust_type_reference_visible_scopes(param) {
+        let mut dependencies = Vec::new();
+        let mut saw_local_import = false;
+        for record in &lo.evidence {
+            let nose_il::EvidenceAnchor::Binding {
+                local_hash: anchor_hash,
+                span,
+                ..
+            } = record.anchor
+            else {
+                continue;
+            };
+            if anchor_hash != local_hash {
+                continue;
+            }
+            if !rust_import_span_is_direct_child_of_scope(lo, scope, span) {
+                continue;
+            }
+            saw_local_import = true;
+            let nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::ImportedBinding {
+                module_hash: actual_module,
+                exported_hash: actual_exported,
+            }) = record.kind
+            else {
+                continue;
+            };
+            if record.status != nose_il::EvidenceStatus::Asserted
+                || actual_module != module_hash
+                || actual_exported != exported_hash
+            {
+                return None;
+            }
+            dependencies.push(record.id);
         }
-        if !rust_import_span_is_direct_child_of_scope(lo, scope, span) {
-            continue;
+        if saw_local_import {
+            return (!dependencies.is_empty()).then_some(dependencies);
         }
-        let nose_il::EvidenceKind::Symbol(nose_il::SymbolEvidenceKind::ImportedBinding {
-            module_hash: actual_module,
-            exported_hash: actual_exported,
-        }) = record.kind
-        else {
-            continue;
-        };
-        if record.status != nose_il::EvidenceStatus::Asserted
-            || actual_module != module_hash
-            || actual_exported != exported_hash
-        {
-            return None;
-        }
-        dependencies.push(record.id);
     }
-    (!dependencies.is_empty()).then_some(dependencies)
+    None
 }
 fn rust_import_span_is_direct_child_of_scope(lo: &Lowering, scope: TsNode, span: Span) -> bool {
     Lowering::named_children(scope).into_iter().any(|child| {
@@ -220,16 +227,29 @@ pub(super) fn rust_type_head_preserving_case(type_text: &str) -> Option<String> 
     (!head.is_empty()).then(|| head.to_string())
 }
 fn rust_module_scope_defines_type_name(lo: &Lowering, node: TsNode, name: &str) -> bool {
-    rust_enclosing_module_scope(node).is_some_and(|scope| {
-        Lowering::named_children(scope)
-            .into_iter()
-            .any(|child| rust_type_namespace_item_defines(lo, child, name))
-    })
+    rust_enclosing_module_scope(node)
+        .is_some_and(|scope| rust_scope_defines_type_name(lo, scope, name))
 }
-fn rust_module_scope_shadows_qualified_root(lo: &Lowering, node: TsNode, root: &str) -> bool {
-    let Some(scope) = rust_enclosing_module_scope(node) else {
-        return false;
-    };
+fn rust_type_reference_scope_defines_type_name(lo: &Lowering, node: TsNode, name: &str) -> bool {
+    rust_type_reference_visible_scopes(node)
+        .into_iter()
+        .any(|scope| rust_scope_defines_type_name(lo, scope, name))
+}
+fn rust_scope_defines_type_name(lo: &Lowering, scope: TsNode, name: &str) -> bool {
+    Lowering::named_children(scope)
+        .into_iter()
+        .any(|child| rust_type_namespace_item_defines(lo, child, name))
+}
+fn rust_type_reference_scope_shadows_qualified_root(
+    lo: &Lowering,
+    node: TsNode,
+    root: &str,
+) -> bool {
+    rust_type_reference_visible_scopes(node)
+        .into_iter()
+        .any(|scope| rust_scope_shadows_qualified_root(lo, scope, root))
+}
+fn rust_scope_shadows_qualified_root(lo: &Lowering, scope: TsNode, root: &str) -> bool {
     Lowering::named_children(scope).into_iter().any(|child| {
         rust_type_namespace_item_defines(lo, child, root)
             || rust_import_item_shadows_qualified_root(lo, child, root)
@@ -332,6 +352,31 @@ pub(super) fn rust_enclosing_module_scope(mut node: TsNode) -> Option<TsNode> {
         node = parent;
     }
     None
+}
+fn rust_type_reference_visible_scopes(mut node: TsNode) -> Vec<TsNode> {
+    let mut scopes = Vec::new();
+    while let Some(parent) = node.parent() {
+        match parent.kind() {
+            "block" | "source_file" => {
+                push_unique_ts_node(&mut scopes, parent);
+                if parent.kind() == "source_file" {
+                    break;
+                }
+            }
+            "declaration_list" if parent.parent().is_some_and(|p| p.kind() == "mod_item") => {
+                push_unique_ts_node(&mut scopes, parent);
+                break;
+            }
+            _ => {}
+        }
+        node = parent;
+    }
+    scopes
+}
+fn push_unique_ts_node<'tree>(nodes: &mut Vec<TsNode<'tree>>, node: TsNode<'tree>) {
+    if nodes.iter().all(|existing| existing.id() != node.id()) {
+        nodes.push(node);
+    }
 }
 fn rust_type_namespace_item_defines(lo: &Lowering, node: TsNode, name: &str) -> bool {
     if !matches!(

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -217,7 +217,16 @@ qualified or exact imported-binding type evidence. In the Tokio `sync_bridge.rs`
 spot check, future-drive oracle exclusions move from `0` to `13` with `0` false
 merges. Non-self fields, local struct fields, project-local `tokio` roots or
 aliases, wildcard/relative imports, type aliases, wrappers,
-and constructor-assigned fields remain closed. The [Rust map_err runtime
+and constructor-assigned fields remain closed in that slice. The [Rust local
+self-field runtime provenance artifact](../bench/recall_loss/rust-local-self-field-runtime-provenance-2026-07-01.v1.json)
+then extends the same receiver type-provenance capability to function/block
+local `struct` plus local `impl` declarations. In Tokio `task_local_set.rs`, the
+local `self.rt.block_on(...)` row moves from
+`receiver-mutation/effect-preserving-contract-missing` to
+`scheduling-boundary/future-drive-scheduling-contract-missing` with `0` false
+merges. Duplicate local structs, wrong local `Runtime` imports, same-scope
+`Runtime` types, namespace aliases named `tokio`, non-self fields, type aliases,
+wrappers, and constructor-assigned fields remain closed. The [Rust map_err runtime
 provenance artifact](../bench/recall_loss/rust-block-on-map-err-runtime-provenance-2026-07-01.v1.json)
 then opens only success-channel-preserving `Result::map_err` adapters over
 already proven `Runtime::new()` or `Builder::build()` results, moving two

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -124,7 +124,16 @@ proves `tokio::runtime::Runtime` or `Handle`; Tokio `sync_bridge.rs` moves from
 `0` to `13` future-drive oracle exclusions with `0` false merges. Non-self
 fields, local struct fields, project-local `tokio` roots or aliases including
 raw-identifier spellings, wildcard/relative imports, type aliases, wrappers,
-and constructor-assigned fields remain closed. The follow-up [Rust map_err
+and constructor-assigned fields remain closed in that slice. The follow-up
+[Rust local self-field runtime provenance artifact](../bench/recall_loss/rust-local-self-field-runtime-provenance-2026-07-01.v1.json)
+reuses the same capability for function/block-local `struct` plus local `impl`
+declarations. Tokio `task_local_set.rs` moves the local
+`self.rt.block_on(...)` row from
+`receiver-mutation/effect-preserving-contract-missing` to
+`scheduling-boundary/future-drive-scheduling-contract-missing` with `0` false
+merges; duplicate local structs, wrong local `Runtime` imports, same-scope
+`Runtime` types, namespace aliases named `tokio`, non-self fields, type aliases,
+wrappers, and constructor-assigned fields remain closed. The follow-up [Rust map_err
 runtime provenance artifact](../bench/recall_loss/rust-block-on-map-err-runtime-provenance-2026-07-01.v1.json)
 opens only success-channel-preserving `Result::map_err` adapters over already
 proven `Runtime::new()` or `Builder::build()` results; wrapper-returned Results


### PR DESCRIPTION
## Summary
- extend Rust tokio runtime self-field domain proof from module-scope struct/impl siblings to local declaration scopes
- keep the proof capability-based: reuse Import/Symbol evidence, node DomainEvidence::Nominal, and existing future-drive/future-settled obligations without opening exact admission
- add hard negatives for local Runtime shadow types, wrong Runtime imports, namespace aliases named tokio, duplicate local structs, and non-self/alias/constructor-assigned closed surfaces
- split self-field verifier tests into a focused module to keep file-length and clippy ratchets green
- add recall-loss artifact and docs linking the new Rust local self-field slice

## Measurement
- Tokio task_local_set.rs line 720-722: before `receiver-mutation/effect-preserving-contract-missing`, after `scheduling-boundary/future-drive-scheduling-contract-missing`
- `target/release/nose verify crates --max-violations 0`: false_merges=0, canon_preservation_violations=0, real=0.98s
- origin/main same gate from separate worktree: false_merges=0, canon_preservation_violations=0, real=2.47s
- Tokio task_local_set.rs spot check: false_merges=0 both before/after; real 0.03s -> 0.02s

## Tests
- `cargo fmt --all`
- `awiki format` from `docs/`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p nose-frontend lower::tests::param_domains::parameter_type_domains_are_dependency_backed_and_not_substring_guesses -- --nocapture`
- `cargo test -p nose-frontend lower::tests::rust_runtime_domains -- --nocapture`
- `cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::rust_block_on -- --nocapture`
- `cargo build --release`
- `target/release/nose verify bench/repos/tokio/tokio/tests/task_local_set.rs --max-violations 0 --recall-loss-report target/recall-loss-rust-local-self-field.task-local.after.json`
- `target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss-rust-local-self-field.crates.after.json`