### PR TITLE
Report Rust async closure source protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,10 @@ break.
   non-self fields, duplicate or shadowed local structs, project-local `tokio`
   roots or aliases, wildcard or relative imports, type aliases, wrapped
   constructors, and constructor-assigned fields remain closed.
+- Added Rust async closure source-protocol reporting. `async |...|` and
+  `async move |...|` closures now reuse the shared `AsyncFunction` source
+  protocol boundary, while synchronous closures and Rust `async { ... }`
+  blocks remain distinct; exact async closure admission remains closed.
 - Added Go channel/goroutine/defer obligation refinement. Go source-backed
   protocol boundaries now report channel send synchronization, receive value,
   comma-ok receive status, select readiness/case/default, goroutine scheduling

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -197,6 +197,20 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --generated-on 2026-07-01
 ```
 
+Build the Rust async closure source-protocol audit with:
+
+```sh
+cargo run -q -p nose-cli -- verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/recall-loss.rust-async-closure.crates.json
+
+python3 scripts/scheduling-lifecycle-boundary-audit.py \
+  --recall-loss-report target/recall-loss.rust-async-closure.crates.json \
+  --output target/rust-async-closure-source-protocol-audit.json \
+  --generated-on 2026-07-01 \
+  --include-zero-surface rust.async.closure
+```
+
 Build the Ruby Thread/Fiber runtime obligation audit with:
 
 ```sh
@@ -646,6 +660,14 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw protocol tags
   from `0` to `36` and async-function tags from `110` to `139` with `0` false
   merges.
+- [rust-async-closure-source-protocol-2026-07-01.v1.json](rust-async-closure-source-protocol-2026-07-01.v1.json)
+  records the Rust async closure source-protocol parity slice. It reuses
+  `AsyncFunction` for `async |...|` and `async move |...|` closures without
+  adding a Rust-only kernel feature or opening exact admission. The pinned
+  120-repo corpus has `0` Rust async closure occurrences, while the same audit
+  now distinguishes those closures from `1,342` Rust async blocks across
+  `4` repos. The checked `crates` gate remains at `0` false merges and `0`
+  canon preservation violations.
 - [ruby-thread-fiber-runtime-reporting-2026-07-01.v1.json](ruby-thread-fiber-runtime-reporting-2026-07-01.v1.json)
   records the Ruby Thread/Fiber reporting-only expansion. `Thread.new`,
   `Thread.start`, `Thread.fork`, `Fiber.new`, and `Fiber.schedule` now reuse

