### PR TITLE
Report Swift async task source protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,15 @@ break.
   representative Swift NIO, Composable Architecture, and Alamofire spot checks
   move async-iteration lifecycle evidence units from `0` to `31` with `0`
   false merges.
+- Added Swift async task source-protocol reporting. Async closures now reuse
+  the existing async-function protocol boundary, while `async let` emits the
+  reusable `TaskSpawn` source protocol capability for child-task scheduling,
+  handle lifecycle, and cancellation/liveness obligations. Exact admission
+  remains closed; the 120-repo audit prices `100` async closures across `4`
+  repos and `51` async-let bindings across `7` repos, and representative
+  Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw protocol tags
+  from `0` to `36` and async-function tags from `110` to `139` with `0` false
+  merges.
 - Added Ruby Thread/Fiber runtime reporting. `Thread.new`, `Thread.start`,
   `Thread.fork`, `Fiber.new`, and `Fiber.schedule` now reuse shared
   task-spawn, task-handle, cancellation/liveness, and concurrency scheduling

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -184,6 +184,19 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --generated-on 2026-07-01
 ```
 
+Build the Swift async task source-protocol audit with:
+
+```sh
+cargo run -q -p nose-cli -- verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/recall-loss.swift-async-task.crates.json
+
+python3 scripts/scheduling-lifecycle-boundary-audit.py \
+  --recall-loss-report target/recall-loss.swift-async-task.crates.json \
+  --output target/scheduling-lifecycle-boundary-audit.swift-async-task.json \
+  --generated-on 2026-07-01
+```
+
 Build the Ruby Thread/Fiber runtime obligation audit with:
 
 ```sh
@@ -625,6 +638,14 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   occurrences across `11` repos, and representative Swift NIO, Composable
   Architecture, and Alamofire spot checks move async-iteration lifecycle
   evidence units from `0` to `31` with `0` false merges.
+- [swift-async-task-source-protocol-2026-07-01.v1.json](swift-async-task-source-protocol-2026-07-01.v1.json)
+  records the Swift async task source-protocol slice. It adds the internal
+  `TaskSpawn` source protocol capability for `async let` and reuses
+  `AsyncFunction` for Swift async closures. The 120-repo audit prices `100`
+  async closures across `4` repos and `51` async-let bindings across `7` repos;
+  Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw protocol tags
+  from `0` to `36` and async-function tags from `110` to `139` with `0` false
+  merges.
 - [ruby-thread-fiber-runtime-reporting-2026-07-01.v1.json](ruby-thread-fiber-runtime-reporting-2026-07-01.v1.json)
   records the Ruby Thread/Fiber reporting-only expansion. `Thread.new`,
   `Thread.start`, `Thread.fork`, `Fiber.new`, and `Fiber.schedule` now reuse