--- a/bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json
+++ b/bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json
@@ -1,0 +1,196 @@
+{
+  "report_kind": "rust-async-closure-source-protocol",
+  "schema_version": 1,
+  "generated_on": "2026-07-01",
+  "scope": {
+    "change": "Rust async closures now preserve a source-backed async-function protocol boundary.",
+    "languages": [
+      "rust"
+    ],
+    "exact_admission_delta": 0,
+    "new_public_semantic_pack_api": false,
+    "new_kernel_enum_or_capability": false,
+    "reporting_only": true
+  },
+  "capability_alignment": {
+    "principle": "Capabilities over features",
+    "reused_capabilities": [
+      "SourceProtocolKind::AsyncFunction",
+      "async-function-scheduling-contract",
+      "runtime-boundary-model",
+      "recall-loss oracle_exclusions.by_obligation"
+    ],
+    "not_a_feature_list": [
+      "No Rust-only protocol kind was added.",
+      "No exact admission path was opened for async closures or async/sync equivalence.",
+      "Rust async closures reuse the same async callable source protocol already used for async function declarations and Swift async closures.",
+      "Rust async blocks remain a separate AsyncBlock protocol surface and are not counted as async closures."
+    ],
+    "fail_closed_boundary": "Exact async closure convergence remains closed until scheduling, callback demand/effect, future result-channel, cancellation/liveness, and exception-channel obligations are dependency-closed."
+  },
+  "new_reporting_surfaces": [
+    {
+      "surface": "rust.async-closure",
+      "syntax": "async move |x: i32| x + 1",
+      "missing_evidence": [
+        "async-function-scheduling-contract",
+        "future-settled-value-channel-contract",
+        "future-callback-demand-effect-contract"
+      ],
+      "notes": [
+        "The lowered Lambda remains inside a raw `async_function` source-protocol boundary.",
+        "Synchronous closures remain ordinary Lambda nodes without an async protocol boundary.",
+        "The scheduling lifecycle audit now separates `async move |...|` closures from `async move { ... }` blocks."
+      ]
+    }
+  ],
+  "focused_hard_negative_fixtures": [
+      {
+        "surface": "rust.sync-closure",
+        "syntax": "|x: i32| x + 1",
+        "expected": "No async-function protocol fact is emitted and the sync closure does not form an exact semantic family with the async closure."
+      },
+    {
+      "surface": "rust.async-block",
+      "syntax": "async move { x + 1 }",
+      "expected": "AsyncBlock remains separate from AsyncFunction."
+    }
+  ],
+  "corpus_pricing": {
+    "source": "target/rust-async-closure-source-protocol-audit.json",
+    "manifest": "bench/goldens/corpus.json",
+    "repos_root": "bench/repos",
+    "rows": [
+      {
+        "surface": "rust.async.closure",
+        "operation": "async closure",
+        "status": "reporting-supported-closed-boundary",
+        "occurrences": 0,
+        "repos": 0,
+        "note": "The pinned 120-repo corpus contains no Rust async closure syntax after comment/string masking; this slice is parity and hard-negative coverage for a supported Rust surface."
+      },
+      {
+        "surface": "rust.async.block",
+        "operation": "async block",
+        "status": "closed-boundary",
+        "occurrences": 1342,
+        "repos": 4,
+        "top_repos": [
+          {
+            "repo": "tokio",
+            "occurrences": 1273
+          },
+          {
+            "repo": "meilisearch",
+            "occurrences": 61
+          },
+          {
+            "repo": "rustls",
+            "occurrences": 5
+          },
+          {
+            "repo": "nushell",
+            "occurrences": 3
+          }
+        ],
+        "top_files": [
+          {
+            "path": "tokio/tokio/tests/macros_select.rs",
+            "occurrences": 109
+          },
+          {
+            "path": "tokio/tokio/tests/rt_common.rs",
+            "occurrences": 86
+          },
+          {
+            "path": "tokio/tokio/tests/task_local_set.rs",
+            "occurrences": 57
+          }
+        ],
+        "note": "The audit now requires `{` after optional `move`, so async closures cannot inflate this async-block row."
+      },
+      {
+        "surface": "rust.async.function",
+        "operation": "async fn",
+        "status": "closed-boundary",
+        "occurrences": 2806,
+        "repos": 4
+      },
+      {
+        "surface": "rust.async.await",
+        "operation": ".await",
+        "status": "closed-boundary",
+        "occurrences": 8647,
+        "repos": 4
+      }
+    ]
+  },
+  "focused_fixture": {
+    "tests": [
+      {
+        "test": "rust::tests::async_closure_preserves_source_backed_protocol_boundary",
+        "command": "cargo test -p nose-frontend async_closure -- --nocapture",
+        "assertions": [
+          "`async move |x: i32| x + 1` emits one raw `async_function` protocol boundary.",
+          "The closure body still contains the Add operation."
+        ]
+      },
+      {
+        "test": "rust::tests::sync_closure_does_not_create_async_protocol_boundary",
+        "command": "cargo test -p nose-frontend sync_closure_does_not_create_async_protocol_boundary",
+        "assertions": [
+          "A synchronous Rust closure does not emit an `async_function` raw protocol tag."
+        ]
+      },
+      {
+        "test": "query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+        "command": "cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence -- --nocapture",
+        "assertions": [
+          "A Rust async closure and an otherwise matching synchronous closure do not form an exact semantic family without async callable proof."
+        ]
+      }
+    ]
+  },
+  "current_crates_gate": {
+    "report": "target/recall-loss.rust-async-closure.crates.json",
+    "total_units": 6933,
+    "interpretable_units": 968,
+    "excluded_units": 5965,
+    "admission_rejections": 810,
+    "false_merges": 0,
+    "canon_checked": 99,
+    "canon_preservation_violations": 0,
+    "gate_passed": true,
+    "origin_main_release_verify_real_seconds": [
+      1.8,
+      1.21,
+      1.09
+    ],
+    "current_release_verify_real_seconds": [
+      1.75,
+      1.09,
+      1.05
+    ],
+    "median_release_verify_real_seconds_delta": -0.12
+  },
+  "validation_commands": [
+    "cargo fmt --check",
+    "python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py",
+    "cargo test -p nose-frontend async_closure -- --nocapture",
+    "cargo test -p nose-frontend sync_closure_does_not_create_async_protocol_boundary",
+    "cargo test -p nose-frontend async_functions_and_blocks_preserve_source_backed_protocol_boundaries",
+    "cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence -- --nocapture",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.rust-async-closure.crates.json --output target/rust-async-closure-source-protocol-audit.json --generated-on 2026-07-01 --include-zero-surface rust.async.closure",
+    "./scripts/check-docs.sh",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.rust-async-closure.crates.json",
+    "cargo build --release -p nose-cli",
+    "cargo build --release -p nose-cli (in /tmp/nose-main-rust-async-closure at origin/main)",
+    "/usr/bin/time -p target/release/nose verify crates --max-violations 0 --recall-loss-report target/recall-loss.rust-async-closure.release.crates.json",
+    "/usr/bin/time -p /tmp/nose-main-rust-async-closure/target/release/nose verify /Users/ak/prjs/cc/nose/crates --max-violations 0 --recall-loss-report /Users/ak/prjs/cc/nose/target/recall-loss.rust-async-closure.release.main-crates.json"
+  ],
+  "next_followups": [
+    "Keep exact Rust async closure recovery closed until future scheduling and callback-effect contracts can prove the closure call and returned Future channel.",
+    "Prioritize higher-prevalence Rust async surfaces such as `.await`, `async fn`, `async {}`, and Tokio Future-drive bridges for exact or reporting follow-ups.",
+    "Use this parity fixture as a guard before enabling any cross-language async callable recovery that includes JS/TS async arrows, Swift async closures, or Rust async closures."
+  ]
+}

--- a/crates/nose-cli/tests/cli/semantic_boundaries.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries.rs
@@ -276,6 +276,25 @@ fn query_mode_semantic_rejects_unproven_rust_await_sync_convergence() {
     );
 }
 
+/// Rust async closures are Future-producing callable boundaries, not ordinary
+/// synchronous lambdas. Exact convergence requires async callable scheduling and
+/// result-channel proof that is not modeled yet.
+#[test]
+fn query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence() {
+    let project = TempProject::new("rs_async_closure_boundary");
+    project.write("sync.rs", "fn make() { let cb = |x: i32| x + 1; }\n");
+    project.write(
+        "async.rs",
+        "fn make() { let cb = async move |x: i32| x + 1; }\n",
+    );
+
+    let json = project.query_semantic_min_json();
+    assert!(
+        !family_contains_all(&json, &["sync.rs", "async.rs"]),
+        "Rust async closures must not merge with sync closures without async callable proof: {json}"
+    );
+}
+
 /// Swift `await` is a task/protocol boundary. It must not be erased into a
 /// synchronous expression until the kernel has scheduling and effect proof for
 /// the relevant Swift async protocol slice.

--- a/crates/nose-frontend/src/rust/expressions.rs
+++ b/crates/nose-frontend/src/rust/expressions.rs
@@ -451,6 +451,7 @@ pub(super) fn lower_index(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 pub(super) fn lower_closure(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);
+    let is_async = rust_closure_has_async_modifier(node);
     let mut kids = Vec::new();
     if let Some(params) = node.child_by_field_name("parameters") {
         lower_params(lo, params, &mut kids);
@@ -460,7 +461,23 @@ pub(super) fn lower_closure(lo: &mut Lowering, node: TsNode) -> NodeId {
         .map(|b| lower_expr(lo, b))
         .unwrap_or_else(|| lo.empty_block(span));
     kids.push(body);
-    lo.add(NodeKind::Lambda, Payload::None, span, &kids)
+    let lambda = lo.add(NodeKind::Lambda, Payload::None, span, &kids);
+    if is_async {
+        lo.protocol_boundary(
+            span,
+            SourceProtocolKind::AsyncFunction,
+            "async_function",
+            &[lambda],
+        )
+    } else {
+        lambda
+    }
+}
+fn rust_closure_has_async_modifier(node: TsNode) -> bool {
+    (0..node.child_count()).any(|index| {
+        node.child(index)
+            .is_some_and(|child| child.kind() == "async")
+    })
 }
 pub(super) fn lower_negative_literal(lo: &mut Lowering, node: TsNode) -> NodeId {
     let span = lo.span(node);

--- a/crates/nose-frontend/src/rust/tests.rs
+++ b/crates/nose-frontend/src/rust/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod async_protocols;
 mod imports;
 mod surfaces;
 
@@ -529,47 +530,6 @@ fn match_typed_integer_literal_pattern_retains_value() {
         match_case_rhs_ints(src).contains(&1),
         "typed integer match patterns should retain their numeric value"
     );
-}
-
-#[test]
-fn async_functions_and_blocks_preserve_source_backed_protocol_boundaries() {
-    let interner = Interner::new();
-    let il = lower(
-        FileId(0),
-        "t.rs",
-        b"pub async fn f(x: i32) -> i32 { async move { x + 1 }.await }\n",
-        &interner,
-    )
-    .expect("lower");
-
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_function",
-        SourceProtocolKind::AsyncFunction,
-    );
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "async_block",
-        SourceProtocolKind::AsyncBlock,
-    );
-    crate::test_helpers::expect_raw_protocol_boundary(
-        &il,
-        &interner,
-        "await",
-        SourceProtocolKind::Await,
-    );
-
-    let ops: Vec<_> = il
-        .nodes
-        .iter()
-        .filter_map(|node| match node.payload {
-            Payload::Op(op) => Some(op),
-            _ => None,
-        })
-        .collect();
-    assert!(ops.contains(&Op::Add), "async block body was lost: {ops:?}");
 }
 
 #[test]