--- a/bench/recall_loss/swift-async-task-source-protocol-2026-07-01.v1.json
+++ b/bench/recall_loss/swift-async-task-source-protocol-2026-07-01.v1.json
@@ -1,0 +1,252 @@
+{
+  "report_kind": "swift-async-task-source-protocol",
+  "schema_version": 1,
+  "generated_on": "2026-07-01",
+  "scope": {
+    "change": "Swift async task source surfaces now preserve protocol boundaries for async closures and async let bindings.",
+    "languages": [
+      "swift"
+    ],
+    "exact_admission_delta": 0,
+    "new_public_semantic_pack_api": false,
+    "new_kernel_enum_or_capability": true,
+    "reporting_only": true
+  },
+  "capability_alignment": {
+    "new_internal_capability": "SourceProtocolKind::TaskSpawn",
+    "reused_capabilities": [
+      "SourceProtocolKind::AsyncFunction",
+      "runtime-boundary-model",
+      "async-function-scheduling-contract",
+      "task-spawn-scheduling-contract",
+      "task-handle-lifecycle-contract",
+      "task-cancellation-liveness-contract",
+      "async-await-scheduling-contract",
+      "exception-channel-contract"
+    ],
+    "principle": "The slice adds a task-spawn source protocol capability rather than a Swift-only feature. Swift async let is a language source boundary for child-task scheduling, handle lifecycle, and cancellation/liveness; async closures reuse the existing async-function protocol capability.",
+    "fail_closed_boundary": "Exact async task, async closure, and async-let convergence remains closed until scheduling, callback effects, result channels, cancellation/liveness, and task lifetime contracts are dependency-closed."
+  },
+  "new_reporting_surfaces": [
+    {
+      "surface": "swift.async-closure",
+      "syntax": "{ request async throws -> Response in ... }",
+      "missing_evidence": [
+        "async-function-scheduling-contract"
+      ],
+      "notes": [
+        "The closure body is wrapped in the same async-function protocol boundary used by async declarations.",
+        "The fallback closure-header parser no longer treats the contextual async keyword as a lambda parameter."
+      ]
+    },
+    {
+      "surface": "swift.async-let",
+      "syntax": "async let value = work()",
+      "missing_evidence": [
+        "task-spawn-scheduling-contract",
+        "task-handle-lifecycle-contract",
+        "task-cancellation-liveness-contract"
+      ],
+      "notes": [
+        "The binding assignment remains inside the task-spawn source boundary.",
+        "Nested try/await expressions keep their existing exception and await scheduling protocol facts."
+      ]
+    }
+  ],
+  "focused_hard_negative_fixtures": [
+    {
+      "surface": "swift.asynclet-identifier",
+      "syntax": "let asynclet = compute()",
+      "expected": "No task-spawn protocol fact; async must be a distinct keyword before let."
+    },
+    {
+      "surface": "swift.no-argument-async-closure",
+      "syntax": "{ () async in 1 }",
+      "expected": "One async-function protocol fact and no invented lambda parameter named async."
+    },
+    {
+      "surface": "swift.async-closure-parameter-header",
+      "syntax": "{ req async throws -> String in ... }",
+      "expected": "The parameter is req; async is preserved as an async-function protocol boundary, not as a parameter."
+    },
+    {
+      "surface": "swift.async-identifier-closure-parameter",
+      "syntax": "{ async in async + 1 }",
+      "expected": "Bare contextual async before in stays a closure parameter, not an async-function protocol boundary."
+    }
+  ],
+  "corpus_pricing": {
+    "source": "target/scheduling-lifecycle-boundary-audit.swift-async-task.json",
+    "manifest": "bench/goldens/corpus.json",
+    "repos_root": "bench/repos",
+    "rows": [
+      {
+        "surface": "swift.async.closure",
+        "operation": "async closure",
+        "status": "reporting-supported-closed-boundary",
+        "occurrences": 100,
+        "repos": 4,
+        "top_repos": [
+          {
+            "repo": "vapor",
+            "occurrences": 86
+          },
+          {
+            "repo": "swift-composable-architecture",
+            "occurrences": 8
+          },
+          {
+            "repo": "nimble",
+            "occurrences": 5
+          },
+          {
+            "repo": "swift-nio",
+            "occurrences": 1
+          }
+        ],
+        "top_files": [
+          {
+            "path": "vapor/Tests/VaporTests/FileTests.swift",
+            "occurrences": 29
+          },
+          {
+            "path": "vapor/Tests/VaporTests/AuthenticationTests.swift",
+            "occurrences": 13
+          },
+          {
+            "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift",
+            "occurrences": 12
+          }
+        ]
+      },
+      {
+        "surface": "swift.async.let",
+        "operation": "async let",
+        "status": "reporting-supported-closed-boundary",
+        "occurrences": 51,
+        "repos": 7,
+        "top_repos": [
+          {
+            "repo": "alamofire",
+            "occurrences": 33
+          },
+          {
+            "repo": "swift-nio",
+            "occurrences": 5
+          },
+          {
+            "repo": "swift-composable-architecture",
+            "occurrences": 4
+          },
+          {
+            "repo": "swiftlint",
+            "occurrences": 4
+          }
+        ],
+        "top_files": [
+          {
+            "path": "alamofire/Tests/ConcurrencyTests.swift",
+            "occurrences": 17
+          },
+          {
+            "path": "alamofire/Tests/OfflineRetrierTests.swift",
+            "occurrences": 16
+          },
+          {
+            "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift",
+            "occurrences": 4
+          }
+        ]
+      }
+    ],
+    "broad_swift_async_bucket": {
+      "surface": "swift.async.function",
+      "operation": "async",
+      "status": "closed-boundary",
+      "occurrences": 3953,
+      "repos": 17
+    }
+  },
+  "representative_spot_check": {
+    "files": [
+      "bench/repos/alamofire/Tests/ConcurrencyTests.swift",
+      "bench/repos/alamofire/Tests/OfflineRetrierTests.swift",
+      "bench/repos/swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift",
+      "bench/repos/vapor/Tests/VaporTests/FileTests.swift"
+    ],
+    "method": "Count source-protocol raw tags in `nose il` output with branch and origin/main release code.",
+    "origin_main": {
+      "task_spawn_raw_tags": 0,
+      "async_function_raw_tags": 110,
+      "await_raw_tags": 244,
+      "try_raw_tags": 120,
+      "async_for_raw_tags": 14,
+      "false_merges": 0
+    },
+    "branch": {
+      "task_spawn_raw_tags": 36,
+      "async_function_raw_tags": 139,
+      "await_raw_tags": 244,
+      "try_raw_tags": 120,
+      "async_for_raw_tags": 14,
+      "false_merges": 0
+    },
+    "interpretation": "The branch preserves async-let task-spawn boundaries that main erased, and adds async-function boundaries for real async closures without changing existing await, try, or async-for counts."
+  },
+  "current_crates_gate": {
+    "branch": {
+      "total_units": 6930,
+      "interpretable_units": 968,
+      "excluded_units": 5962,
+      "admission_rejections": 810,
+      "false_merges": 0,
+      "canon_preservation_violations": 0,
+      "release_verify_real_seconds": [
+        1.78,
+        1.08,
+        1.13
+      ]
+    },
+    "origin_main": {
+      "total_units": 6906,
+      "interpretable_units": 957,
+      "excluded_units": 5949,
+      "admission_rejections": 800,
+      "false_merges": 0,
+      "canon_preservation_violations": 0,
+      "release_verify_real_seconds": [
+        1.72,
+        1.22,
+        1.28
+      ]
+    },
+    "delta": {
+      "total_units": 24,
+      "interpretable_units": 11,
+      "excluded_units": 13,
+      "admission_rejections": 10,
+      "false_merges": 0,
+      "canon_preservation_violations": 0,
+      "median_release_verify_real_seconds": -0.15
+    }
+  },
+  "validation_commands": [
+    "cargo fmt --check",
+    "cargo test -p nose-frontend swift::tests:: -- --nocapture",
+    "cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime::swift -- --nocapture",
+    "cargo test -p nose-semantics library_api_contracts::demand_effect::promise_and_protocol_demand_profiles_keep_async_boundaries -- --nocapture",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.swift-async-task.crates.json --output target/scheduling-lifecycle-boundary-audit.swift-async-task.json --generated-on 2026-07-01",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.swift-async-task.crates.json",
+    "cargo build --release -p nose-cli",
+    "/usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.swift-async-task.release.crates.json",
+    "origin/main worktree: cargo build --release -p nose-cli && /usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.swift-async-task.release.main.crates.json",
+    "branch/main `nose il` spot-checks over Alamofire ConcurrencyTests, Alamofire OfflineRetrierTests, Swift NIO NIOAsyncSequenceTests, and Vapor FileTests",
+    "target/release/nose verify bench/repos/alamofire/Tests/ConcurrencyTests.swift bench/repos/alamofire/Tests/OfflineRetrierTests.swift bench/repos/swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift bench/repos/vapor/Tests/VaporTests/FileTests.swift --max-violations 0 --recall-loss-report target/recall-loss.swift-async-task.spot.json",
+    "Quick AsyncExample.swift spot-check: function-typed async closure parameters no longer emit async_function raw protocol tags"
+  ],
+  "next_exact_work_policy": [
+    "Do not collapse async-let values with synchronous assignments from the task-spawn label alone.",
+    "Do not treat async closures as ordinary synchronous lambdas until scheduling, callback demand/effect, and exception-channel obligations are modeled.",
+    "Keep Swift `Task { ... }`, task groups, continuations, async iteration, async closure, and async let as separate source/runtime evidence anchors that map onto shared task and async-function capabilities."
+  ]
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary.rs
@@ -115,6 +115,11 @@ fn push_source_protocol_missing_evidence(
             push_unique(labels, "goroutine-callback-effect-contract");
             push_unique(labels, "concurrency-scheduling-contract");
         }
+        nose_il::SourceProtocolKind::TaskSpawn => {
+            push_unique(labels, "task-spawn-scheduling-contract");
+            push_unique(labels, "task-handle-lifecycle-contract");
+            push_unique(labels, "task-cancellation-liveness-contract");
+        }
         nose_il::SourceProtocolKind::TryPropagation => {
             push_unique(labels, "exception-channel-contract");
         }

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs
@@ -249,6 +249,22 @@ fn swift_continuation_bridges_reject_local_runtime_shadows() {
 }
 
 #[test]
+fn swift_async_let_reports_task_spawn_protocol_obligations() {
+    let labels = missing_evidence_for_protocol(
+        "async-let.swift",
+        "func run() async throws -> Int {\n  async let value: Int = try await work()\n  return try await value\n}\n",
+        Lang::Swift,
+        nose_il::SourceProtocolKind::TaskSpawn,
+    );
+
+    assert!(labels.contains(&"task-spawn-scheduling-contract"));
+    assert!(labels.contains(&"task-handle-lifecycle-contract"));
+    assert!(labels.contains(&"task-cancellation-liveness-contract"));
+    assert!(labels.contains(&"async-await-scheduling-contract"));
+    assert!(labels.contains(&"exception-channel-contract"));
+}
+
+#[test]
 fn swift_async_iteration_reports_shared_protocol_obligations() {
     let labels = missing_evidence_for_protocol(
         "stream.swift",

--- a/crates/nose-frontend/src/lower.rs
+++ b/crates/nose-frontend/src/lower.rs
@@ -23,6 +23,7 @@ pub(crate) const PROTOCOL_BOUNDARY_TAGS: &[&str] = &[
     "select",
     "select_case",
     "select_default",
+    "task_spawn",
     "try",
     "yield",
 ];

--- a/crates/nose-frontend/src/swift/helpers.rs
+++ b/crates/nose-frontend/src/swift/helpers.rs
@@ -113,7 +113,7 @@ fn consume_swift_try_token(text: &str) -> Option<&str> {
         .or_else(|| consume_swift_keyword(text, "try"))
 }
 
-fn consume_swift_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
+pub(super) fn consume_swift_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
     let rest = text.strip_prefix(keyword)?;
     if rest
         .chars()
@@ -125,7 +125,7 @@ fn consume_swift_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
     Some(rest)
 }
 
-fn is_swift_identifier_continue(ch: char) -> bool {
+pub(super) fn is_swift_identifier_continue(ch: char) -> bool {
     ch == '_' || ch.is_alphanumeric()
 }
 

--- a/crates/nose-frontend/src/swift/lambdas.rs
+++ b/crates/nose-frontend/src/swift/lambdas.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub(super) fn lower_lambda(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
+    let is_async = swift_lambda_is_async(lo.text(node));
     let mut kids = Vec::new();
     if let Some(lambda_type) = node.child_by_field_name("type") {
         lower_lambda_type_params(lo, lambda_type, &mut kids);
@@ -21,7 +22,16 @@ pub(super) fn lower_lambda(lo: &mut Lowering, node: TsNode) -> NodeId {
         .map(|body| lower_function_body(lo, body))
         .unwrap_or_else(|| lo.empty_block(span));
     dedupe_lambda_params(lo, &mut kids);
-    kids.push(body);
+    kids.push(if is_async {
+        lo.protocol_boundary(
+            span,
+            SourceProtocolKind::AsyncFunction,
+            "async_function",
+            &[body],
+        )
+    } else {
+        body
+    });
     lo.add(NodeKind::Lambda, Payload::None, span, &kids)
 }
 pub(super) fn dedupe_lambda_params(lo: &Lowering, kids: &mut Vec<NodeId>) {
@@ -62,8 +72,8 @@ pub(super) fn lambda_parameter_names_from_text(text: &str) -> Vec<String> {
         return Vec::new();
     };
     let inner = inner.trim();
-    if let Some((header, _body)) = inner.split_once(" in ") {
-        return header
+    if let Some((header, _body)) = split_swift_lambda_in(inner) {
+        return swift_lambda_parameter_header(header)
             .trim()
             .trim_start_matches('(')
             .trim_end_matches(')')
@@ -76,6 +86,224 @@ pub(super) fn lambda_parameter_names_from_text(text: &str) -> Vec<String> {
     }
     Vec::new()
 }
+
+pub(super) fn swift_lambda_is_async(text: &str) -> bool {
+    swift_lambda_header(text).is_some_and(swift_lambda_header_has_async)
+}
+
+fn swift_lambda_header(text: &str) -> Option<&str> {
+    let inner = text
+        .trim()
+        .strip_prefix('{')
+        .and_then(|text| text.strip_suffix('}'))?
+        .trim();
+    split_swift_lambda_in(inner).map(|(header, _)| header.trim())
+}
+
+fn swift_lambda_header_has_async(header: &str) -> bool {
+    let header = swift_lambda_header_without_capture_list(header.trim());
+    swift_lambda_async_modifier_offset(header).is_some()
+}
+
+fn swift_lambda_parameter_header(header: &str) -> &str {
+    let header = swift_lambda_header_without_capture_list(header.trim());
+    let before_return = swift_lambda_top_level_return_arrow(header)
+        .map(|idx| &header[..idx])
+        .unwrap_or(header)
+        .trim();
+    swift_lambda_signature_modifier_start(before_return)
+        .map(|idx| before_return[..idx].trim())
+        .unwrap_or(before_return)
+}
+
+fn swift_lambda_header_tokens(header: &str) -> impl Iterator<Item = &str> {
+    header
+        .split(|ch: char| {
+            ch.is_whitespace()
+                || matches!(
+                    ch,
+                    '(' | ')' | ',' | ':' | '-' | '>' | '[' | ']' | '{' | '}'
+                )
+        })
+        .filter(|token| !token.is_empty())
+}
+
+fn swift_lambda_header_without_capture_list(header: &str) -> &str {
+    let trimmed = header.trim_start();
+    if !trimmed.starts_with('[') {
+        return trimmed;
+    }
+    let mut depth = 0usize;
+    for (idx, ch) in trimmed.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return trimmed[idx + 1..].trim_start();
+                }
+            }
+            _ => {}
+        }
+    }
+    trimmed
+}
+
+fn split_swift_lambda_in(text: &str) -> Option<(&str, &str)> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    for (idx, ch) in text.char_indices() {
+        if paren_depth == 0
+            && bracket_depth == 0
+            && brace_depth == 0
+            && is_swift_keyword_at(text, idx, "in")
+        {
+            return Some((&text[..idx], &text[idx + "in".len()..]));
+        }
+        match ch {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn swift_lambda_signature_modifier_start(header: &str) -> Option<usize> {
+    ["async", "throws", "rethrows"]
+        .into_iter()
+        .filter_map(|keyword| swift_lambda_modifier_offset(header, keyword))
+        .min()
+}
+
+fn swift_lambda_async_modifier_offset(header: &str) -> Option<usize> {
+    swift_lambda_modifier_offset(header, "async")
+}
+
+fn swift_lambda_modifier_offset(header: &str, keyword: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    for (idx, ch) in header.char_indices() {
+        if paren_depth == 0
+            && bracket_depth == 0
+            && brace_depth == 0
+            && swift_lambda_keyword_is_signature_modifier(header, idx, keyword)
+        {
+            return Some(idx);
+        }
+        match ch {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn swift_lambda_top_level_return_arrow(header: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    for (idx, ch) in header.char_indices() {
+        if paren_depth == 0
+            && bracket_depth == 0
+            && brace_depth == 0
+            && header[idx..].starts_with("->")
+        {
+            return Some(idx);
+        } else {
+            match ch {
+                '(' => paren_depth += 1,
+                ')' => paren_depth = paren_depth.saturating_sub(1),
+                '[' => bracket_depth += 1,
+                ']' => bracket_depth = bracket_depth.saturating_sub(1),
+                '{' => brace_depth += 1,
+                '}' => brace_depth = brace_depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn swift_lambda_keyword_is_signature_modifier(header: &str, idx: usize, keyword: &str) -> bool {
+    if !is_swift_keyword_at(header, idx, keyword) {
+        return false;
+    }
+    let before = header[..idx].trim_end();
+    let after = header[idx + keyword.len()..].trim_start();
+    swift_lambda_modifier_prefix_is_valid(before)
+        && swift_lambda_modifier_tail_is_valid(keyword, after)
+}
+
+fn swift_lambda_modifier_prefix_is_valid(before: &str) -> bool {
+    if swift_lambda_has_top_level_colon(before) {
+        return false;
+    }
+    if before.ends_with(')') {
+        return true;
+    }
+    swift_lambda_header_tokens(before)
+        .filter(|token| !token.starts_with('@'))
+        .any(|token| !matches!(token, "async" | "throws" | "rethrows"))
+}
+
+fn swift_lambda_modifier_tail_is_valid(keyword: &str, after: &str) -> bool {
+    if after.is_empty() || after.starts_with("->") {
+        return true;
+    }
+    if keyword == "async" {
+        return consume_swift_keyword(after, "throws")
+            .or_else(|| consume_swift_keyword(after, "rethrows"))
+            .is_some_and(|rest| {
+                let rest = rest.trim_start();
+                rest.is_empty() || rest.starts_with("->")
+            });
+    }
+    false
+}
+
+fn swift_lambda_has_top_level_colon(text: &str) -> bool {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    for ch in text.chars() {
+        if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && ch == ':' {
+            return true;
+        }
+        match ch {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
+}
+
+fn is_swift_keyword_at(text: &str, idx: usize, keyword: &str) -> bool {
+    if !text[idx..].starts_with(keyword) {
+        return false;
+    }
+    let before = text[..idx].chars().next_back();
+    let after = text[idx + keyword.len()..].chars().next();
+    !before.is_some_and(is_swift_identifier_continue)
+        && !after.is_some_and(is_swift_identifier_continue)
+}
+
 pub(super) fn lambda_parameter_name_from_header_part(part: &str) -> Option<String> {
     let before_type = part.trim().split(':').next()?.trim();
     let name = before_type

--- a/crates/nose-frontend/src/swift/properties.rs
+++ b/crates/nose-frontend/src/swift/properties.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(super) fn lower_property(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
     let mut assigns = Vec::new();
+    let is_async_let = swift_property_is_async_let(lo.text(node));
     let mut cursor = node.walk();
     let names: Vec<TsNode> = node.children_by_field_name("name", &mut cursor).collect();
     let values = field_children(node, "value");
@@ -20,7 +21,12 @@ pub(super) fn lower_property(lo: &mut Lowering, node: TsNode) -> NodeId {
             .map(|value| lower_expr(lo, *value))
             .or_else(|| lower_computed_property(lo, node))
             .unwrap_or_else(|| lo.add(NodeKind::Lit, Payload::Lit(LitClass::Null), span, &[]));
-        assigns.push(lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]));
+        let assign = lo.add(NodeKind::Assign, Payload::None, span, &[lhs, rhs]);
+        assigns.push(if is_async_let {
+            lo.protocol_boundary(span, SourceProtocolKind::TaskSpawn, "task_spawn", &[assign])
+        } else {
+            assign
+        });
     }
     if assigns.is_empty() {
         lower_computed_property(lo, node).unwrap_or_else(|| lo.empty_block(span))
@@ -29,6 +35,14 @@ pub(super) fn lower_property(lo: &mut Lowering, node: TsNode) -> NodeId {
     } else {
         lo.add(NodeKind::Block, Payload::None, span, &assigns)
     }
+}
+
+fn swift_property_is_async_let(text: &str) -> bool {
+    let text = text.trim_start();
+    let Some(after_async) = consume_swift_keyword(text, "async") else {
+        return false;
+    };
+    consume_swift_keyword(after_async.trim_start(), "let").is_some()
 }
 pub(super) fn record_property_binding_domain(
     lo: &mut Lowering,

--- a/crates/nose-frontend/src/swift/tests.rs
+++ b/crates/nose-frontend/src/swift/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod async_protocols;
 mod surfaces;
 
 fn il_with_interner(src: &str) -> (Il, Interner) {
@@ -448,122 +449,6 @@ func fetch(_ key: String) async throws -> Int
         "protocol function requirement should be a method-like unit"
     );
     assert!(il.nodes.iter().any(|node| node.kind == NodeKind::Param));
-}
-
-#[test]
-fn async_function_preserves_source_backed_async_boundary() {
-    let (il, interner) = il_with_interner(
-        r#"
-func fetch(_ key: String) async -> Int {
-  return key.count
-}
-"#,
-    );
-
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_function",
-        SourceProtocolKind::AsyncFunction,
-    );
-}
-
-#[test]
-fn async_for_preserves_source_backed_async_iteration_boundary() {
-    let (il, interner) = il_with_interner(
-        r#"
-func read(_ stream: AsyncStream<Int>) async {
-  for await value in stream {
-    print(value)
-  }
-}
-"#,
-    );
-
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_for",
-        SourceProtocolKind::AsyncIteration,
-    );
-    assert!(
-        !raw_names(&il, &interner).iter().any(|name| name == "try"),
-        "plain for-await should not introduce a try-propagation boundary"
-    );
-}
-
-#[test]
-fn throwing_async_for_preserves_iteration_and_try_boundaries() {
-    let (il, interner) = il_with_interner(
-        r#"
-func read(_ stream: AsyncThrowingStream<Int, Error>) async throws {
-  for try await value in stream {
-    print(value)
-  }
-}
-"#,
-    );
-
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_for",
-        SourceProtocolKind::AsyncIteration,
-    );
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "try",
-        SourceProtocolKind::TryPropagation,
-    );
-}
-
-#[test]
-fn async_for_keywords_do_not_match_identifier_prefixes() {
-    let (il, interner) = il_with_interner(
-        r#"
-func read(_ awaiters: [Int], _ values: [Int]) {
-  for awaiter in awaiters {
-    print(awaiter)
-  }
-  for tryawait in values {
-    print(tryawait)
-  }
-}
-"#,
-    );
-    let raw = raw_names(&il, &interner);
-
-    assert!(
-        !raw.iter().any(|name| name == "async_for"),
-        "ordinary identifiers prefixed with await/try-await should not create async iteration boundaries: {raw:?}"
-    );
-    assert!(
-        !raw.iter().any(|name| name == "try"),
-        "ordinary identifiers prefixed with try should not create try-propagation boundaries: {raw:?}"
-    );
-}
-
-#[test]
-fn multiline_throwing_async_for_anchors_try_to_keyword_line() {
-    let (il, interner) = il_with_interner(
-        "func read(_ stream: AsyncThrowingStream<Int, Error>) async throws {\n  for\n    try await value in stream {\n      print(value)\n    }\n}\n",
-    );
-
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_for",
-        SourceProtocolKind::AsyncIteration,
-    );
-    let try_node = crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "try",
-        SourceProtocolKind::TryPropagation,
-    );
-    assert_eq!(il.node(try_node).span.start_line, 3);
-    assert_eq!(il.node(try_node).span.end_line, 3);
 }
 
 #[test]

--- a/crates/nose-frontend/src/swift/tests/async_protocols.rs
+++ b/crates/nose-frontend/src/swift/tests/async_protocols.rs
@@ -1,0 +1,263 @@
+use super::*;
+
+#[test]
+fn closure_header_async_identifier_is_not_async_modifier() {
+    assert_eq!(
+        lambda_parameter_names_from_text("{ async in async + 1 }"),
+        vec!["async".to_string()]
+    );
+    assert!(
+        !swift_lambda_is_async("{ async in async + 1 }"),
+        "a bare contextual `async` before `in` is a parameter name, not an async closure modifier"
+    );
+    assert_eq!(
+        lambda_parameter_names_from_text("{ req async throws -> String in req.value }"),
+        vec!["req".to_string()]
+    );
+    assert!(
+        swift_lambda_is_async("{ req async throws -> String in req.value }"),
+        "`async` after a closure parameter is the async closure modifier"
+    );
+    assert_eq!(
+        lambda_parameter_names_from_text(
+            "{ (closure: @escaping () async throws -> Void) in closure }"
+        ),
+        vec!["closure".to_string()]
+    );
+    assert!(
+        !swift_lambda_is_async("{ (closure: @escaping () async throws -> Void) in closure }"),
+        "`async` inside a function-typed closure parameter is not the closure modifier"
+    );
+}
+
+#[test]
+fn function_typed_async_parameter_does_not_create_async_closure_boundary() {
+    let (il, interner) = il_with_interner(
+        r#"
+func install() {
+  let handle: (@escaping () async throws -> Void) -> () async -> Void = { (closure: @escaping () async throws -> Void) in
+    {
+      try await closure()
+    }
+  }
+}
+"#,
+    );
+    let raw = raw_names(&il, &interner);
+
+    assert!(
+        !raw.iter().any(|name| name == "async_function"),
+        "function-typed async parameters should not make the outer closure an async-function boundary: {raw:?}"
+    );
+}
+
+#[test]
+fn async_function_preserves_source_backed_async_boundary() {
+    let (il, interner) = il_with_interner(
+        r#"
+func fetch(_ key: String) async -> Int {
+  return key.count
+}
+"#,
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_function",
+        SourceProtocolKind::AsyncFunction,
+    );
+}
+
+#[test]
+fn async_closure_preserves_source_backed_async_boundary() {
+    let (il, interner) = il_with_interner(
+        r#"
+func install(_ route: Route) {
+  route.get("x") { req async throws -> String in
+    return try await req.load()
+  }
+}
+"#,
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_function",
+        SourceProtocolKind::AsyncFunction,
+    );
+    let async_sym = interner.intern("async");
+    assert!(
+        !il.nodes.iter().any(|node| {
+            node.kind == NodeKind::Param && node.payload == Payload::Name(async_sym)
+        }),
+        "async closure keyword should not lower as a lambda parameter"
+    );
+}
+
+#[test]
+fn no_argument_async_closure_does_not_create_async_parameter() {
+    let (il, interner) = il_with_interner(
+        r#"
+func make() {
+  let work: () async -> Int = { () async in 1 }
+}
+"#,
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_function",
+        SourceProtocolKind::AsyncFunction,
+    );
+    let async_sym = interner.intern("async");
+    assert!(
+        !il.nodes.iter().any(|node| {
+            node.kind == NodeKind::Param && node.payload == Payload::Name(async_sym)
+        }),
+        "no-argument async closure should not invent an `async` parameter"
+    );
+}
+
+#[test]
+fn async_let_preserves_source_backed_task_spawn_boundary() {
+    let (il, interner) = il_with_interner(
+        r#"
+func fetch() async throws -> Int {
+  async let first: Int = try await compute()
+  return try await first
+}
+"#,
+    );
+
+    let task_spawn = crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "task_spawn",
+        SourceProtocolKind::TaskSpawn,
+    );
+    assert!(
+        il.children(task_spawn)
+            .iter()
+            .any(|&child| il.kind(child) == NodeKind::Assign),
+        "async let task-spawn boundary should retain the binding assignment"
+    );
+}
+
+#[test]
+fn async_let_keyword_does_not_match_identifier_prefixes() {
+    let (il, interner) = il_with_interner(
+        r#"
+func fetch() {
+  let asynclet = compute()
+  let asynchronous = compute()
+}
+"#,
+    );
+    let raw = raw_names(&il, &interner);
+
+    assert!(
+        !raw.iter().any(|name| name == "task_spawn"),
+        "ordinary identifiers prefixed with async should not create task-spawn boundaries: {raw:?}"
+    );
+}
+
+#[test]
+fn async_for_preserves_source_backed_async_iteration_boundary() {
+    let (il, interner) = il_with_interner(
+        r#"
+func read(_ stream: AsyncStream<Int>) async {
+  for await value in stream {
+    print(value)
+  }
+}
+"#,
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_for",
+        SourceProtocolKind::AsyncIteration,
+    );
+    assert!(
+        !raw_names(&il, &interner).iter().any(|name| name == "try"),
+        "plain for-await should not introduce a try-propagation boundary"
+    );
+}
+
+#[test]
+fn throwing_async_for_preserves_iteration_and_try_boundaries() {
+    let (il, interner) = il_with_interner(
+        r#"
+func read(_ stream: AsyncThrowingStream<Int, Error>) async throws {
+  for try await value in stream {
+    print(value)
+  }
+}
+"#,
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_for",
+        SourceProtocolKind::AsyncIteration,
+    );
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "try",
+        SourceProtocolKind::TryPropagation,
+    );
+}
+
+#[test]
+fn async_for_keywords_do_not_match_identifier_prefixes() {
+    let (il, interner) = il_with_interner(
+        r#"
+func read(_ awaiters: [Int], _ values: [Int]) {
+  for awaiter in awaiters {
+    print(awaiter)
+  }
+  for tryawait in values {
+    print(tryawait)
+  }
+}
+"#,
+    );
+    let raw = raw_names(&il, &interner);
+
+    assert!(
+        !raw.iter().any(|name| name == "async_for"),
+        "ordinary identifiers prefixed with await/try-await should not create async iteration boundaries: {raw:?}"
+    );
+    assert!(
+        !raw.iter().any(|name| name == "try"),
+        "ordinary identifiers prefixed with try should not create try-propagation boundaries: {raw:?}"
+    );
+}
+
+#[test]
+fn multiline_throwing_async_for_anchors_try_to_keyword_line() {
+    let (il, interner) = il_with_interner(
+        "func read(_ stream: AsyncThrowingStream<Int, Error>) async throws {\n  for\n    try await value in stream {\n      print(value)\n    }\n}\n",
+    );
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_for",
+        SourceProtocolKind::AsyncIteration,
+    );
+    let try_node = crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "try",
+        SourceProtocolKind::TryPropagation,
+    );
+    assert_eq!(il.node(try_node).span.start_line, 3);
+    assert_eq!(il.node(try_node).span.end_line, 3);
+}

--- a/crates/nose-il/src/node/source.rs
+++ b/crates/nose-il/src/node/source.rs
@@ -69,6 +69,7 @@ pub enum SourceProtocolKind {
     ChannelSend,
     Defer,
     GoRoutine,
+    TaskSpawn,
     TryPropagation,
     Yield,
 }

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -506,7 +506,9 @@ pub fn source_protocol_demand_effect_profile(protocol: SourceProtocolKind) -> De
             callback: None,
             effect_visibility: EffectVisibility::ChannelBoundary,
         },
-        SourceProtocolKind::Defer | SourceProtocolKind::GoRoutine => DemandEffectProfile {
+        SourceProtocolKind::Defer
+        | SourceProtocolKind::GoRoutine
+        | SourceProtocolKind::TaskSpawn => DemandEffectProfile {
             operation: DemandOperation::ProtocolBoundary,
             order: EvaluationOrder::ProtocolDefined,
             child_demand: ChildDemand::ProtocolBoundary,

--- a/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
@@ -258,6 +258,10 @@ fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
         DemandOperation::ProtocolBoundary
     );
     assert_eq!(
+        source_protocol_demand_effect_profile(SourceProtocolKind::TaskSpawn).effect_visibility,
+        EffectVisibility::ProtocolBoundary
+    );
+    assert_eq!(
         source_protocol_demand_effect_profile(SourceProtocolKind::AsyncIteration).effect_visibility,
         EffectVisibility::AsyncBoundary
     );

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -588,12 +588,15 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   expressions preserve a raw async boundary and emit
   `Source::Protocol(Await)` at that source span. JS/TS and Python `yield`
   expressions emit `Source::Protocol(Yield)`. Rust `async {}` and `?` emit
-  `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. These
-  are future protocol/demand proof anchors, not evidence that the source
-  operation is equivalent to its operand or body. Go `go`, `defer`, channel
-  send/receive, receive-status projection, `select`, and select cases/defaults
-  likewise preserve source-backed protocol anchors instead of ordinary calls,
-  values, or generic sequences. Python list/set/dict comprehensions and generator
+  `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. Swift
+  async closures reuse `Source::Protocol(AsyncFunction)`, and Swift `async let`
+  bindings emit `Source::Protocol(TaskSpawn)` so child-task scheduling, handle
+  lifecycle, and cancellation/liveness remain fail-closed. These are future
+  protocol/demand proof anchors, not evidence that the source operation is
+  equivalent to its operand or body. Go `go`, `defer`, channel send/receive,
+  receive-status projection, `select`, and select cases/defaults likewise
+  preserve source-backed protocol anchors instead of ordinary calls, values, or
+  generic sequences. Python list/set/dict comprehensions and generator
   expressions emit source-comprehension facts so exact consumers can distinguish
   eager materialized lists, lazy generators, set deduplication, and dict
   materialization even when the lowered HOF body shape is similar. Rust range

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -248,6 +248,16 @@ occurrences across `11` repos, and representative Swift NIO, Composable
 Architecture, and Alamofire spot checks move async-iteration lifecycle evidence
 units from `0` to `31` with `0` false merges. Exact async-sequence recovery
 remains closed.
+The follow-up [Swift async task source-protocol artifact](../bench/recall_loss/swift-async-task-source-protocol-2026-07-01.v1.json)
+keeps exact admission closed while extending source syntax reporting to Swift
+async closures and `async let`. Async closures reuse the existing
+`AsyncFunction` protocol boundary; `async let` adds the reusable
+`TaskSpawn` source protocol capability and maps it onto task-spawn scheduling,
+task-handle lifecycle, and cancellation/liveness obligations rather than a
+Swift-only feature row. The 120-repo audit prices `100` async closures across
+`4` repos and `51` async-let bindings across `7` repos. Alamofire/Swift
+NIO/Vapor spot checks move `task_spawn` raw protocol tags from `0` to `36` and
+async-function tags from `110` to `139` with `0` false merges.
 The follow-up [promise-protocol-hard-negatives-2026-06-28.v1.json](../bench/recall_loss/promise-protocol-hard-negatives-2026-06-28.v1.json)
 pins the Promise-specific hard negatives before any recovery slice opens:
 async-function/sync, Promise executor/sync, Promise.resolve/sync,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2363,6 +2363,18 @@ Swift NIO, Composable Architecture, and Alamofire spot checks move
 async-iteration lifecycle evidence units from `0` to `31` with `0` false
 merges.
 
+2026-07-01 Swift async task source-protocol note:
+The [swift-async-task-source-protocol-2026-07-01.v1.json](../bench/recall_loss/swift-async-task-source-protocol-2026-07-01.v1.json)
+artifact extends Swift source syntax reporting without adding a Swift-only
+feature row. Async closures reuse the existing `AsyncFunction` source protocol;
+`async let` adds the reusable `TaskSpawn` source protocol capability and maps
+it to task-spawn scheduling, task-handle lifecycle, and cancellation/liveness
+obligations. Exact admission remains closed. The 120-repo audit prices `100`
+async closures across `4` repos and `51` async-let bindings across `7` repos,
+and Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw protocol tags
+from `0` to `36` plus async-function tags from `110` to `139` with `0` false
+merges.
+
 ## See also
 
 - Back to [semantic-kernel](semantic-kernel.md).

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -260,6 +260,15 @@ keyword span. The 120-repo audit prices `193` Swift async iteration
 occurrences across `11` repos, and representative Swift NIO, Composable
 Architecture, and Alamofire spot checks move async-iteration lifecycle evidence
 units from `0` to `31` with `0` false merges.
+The follow-up [Swift async task source-protocol artifact](../bench/recall_loss/swift-async-task-source-protocol-2026-07-01.v1.json)
+keeps the same reporting-only boundary for Swift task source syntax. Async
+closures reuse `Source::Protocol(AsyncFunction)`, while `async let` emits the
+reusable `Source::Protocol(TaskSpawn)` capability for child-task scheduling,
+handle lifecycle, and cancellation/liveness obligations. The 120-repo audit
+prices `100` async closures across `4` repos and `51` async-let bindings
+across `7` repos; Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw
+protocol tags from `0` to `36` and async-function tags from `110` to `139`
+with `0` false merges.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, selected property/non-factory method/view surfaces,
 and selected non-call sentinels, with occurrence evidence covering selected

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -126,12 +126,14 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("java", "java.stream.lifecycle", "stream/parallelStream", "lifecycle-materialization-boundary", "java-stream-lifecycle-contract-missing", "stream lifecycle", "Java streams need lazy/eager lifecycle and terminal materialization proof", re.compile(r"\.\s*(?:stream|parallelStream)\s*\(")),
     Pattern("swift", "swift.async.await", "await", "scheduling-boundary", "async-await-scheduling-contract-missing", "await scheduling", "Swift await has task scheduling and actor/lifetime boundaries", re.compile(r"\bawait\b")),
     Pattern("swift", "swift.async.function", "async", "scheduling-boundary", "async-function-scheduling-contract-missing", "async function scheduling", "Swift async surfaces create task/future-like protocol boundaries", re.compile(r"\basync\b")),
+    Pattern("swift", "swift.async.closure", "async closure", "scheduling-boundary", "async-function-scheduling-contract-missing", "async closure scheduling", "Swift async closures create async callable protocol boundaries even when the surrounding function is synchronous", re.compile(r"(?!x)x"), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.async.iteration", "for await/for try await", "lifecycle-materialization-boundary", "async-iteration-lifecycle-contract-missing", "async iteration lifecycle", "Swift async sequence loops need async iterator lifecycle, value-channel, scheduling, and throwing-channel proof", re.compile(r"\bfor\s+(?:try[!?]?\s+)?await\b"), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.error.throws", "throws/try", "exception-channel", "swift-throws-exception-channel-contract-missing", "throws channel", "Swift throws/try is an explicit error channel", re.compile(r"\b(?:throws|try)\b")),
     Pattern("swift", "swift.task.spawn", "Task/Task.detached", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "task scheduling", "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries", re.compile(r"\bTask(?:\s*\.\s*detached\s*(?:\{|\()|\s*\{)")),
     Pattern("swift", "swift.task.sleep", "Task.sleep", "scheduling-boundary", "timer-scheduling-contract-missing", "task sleep timer", "Swift Task.sleep creates a timer-backed scheduling boundary and cancellation/liveness boundary", re.compile(r"\bTask\s*\.\s*sleep\s*\("), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.task.yield", "Task.yield", "scheduling-boundary", "task-yield-scheduling-contract-missing", "task yield", "Swift Task.yield yields to the task scheduler and must not collapse into sync value equivalence", re.compile(r"\bTask\s*\.\s*yield\s*\("), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.task.group", "withTaskGroup/withThrowingTaskGroup/withDiscardingTaskGroup/withThrowingDiscardingTaskGroup", "success-error-result-channel", "async-aggregate-all-completion-contract-missing", "task-group aggregate", "Swift task groups need all-completion, result-channel, cancellation/liveness, and throwing error-channel proof", re.compile(r"\bwith(?:Throwing)?(?:Discarding)?TaskGroup\s*\("), "reporting-supported-closed-boundary"),
+    Pattern("swift", "swift.async.let", "async let", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "structured task binding", "Swift async let creates a child task with scheduling, handle lifecycle, cancellation/liveness, and awaited result boundaries", re.compile(r"\basync\s+let\b"), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.continuation.checked", "withCheckedContinuation/withUnsafeContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift continuation bridge", "Swift continuation bridges suspend and resume through a callback-settled future-like result channel", re.compile(r"\bwith(?:Checked|Unsafe)Continuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.continuation.throwing", "withCheckedThrowingContinuation/withUnsafeThrowingContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift throwing continuation bridge", "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels", re.compile(r"\bwith(?:Checked|Unsafe)ThrowingContinuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.thread.fiber", "Thread/Fiber", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "thread/fiber scheduling", "Thread/Fiber APIs create scheduler and lifecycle boundaries", re.compile(r"\b(?:Thread\s*\.\s*(?:new|start|fork)|Fiber\s*\.\s*(?:new|schedule))\b"), "reporting-supported-closed-boundary"),
@@ -666,6 +668,8 @@ def count_file(text: str, language: str) -> dict[Pattern, int]:
     for pattern in PATTERNS:
         if pattern.language != language:
             continue
+        if pattern.surface == "swift.async.closure":
+            continue
         count = sum(1 for _ in pattern.regex.finditer(masked))
         if count:
             counts[pattern] = count
@@ -683,7 +687,158 @@ def count_file(text: str, language: str) -> dict[Pattern, int]:
         counts.update(go_channel_protocol_counts(masked))
     elif language == "java":
         counts.update(java_future_receiver_counts(masked))
+    elif language == "swift":
+        counts.update(swift_async_closure_counts(masked))
     return counts
+
+
+def swift_async_closure_counts(text: str) -> dict[Pattern, int]:
+    pattern = next(item for item in PATTERNS if item.surface == "swift.async.closure")
+    count = 0
+    for header in iter_swift_closure_headers(text):
+        if swift_closure_header_has_top_level_async_modifier(header):
+            count += 1
+    return {pattern: count} if count else {}
+
+
+def iter_swift_closure_headers(text: str):
+    for start, ch in enumerate(text):
+        if ch != "{":
+            continue
+        paren_depth = 0
+        bracket_depth = 0
+        brace_depth = 0
+        idx = start + 1
+        while idx < len(text):
+            current = text[idx]
+            if current == "\n":
+                break
+            if (
+                paren_depth == 0
+                and bracket_depth == 0
+                and brace_depth == 0
+                and is_word_at(text, idx, "in")
+            ):
+                yield text[start + 1 : idx].strip()
+                break
+            if current == "(":
+                paren_depth += 1
+            elif current == ")":
+                paren_depth = max(0, paren_depth - 1)
+            elif current == "[":
+                bracket_depth += 1
+            elif current == "]":
+                bracket_depth = max(0, bracket_depth - 1)
+            elif current == "{":
+                brace_depth += 1
+            elif current == "}":
+                if brace_depth == 0:
+                    break
+                brace_depth -= 1
+            idx += 1
+
+
+def swift_closure_header_has_top_level_async_modifier(header: str) -> bool:
+    header = swift_closure_header_without_capture_list(header)
+    for idx, _ in iter_top_level_word_offsets(header, "async"):
+        before = header[:idx].rstrip()
+        after = header[idx + len("async") :].lstrip()
+        if swift_closure_modifier_prefix_is_valid(before) and swift_closure_async_tail_is_valid(after):
+            return True
+    return False
+
+
+def swift_closure_header_without_capture_list(header: str) -> str:
+    trimmed = header.lstrip()
+    if not trimmed.startswith("["):
+        return trimmed
+    depth = 0
+    for idx, ch in enumerate(trimmed):
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth = max(0, depth - 1)
+            if depth == 0:
+                return trimmed[idx + 1 :].lstrip()
+    return trimmed
+
+
+def iter_top_level_word_offsets(text: str, word: str):
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    for idx, ch in enumerate(text):
+        if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0 and is_word_at(text, idx, word):
+            yield idx, word
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif ch == "[":
+            bracket_depth += 1
+        elif ch == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+        elif ch == "{":
+            brace_depth += 1
+        elif ch == "}":
+            brace_depth = max(0, brace_depth - 1)
+
+
+def swift_closure_modifier_prefix_is_valid(before: str) -> bool:
+    if swift_has_top_level_colon(before):
+        return False
+    if before.endswith(")"):
+        return True
+    return any(
+        token not in {"async", "throws", "rethrows"} and not token.startswith("@")
+        for token in re.split(r"[\s(),:\-\>\[\]{}]+", before)
+        if token
+    )
+
+
+def swift_closure_async_tail_is_valid(after: str) -> bool:
+    if not after or after.startswith("->"):
+        return True
+    for keyword in ("throws", "rethrows"):
+        if is_word_at(after, 0, keyword):
+            rest = after[len(keyword) :].lstrip()
+            return not rest or rest.startswith("->")
+    return False
+
+
+def swift_has_top_level_colon(text: str) -> bool:
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    for ch in text:
+        if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0 and ch == ":":
+            return True
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif ch == "[":
+            bracket_depth += 1
+        elif ch == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+        elif ch == "{":
+            brace_depth += 1
+        elif ch == "}":
+            brace_depth = max(0, brace_depth - 1)
+    return False
+
+
+def is_word_at(text: str, idx: int, word: str) -> bool:
+    if not text.startswith(word, idx):
+        return False
+    before = text[idx - 1] if idx > 0 else ""
+    after_idx = idx + len(word)
+    after = text[after_idx] if after_idx < len(text) else ""
+    return not is_identifier_continue(before) and not is_identifier_continue(after)
+
+
+def is_identifier_continue(ch: str) -> bool:
+    return ch == "_" or ch.isalnum()
 
 
 def go_channel_protocol_counts(text: str) -> dict[Pattern, int]:


### PR DESCRIPTION
## Summary
- add reusable internal SourceProtocolKind::TaskSpawn and map Swift async let onto it
- preserve Swift async closures as AsyncFunction protocol boundaries while keeping function-typed async parameters as ordinary closure parameters
- add checked 120-repo pricing/evidence docs and keep exact admission closed

## Quantitative evidence
- 120-repo audit prices Swift async closures at 100 occurrences across 4 repos and async let at 51 occurrences across 7 repos
- Alamofire/Swift NIO/Vapor spot checks move task_spawn raw protocol tags from 0 to 36 and async_function tags from 110 to 139, with await/try/async_for counts unchanged
- verify crates: false_merges=0, canon_preservation_violations=0
- release verify crates median: branch 1.13s vs origin/main 1.28s (-0.15s; no degradation)

## Review fixes
- fixed the false async-closure report for synchronous closures whose parameter type is async, e.g. (closure: @escaping () async throws -> Void) in
- changed the Swift async-closure audit row from a broad regex to a top-level modifier scanner; the count changed from 101/5 repos to 100/4 repos by dropping the Quick false positive
- included --recall-loss-report in the recorded audit regeneration command

## Validation
- cargo fmt --check
- cargo test -p nose-frontend swift::tests:: -- --nocapture
- cargo test -p nose-cli --lib verify_admission::runtime_boundary::tests::async_runtime::swift -- --nocapture
- cargo test -p nose-semantics library_api_contracts::demand_effect::promise_and_protocol_demand_profiles_keep_async_boundaries -- --nocapture
- cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.swift-async-task.crates.json
- python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.swift-async-task.crates.json --output target/scheduling-lifecycle-boundary-audit.swift-async-task.json --generated-on 2026-07-01
- ./scripts/check-docs.sh
- ./scripts/check-duplication.sh
- ./scripts/check-ci-local.sh --fast