--- a/crates/nose-frontend/src/rust/tests/async_protocols.rs
+++ b/crates/nose-frontend/src/rust/tests/async_protocols.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[test]
+fn async_functions_and_blocks_preserve_source_backed_protocol_boundaries() {
+    let interner = Interner::new();
+    let il = lower(
+        FileId(0),
+        "t.rs",
+        b"pub async fn f(x: i32) -> i32 { async move { x + 1 }.await }\n",
+        &interner,
+    )
+    .expect("lower");
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_function",
+        SourceProtocolKind::AsyncFunction,
+    );
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_block",
+        SourceProtocolKind::AsyncBlock,
+    );
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "await",
+        SourceProtocolKind::Await,
+    );
+
+    let ops: Vec<_> = il
+        .nodes
+        .iter()
+        .filter_map(|node| match node.payload {
+            Payload::Op(op) => Some(op),
+            _ => None,
+        })
+        .collect();
+    assert!(ops.contains(&Op::Add), "async block body was lost: {ops:?}");
+}
+
+#[test]
+fn async_closure_preserves_source_backed_protocol_boundary() {
+    let interner = Interner::new();
+    let il = lower(
+        FileId(0),
+        "t.rs",
+        b"fn f() { let cb = async move |x: i32| x + 1; }\n",
+        &interner,
+    )
+    .expect("lower");
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "async_function",
+        SourceProtocolKind::AsyncFunction,
+    );
+
+    let ops: Vec<_> = il
+        .nodes
+        .iter()
+        .filter_map(|node| match node.payload {
+            Payload::Op(op) => Some(op),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        ops.contains(&Op::Add),
+        "async closure body was lost: {ops:?}"
+    );
+}
+
+#[test]
+fn sync_closure_does_not_create_async_protocol_boundary() {
+    let (interner, il) = lower_rust("fn f() { let cb = |x: i32| x + 1; }\n");
+
+    let raw = raw_names(&il, &interner);
+    assert!(
+        !raw.iter().any(|name| name == "async_function"),
+        "sync closure must not create an async_function protocol boundary: {raw:?}"
+    );
+}

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -588,14 +588,14 @@ First-party frontends now emit these facts as `EvidenceRecord`:
   expressions preserve a raw async boundary and emit
   `Source::Protocol(Await)` at that source span. JS/TS and Python `yield`
   expressions emit `Source::Protocol(Yield)`. Rust `async {}` and `?` emit
-  `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. Swift
-  async closures reuse `Source::Protocol(AsyncFunction)`, and Swift `async let`
-  bindings emit `Source::Protocol(TaskSpawn)` so child-task scheduling, handle
-  lifecycle, and cancellation/liveness remain fail-closed. These are future
-  protocol/demand proof anchors, not evidence that the source operation is
-  equivalent to its operand or body. Go `go`, `defer`, channel send/receive,
-  receive-status projection, `select`, and select cases/defaults likewise
-  preserve source-backed protocol anchors instead of ordinary calls, values, or
+  `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. Rust
+  and Swift async closures reuse `Source::Protocol(AsyncFunction)`, and Swift
+  `async let` bindings emit `Source::Protocol(TaskSpawn)` so child-task
+  scheduling, handle lifecycle, and cancellation/liveness remain fail-closed.
+  These are future protocol/demand proof anchors, not evidence that the source
+  operation is equivalent to its operand or body. Go `go`, `defer`, channel
+  send/receive, receive-status projection, `select`, and select cases/defaults
+  likewise preserve source-backed protocol anchors instead of ordinary calls, values, or
   generic sequences. Python list/set/dict comprehensions and generator
   expressions emit source-comprehension facts so exact consumers can distinguish
   eager materialized lists, lazy generators, set deduplication, and dict

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -258,6 +258,14 @@ Swift-only feature row. The 120-repo audit prices `100` async closures across
 `4` repos and `51` async-let bindings across `7` repos. Alamofire/Swift
 NIO/Vapor spot checks move `task_spawn` raw protocol tags from `0` to `36` and
 async-function tags from `110` to `139` with `0` false merges.
+The follow-up [Rust async closure source-protocol artifact](../bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json)
+applies the same async callable boundary to Rust `async |...|` and
+`async move |...|` closures without adding a Rust-only feature. Rust async
+closures reuse `AsyncFunction`; Rust `async { ... }` blocks remain the separate
+`AsyncBlock` protocol surface. The pinned 120-repo audit has `0` Rust async
+closure occurrences, so this is a parity/hard-negative slice, while the audit
+now keeps the `1,342` Rust async-block occurrences across `4` repos distinct
+from closure syntax.
 The follow-up [promise-protocol-hard-negatives-2026-06-28.v1.json](../bench/recall_loss/promise-protocol-hard-negatives-2026-06-28.v1.json)
 pins the Promise-specific hard negatives before any recovery slice opens:
 async-function/sync, Promise executor/sync, Promise.resolve/sync,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1632,7 +1632,8 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   generator protocol boundaries with `Source::Protocol(Yield)`. Rust `async {}`
   and `?` also preserve raw protocol boundaries with
   `Source::Protocol(AsyncBlock)` and
-  `Source::Protocol(TryPropagation)`. This closes the old exact async/sync and
+  `Source::Protocol(TryPropagation)`, and Rust async closures reuse
+  `Source::Protocol(AsyncFunction)`. This closes the old exact async/sync and
   error-propagation convergence paths, plus generator/body erasure, until
   language/runtime-specific protocol contracts can prove receiver, demand,
   scheduling, suspension, exception, and effect obligations.
@@ -2374,6 +2375,18 @@ async closures across `4` repos and `51` async-let bindings across `7` repos,
 and Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw protocol tags
 from `0` to `36` plus async-function tags from `110` to `139` with `0` false
 merges.
+
+2026-07-01 Rust async closure source-protocol note:
+The [rust-async-closure-source-protocol-2026-07-01.v1.json](../bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json)
+artifact extends Rust async callable source reporting without adding a Rust-only
+feature row. Rust `async |...|` and `async move |...|` closures reuse the
+existing `AsyncFunction` source protocol, while Rust `async { ... }` and
+`async move { ... }` blocks remain separate `AsyncBlock` source protocol
+surfaces. Exact admission remains closed. The pinned 120-repo audit has `0`
+Rust async closure occurrences, so this is a parity and hard-negative slice;
+the same audit now prices `1,342` Rust async blocks across `4` repos without
+letting closure syntax inflate the block row. The checked `crates` gate remains
+at `0` false merges and `0` canon preservation violations.
 
 ## See also
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -18,7 +18,9 @@ factories; provider-local shadows, mutation facts, raw coordinate sequences, and
 ambiguous provider factory shapes stay closed.
 JS/TS, Python, Rust, and Swift runtime-body async functions are preserved as raw
 async protocol boundaries with `Source::Protocol(AsyncFunction)` evidence, even
-when the body has no `await`. JS/TS, Python, Rust, and Swift `await`
+when the body has no `await`. Rust and Swift async closures reuse that same
+async callable protocol boundary; Rust `async {}` blocks remain the separate
+`AsyncBlock` protocol surface. JS/TS, Python, Rust, and Swift `await`
 expressions are preserved as raw async protocol boundaries with
 `Source::Protocol(Await)` evidence instead of being erased into their operand.
 The near-channel fingerprint build can look through supported async protocol
@@ -269,6 +271,13 @@ prices `100` async closures across `4` repos and `51` async-let bindings
 across `7` repos; Alamofire/Swift NIO/Vapor spot checks move `task_spawn` raw
 protocol tags from `0` to `36` and async-function tags from `110` to `139`
 with `0` false merges.
+The follow-up [Rust async closure artifact](../bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json)
+keeps Rust async callable syntax on the same capability: `async |...|` and
+`async move |...|` closures reuse `Source::Protocol(AsyncFunction)`, while
+`async { ... }` and `async move { ... }` blocks remain separate `AsyncBlock`
+boundaries. The pinned 120-repo corpus has `0` Rust async closure occurrences,
+but the hard-negative fixture prevents future async closures from collapsing
+into ordinary synchronous lambdas.
 Library/API identity is consolidated through internal `LibraryApiContract` rows
 for factory, constructor, selected property/non-factory method/view surfaces,
 and selected non-call sentinels, with occurrence evidence covering selected
@@ -679,11 +688,11 @@ migrated.
   on C type-alias evidence. Rust emits macro invocation syntax for selected
   macro-backed APIs, half-open/inclusive range expression facts, tuple-struct
   single-wildcard pattern facts, plus async/error protocol facts for async
-  functions, `.await`, `async {}`, and `?`. These are stored directly as
+  functions, async closures, `.await`, `async {}`, and `?`. These are stored directly as
   `EvidenceRecord::Source`; there is no source-fact side-table fallback.
   Normalize and detect consume source facts only where a semantic contract
   requires that exact source surface. Current JS/TS/Python/Rust/Swift async
-  function and `await` nodes, JS/TS/Python `yield` nodes, Rust `async`/`?` nodes,
+  function/closure and `await` nodes, JS/TS/Python `yield` nodes, Rust `async`/`?` nodes,
   Swift `try` nodes, and Go concurrency/channel
   nodes remain raw exact-closed protocol anchors until such a contract exists.
   Python returned generator/set comprehensions and unsupported cardinality
@@ -1436,7 +1445,7 @@ Semantic knowledge still appears in several forms outside the facade:
   ecosystem APIs, and broader protocol/API evidence paths still rely on contract
   rows plus local proof or remain exact-closed. Raw Python async-looking field names such
   as `aread` no longer rewrite to sync names without an explicit protocol/API
-  evidence path, JS/TS/Python/Rust/Swift async function and `await` expressions
+  evidence path, JS/TS/Python/Rust/Swift async function/closure and `await` expressions
   no longer erase to their body or operand without async protocol proof,
   JS/TS/Python `yield` no longer erases to its yielded expression without
   generator protocol proof, and Rust `async {}`/`?` no longer erase to their body

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -109,7 +109,8 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("python", "python.generator.yield", "yield", "lifecycle-materialization-boundary", "generator-yield-lifecycle-contract-missing", "generator lifecycle", "yield has suspension and iterator lifecycle semantics", re.compile(r"\byield(?:\s+from)?\b")),
     Pattern("rust", "rust.async.await", ".await", "scheduling-boundary", "async-await-scheduling-contract-missing", "future await", "Rust .await polls a Future and must keep wake/scheduling effects explicit", re.compile(r"\.\s*await\b")),
     Pattern("rust", "rust.async.function", "async fn", "scheduling-boundary", "async-function-scheduling-contract-missing", "async function scheduling", "async fn creates a suspended async function boundary", re.compile(r"\basync\s+fn\b")),
-    Pattern("rust", "rust.async.block", "async block", "scheduling-boundary", "async-block-scheduling-contract-missing", "async block construction", "async blocks create suspended async boundaries", re.compile(r"\basync\s+(?:move\b|\{)")),
+    Pattern("rust", "rust.async.closure", "async closure", "scheduling-boundary", "async-function-scheduling-contract-missing", "async closure scheduling", "Rust async closures create suspended async callable protocol boundaries even when the surrounding function is synchronous", re.compile(r"\basync\s+(?:move\s+)?\|"), "reporting-supported-closed-boundary"),
+    Pattern("rust", "rust.async.block", "async block", "scheduling-boundary", "async-block-scheduling-contract-missing", "async block construction", "async blocks create suspended async boundaries", re.compile(r"\basync\s+(?:move\s*)?\{")),
     Pattern("rust", "rust.async.spawn", "tokio/async-std spawn", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "task spawn", "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries", re.compile(r"\b(?:tokio(?:::task)?|async_std::task)\s*::\s*spawn(?:_blocking)?\s*\(")),
     Pattern("rust", "rust.async.join", "tokio/futures/futures_util join/try_join", "success-error-result-channel", "async-aggregate-all-completion-contract-missing", "future all-completion aggregate", "qualified runtime join style macros need all-completion result-channel proof", re.compile(r"\b(?:tokio|futures|futures_util)::(?:join|try_join)!\s*\(")),
     Pattern("rust", "rust.async.select", "tokio/futures/futures_util select", "cancellation-liveness-boundary", "async-aggregate-first-completion-contract-missing", "future first-completion aggregate", "qualified runtime select style macros need first-completion, cancellation, and result-channel proof", re.compile(r"\b(?:tokio|futures|futures_util)::select!\s*\(")),
@@ -581,6 +582,51 @@ GO_CHANNEL_SELECT_DEFAULT = Pattern(
 )
 
 
+def all_known_patterns() -> tuple[Pattern, ...]:
+    return PATTERNS + (
+        PYTHON_ASYNCIO_ALIAS_TASK,
+        PYTHON_ASYNCIO_ALIAS_SLEEP,
+        PYTHON_ASYNCIO_ALIAS_GATHER,
+        PYTHON_ASYNCIO_ALIAS_WAIT,
+        PYTHON_ASYNCIO_ALIAS_RUN,
+        PYTHON_ASYNCIO_ALIAS_WAIT_FOR,
+        PYTHON_ASYNCIO_ALIAS_SHIELD,
+        PYTHON_ASYNCIO_ALIAS_THREADSAFE,
+        PYTHON_ASYNCIO_ALIAS_TO_THREAD,
+        PYTHON_ASYNCIO_IMPORTED_TASK,
+        PYTHON_ASYNCIO_IMPORTED_SLEEP,
+        PYTHON_ASYNCIO_IMPORTED_GATHER,
+        PYTHON_ASYNCIO_IMPORTED_WAIT,
+        PYTHON_ASYNCIO_IMPORTED_RUN,
+        PYTHON_ASYNCIO_IMPORTED_WAIT_FOR,
+        PYTHON_ASYNCIO_IMPORTED_SHIELD,
+        PYTHON_ASYNCIO_IMPORTED_THREADSAFE,
+        PYTHON_ASYNCIO_IMPORTED_TO_THREAD,
+        RUST_IMPORTED_ASYNC_SPAWN,
+        RUST_IMPORTED_ASYNC_JOIN,
+        RUST_IMPORTED_ASYNC_SELECT,
+        JAVA_FUTURE_FULFILLMENT_CONTINUATION,
+        JAVA_FUTURE_EXCEPTION_CONTINUATION,
+        JAVA_FUTURE_SETTLEMENT_CONTINUATION,
+        JAVA_FUTURE_ALL_COMPLETION_CONTINUATION,
+        JAVA_FUTURE_FIRST_COMPLETION_CONTINUATION,
+        JAVA_FUTURE_HANDLE_GET,
+        JAVA_FUTURE_HANDLE_CANCEL,
+        JAVA_FUTURE_HANDLE_STATUS,
+        JAVA_EXECUTOR_EXECUTE,
+        JAVA_EXECUTOR_SUBMIT,
+        JAVA_EXECUTOR_INVOKE_ALL,
+        JAVA_EXECUTOR_INVOKE_ANY,
+        JAVA_SCHEDULED_EXECUTOR_SCHEDULE,
+        JAVA_SCHEDULED_EXECUTOR_INTERVAL,
+        GO_CHANNEL_SEND,
+        GO_CHANNEL_RECEIVE,
+        GO_CHANNEL_RECEIVE_STATUS,
+        GO_CHANNEL_SELECT_CASE,
+        GO_CHANNEL_SELECT_DEFAULT,
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", default=DEFAULT_MANIFEST)
@@ -588,6 +634,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output", default=DEFAULT_OUTPUT)
     parser.add_argument("--generated-on", default=DEFAULT_GENERATED_ON)
     parser.add_argument("--recall-loss-report", default=None)
+    parser.add_argument(
+        "--include-zero-surface",
+        action="append",
+        default=[],
+        help="Emit an explicitly searched surface even when the occurrence count is zero.",
+    )
     return parser.parse_args()
 
 
@@ -1536,6 +1588,14 @@ def java_exact_imported_concurrent_types(text: str) -> set[str]:
 
 def summarize(args: argparse.Namespace) -> dict[str, Any]:
     repos = load_repos(Path(args.manifest))
+    include_zero_surfaces = set(args.include_zero_surface)
+    known_patterns = {pattern.surface: pattern for pattern in all_known_patterns()}
+    unknown_zero_surfaces = sorted(include_zero_surfaces - set(known_patterns))
+    if unknown_zero_surfaces:
+        raise SystemExit(
+            "unknown --include-zero-surface value(s): "
+            + ", ".join(unknown_zero_surfaces)
+        )
     by_pattern: dict[Pattern, Counter[str]] = defaultdict(Counter)
     file_counts: dict[Pattern, Counter[str]] = defaultdict(Counter)
     language_counts: Counter[str] = Counter()
@@ -1560,9 +1620,15 @@ def summarize(args: argparse.Namespace) -> dict[str, Any]:
                 family_counts[pattern.obligation_family] += count
 
     surfaces = []
-    for pattern, repo_counts in by_pattern.items():
+    patterns_for_report = list(by_pattern.keys())
+    for surface in sorted(include_zero_surfaces):
+        pattern = known_patterns[surface]
+        if pattern not in by_pattern:
+            patterns_for_report.append(pattern)
+    for pattern in patterns_for_report:
+        repo_counts = by_pattern[pattern]
         occurrences = sum(repo_counts.values())
-        if occurrences == 0:
+        if occurrences == 0 and pattern.surface not in include_zero_surfaces:
             continue
         surfaces.append(
             {
@@ -1631,6 +1697,8 @@ def regenerate_command(args: argparse.Namespace) -> str:
         parts.extend(["--output", args.output])
     if args.generated_on != DEFAULT_GENERATED_ON:
         parts.extend(["--generated-on", args.generated_on])
+    for surface in args.include_zero_surface:
+        parts.extend(["--include-zero-surface", surface])
     return " ".join(parts)
 
 
@@ -1767,6 +1835,11 @@ def hard_negative_inventory() -> list[dict[str, Any]]:
             "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
             "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
             "status": "mapped-existing",
+        },
+        {
+            "class": "Rust async closures versus synchronous closures and async blocks",
+            "evidence": "crates/nose-frontend/src/rust/tests/async_protocols.rs::async_closure_preserves_source_backed_protocol_boundary, ::sync_closure_does_not_create_async_protocol_boundary, and crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+            "status": "expanded-this-slice",
         },
         {
             "class": "Swift structured-concurrency runtime names shadowed by local Task bindings, Task extensions, same-file task-group functions, or project-visible task-group functions",


### PR DESCRIPTION
## Summary
- preserve Rust `async |...|` / `async move |...|` closures as `Source::Protocol(AsyncFunction)` boundaries
- keep synchronous closures and Rust `async { ... }` blocks distinct, including a query-level hard negative
- add Rust async closure pricing/docs/checked recall-loss artifact and split async block audit matching to require `{`

## Evidence
- 120-repo corpus: `rust.async.closure` = 0 occurrences / 0 repos; `rust.async.block` = 1,342 occurrences / 4 repos after the closure/block split
- `verify crates`: 6,933 total units, 968 interpretable, 5,965 excluded, 810 admission rejections, 0 false merges, 0 canon preservation violations
- release verify median: current 1.09s vs origin/main 1.21s, delta -0.12s

## Validation
- `cargo fmt --check`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py`
- `python3 -m json.tool bench/recall_loss/rust-async-closure-source-protocol-2026-07-01.v1.json >/dev/null`
- `cargo test -p nose-frontend async_closure -- --nocapture`
- `cargo test -p nose-frontend sync_closure_does_not_create_async_protocol_boundary`
- `cargo test -p nose-frontend async_functions_and_blocks_preserve_source_backed_protocol_boundaries`
- `cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence -- --nocapture`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --output target/rust-async-closure-source-protocol-audit.json --generated-on 2026-07-01`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.rust-async-closure.crates.json`
- `./scripts/check-docs.sh`
- release build and timed verify for current branch and origin/main