### PR TITLE
Report Ruby yield callback protocol boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,8 +192,8 @@ break.
   stays distinct from `return a, b` and direct `block.call(a, b)` without
   opening exact admission. The 120-repo audit prices `801` occurrences across
   `17` repos, the checked `crates` recall-loss gate stays at `0` false merges,
-  and the Ruby-heavy query regression measured `2697.80ms -> 2677.42ms`
-  (`-0.76%`) with one stable-count `rspec-core` representative-label drift.
+  and the Ruby-heavy query regression measured `2504.55ms -> 2574.79ms`
+  (`+2.80%`) with one stable-count `rspec-core` representative-label drift.
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust
   async blocks in near/witness builds, so Rust `async fn`/`.await` and Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,13 @@ break.
   obligations when the runtime root is not defined in the same file. Exact
   admission remains closed; the 120-repo audit marks `74` Ruby Thread/Fiber
   occurrences across `11` repos as reporting-supported closed boundaries.
+- Added Ruby yield source-protocol reporting. Block `yield` now preserves a
+  source-backed callback demand/effect boundary instead of erasing into an
+  ordinary `Seq`, so `yield a, b` stays distinct from `return a, b` without
+  opening exact admission. The 120-repo audit prices `801` occurrences across
+  `17` repos, the checked `crates` recall-loss gate stays at `0` false merges,
+  and the Ruby-heavy query regression measured `2697.80ms -> 2677.42ms`
+  (`-0.76%`).
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust
   async blocks in near/witness builds, so Rust `async fn`/`.await` and Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,12 +187,13 @@ break.
   admission remains closed; the 120-repo audit marks `74` Ruby Thread/Fiber
   occurrences across `11` repos as reporting-supported closed boundaries.
 - Added Ruby yield source-protocol reporting. Block `yield` now preserves a
-  source-backed callback demand/effect boundary instead of erasing into an
-  ordinary `Seq`, so `yield a, b` stays distinct from `return a, b` without
+  source-backed `BlockYield` callback demand/effect boundary instead of erasing
+  into an ordinary `Seq` or sharing generator-yield semantics, so `yield a, b`
+  stays distinct from `return a, b` and direct `block.call(a, b)` without
   opening exact admission. The 120-repo audit prices `801` occurrences across
   `17` repos, the checked `crates` recall-loss gate stays at `0` false merges,
   and the Ruby-heavy query regression measured `2697.80ms -> 2677.42ms`
-  (`-0.76%`).
+  (`-0.76%`) with one stable-count `rspec-core` representative-label drift.
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust
   async blocks in near/witness builds, so Rust `async fn`/`.await` and Swift

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -744,14 +744,17 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   reporting-supported, and prices `74` occurrences across `11` repos.
 - [ruby-yield-source-protocol-reporting-2026-07-01.v1.json](ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
   records the Ruby block-yield reporting-only expansion. Ruby `yield` now
-  preserves a source-backed protocol boundary and reports callback
-  demand/effect obligations without opening exact admission.
+  preserves a source-backed `BlockYield` protocol boundary and reports callback
+  demand/effect obligations without opening exact admission or widening
+  generator-yield semantics.
 - [scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
   records the matching 120-repo pricing: `801` Ruby yield occurrences across
   `17` repos are reporting-supported closed boundaries.
 - [ruby-yield-source-protocol-query-regression-2026-07-01.v1.json](ruby-yield-source-protocol-query-regression-2026-07-01.v1.json)
   records the Ruby-heavy product query regression. The 6-repo alternating r9
-  aggregate median was `2697.80ms -> 2677.42ms` (`-0.76%`).
+  aggregate median was `2697.80ms -> 2677.42ms` (`-0.76%`). `rspec-core`
+  changed one same-location 3-member HTML family's representative label from
+  `pre` to `code` while keeping the family count stable.
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -239,6 +239,19 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --generated-on 2026-07-01
 ```
 
+Build the Ruby yield source-protocol audit with:
+
+```sh
+cargo run -q -p nose-cli -- verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json
+
+python3 scripts/scheduling-lifecycle-boundary-audit.py \
+  --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json \
+  --output target/scheduling-lifecycle-boundary-audit.ruby-yield-source-protocol.json \
+  --generated-on 2026-07-01
+```
+
 Build the Java `CompletableFuture`/FutureLike obligation audit with:
 
 ```sh
@@ -729,6 +742,16 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   records the matching 120-repo source-prevalence pricing. It raises total
   source prevalence from `146,987` to `146,988`, marks the Ruby Thread/Fiber row
   reporting-supported, and prices `74` occurrences across `11` repos.
+- [ruby-yield-source-protocol-reporting-2026-07-01.v1.json](ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
+  records the Ruby block-yield reporting-only expansion. Ruby `yield` now
+  preserves a source-backed protocol boundary and reports callback
+  demand/effect obligations without opening exact admission.
+- [scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
+  records the matching 120-repo pricing: `801` Ruby yield occurrences across
+  `17` repos are reporting-supported closed boundaries.
+- [ruby-yield-source-protocol-query-regression-2026-07-01.v1.json](ruby-yield-source-protocol-query-regression-2026-07-01.v1.json)
+  records the Ruby-heavy product query regression. The 6-repo alternating r9
+  aggregate median was `2697.80ms -> 2677.42ms` (`-0.76%`).
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -250,6 +250,15 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json \
   --output target/scheduling-lifecycle-boundary-audit.ruby-yield-source-protocol.json \
   --generated-on 2026-07-01
+
+python3 scripts/query-regression-harness.py \
+  --baseline-binary /tmp/nose-ruby-yield-main-target/release/nose \
+  --current-binary target/release/nose \
+  --baseline-source-ref origin/main \
+  --current-source-ref ruby-yield-source-protocol \
+  --repo rubocop --repo rspec-core --repo sidekiq \
+  --repo rack --repo fastlane --repo sinatra \
+  --output target/ruby-yield-source-protocol-query-regression.json
 ```
 
 Build the Java `CompletableFuture`/FutureLike obligation audit with:

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -256,6 +256,7 @@ python3 scripts/query-regression-harness.py \
   --current-binary target/release/nose \
   --baseline-source-ref origin/main \
   --current-source-ref ruby-yield-source-protocol \
+  --iterations 15 \
   --repo rubocop --repo rspec-core --repo sidekiq \
   --repo rack --repo fastlane --repo sinatra \
   --output target/ruby-yield-source-protocol-query-regression.json
@@ -760,8 +761,8 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   records the matching 120-repo pricing: `801` Ruby yield occurrences across
   `17` repos are reporting-supported closed boundaries.
 - [ruby-yield-source-protocol-query-regression-2026-07-01.v1.json](ruby-yield-source-protocol-query-regression-2026-07-01.v1.json)
-  records the Ruby-heavy product query regression. The 6-repo alternating r9
-  aggregate median was `2697.80ms -> 2677.42ms` (`-0.76%`). `rspec-core`
+  records the Ruby-heavy product query regression. The 6-repo alternating r15
+  aggregate median was `2504.55ms -> 2574.79ms` (`+2.80%`). `rspec-core`
   changed one same-location 3-member HTML family's representative label from
   `pre` to `code` while keeping the family count stable.
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)

--- a/bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json
@@ -1,5 +1,18 @@
 {
   "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-ruby-yield-main-target/release/nose",
+    "baseline_binary_sha256": "75122ff344229760ce3103f2bd1e318af28213d4ccb143d73148ed5fef1ff233",
+    "baseline_source_ref": "origin/main",
+    "baseline_source_sha": "9ebb1a06fa86cf9bc87f56e70bf89203c505255b",
+    "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "current_binary_sha256": "ba11ffcb0c619c8efd96119ec6386b073c6a556b30aec75c2b75568997b70578",
+    "current_source_ref": "ruby-yield-source-protocol",
+    "current_source_sha": "c89847c28377953b4e04f741e88818977a7c5c1a",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-yield-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-yield-source-protocol --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json",
+    "working_tree_status_before_measurement": ""
+  },
   "repos": [
     "rubocop",
     "rspec-core",
@@ -10,1139 +23,1785 @@
   ],
   "runs": [
     {
-      "bytes": 138919,
-      "elapsed_ms": 549.1985420230776,
+      "bytes": 138988,
+      "elapsed_ms": 451.4023340307176,
       "families": 104,
       "iteration": 1,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 569.4828329142183,
-      "families": 104,
-      "iteration": 1,
-      "label": "current",
-      "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
-    },
-    {
-      "bytes": 35497,
-      "elapsed_ms": 146.36029093526304,
+      "bytes": 35566,
+      "elapsed_ms": 107.88945807144046,
       "families": 8,
       "iteration": 1,
       "label": "baseline",
       "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
-      "bytes": 35383,
-      "elapsed_ms": 157.61399990879,
-      "families": 8,
-      "iteration": 1,
-      "label": "current",
-      "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 107.91158303618431,
+      "bytes": 32237,
+      "elapsed_ms": 77.22791703417897,
       "families": 6,
       "iteration": 1,
       "label": "baseline",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 97.1237919293344,
-      "families": 6,
-      "iteration": 1,
-      "label": "current",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 75.88983280584216,
+      "bytes": 28232,
+      "elapsed_ms": 83.35754205472767,
       "families": 3,
       "iteration": 1,
       "label": "baseline",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 97.87125000730157,
-      "families": 3,
-      "iteration": 1,
-      "label": "current",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1749.8702921438962,
+      "bytes": 71641,
+      "elapsed_ms": 1569.485125131905,
       "families": 28,
       "iteration": 1,
       "label": "baseline",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1674.0881248842925,
-      "families": 28,
-      "iteration": 1,
-      "label": "current",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 77.52099982462823,
+      "bytes": 27177,
+      "elapsed_ms": 69.18683415278792,
       "families": 1,
       "iteration": 1,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 73.14004190266132,
+      "bytes": 138988,
+      "elapsed_ms": 461.5589170716703,
+      "families": 104,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 157.28841698728502,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 96.07945894822478,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 74.96500015258789,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1559.0890001039952,
+      "families": 28,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 89.07187497243285,
       "families": 1,
       "iteration": 1,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 461.795249953866,
+      "bytes": 138988,
+      "elapsed_ms": 510.69883396849036,
       "families": 104,
       "iteration": 2,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 597.0500831026584,
-      "families": 104,
-      "iteration": 2,
-      "label": "baseline",
-      "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
-    },
-    {
-      "bytes": 35383,
-      "elapsed_ms": 156.57191700302064,
+      "bytes": 35452,
+      "elapsed_ms": 104.52166711911559,
       "families": 8,
       "iteration": 2,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
     },
     {
-      "bytes": 35497,
-      "elapsed_ms": 121.39245797879994,
-      "families": 8,
-      "iteration": 2,
-      "label": "baseline",
-      "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 127.58358404971659,
+      "bytes": 32237,
+      "elapsed_ms": 76.59258297644556,
       "families": 6,
       "iteration": 2,
       "label": "current",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 94.930041115731,
-      "families": 6,
-      "iteration": 2,
-      "label": "baseline",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 82.88637502118945,
+      "bytes": 28232,
+      "elapsed_ms": 66.79112510755658,
       "families": 3,
       "iteration": 2,
       "label": "current",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 83.05349992588162,
-      "families": 3,
-      "iteration": 2,
-      "label": "baseline",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1769.0328329335898,
+      "bytes": 71641,
+      "elapsed_ms": 1699.012208962813,
       "families": 28,
       "iteration": 2,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1662.3484590090811,
-      "families": 28,
-      "iteration": 2,
-      "label": "baseline",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 67.44433310814202,
+      "bytes": 27177,
+      "elapsed_ms": 61.46604078821838,
       "families": 1,
       "iteration": 2,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 67.4748329911381,
+      "bytes": 138988,
+      "elapsed_ms": 441.9725830666721,
+      "families": 104,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 135.99566696211696,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 86.0220838803798,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 84.04200011864305,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1577.8468751814216,
+      "families": 28,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 88.2652080617845,
       "families": 1,
       "iteration": 2,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 540.2127089910209,
+      "bytes": 138988,
+      "elapsed_ms": 517.1754998154938,
       "families": 104,
       "iteration": 3,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 545.1207500882447,
-      "families": 104,
-      "iteration": 3,
-      "label": "current",
-      "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
-    },
-    {
-      "bytes": 35497,
-      "elapsed_ms": 194.85916709527373,
+      "bytes": 35566,
+      "elapsed_ms": 126.02404202334583,
       "families": 8,
       "iteration": 3,
       "label": "baseline",
       "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
-      "bytes": 35383,
-      "elapsed_ms": 156.5452921204269,
-      "families": 8,
-      "iteration": 3,
-      "label": "current",
-      "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 99.35066592879593,
+      "bytes": 32237,
+      "elapsed_ms": 88.90991704538465,
       "families": 6,
       "iteration": 3,
       "label": "baseline",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 99.597540916875,
-      "families": 6,
-      "iteration": 3,
-      "label": "current",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 92.4877910874784,
+      "bytes": 28232,
+      "elapsed_ms": 66.80720811709762,
       "families": 3,
       "iteration": 3,
       "label": "baseline",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 88.54670799337327,
-      "families": 3,
-      "iteration": 3,
-      "label": "current",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1754.3712500482798,
+      "bytes": 71641,
+      "elapsed_ms": 1666.803542058915,
       "families": 28,
       "iteration": 3,
       "label": "baseline",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1608.69075008668,
-      "families": 28,
-      "iteration": 3,
-      "label": "current",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 78.66062503308058,
+      "bytes": 27177,
+      "elapsed_ms": 66.40145811252296,
       "families": 1,
       "iteration": 3,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 98.74337492510676,
+      "bytes": 138988,
+      "elapsed_ms": 485.329459188506,
+      "families": 104,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 132.10120797157288,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 97.5773751270026,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 96.60541592165828,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1588.4134171064943,
+      "families": 28,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 94.74633308127522,
       "families": 1,
       "iteration": 3,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 562.0399999897927,
+      "bytes": 138988,
+      "elapsed_ms": 513.9399589970708,
       "families": 104,
       "iteration": 4,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 573.3572500757873,
-      "families": 104,
-      "iteration": 4,
-      "label": "baseline",
-      "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
-    },
-    {
-      "bytes": 35383,
-      "elapsed_ms": 152.72420807741582,
+      "bytes": 35452,
+      "elapsed_ms": 113.0958329886198,
       "families": 8,
       "iteration": 4,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
     },
     {
-      "bytes": 35497,
-      "elapsed_ms": 161.1307500861585,
-      "families": 8,
-      "iteration": 4,
-      "label": "baseline",
-      "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 87.27737492881715,
+      "bytes": 32237,
+      "elapsed_ms": 80.27691696770489,
       "families": 6,
       "iteration": 4,
       "label": "current",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 93.67274981923401,
-      "families": 6,
-      "iteration": 4,
-      "label": "baseline",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 126.92599999718368,
+      "bytes": 28232,
+      "elapsed_ms": 61.99391698464751,
       "families": 3,
       "iteration": 4,
       "label": "current",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 87.58441614918411,
-      "families": 3,
-      "iteration": 4,
-      "label": "baseline",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1701.713833026588,
+      "bytes": 71641,
+      "elapsed_ms": 1738.793957978487,
       "families": 28,
       "iteration": 4,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1663.6942918412387,
-      "families": 28,
-      "iteration": 4,
-      "label": "baseline",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 69.3510421551764,
+      "bytes": 27177,
+      "elapsed_ms": 69.35366592369974,
       "families": 1,
       "iteration": 4,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 71.1216249037534,
+      "bytes": 138988,
+      "elapsed_ms": 517.8982079960406,
+      "families": 104,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 128.39104211889207,
+      "families": 8,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 95.47275002114475,
+      "families": 6,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 85.10229201056063,
+      "families": 3,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1567.3311660066247,
+      "families": 28,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 92.45287510566413,
       "families": 1,
       "iteration": 4,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 508.16470803692937,
+      "bytes": 138988,
+      "elapsed_ms": 525.6787920370698,
       "families": 104,
       "iteration": 5,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 619.6036671753973,
+      "bytes": 35566,
+      "elapsed_ms": 122.14645813219249,
+      "families": 8,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 82.17566693201661,
+      "families": 6,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 99.47858308441937,
+      "families": 3,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1688.6269999668002,
+      "families": 28,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 64.96095797047019,
+      "families": 1,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 472.5306248292327,
       "families": 104,
       "iteration": 5,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 35497,
-      "elapsed_ms": 172.12162516079843,
-      "families": 8,
-      "iteration": 5,
-      "label": "baseline",
-      "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
-    },
-    {
-      "bytes": 35383,
-      "elapsed_ms": 144.0079160965979,
+      "bytes": 35452,
+      "elapsed_ms": 146.8537908513099,
       "families": 8,
       "iteration": 5,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 103.47945801913738,
-      "families": 6,
-      "iteration": 5,
-      "label": "baseline",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 115.46616698615253,
+      "bytes": 32237,
+      "elapsed_ms": 89.93329084478319,
       "families": 6,
       "iteration": 5,
       "label": "current",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 89.44141701795161,
-      "families": 3,
-      "iteration": 5,
-      "label": "baseline",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 86.23179187998176,
+      "bytes": 28232,
+      "elapsed_ms": 90.79970908351243,
       "families": 3,
       "iteration": 5,
       "label": "current",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1792.1437921468168,
-      "families": 28,
-      "iteration": 5,
-      "label": "baseline",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1618.4515000786632,
+      "bytes": 71641,
+      "elapsed_ms": 1743.3324169833213,
       "families": 28,
       "iteration": 5,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 63.619582913815975,
-      "families": 1,
-      "iteration": 5,
-      "label": "baseline",
-      "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 72.62741588056087,
+      "bytes": 27177,
+      "elapsed_ms": 88.42799998819828,
       "families": 1,
       "iteration": 5,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 555.2691251505166,
+      "bytes": 138988,
+      "elapsed_ms": 443.3639170601964,
       "families": 104,
       "iteration": 6,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 517.8433749824762,
+      "bytes": 35452,
+      "elapsed_ms": 147.36445806920528,
+      "families": 8,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 101.98358306661248,
+      "families": 6,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 94.28804204799235,
+      "families": 3,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1620.3061251435429,
+      "families": 28,
+      "iteration": 6,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 68.72774986550212,
+      "families": 1,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 504.9747920129448,
       "families": 104,
       "iteration": 6,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 35383,
-      "elapsed_ms": 159.1279578860849,
-      "families": 8,
-      "iteration": 6,
-      "label": "current",
-      "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
-    },
-    {
-      "bytes": 35497,
-      "elapsed_ms": 147.63983408920467,
+      "bytes": 35566,
+      "elapsed_ms": 145.60225000604987,
       "families": 8,
       "iteration": 6,
       "label": "baseline",
       "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 102.68899984657764,
-      "families": 6,
-      "iteration": 6,
-      "label": "current",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 120.6290831323713,
+      "bytes": 32237,
+      "elapsed_ms": 106.3219578936696,
       "families": 6,
       "iteration": 6,
       "label": "baseline",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 94.58249993622303,
-      "families": 3,
-      "iteration": 6,
-      "label": "current",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 85.11599991470575,
+      "bytes": 28232,
+      "elapsed_ms": 77.19850004650652,
       "families": 3,
       "iteration": 6,
       "label": "baseline",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1791.3691659923643,
-      "families": 28,
-      "iteration": 6,
-      "label": "current",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1606.152958003804,
+      "bytes": 71641,
+      "elapsed_ms": 1636.9203750509769,
       "families": 28,
       "iteration": 6,
       "label": "baseline",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 84.68062500469387,
-      "families": 1,
-      "iteration": 6,
-      "label": "current",
-      "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 85.71333414874971,
+      "bytes": 27177,
+      "elapsed_ms": 79.07387497834861,
       "families": 1,
       "iteration": 6,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 483.73166704550385,
+      "bytes": 138988,
+      "elapsed_ms": 419.5592920295894,
       "families": 104,
       "iteration": 7,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 563.997833058238,
+      "bytes": 35566,
+      "elapsed_ms": 154.27533397451043,
+      "families": 8,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 93.02787506021559,
+      "families": 6,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 90.9902909770608,
+      "families": 3,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1577.0433330908418,
+      "families": 28,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 70.79495792277157,
+      "families": 1,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 533.9679170865566,
       "families": 104,
       "iteration": 7,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 35497,
-      "elapsed_ms": 149.35541711747646,
-      "families": 8,
-      "iteration": 7,
-      "label": "baseline",
-      "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
-    },
-    {
-      "bytes": 35383,
-      "elapsed_ms": 176.23529210686684,
+      "bytes": 35452,
+      "elapsed_ms": 145.8244170062244,
       "families": 8,
       "iteration": 7,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 91.78237500600517,
-      "families": 6,
-      "iteration": 7,
-      "label": "baseline",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 87.654999922961,
+      "bytes": 32237,
+      "elapsed_ms": 91.86525014229119,
       "families": 6,
       "iteration": 7,
       "label": "current",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 89.68212502077222,
-      "families": 3,
-      "iteration": 7,
-      "label": "baseline",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 104.770417092368,
+      "bytes": 28232,
+      "elapsed_ms": 82.25216600112617,
       "families": 3,
       "iteration": 7,
       "label": "current",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1722.1172919962555,
-      "families": 28,
-      "iteration": 7,
-      "label": "baseline",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1700.4225000273436,
+      "bytes": 71641,
+      "elapsed_ms": 1819.6641670074314,
       "families": 28,
       "iteration": 7,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 69.97837498784065,
-      "families": 1,
-      "iteration": 7,
-      "label": "baseline",
-      "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 68.67741700261831,
+      "bytes": 27177,
+      "elapsed_ms": 70.33491600304842,
       "families": 1,
       "iteration": 7,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 485.62608379870653,
+      "bytes": 138988,
+      "elapsed_ms": 417.72383404895663,
       "families": 104,
       "iteration": 8,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 600.6100829690695,
+      "bytes": 35452,
+      "elapsed_ms": 166.03183303959668,
+      "families": 8,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.79229187592864,
+      "families": 6,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 84.789666114375,
+      "families": 3,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1602.5250419043005,
+      "families": 28,
+      "iteration": 8,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 73.74925003387034,
+      "families": 1,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 568.4177500661463,
       "families": 104,
       "iteration": 8,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 35383,
-      "elapsed_ms": 135.6005840934813,
-      "families": 8,
-      "iteration": 8,
-      "label": "current",
-      "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
-    },
-    {
-      "bytes": 35497,
-      "elapsed_ms": 188.01633408293128,
+      "bytes": 35566,
+      "elapsed_ms": 149.03595787473023,
       "families": 8,
       "iteration": 8,
       "label": "baseline",
       "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 103.76258287578821,
-      "families": 6,
-      "iteration": 8,
-      "label": "current",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 105.47741688787937,
+      "bytes": 32237,
+      "elapsed_ms": 79.71920794807374,
       "families": 6,
       "iteration": 8,
       "label": "baseline",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 83.41304119676352,
-      "families": 3,
-      "iteration": 8,
-      "label": "current",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 91.74404200166464,
+      "bytes": 28232,
+      "elapsed_ms": 68.72279103845358,
       "families": 3,
       "iteration": 8,
       "label": "baseline",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1768.5510420706123,
-      "families": 28,
-      "iteration": 8,
-      "label": "current",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1629.346165806055,
+      "bytes": 71641,
+      "elapsed_ms": 1687.5984170474112,
       "families": 28,
       "iteration": 8,
       "label": "baseline",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 61.750165885314345,
-      "families": 1,
-      "iteration": 8,
-      "label": "current",
-      "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 82.78820803388953,
+      "bytes": 27177,
+      "elapsed_ms": 70.32170798629522,
       "families": 1,
       "iteration": 8,
       "label": "baseline",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 561.3130000419915,
+      "bytes": 138988,
+      "elapsed_ms": 492.83600016497076,
       "families": 104,
       "iteration": 9,
       "label": "baseline",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 138919,
-      "elapsed_ms": 531.6411671228707,
+      "bytes": 35566,
+      "elapsed_ms": 153.87304197065532,
+      "families": 8,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 96.21258289553225,
+      "families": 6,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 81.34962501935661,
+      "families": 3,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1533.396374899894,
+      "families": 28,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 114.76279213093221,
+      "families": 1,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 560.1880829781294,
       "families": 104,
       "iteration": 9,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
     },
     {
-      "bytes": 35497,
-      "elapsed_ms": 157.90245798416436,
-      "families": 8,
-      "iteration": 9,
-      "label": "baseline",
-      "repo": "rspec-core",
-      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
-    },
-    {
-      "bytes": 35383,
-      "elapsed_ms": 179.4082501437515,
+      "bytes": 35452,
+      "elapsed_ms": 116.32775003090501,
       "families": 8,
       "iteration": 9,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
     },
     {
-      "bytes": 32168,
-      "elapsed_ms": 109.15912501513958,
-      "families": 6,
-      "iteration": 9,
-      "label": "baseline",
-      "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
-    },
-    {
-      "bytes": 32168,
-      "elapsed_ms": 109.299625037238,
+      "bytes": 32237,
+      "elapsed_ms": 78.67154199630022,
       "families": 6,
       "iteration": 9,
       "label": "current",
       "repo": "sidekiq",
-      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
     },
     {
-      "bytes": 28163,
-      "elapsed_ms": 84.11812502890825,
-      "families": 3,
-      "iteration": 9,
-      "label": "baseline",
-      "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
-    },
-    {
-      "bytes": 28163,
-      "elapsed_ms": 79.70024994574487,
+      "bytes": 28232,
+      "elapsed_ms": 74.53629095107317,
       "families": 3,
       "iteration": 9,
       "label": "current",
       "repo": "rack",
-      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 71572,
-      "elapsed_ms": 1819.118709070608,
-      "families": 28,
-      "iteration": 9,
-      "label": "baseline",
-      "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
-    },
-    {
-      "bytes": 71572,
-      "elapsed_ms": 1720.0639580842108,
+      "bytes": 71641,
+      "elapsed_ms": 1704.3285418767482,
       "families": 28,
       "iteration": 9,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
-      "bytes": 27108,
-      "elapsed_ms": 91.54841699637473,
-      "families": 1,
-      "iteration": 9,
-      "label": "baseline",
-      "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
-    },
-    {
-      "bytes": 27108,
-      "elapsed_ms": 74.11645795218647,
+      "bytes": 27177,
+      "elapsed_ms": 65.00704097561538,
       "families": 1,
       "iteration": 9,
       "label": "current",
       "repo": "sinatra",
-      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 480.0508329644799,
+      "families": 104,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 136.48166600614786,
+      "families": 8,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 96.04625008068979,
+      "families": 6,
+      "iteration": 10,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.84862498193979,
+      "families": 3,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1622.9621251113713,
+      "families": 28,
+      "iteration": 10,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 80.6806671898812,
+      "families": 1,
+      "iteration": 10,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 475.01620883122087,
+      "families": 104,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 111.50570912286639,
+      "families": 8,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 80.80337499268353,
+      "families": 6,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 110.09604204446077,
+      "families": 3,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1678.3887499477714,
+      "families": 28,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 66.05575000867248,
+      "families": 1,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 474.8264169320464,
+      "families": 104,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 141.00674982182682,
+      "families": 8,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 112.45983303524554,
+      "families": 6,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.15733403712511,
+      "families": 3,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1630.135582992807,
+      "families": 28,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 93.0968748871237,
+      "families": 1,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 474.61295779794455,
+      "families": 104,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 116.89087492413819,
+      "families": 8,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 100.78320908360183,
+      "families": 6,
+      "iteration": 11,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 88.41508394107223,
+      "families": 3,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1662.3511251527816,
+      "families": 28,
+      "iteration": 11,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 65.988166956231,
+      "families": 1,
+      "iteration": 11,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 517.4644589424133,
+      "families": 104,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 137.50283303670585,
+      "families": 8,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.29420799016953,
+      "families": 6,
+      "iteration": 12,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 83.11337511986494,
+      "families": 3,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1712.052958086133,
+      "families": 28,
+      "iteration": 12,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 80.92200011014938,
+      "families": 1,
+      "iteration": 12,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 412.111499812454,
+      "families": 104,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 126.57108413986862,
+      "families": 8,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 117.68262484110892,
+      "families": 6,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 79.74958303384483,
+      "families": 3,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1638.4712080471218,
+      "families": 28,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 62.850499991327524,
+      "families": 1,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 529.1253330651671,
+      "families": 104,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 156.3354169484228,
+      "families": 8,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 89.9146250449121,
+      "families": 6,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 78.89841683208942,
+      "families": 3,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1738.7711249757558,
+      "families": 28,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 69.26850019954145,
+      "families": 1,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 429.74904202856123,
+      "families": 104,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 155.67949996329844,
+      "families": 8,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.89741700701416,
+      "families": 6,
+      "iteration": 13,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 88.40866689570248,
+      "families": 3,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1566.198917105794,
+      "families": 28,
+      "iteration": 13,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 92.74029219523072,
+      "families": 1,
+      "iteration": 13,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 565.7087077852339,
+      "families": 104,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 134.10354196093976,
+      "families": 8,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 84.8572498653084,
+      "families": 6,
+      "iteration": 14,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 70.4977079294622,
+      "families": 3,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1804.4332081917673,
+      "families": 28,
+      "iteration": 14,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 66.63983385078609,
+      "families": 1,
+      "iteration": 14,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 481.1648749746382,
+      "families": 104,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 155.07208416238427,
+      "families": 8,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 112.67004115507007,
+      "families": 6,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 90.98295797593892,
+      "families": 3,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1581.5752919297665,
+      "families": 28,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 92.043082928285,
+      "families": 1,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 487.3578338883817,
+      "families": 104,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 114.3825410399586,
+      "families": 8,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 85.59312485158443,
+      "families": 6,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 109.28970808163285,
+      "families": 3,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1663.45200012438,
+      "families": 28,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 67.25799990817904,
+      "families": 1,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 515.36133303307,
+      "families": 104,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 144.72587499767542,
+      "families": 8,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 104.71099987626076,
+      "families": 6,
+      "iteration": 15,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 79.9479999113828,
+      "families": 3,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1708.1877081654966,
+      "families": 28,
+      "iteration": 15,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 93.98116706870496,
+      "families": 1,
+      "iteration": 15,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
     }
   ],
   "summary": {
-    "aggregate_delta_pct": -0.7556209938793222,
-    "aggregate_median_ms": {
-      "baseline": 2697.803165996447,
-      "current": 2677.417998900637
-    },
+    "aggregate_baseline_median_ms": 2504.552209051326,
+    "aggregate_current_median_ms": 2574.786585289985,
+    "aggregate_delta_pct": 2.8042688024164764,
     "by_repo": {
       "fastlane": {
         "baseline": {
           "bytes": [
-            71572
+            71641
           ],
           "families": [
             28
           ],
           "hashes": [
-            "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+            "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 1722.1172919962555
+          "median_ms": 1636.9203750509769
         },
         "current": {
           "bytes": [
-            71572
+            71641
           ],
           "families": [
             28
           ],
           "hashes": [
-            "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+            "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 1701.713833026588
+          "median_ms": 1699.012208962813
         }
       },
       "rack": {
         "baseline": {
           "bytes": [
-            28163
+            28232
           ],
           "families": [
             3
           ],
           "hashes": [
-            "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+            "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 87.58441614918411
+          "median_ms": 84.04200011864305
         },
         "current": {
           "bytes": [
-            28163
+            28232
           ],
           "families": [
             3
           ],
           "hashes": [
-            "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+            "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 88.54670799337327
+          "median_ms": 83.11337511986494
         }
       },
       "rspec-core": {
         "baseline": {
           "bytes": [
-            35497
+            35566
           ],
           "families": [
             8
           ],
           "hashes": [
-            "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+            "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
           ],
-          "median_ms": 157.90245798416436
+          "median_ms": 135.99566696211696
         },
         "current": {
           "bytes": [
-            35383
+            35452
           ],
           "families": [
             8
           ],
           "hashes": [
-            "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+            "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
           ],
-          "median_ms": 156.57191700302064
+          "median_ms": 137.50283303670585
         }
       },
       "rubocop": {
         "baseline": {
           "bytes": [
-            138919
+            138988
           ],
           "families": [
             104
           ],
           "hashes": [
-            "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+            "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
           ],
-          "median_ms": 549.1985420230776
+          "median_ms": 487.3578338883817
         },
         "current": {
           "bytes": [
-            138919
+            138988
           ],
           "families": [
             104
           ],
           "hashes": [
-            "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+            "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
           ],
-          "median_ms": 555.2691251505166
+          "median_ms": 485.329459188506
         }
       },
       "sidekiq": {
         "baseline": {
           "bytes": [
-            32168
+            32237
           ],
           "families": [
             6
           ],
           "hashes": [
-            "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+            "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 103.47945801913738
+          "median_ms": 89.9146250449121
         },
         "current": {
           "bytes": [
-            32168
+            32237
           ],
           "families": [
             6
           ],
           "hashes": [
-            "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+            "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 102.68899984657764
+          "median_ms": 96.07945894822478
         }
       },
       "sinatra": {
         "baseline": {
           "bytes": [
-            27108
+            27177
           ],
           "families": [
             1
           ],
           "hashes": [
-            "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+            "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 77.52099982462823
+          "median_ms": 70.32170798629522
         },
         "current": {
           "bytes": [
-            27108
+            27177
           ],
           "families": [
             1
           ],
           "hashes": [
-            "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+            "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 72.62741588056087
+          "median_ms": 73.74925003387034
         }
       }
     },

--- a/bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json
@@ -1,0 +1,1158 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "repos": [
+    "rubocop",
+    "rspec-core",
+    "sidekiq",
+    "rack",
+    "fastlane",
+    "sinatra"
+  ],
+  "runs": [
+    {
+      "bytes": 138919,
+      "elapsed_ms": 549.1985420230776,
+      "families": 104,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 569.4828329142183,
+      "families": 104,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 146.36029093526304,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 157.61399990879,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 107.91158303618431,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 97.1237919293344,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 75.88983280584216,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 97.87125000730157,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1749.8702921438962,
+      "families": 28,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1674.0881248842925,
+      "families": 28,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 77.52099982462823,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 73.14004190266132,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 461.795249953866,
+      "families": 104,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 597.0500831026584,
+      "families": 104,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 156.57191700302064,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 121.39245797879994,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 127.58358404971659,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 94.930041115731,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 82.88637502118945,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 83.05349992588162,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1769.0328329335898,
+      "families": 28,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1662.3484590090811,
+      "families": 28,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 67.44433310814202,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 67.4748329911381,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 540.2127089910209,
+      "families": 104,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 545.1207500882447,
+      "families": 104,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 194.85916709527373,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 156.5452921204269,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 99.35066592879593,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 99.597540916875,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 92.4877910874784,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 88.54670799337327,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1754.3712500482798,
+      "families": 28,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1608.69075008668,
+      "families": 28,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 78.66062503308058,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 98.74337492510676,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 562.0399999897927,
+      "families": 104,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 573.3572500757873,
+      "families": 104,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 152.72420807741582,
+      "families": 8,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 161.1307500861585,
+      "families": 8,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 87.27737492881715,
+      "families": 6,
+      "iteration": 4,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 93.67274981923401,
+      "families": 6,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 126.92599999718368,
+      "families": 3,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 87.58441614918411,
+      "families": 3,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1701.713833026588,
+      "families": 28,
+      "iteration": 4,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1663.6942918412387,
+      "families": 28,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 69.3510421551764,
+      "families": 1,
+      "iteration": 4,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 71.1216249037534,
+      "families": 1,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 508.16470803692937,
+      "families": 104,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 619.6036671753973,
+      "families": 104,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 172.12162516079843,
+      "families": 8,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 144.0079160965979,
+      "families": 8,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 103.47945801913738,
+      "families": 6,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 115.46616698615253,
+      "families": 6,
+      "iteration": 5,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 89.44141701795161,
+      "families": 3,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 86.23179187998176,
+      "families": 3,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1792.1437921468168,
+      "families": 28,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1618.4515000786632,
+      "families": 28,
+      "iteration": 5,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 63.619582913815975,
+      "families": 1,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 72.62741588056087,
+      "families": 1,
+      "iteration": 5,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 555.2691251505166,
+      "families": 104,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 517.8433749824762,
+      "families": 104,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 159.1279578860849,
+      "families": 8,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 147.63983408920467,
+      "families": 8,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 102.68899984657764,
+      "families": 6,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 120.6290831323713,
+      "families": 6,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 94.58249993622303,
+      "families": 3,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 85.11599991470575,
+      "families": 3,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1791.3691659923643,
+      "families": 28,
+      "iteration": 6,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1606.152958003804,
+      "families": 28,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 84.68062500469387,
+      "families": 1,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 85.71333414874971,
+      "families": 1,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 483.73166704550385,
+      "families": 104,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 563.997833058238,
+      "families": 104,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 149.35541711747646,
+      "families": 8,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 176.23529210686684,
+      "families": 8,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 91.78237500600517,
+      "families": 6,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 87.654999922961,
+      "families": 6,
+      "iteration": 7,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 89.68212502077222,
+      "families": 3,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 104.770417092368,
+      "families": 3,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1722.1172919962555,
+      "families": 28,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1700.4225000273436,
+      "families": 28,
+      "iteration": 7,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 69.97837498784065,
+      "families": 1,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 68.67741700261831,
+      "families": 1,
+      "iteration": 7,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 485.62608379870653,
+      "families": 104,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 600.6100829690695,
+      "families": 104,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 135.6005840934813,
+      "families": 8,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 188.01633408293128,
+      "families": 8,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 103.76258287578821,
+      "families": 6,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 105.47741688787937,
+      "families": 6,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 83.41304119676352,
+      "families": 3,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 91.74404200166464,
+      "families": 3,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1768.5510420706123,
+      "families": 28,
+      "iteration": 8,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1629.346165806055,
+      "families": 28,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 61.750165885314345,
+      "families": 1,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 82.78820803388953,
+      "families": 1,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 561.3130000419915,
+      "families": 104,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 138919,
+      "elapsed_ms": 531.6411671228707,
+      "families": 104,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+    },
+    {
+      "bytes": 35497,
+      "elapsed_ms": 157.90245798416436,
+      "families": 8,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+    },
+    {
+      "bytes": 35383,
+      "elapsed_ms": 179.4082501437515,
+      "families": 8,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 109.15912501513958,
+      "families": 6,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 32168,
+      "elapsed_ms": 109.299625037238,
+      "families": 6,
+      "iteration": 9,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 84.11812502890825,
+      "families": 3,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 28163,
+      "elapsed_ms": 79.70024994574487,
+      "families": 3,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1819.118709070608,
+      "families": 28,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 71572,
+      "elapsed_ms": 1720.0639580842108,
+      "families": 28,
+      "iteration": 9,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 91.54841699637473,
+      "families": 1,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    },
+    {
+      "bytes": 27108,
+      "elapsed_ms": 74.11645795218647,
+      "families": 1,
+      "iteration": 9,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+    }
+  ],
+  "summary": {
+    "aggregate_delta_pct": -0.7556209938793222,
+    "aggregate_median_ms": {
+      "baseline": 2697.803165996447,
+      "current": 2677.417998900637
+    },
+    "by_repo": {
+      "fastlane": {
+        "baseline": {
+          "bytes": [
+            71572
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+          ],
+          "median_ms": 1722.1172919962555
+        },
+        "current": {
+          "bytes": [
+            71572
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "d528eef5da285b097e272d3469643465d61bf79e9ac2416d9d9f95a2d4a6ef5b"
+          ],
+          "median_ms": 1701.713833026588
+        }
+      },
+      "rack": {
+        "baseline": {
+          "bytes": [
+            28163
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+          ],
+          "median_ms": 87.58441614918411
+        },
+        "current": {
+          "bytes": [
+            28163
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "c81ea23d5c374029b4aae121d9424b9a1dd12a0886835a9f2818f005c76db2c0"
+          ],
+          "median_ms": 88.54670799337327
+        }
+      },
+      "rspec-core": {
+        "baseline": {
+          "bytes": [
+            35497
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "f6cc3391c17d0e2a16d35163c41c77225e9034989689e121dfe5e51d244bbbae"
+          ],
+          "median_ms": 157.90245798416436
+        },
+        "current": {
+          "bytes": [
+            35383
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "bc070a5b93cddbbd22093da00bdd3519adc29b6c727a1bedd54e5091ef70a6a5"
+          ],
+          "median_ms": 156.57191700302064
+        }
+      },
+      "rubocop": {
+        "baseline": {
+          "bytes": [
+            138919
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+          ],
+          "median_ms": 549.1985420230776
+        },
+        "current": {
+          "bytes": [
+            138919
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "85107b6e2d15ec41c0be448eda573bd11e99ecca5eb3611a9920333b8ebe56e8"
+          ],
+          "median_ms": 555.2691251505166
+        }
+      },
+      "sidekiq": {
+        "baseline": {
+          "bytes": [
+            32168
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+          ],
+          "median_ms": 103.47945801913738
+        },
+        "current": {
+          "bytes": [
+            32168
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "42b4deb2bb91924071ec76a0c45a70253d8ddd4d52156eb615b8660be10e43bb"
+          ],
+          "median_ms": 102.68899984657764
+        }
+      },
+      "sinatra": {
+        "baseline": {
+          "bytes": [
+            27108
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+          ],
+          "median_ms": 77.52099982462823
+        },
+        "current": {
+          "bytes": [
+            27108
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a1e93eedc1395322b14d1fcf83d3404a096183fb1f5937fa1f702d6c50ed6d6b"
+          ],
+          "median_ms": 72.62741588056087
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "fastlane": true,
+      "rack": true,
+      "rspec-core": false,
+      "rubocop": true,
+      "sidekiq": true,
+      "sinatra": true
+    }
+  }
+}

--- a/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
@@ -1,0 +1,120 @@
+{
+  "capability_alignment": {
+    "capability": "source-backed callback demand/effect protocol boundary",
+    "not_a_feature_list": [
+      "No Ruby-specific exact admission was opened.",
+      "No public semantic-pack API was added.",
+      "Yield demand/effect profiling was generalized to a conservative protocol boundary instead of overloading generator suspension for Ruby block yield."
+    ],
+    "principle": "Capabilities over features",
+    "reused_capabilities": [
+      "SourceProtocolKind::Yield",
+      "runtime-boundary-model",
+      "callback-demand-effect obligation vocabulary",
+      "recall-loss oracle_exclusions/by_obligation rollups"
+    ]
+  },
+  "corpus_pricing": {
+    "occurrences": 801,
+    "operation": "yield",
+    "repos": 17,
+    "source": "bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json",
+    "status": "reporting-supported-closed-boundary",
+    "surface": "ruby.generator.yield",
+    "top_repos": [
+      {
+        "occurrences": 228,
+        "repo": "rubocop"
+      },
+      {
+        "occurrences": 98,
+        "repo": "rspec-core"
+      },
+      {
+        "occurrences": 81,
+        "repo": "sidekiq"
+      },
+      {
+        "occurrences": 65,
+        "repo": "rack"
+      },
+      {
+        "occurrences": 55,
+        "repo": "fastlane"
+      },
+      {
+        "occurrences": 38,
+        "repo": "sinatra"
+      },
+      {
+        "occurrences": 36,
+        "repo": "devise"
+      },
+      {
+        "occurrences": 34,
+        "repo": "liquid"
+      }
+    ]
+  },
+  "current_crates_gate": {
+    "admission_rejections": 811,
+    "advisory_disagreements": 4,
+    "canon_checked": 99,
+    "canon_preservation_violations": 0,
+    "excluded_units": 5990,
+    "false_merges": 0,
+    "fingerprint_groups": 38,
+    "gate_passed": true,
+    "interpretable_units": 969,
+    "lossy_fingerprint_collisions": 0,
+    "max_violations": 0,
+    "report": "target/recall-loss.ruby-yield-source-protocol.crates.json",
+    "total_units": 6959
+  },
+  "generated_on": "2026-07-01",
+  "next_exact_work_policy": {
+    "status": "closed_until_evidence",
+    "summary": "Ruby block yield reporting is now source-backed. Exact convergence still needs block identity, callback argument/result role, effect visibility, non-local control, and exception behavior proof."
+  },
+  "product_query_regression": {
+    "aggregate_baseline_median_ms": 2697.803165996447,
+    "aggregate_current_median_ms": 2677.417998900637,
+    "aggregate_delta_pct": -0.7556209938793222,
+    "hashes_identical_by_repo": {
+      "fastlane": true,
+      "rack": true,
+      "rspec-core": false,
+      "rubocop": true,
+      "sidekiq": true,
+      "sinatra": true
+    },
+    "method": "1 warmup per binary/repo, then 9 alternating measured runs over Ruby yield-heavy repos",
+    "non_identical_hash_explanation": "rspec-core kept the same family count; one 3-location HTML family changed representative name from pre to code at the same lines.",
+    "source": "bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json",
+    "subset": [
+      "rubocop",
+      "rspec-core",
+      "sidekiq",
+      "rack",
+      "fastlane",
+      "sinatra"
+    ]
+  },
+  "report_kind": "ruby-yield-source-protocol-reporting",
+  "schema_version": 1,
+  "scope": {
+    "exact_admission_opened": false,
+    "kind": "reporting-and-lowering-only",
+    "semantic_admission_delta": 0,
+    "summary": "Ruby yield now preserves a source-backed protocol boundary and reports block callback demand/effect obligations instead of being erased into an ordinary Seq value."
+  },
+  "validation_commands": [
+    "cargo test -p nose-frontend ruby::tests::yield_preserves_source_backed_protocol_boundary -- --nocapture",
+    "cargo test -p nose-cli yield_protocol_missing_evidence_is_language_specific -- --nocapture",
+    "cargo test -p nose-cli recall_loss_report::obligations::tests::async_protocol_labels_have_specific_obligations -- --nocapture",
+    "cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence -- --nocapture",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json --generated-on 2026-07-01"
+  ]
+}

--- a/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
@@ -77,9 +77,9 @@
     "summary": "Ruby block yield reporting is now source-backed. Exact convergence still needs block identity, callback argument/result role, effect visibility, non-local control, and exception behavior proof."
   },
   "product_query_regression": {
-    "aggregate_baseline_median_ms": 2697.803165996447,
-    "aggregate_current_median_ms": 2677.417998900637,
-    "aggregate_delta_pct": -0.7556209938793222,
+    "aggregate_baseline_median_ms": 2504.552209051326,
+    "aggregate_current_median_ms": 2574.786585289985,
+    "aggregate_delta_pct": 2.8042688024164764,
     "hashes_identical_by_repo": {
       "fastlane": true,
       "rack": true,
@@ -88,7 +88,7 @@
       "sidekiq": true,
       "sinatra": true
     },
-    "method": "1 warmup per binary/repo, then 9 alternating measured runs over Ruby yield-heavy repos",
+    "method": "1 warmup per binary/repo, then 15 alternating measured runs over Ruby yield-heavy repos",
     "non_identical_hash_explanation": "rspec-core kept the same family count; one 3-location HTML family changed representative name from pre to code at the same lines.",
     "source": "bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json",
     "subset": [
@@ -116,6 +116,6 @@
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
     "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json",
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json --generated-on 2026-07-01",
-    "rerun the alternating Ruby-heavy query harness recorded in bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json"
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-yield-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-yield-source-protocol --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json"
   ]
 }

--- a/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
@@ -4,11 +4,11 @@
     "not_a_feature_list": [
       "No Ruby-specific exact admission was opened.",
       "No public semantic-pack API was added.",
-      "Yield demand/effect profiling was generalized to a conservative protocol boundary instead of overloading generator suspension for Ruby block yield."
+      "Generator yield keeps SourceProtocolKind::Yield; Ruby block yield uses SourceProtocolKind::BlockYield with a callback invocation profile."
     ],
     "principle": "Capabilities over features",
     "reused_capabilities": [
-      "SourceProtocolKind::Yield",
+      "SourceProtocolKind::BlockYield",
       "runtime-boundary-model",
       "callback-demand-effect obligation vocabulary",
       "recall-loss oracle_exclusions/by_obligation rollups"
@@ -61,7 +61,7 @@
     "advisory_disagreements": 4,
     "canon_checked": 99,
     "canon_preservation_violations": 0,
-    "excluded_units": 5990,
+    "excluded_units": 5991,
     "false_merges": 0,
     "fingerprint_groups": 38,
     "gate_passed": true,
@@ -69,7 +69,7 @@
     "lossy_fingerprint_collisions": 0,
     "max_violations": 0,
     "report": "target/recall-loss.ruby-yield-source-protocol.crates.json",
-    "total_units": 6959
+    "total_units": 6960
   },
   "generated_on": "2026-07-01",
   "next_exact_work_policy": {
@@ -106,7 +106,7 @@
     "exact_admission_opened": false,
     "kind": "reporting-and-lowering-only",
     "semantic_admission_delta": 0,
-    "summary": "Ruby yield now preserves a source-backed protocol boundary and reports block callback demand/effect obligations instead of being erased into an ordinary Seq value."
+    "summary": "Ruby yield now preserves a source-backed BlockYield protocol boundary and reports block callback demand/effect obligations instead of being erased into an ordinary Seq value."
   },
   "validation_commands": [
     "cargo test -p nose-frontend ruby::tests::yield_preserves_source_backed_protocol_boundary -- --nocapture",
@@ -115,6 +115,7 @@
     "cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence -- --nocapture",
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
     "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json",
-    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json --generated-on 2026-07-01"
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json --generated-on 2026-07-01",
+    "rerun the alternating Ruby-heavy query harness recorded in bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json"
   ]
 }

--- a/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
+++ b/bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json
@@ -20,7 +20,7 @@
     "repos": 17,
     "source": "bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json",
     "status": "reporting-supported-closed-boundary",
-    "surface": "ruby.generator.yield",
+    "surface": "ruby.block.yield",
     "top_repos": [
       {
         "occurrences": 228,

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
@@ -1,0 +1,5410 @@
+{
+  "current_recall_loss": {
+    "relevant_obligations": [
+      {
+        "count": 17,
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_interpretable": 17
+      },
+      {
+        "count": 10,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-rust-macro-call-effect-proof-missing",
+        "oracle_interpretable": 10
+      },
+      {
+        "count": 9,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-member-call-effect-proof-missing",
+        "oracle_interpretable": 9
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-assignment-effect-proof-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-direct-function-call-effect-contract-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 2,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-identity-or-shape-proof-missing",
+        "oracle_interpretable": 2
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-imported-function-call-effect-contract-missing",
+        "oracle_interpretable": 1
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "predicate-callback-demand-effect-profile-missing",
+        "oracle_interpretable": 1
+      }
+    ],
+    "relevant_oracle_exclusion_obligations": [
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 576,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_excluded": 576
+      },
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 3,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "oracle_excluded": 3
+      }
+    ],
+    "report": "target/recall-loss.ruby-yield-source-protocol.crates.json",
+    "soundness_gate": {
+      "advisory_disagreements": 4,
+      "canon_preservation_violations": 0,
+      "false_merges": 0,
+      "fingerprint_groups": 38,
+      "gate_passed": true,
+      "lossy_fingerprint_collisions": 0,
+      "max_violations": 0
+    },
+    "summary": {
+      "admission_rejections": 811,
+      "canon_checked": 99,
+      "canon_preservation_violations": 0,
+      "excluded_units": 5990,
+      "interpretable_units": 969,
+      "total_units": 6959
+    }
+  },
+  "generated_on": "2026-07-01",
+  "hard_negative_inventory": [
+    {
+      "class": "thenable assimilation and custom Promise-like receivers",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "first-settled versus all-settled aggregate semantics",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "executor callback timing and thrown executor errors",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::promise_constructor_missing_evidence_splits_executor_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "scheduler/microtask ordering versus synchronous evaluation",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::scheduler_and_interval_calls_report_timing_and_lifecycle_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "interval stream liveness/cardinality",
+      "evidence": "crates/nose-cli/tests/cli/commands/recall_loss_report.rs::recall_loss_report_splits_promise_protocol_boundaries",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
+      "evidence": "docs/scheduling-channel-callback-obligations-594.md",
+      "status": "mapped-doc-policy"
+    },
+    {
+      "class": "Go direct call versus goroutine/defer scheduling and callback effects",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_select_defer_and_goroutine_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Go channel receive value/status, channel send, and select/default readiness boundaries",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_channel_protocol_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Python async iterator and async context-manager protocol boundaries versus synchronous loops, comprehensions, and with-blocks",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries/python_async_protocol.rs::query_mode_semantic_rejects_unproven_python_async_protocol_lifecycle_convergence, ::query_mode_semantic_rejects_unproven_python_async_comprehension_convergence, crates/nose-frontend/src/python/tests.rs::async_for_preserves_source_backed_iteration_boundary, ::async_comprehension_preserves_source_backed_iteration_boundary, ::multi_clause_async_comprehension_preserves_source_backed_iteration_boundary, ::async_with_preserves_source_backed_context_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::python_async_lifecycle_protocols_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Ruby block yield callback demand/effect versus ordinary value return or direct call",
+      "evidence": "crates/nose-frontend/src/ruby/tests.rs::yield_preserves_source_backed_protocol_boundary, crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::yield_protocol_missing_evidence_is_language_specific, and crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs::query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Rust async closures versus synchronous closures and async blocks",
+      "evidence": "crates/nose-frontend/src/rust/tests/async_protocols.rs::async_closure_preserves_source_backed_protocol_boundary, ::sync_closure_does_not_create_async_protocol_boundary, and crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Swift structured-concurrency runtime names shadowed by local Task bindings, Task extensions, same-file task-group functions, or project-visible task-group functions",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_structured_concurrency_rejects_local_runtime_shadows",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Swift throwing functions and closures versus non-throwing callables, plus async throwing callables that must retain both scheduling and exception-channel obligations",
+      "evidence": "crates/nose-frontend/src/swift/tests/async_protocols.rs::async_throwing_function_preserves_scheduling_and_exception_boundaries, ::async_throwing_closure_keeps_exception_boundary_inside_async_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_throwing_callables_report_exception_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletableFuture static calls without exact stdlib type identity, or with local/conflicting type names",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completable_future_static_attribution_requires_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletionStage-style receiver continuations without import-backed java.util.concurrent type-domain evidence",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completion_stage_receiver_methods_require_import_backed_type_domain",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future local receivers with reassignment, local shadows, or conflicting imports, plus conflicting Executor local receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future field receivers that are implicit, non-this, member-shadowed, duplicate, or conflicting, plus conflicting Executor field receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    }
+  ],
+  "policy": {
+    "go_channel_operation_pricing": "Directional channel type arrows such as <-chan and chan<- are excluded from send/receive operation counts.",
+    "note": "Counts price boundary surfaces; they do not prove exact semantics.",
+    "raw_source_snippets_included": false,
+    "semantic_admission_delta": 0,
+    "source_prevalence_only": true
+  },
+  "recommended_order": [
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "rank": 1,
+      "repos": 17,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "rank": 2,
+      "repos": 8,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "rank": 3,
+      "repos": 18,
+      "why": "new Promise is high-risk because timing, resolve/reject callback, and throw-to-rejection behavior interact."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "rank": 4,
+      "repos": 7,
+      "why": "Cancellation appears across JS/TS scheduling APIs and must stay separate from fulfillment/rejection recovery."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "rank": 5,
+      "repos": 11,
+      "why": "Repeated emission/liveness needs lifecycle proof before interval streams can be compared exactly."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "rank": 6,
+      "repos": 14,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-value-channel-contract-missing",
+      "occurrences": 4294,
+      "operation": "channel receive",
+      "rank": 7,
+      "repos": 13,
+      "why": "Go channel protocol boundaries now split blocking, synchronization, close-status, and select readiness obligations."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-synchronization-contract-missing",
+      "occurrences": 1525,
+      "operation": "channel send",
+      "rank": 8,
+      "repos": 12,
+      "why": "Go channel protocol boundaries now split blocking, synchronization, close-status, and select readiness obligations."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-readiness-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "rank": 9,
+      "repos": 13,
+      "why": "Go channel protocol boundaries now split blocking, synchronization, close-status, and select readiness obligations."
+    },
+    {
+      "language": "go",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-case-selection-contract-missing",
+      "occurrences": 3590,
+      "operation": "select case",
+      "rank": 10,
+      "repos": 13,
+      "why": "Go channel protocol boundaries now split blocking, synchronization, close-status, and select readiness obligations."
+    }
+  ],
+  "regenerate": [
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json --generated-on 2026-07-01"
+  ],
+  "report_kind": "scheduling-lifecycle-boundary-audit",
+  "schema_version": 1,
+  "summary": {
+    "languages": {
+      "c": 81,
+      "go": 31500,
+      "java": 6702,
+      "javascript-typescript": 45382,
+      "python": 6439,
+      "ruby": 4885,
+      "rust": 13228,
+      "swift": 47385
+    },
+    "obligation_families": {
+      "callback-demand-effect": 801,
+      "cancellation-liveness-boundary": 547,
+      "channel-boundary": 12030,
+      "exception-channel": 37808,
+      "executor-callback": 795,
+      "lifecycle-materialization-boundary": 22811,
+      "scheduling-boundary": 79498,
+      "success-error-result-channel": 1312
+    },
+    "repos_in_manifest": 120,
+    "total_source_prevalence": 155602
+  },
+  "surfaces": [
+    {
+      "boundary": "await scheduling",
+      "language": "javascript-typescript",
+      "note": "await is scheduling and thenable assimilation, not sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 29305,
+      "operation": "await",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.await",
+      "top_files": [
+        {
+          "occurrences": 1058,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 689,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 673,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 635,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 615,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 615,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 487,
+          "path": "drizzle-orm/integration-tests/tests/sqlite/sqlite-common.ts"
+        },
+        {
+          "occurrences": 484,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12136,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3321,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 2666,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2413,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1604,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 1592,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 1171,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 1164,
+          "repo": "swr"
+        }
+      ]
+    },
+    {
+      "boundary": "throws channel",
+      "language": "swift",
+      "note": "Swift throws/try is an explicit error channel",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "swift-throws-exception-channel-contract-missing",
+      "occurrences": 26608,
+      "operation": "throws/try",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "swift.error.throws",
+      "top_files": [
+        {
+          "occurrences": 664,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 489,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 450,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 406,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 396,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 364,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 344,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 304,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14760,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2508,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1466,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 1356,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 1107,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 914,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 805,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "defer lifecycle",
+      "language": "go",
+      "note": "defer has scope-exit ordering and panic interaction semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "defer-lifecycle-ordering-contract-missing",
+      "occurrences": 17521,
+      "operation": "defer statement",
+      "repos": 16,
+      "status": "closed-boundary",
+      "surface": "go.concurrent.defer",
+      "top_files": [
+        {
+          "occurrences": 1001,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 560,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 494,
+          "path": "nats-server/server/jetstream_consumer_test.go"
+        },
+        {
+          "occurrences": 461,
+          "path": "nats-server/server/filestore_test.go"
+        },
+        {
+          "occurrences": 420,
+          "path": "nats-server/server/mqtt_test.go"
+        },
+        {
+          "occurrences": 396,
+          "path": "nats-server/server/jetstream_cluster_3_test.go"
+        },
+        {
+          "occurrences": 394,
+          "path": "nats-server/server/jetstream_cluster_1_test.go"
+        },
+        {
+          "occurrences": 379,
+          "path": "nats-server/server/gateway_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10073,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 2461,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1797,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 1151,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 581,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 449,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 422,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 161,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "javascript-typescript",
+      "note": "async functions have scheduling and rejection boundaries even without explicit await",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 14491,
+      "operation": "async function",
+      "repos": 22,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.function",
+      "top_files": [
+        {
+          "occurrences": 352,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 314,
+          "path": "ky/test/hooks.ts"
+        },
+        {
+          "occurrences": 278,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 278,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 210,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 207,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 198,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 192,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4595,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 1621,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1607,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 1079,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 883,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 814,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 688,
+          "repo": "axios"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "swift",
+      "note": "Swift await has task scheduling and actor/lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8689,
+      "operation": "await",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "swift.async.await",
+      "top_files": [
+        {
+          "occurrences": 612,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 556,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 263,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 257,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 251,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 221,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 153,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 150,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3169,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2261,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 969,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 944,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 724,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 155,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 139,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 96,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "future await",
+      "language": "rust",
+      "note": "Rust .await polls a Future and must keep wake/scheduling effects explicit",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8647,
+      "operation": ".await",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.await",
+      "top_files": [
+        {
+          "occurrences": 545,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/proxy.rs"
+        },
+        {
+          "occurrences": 255,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 227,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 221,
+          "path": "meilisearch/crates/meilisearch/tests/dumps/mod.rs"
+        },
+        {
+          "occurrences": 193,
+          "path": "meilisearch/crates/meilisearch/tests/search/mod.rs"
+        },
+        {
+          "occurrences": 147,
+          "path": "meilisearch/crates/meilisearch/tests/tasks/mod.rs"
+        },
+        {
+          "occurrences": 141,
+          "path": "meilisearch/crates/meilisearch/tests/batches/mod.rs"
+        },
+        {
+          "occurrences": 138,
+          "path": "meilisearch/crates/meilisearch/tests/documents/get_documents.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5632,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 2942,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 39,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 34,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing callable error channel",
+      "language": "swift",
+      "note": "Swift body-bearing throwing functions expose an error channel even when the body has no explicit try expression",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 7008,
+      "operation": "func/init/subscript throws/rethrows",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_function",
+      "top_files": [
+        {
+          "occurrences": 135,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 133,
+          "path": "swift-nio/Tests/NIOCoreTests/ByteBufferTest.swift"
+        },
+        {
+          "occurrences": 82,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 76,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 74,
+          "path": "swift-nio/Tests/NIOPosixTests/CodecTest.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 64,
+          "path": "swift-collections/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3459,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 864,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 518,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 445,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 387,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 284,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 219,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 165,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive value",
+      "language": "go",
+      "note": "Go channel receives have blocking, synchronization, and close/zero-value channel semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-value-channel-contract-missing",
+      "occurrences": 4294,
+      "operation": "channel receive",
+      "repos": 13,
+      "status": "closed-boundary",
+      "surface": "go.channel.receive",
+      "top_files": [
+        {
+          "occurrences": 126,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 102,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 98,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "delve/service/test/integration2_test.go"
+        },
+        {
+          "occurrences": 82,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 73,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 68,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 65,
+          "path": "nats-server/server/norace_2_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1476,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1354,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 541,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 537,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 175,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 85,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 17,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "exception channel",
+      "language": "ruby",
+      "note": "raise/rescue changes error channels and non-local control",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 4010,
+      "operation": "raise/rescue",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "ruby.exception",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 71,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 67,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 53,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 50,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1334,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 699,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 343,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 264,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 226,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 155,
+          "repo": "sinatra"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "swift",
+      "note": "Swift async surfaces create task/future-like protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 3953,
+      "operation": "async",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "swift.async.function",
+      "top_files": [
+        {
+          "occurrences": 134,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 71,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 62,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 54,
+          "path": "vapor/Tests/VaporMacroTests/HTTPMethodMacroTests.swift"
+        },
+        {
+          "occurrences": 53,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 50,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 47,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1379,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 680,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 670,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 334,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 226,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 179,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 131,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 115,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "select case selection",
+      "language": "go",
+      "note": "Go select cases require readiness, case-selection, and send/receive side-effect proof",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-case-selection-contract-missing",
+      "occurrences": 3590,
+      "operation": "select case",
+      "repos": 13,
+      "status": "closed-boundary",
+      "surface": "go.channel.select.case",
+      "top_files": [
+        {
+          "occurrences": 110,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 106,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 71,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 67,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 63,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 62,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 61,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1342,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1086,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 533,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 430,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 82,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 29,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 15,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "executor scheduling",
+      "language": "java",
+      "note": "Executor/Future APIs introduce scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "java-executor-scheduling-contract-missing",
+      "occurrences": 3297,
+      "operation": "Executor/Future",
+      "repos": 16,
+      "status": "closed-boundary",
+      "surface": "java.future.executor",
+      "top_files": [
+        {
+          "occurrences": 59,
+          "path": "netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 33,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1338,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 1173,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 343,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 107,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 86,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 84,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 57,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 44,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "rust",
+      "note": "async fn creates a suspended async function boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2806,
+      "operation": "async fn",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 67,
+          "path": "meilisearch/crates/meilisearch/tests/common/index.rs"
+        },
+        {
+          "occurrences": 60,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 56,
+          "path": "meilisearch/crates/meilisearch/tests/common/server.rs"
+        },
+        {
+          "occurrences": 49,
+          "path": "meilisearch/crates/meilisearch/tests/search/errors.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 37,
+          "path": "meilisearch/crates/meilisearch/tests/auth/api_keys.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1405,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 1352,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 28,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 21,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "generator lifecycle",
+      "language": "python",
+      "note": "yield has suspension and iterator lifecycle semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "generator-yield-lifecycle-contract-missing",
+      "occurrences": 2404,
+      "operation": "yield",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "python.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 86,
+          "path": "sympy/sympy/utilities/iterables.py"
+        },
+        {
+          "occurrences": 83,
+          "path": "black/src/black/linegen.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "scrapy/tests/test_crawl.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sympy/sympy/core/facts.py"
+        },
+        {
+          "occurrences": 39,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 37,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 31,
+          "path": "packaging/src/packaging/tags.py"
+        },
+        {
+          "occurrences": 29,
+          "path": "rich/rich/segment.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 540,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 446,
+          "repo": "sympy"
+        },
+        {
+          "occurrences": 367,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 339,
+          "repo": "rich"
+        },
+        {
+          "occurrences": 172,
+          "repo": "black"
+        },
+        {
+          "occurrences": 139,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 76,
+          "repo": "poetry"
+        },
+        {
+          "occurrences": 64,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Java streams need lazy/eager lifecycle and terminal materialization proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 1996,
+      "operation": "stream/parallelStream",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "java.stream.lifecycle",
+      "top_files": [
+        {
+          "occurrences": 137,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/GeoPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 124,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java"
+        },
+        {
+          "occurrences": 80,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGeospatialCommandsTest.java"
+        },
+        {
+          "occurrences": 75,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 60,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "netty/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java"
+        },
+        {
+          "occurrences": 24,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 535,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 508,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 385,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 280,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 102,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 88,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 29,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 24,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "goroutine scheduling",
+      "language": "go",
+      "note": "go statements spawn concurrent execution",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "repos": 14,
+      "status": "closed-boundary",
+      "surface": "go.concurrent.goroutine",
+      "top_files": [
+        {
+          "occurrences": 52,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "prometheus/discovery/kubernetes/kubernetes.go"
+        },
+        {
+          "occurrences": 23,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 22,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 20,
+          "path": "nats-server/server/jwt_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 501,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 439,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 364,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 253,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 126,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 91,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 60,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 36,
+          "repo": "hugo"
+        }
+      ]
+    },
+    {
+      "boundary": "channel select",
+      "language": "go",
+      "note": "select has readiness, default, and scheduling semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-readiness-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "repos": 13,
+      "status": "closed-boundary",
+      "surface": "go.channel.select",
+      "top_files": [
+        {
+          "occurrences": 62,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 58,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 45,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 33,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 31,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "nats-server/server/routes_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "prometheus/scrape/scrape_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 706,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 574,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 279,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 250,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 47,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 25,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 21,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "python",
+      "note": "Python await has coroutine scheduling and exception channel semantics",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 1789,
+      "operation": "await",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "python.async.await",
+      "top_files": [
+        {
+          "occurrences": 145,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 122,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 78,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 72,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 62,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 54,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 50,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 716,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 661,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 200,
+          "repo": "black"
+        },
+        {
+          "occurrences": 196,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 5,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "python",
+      "note": "async def creates coroutine protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 1596,
+      "operation": "async def",
+      "repos": 9,
+      "status": "closed-boundary",
+      "surface": "python.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 75,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 57,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/result.py"
+        },
+        {
+          "occurrences": 53,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "scrapy/tests/test_spidermiddleware.py"
+        },
+        {
+          "occurrences": 40,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 790,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 424,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 209,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 144,
+          "repo": "black"
+        },
+        {
+          "occurrences": 19,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 3,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "channel send synchronization",
+      "language": "go",
+      "note": "Go channel sends have blocking and synchronization semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-synchronization-contract-missing",
+      "occurrences": 1525,
+      "operation": "channel send",
+      "repos": 12,
+      "status": "closed-boundary",
+      "surface": "go.channel.send",
+      "top_files": [
+        {
+          "occurrences": 43,
+          "path": "nats-server/server/filestore.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jwt_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "minio/cmd/metrics.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "prometheus/tsdb/head_wal.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/reload_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "etcd/server/etcdserver/server_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "nats-server/server/leafnode_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 474,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 436,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 275,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 189,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 39,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 33,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 28,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 18,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async block construction",
+      "language": "rust",
+      "note": "async blocks create suspended async boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-block-scheduling-contract-missing",
+      "occurrences": 1342,
+      "operation": "async block",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.block",
+      "top_files": [
+        {
+          "occurrences": 109,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 86,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 57,
+          "path": "tokio/tokio/tests/task_local_set.rs"
+        },
+        {
+          "occurrences": 43,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 42,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio-util/tests/task_join_map.rs"
+        },
+        {
+          "occurrences": 33,
+          "path": "tokio/tokio/tests/rt_basic.rs"
+        },
+        {
+          "occurrences": 31,
+          "path": "tokio/tokio/tests/task_join_set.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1273,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 5,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "block callback",
+      "language": "ruby",
+      "note": "Ruby yield invokes a block with demand/effect obligations",
+      "obligation_family": "callback-demand-effect",
+      "obligation_subreason": "ruby-yield-callback-demand-effect-contract-missing",
+      "occurrences": 801,
+      "operation": "yield",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 26,
+          "path": "rubocop/spec/rubocop/cop/style/explicit_block_argument_spec.rb"
+        },
+        {
+          "occurrences": 22,
+          "path": "rspec-core/benchmarks/capture_block_vs_yield.rb"
+        },
+        {
+          "occurrences": 18,
+          "path": "rack/test/spec_deflater.rb"
+        },
+        {
+          "occurrences": 16,
+          "path": "sinatra/lib/sinatra/base.rb"
+        },
+        {
+          "occurrences": 12,
+          "path": "rubocop/spec/rubocop/cop/layout/hash_alignment_spec.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "faraday/lib/faraday/connection.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "rack/test/spec_lint.rb"
+        },
+        {
+          "occurrences": 8,
+          "path": "rspec-core/lib/rspec/core/configuration.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 228,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 98,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 55,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 38,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 36,
+          "repo": "devise"
+        },
+        {
+          "occurrences": 34,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "executor timing",
+      "language": "javascript-typescript",
+      "note": "new Promise needs executor timing, resolve/reject callback, and throw-to-rejection contracts",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.executor",
+      "top_files": [
+        {
+          "occurrences": 46,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 28,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 20,
+          "path": "axios/tests/unit/prototypePollution.test.js"
+        },
+        {
+          "occurrences": 20,
+          "path": "trpc/packages/tests/server/websockets.test.ts"
+        },
+        {
+          "occurrences": 12,
+          "path": "esbuild/scripts/plugin-tests.js"
+        },
+        {
+          "occurrences": 12,
+          "path": "prettier/tests/format/flow/flow-repo/promises/promise.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 151,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 135,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 96,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 89,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 80,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 61,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 55,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 50,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "select default liveness",
+      "language": "go",
+      "note": "Go select defaults change blocking and liveness behavior",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-default-liveness-contract-missing",
+      "occurrences": 546,
+      "operation": "select default",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "go.channel.select.default",
+      "top_files": [
+        {
+          "occurrences": 14,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/gateway_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 11,
+          "path": "prometheus/storage/remote/queue_manager.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "etcd/pkg/proxy/server.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "prometheus/tsdb/db.go"
+        },
+        {
+          "occurrences": 9,
+          "path": "nats-server/server/jetstream_cluster_long_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 195,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 144,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 94,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 71,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 13,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 2,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "all-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.all needs ordered all-fulfilled value and first rejection semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "execa/test/convert/concurrent.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 12,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 11,
+          "path": "zod/packages/zod/src/v4/core/schemas.ts"
+        },
+        {
+          "occurrences": 9,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "date-fns/pkgs/docs/src/bin.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "execa/test/pipe/streaming.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 79,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 62,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 60,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 56,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 29,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 17,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 17,
+          "repo": "zod"
+        },
+        {
+          "occurrences": 16,
+          "repo": "date-fns"
+        }
+      ]
+    },
+    {
+      "boundary": "async context lifecycle",
+      "language": "python",
+      "note": "async with needs async enter/exit cleanup, exception-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-context-lifecycle-contract-missing",
+      "occurrences": 361,
+      "operation": "async with",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.context",
+      "top_files": [
+        {
+          "occurrences": 66,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 59,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 33,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 27,
+          "path": "httpx/tests/client/test_auth.py"
+        },
+        {
+          "occurrences": 26,
+          "path": "httpx/tests/client/test_async_client.py"
+        },
+        {
+          "occurrences": 14,
+          "path": "scrapy/tests/test_scheduler.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "scrapy/tests/test_downloadermiddleware.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 169,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 95,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 77,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 19,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "task spawn",
+      "language": "rust",
+      "note": "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "rust.async.spawn",
+      "top_files": [
+        {
+          "occurrences": 32,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 18,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 16,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 12,
+          "path": "tokio/tokio/tests/task_abort.rs"
+        },
+        {
+          "occurrences": 11,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "meilisearch/crates/meilisearch/src/routes/indexes/documents.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/net_named_pipe.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 284,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 62,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "future channel",
+      "language": "java",
+      "note": "CompletableFuture needs success/error channel and scheduling proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 276,
+      "operation": "CompletableFuture",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "java.future.completable",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "retrofit/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 112,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 64,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 55,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 29,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 7,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 6,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "cancellation signal",
+      "language": "javascript-typescript",
+      "note": "AbortSignal/AbortController can change scheduling and rejection outcomes",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "js-ts.cancellation.abort",
+      "top_files": [
+        {
+          "occurrences": 18,
+          "path": "execa/test/terminate/cancel.js"
+        },
+        {
+          "occurrences": 18,
+          "path": "execa/test/ipc/graceful.js"
+        },
+        {
+          "occurrences": 14,
+          "path": "execa/test/terminate/graceful.js"
+        },
+        {
+          "occurrences": 13,
+          "path": "trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test-d/arguments/options.test-d.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test/pipe/abort.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "trpc/packages/client/src/internals/signals.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 108,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 87,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 30,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 17,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 8,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 4,
+          "repo": "pixijs"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle get",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose blocking settled-value and exception channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 249,
+      "operation": "Future.get",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.get",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 83,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 28,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 23,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 13,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 11,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 8,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle cancellation",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose cancellation and task-handle liveness boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 239,
+      "operation": "Future.cancel/isCancelled",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.cancel",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 104,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 101,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 14,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 3,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service future scheduling",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService receivers schedule callbacks and return Future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 222,
+      "operation": "ExecutorService.submit",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.submit",
+      "top_files": [
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 90,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 72,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 27,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 6,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 5,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 4,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 4,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task scheduling",
+      "language": "swift",
+      "note": "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 215,
+      "operation": "Task/Task.detached",
+      "repos": 12,
+      "status": "closed-boundary",
+      "surface": "swift.task.spawn",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift"
+        },
+        {
+          "occurrences": 21,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "rxswift/Sources/AllTestz/PrimitiveSequence+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 63,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 35,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 31,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 23,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 23,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 16,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 6,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "swift",
+      "note": "Swift async sequence loops need async iterator lifecycle, value-channel, scheduling, and throwing-channel proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 193,
+      "operation": "for await/for try await",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Sources/ServiceLifecycle/ServiceGroup.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxswift/Sources/AllTestz/Observable+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 72,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 67,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 13,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "executor runnable scheduling",
+      "language": "java",
+      "note": "Import-backed Java Executor receivers schedule callback execution without returning a task handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 180,
+      "operation": "Executor.execute",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor.execute",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "netty/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "mockito/mockito-core/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 114,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 38,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 2,
+          "repo": "gson"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing closure error channel",
+      "language": "swift",
+      "note": "Swift throwing closures expose the same error-channel obligation as throwing functions and async throwing closures",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 169,
+      "operation": "closure throws/rethrows",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_closure",
+      "top_files": [
+        {
+          "occurrences": 16,
+          "path": "swift-collections/Tests/DequeTests/RigidDequeTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "vapor/Tests/VaporTests/QueryTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "vapor/Tests/VaporTests/ContentTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Sources/AllTestz/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Tests/VaporMacroTests/AuthMiddlewareMacroTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 58,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 52,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 38,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "task sleep timer",
+      "language": "swift",
+      "note": "Swift Task.sleep creates a timer-backed scheduling boundary and cancellation/liveness boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 161,
+      "operation": "Task.sleep",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.sleep",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-nio/Tests/NIOPosixTests/EventLoopTest.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Tests/KingfisherTests/KingfisherManagerTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "nimble/Tests/NimbleTests/AsyncAwaitTest.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 71,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 32,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 10,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive status",
+      "language": "go",
+      "note": "Go comma-ok receives expose the channel close status as an additional protocol result",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-status-contract-missing",
+      "occurrences": 155,
+      "operation": "comma-ok channel receive",
+      "repos": 9,
+      "status": "closed-boundary",
+      "surface": "go.channel.receive_status",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 12,
+          "path": "etcd/tests/integration/clientv3/lease/lease_test.go"
+        },
+        {
+          "occurrences": 6,
+          "path": "etcd/tests/integration/cache_test.go"
+        },
+        {
+          "occurrences": 5,
+          "path": "etcd/tests/integration/v3_election_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "etcd/cache/cache_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/admin-handlers.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/internal/grid/muxclient.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 84,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 48,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 11,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 5,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 1,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "task-group aggregate",
+      "language": "swift",
+      "note": "Swift task groups need all-completion, result-channel, cancellation/liveness, and throwing error-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 153,
+      "operation": "withTaskGroup/withThrowingTaskGroup/withDiscardingTaskGroup/withThrowingDiscardingTaskGroup",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.group",
+      "top_files": [
+        {
+          "occurrences": 31,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 18,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 14,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 9,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/CancellationTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 68,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 4,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 3,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 1,
+          "repo": "fastlane"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle lifecycle",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose task-handle lifecycle status",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "task-handle-lifecycle-contract-missing",
+      "occurrences": 127,
+      "operation": "Future.isDone",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.status",
+      "top_files": [
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 61,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 49,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 10,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "python",
+      "note": "async for statements and comprehensions need async iterator lifecycle, value-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 114,
+      "operation": "async for",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "httpx/tests/test_content.py"
+        },
+        {
+          "occurrences": 16,
+          "path": "httpx/tests/models/test_responses.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "black/tests/data/cases/python37.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "httpx/httpx/_models.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_spidermiddleware_referer.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/starred_for_target.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 48,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 30,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 20,
+          "repo": "black"
+        },
+        {
+          "occurrences": 15,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timer",
+      "language": "python",
+      "note": "asyncio sleep creates a timer-backed scheduling boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 104,
+      "operation": "asyncio.sleep",
+      "repos": 6,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.sleep",
+      "top_files": [
+        {
+          "occurrences": 48,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 9,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "flask/tests/test_async.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_command_parse.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_utils_defer.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 3,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 59,
+          "repo": "black"
+        },
+        {
+          "occurrences": 32,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "async closure scheduling",
+      "language": "swift",
+      "note": "Swift async closures create async callable protocol boundaries even when the surrounding function is synchronous",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 100,
+      "operation": "async closure",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.closure",
+      "top_files": [
+        {
+          "occurrences": 29,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "vapor/Tests/VaporTests/AuthenticationTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "swift-composable-architecture/Benchmarks/Benchmarks/swift-composable-architecture-benchmark/Benchmarks.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "vapor/Tests/VaporTests/MiddlewareTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "vapor/Tests/VaporTests/RouteTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "nimble/Tests/NimbleTests/Matchers/EqualTest.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 86,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-nio"
+        }
+      ]
+    },
+    {
+      "boundary": "thread/fiber scheduling",
+      "language": "ruby",
+      "note": "Thread/Fiber APIs create scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 74,
+      "operation": "Thread/Fiber",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.thread.fiber",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "puma/test/test_cli.rb"
+        },
+        {
+          "occurrences": 6,
+          "path": "rack/test/spec_multipart.rb"
+        },
+        {
+          "occurrences": 4,
+          "path": "puma/test/test_pumactl.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/test/test_thread_pool.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/lib/puma/cluster/worker.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/benchmarks/local/response_time_wrk.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "fastlane/fastlane/lib/fastlane/swift_lane_manager.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "puma/test/test_puma_server_ssl.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 36,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 10,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 10,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jekyll"
+        },
+        {
+          "occurrences": 2,
+          "repo": "asciidoctor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rspec-core"
+        }
+      ]
+    },
+    {
+      "boundary": "interval lifecycle",
+      "language": "javascript-typescript",
+      "note": "setInterval and timers interval streams have repeated emission, cancellation, and liveness semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.interval",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjs/packages/rxjs/spec/Observable-spec.ts"
+        },
+        {
+          "occurrences": 4,
+          "path": "swr/test/use-swr-subscription.test.tsx"
+        },
+        {
+          "occurrences": 3,
+          "path": "drizzle-orm/drizzle-kit/src/cli/views.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/example/src/main/resources/io/netty/example/stomp/websocket/stomp.js"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/src/internal/scheduler/intervalProvider.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/spec/schedulers/TestScheduler-spec.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 16,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 7,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 7,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 6,
+          "repo": "swr"
+        },
+        {
+          "occurrences": 3,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "thread scheduling",
+      "language": "c",
+      "note": "pthread_create introduces thread scheduling and lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "c-pthread-scheduling-contract-missing",
+      "occurrences": 68,
+      "operation": "pthread_create",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "c.thread.pthread",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "redis/tests/modules/blockedclient.c"
+        },
+        {
+          "occurrences": 3,
+          "path": "redis/tests/modules/blockonbackground.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/name-hash.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/transport-helper.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/read-cache.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/fsmonitor--daemon.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/pack-objects.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/helper/test-trace2.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 23,
+          "repo": "git"
+        },
+        {
+          "occurrences": 7,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 5,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 3,
+          "repo": "libuv"
+        },
+        {
+          "occurrences": 2,
+          "repo": "raylib"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jq"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nginx"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime join style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "repos": 2,
+      "status": "closed-boundary",
+      "surface": "rust.async.join",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_try_join.rs"
+        },
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_try_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_join.rs"
+        },
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "meilisearch/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 67,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 1,
+          "repo": "meilisearch"
+        }
+      ]
+    },
+    {
+      "boundary": "structured task binding",
+      "language": "swift",
+      "note": "Swift async let creates a child task with scheduling, handle lifecycle, cancellation/liveness, and awaited result boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 51,
+      "operation": "async let",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.let",
+      "top_files": [
+        {
+          "occurrences": 17,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 16,
+          "path": "alamofire/Tests/OfflineRetrierTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "vapor/Tests/VaporTests/EndpointCacheTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 33,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 5,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift throwing continuation bridge",
+      "language": "swift",
+      "note": "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 43,
+      "operation": "withCheckedThrowingContinuation/withUnsafeThrowingContinuation",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.throwing",
+      "top_files": [
+        {
+          "occurrences": 8,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-nio/Sources/NIOCore/AsyncAwaitSupport.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/Sources/RxSwift/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOPosix/NIOThreadPool.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingChannel.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/BufferedStream.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOFS/Internal/BufferedStream.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 18,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 13,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 1,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "first-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.race needs first-settled ordering and liveness proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "execa/test/convert/iterable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/setup/server.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/convert/readable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "ky/source/core/Ky.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/client/src/links/localLink.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/mysql2/session.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/singlestore/session.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 15,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 4,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 3,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 3,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 2,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift continuation bridge",
+      "language": "swift",
+      "note": "Swift continuation bridges suspend and resume through a callback-settled future-like result channel",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 30,
+      "operation": "withCheckedContinuation/withUnsafeContinuation",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.checked",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "alamofire/Tests/RequestInterceptorTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingEventLoop.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NIOThreadPoolTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "alamofire/Source/Features/Concurrency.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/Concurrency Primitives/TokenBucket.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/NIOFS/Internal/Concurrency Primitives/TokenBucket.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 7,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor timer",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService schedule calls add timer-backed task scheduling and Future result channels",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 27,
+      "operation": "ScheduledExecutorService.schedule",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.schedule",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadWorker.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio future drive",
+      "language": "python",
+      "note": "asyncio.run drives a coroutine to completion with scheduling, result-channel, and exception boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "future-drive-scheduling-contract-missing",
+      "occurrences": 23,
+      "operation": "asyncio.run",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/_concurrency_fixtures.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/tests/test_concurrency_manager_shutdown.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "curl/tests/http/testenv/ws_echo_server.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/AsyncCrawlerRunner/reactorless_simple.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor interval lifecycle",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService repeating schedules expose interval lifecycle and cancellation boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 22,
+      "operation": "ScheduledExecutorService.scheduleAtFixedRate/scheduleWithFixedDelay",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.interval",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "jedis/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "commons-lang"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service all-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAll waits for all submitted tasks and returns Future result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 21,
+      "operation": "ExecutorService.invokeAll",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_all",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "all-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.allSettled needs settled-record channel and shape proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-settled-contract-missing",
+      "occurrences": 17,
+      "operation": "Promise.allSettled",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/lib/resolve/wait-subprocess.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "jest/packages/jest-haste-map/src/watchers/index.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/streaming.test.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/adapters/standalone.test.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/pipe/setup.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/resolve/exit-async.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/buffer-messages.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/convert/concurrent.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 5,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 2,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio all-completion aggregate",
+      "language": "python",
+      "note": "asyncio gather needs all-completion, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.gather",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/examples/asyncio/gather_orm_statements.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_downloadermiddleware_robotstxt.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/pipelines/media.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "black"
+        },
+        {
+          "occurrences": 6,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "future settled value",
+      "language": "java",
+      "note": "CompletableFuture settled factories create fulfilled or exceptional future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 14,
+      "operation": "CompletableFuture.completedFuture/failedFuture",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.factory",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 13,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio task spawn",
+      "language": "python",
+      "note": "asyncio task APIs create scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.task",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/core/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/defer.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "black"
+        }
+      ]
+    },
+    {
+      "boundary": "non-local jump",
+      "language": "c",
+      "note": "setjmp/longjmp is non-local control flow, not ordinary return",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "c-nonlocal-jump-contract-missing",
+      "occurrences": 13,
+      "operation": "setjmp/longjmp",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "c.nonlocal_jump",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "sqlite/autosetup/jimsh0.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/unit-tests/clar/clar.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "lua/ltests.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "redis/modules/vector-sets/fastjson_test.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "vim/src/if_python3.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 2,
+          "repo": "git"
+        },
+        {
+          "occurrences": 2,
+          "repo": "lua"
+        },
+        {
+          "occurrences": 2,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vim"
+        }
+      ]
+    },
+    {
+      "boundary": "future task spawn",
+      "language": "java",
+      "note": "CompletableFuture async factories schedule executor callbacks and return future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "CompletableFuture.supplyAsync/runAsync",
+      "repos": 4,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.spawn",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task yield",
+      "language": "swift",
+      "note": "Swift Task.yield yields to the task scheduler and must not collapse into sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-yield-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "Task.yield",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.yield",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-composable-architecture/Sources/ComposableArchitecture/TestStore.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/DebugTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduler yield",
+      "language": "javascript-typescript",
+      "note": "scheduler.yield needs microtask/order proof",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "scheduler-yield-microtask-order-contract-missing",
+      "occurrences": 11,
+      "operation": "scheduler.yield",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.scheduler",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/generator.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/web-transform.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/duplex.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/graceful.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/incoming.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/ipc/get-each.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/transform/generator-main.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/convert/writable.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 11,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "future settlement continuation",
+      "language": "java",
+      "note": "Future-like receivers need settlement continuation and callback demand/effect proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settlement-continuation-contract-missing",
+      "occurrences": 10,
+      "operation": "FutureLike.handle/whenComplete",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completion_stage.settlement",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 9,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "imported future all-completion aggregate",
+      "language": "rust",
+      "note": "import-backed tokio/futures/futures_util join-style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 8,
+      "operation": "use runtime::join; join!",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join.imported",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "tokio/tokio/tests/tcp_connect.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tests-integration/tests/process_stdio.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/tcp_stream.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service first-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAny exposes first-success completion, cancellation, and exception boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 6,
+      "operation": "ExecutorService.invokeAny",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_any",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio cancellation shield",
+      "language": "python",
+      "note": "asyncio.shield changes cancellation propagation while preserving an awaitable result channel",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 5,
+      "operation": "asyncio.shield",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.shield",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "sqlalchemy/lib/sqlalchemy/connectors/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlalchemy"
+        }
+      ]
+    },
+    {
+      "boundary": "future first-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime select style macros need first-completion, cancellation, and result-channel proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 5,
+      "operation": "tokio/futures/futures_util select",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "rust.async.select",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/examples/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "java",
+      "note": "CompletableFuture.allOf needs all-completion and exceptional completion proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "CompletableFuture.allOf",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.all",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio completion aggregate",
+      "language": "python",
+      "note": "asyncio wait needs completion-selection, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "asyncio.wait",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.wait",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/extensions/feedexport.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timeout wait",
+      "language": "python",
+      "note": "asyncio.wait_for adds timer and cancellation/liveness boundaries around an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "asyncio.wait_for",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait_for",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/util/queue.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "imported task spawn",
+      "language": "rust",
+      "note": "import-backed tokio/async-std spawn bindings introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn.imported",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_handle_block_on.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread-safe task submission",
+      "language": "python",
+      "note": "asyncio.run_coroutine_threadsafe schedules a coroutine onto another loop and returns a future handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "asyncio.run_coroutine_threadsafe",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run_coroutine_threadsafe",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/shell.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/commands/shell.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "imported asyncio timer",
+      "language": "python",
+      "note": "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "from asyncio import sleep; binding",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.imported.sleep",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spider_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "first-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.any needs first-fulfilled and AggregateError rejection proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-first-fulfilled-contract-missing",
+      "occurrences": 1,
+      "operation": "Promise.any",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "jest/packages/expect/src/__tests__/toThrowMatchers.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "jest"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread offload",
+      "language": "python",
+      "note": "asyncio.to_thread schedules a callback on a worker thread and returns an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 1,
+      "operation": "asyncio.to_thread",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.to_thread",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "scrapy"
+        }
+      ]
+    }
+  ],
+  "tracking_issue": {
+    "number": 602,
+    "url": "https://github.com/corca-ai/nose/issues/602"
+  }
+}

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
@@ -82,9 +82,9 @@
       "admission_rejections": 811,
       "canon_checked": 99,
       "canon_preservation_violations": 0,
-      "excluded_units": 5990,
+      "excluded_units": 5991,
       "interpretable_units": 969,
-      "total_units": 6959
+      "total_units": 6960
     }
   },
   "generated_on": "2026-07-01",

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json
@@ -1976,7 +1976,7 @@
       "operation": "yield",
       "repos": 17,
       "status": "reporting-supported-closed-boundary",
-      "surface": "ruby.generator.yield",
+      "surface": "ruby.block.yield",
       "top_files": [
         {
           "occurrences": 26,

--- a/crates/nose-cli/src/recall_loss_report/obligations.rs
+++ b/crates/nose-cli/src/recall_loss_report/obligations.rs
@@ -440,6 +440,13 @@ const RUNTIME_BOUNDARY_OBLIGATIONS: &[RuntimeBoundaryRule] = &[
         ),
     },
     RuntimeBoundaryRule {
+        evidence: "ruby-yield-callback-demand-effect-contract",
+        obligation: (
+            "callback-demand-effect",
+            "ruby-yield-callback-demand-effect-contract-missing",
+        ),
+    },
+    RuntimeBoundaryRule {
         evidence: "goroutine-scheduling-contract",
         obligation: (
             "scheduling-boundary",

--- a/crates/nose-cli/src/recall_loss_report/obligations/tests.rs
+++ b/crates/nose-cli/src/recall_loss_report/obligations/tests.rs
@@ -147,6 +147,13 @@ fn async_protocol_labels_have_specific_obligations() {
         )
     );
     assert_eq!(
+        runtime_boundary_obligation(&["ruby-yield-callback-demand-effect-contract"]),
+        (
+            "callback-demand-effect",
+            "ruby-yield-callback-demand-effect-contract-missing",
+        )
+    );
+    assert_eq!(
         runtime_boundary_obligation(&[
             "async-iteration-lifecycle-contract",
             "async-iteration-value-channel-contract",

--- a/crates/nose-cli/src/verify_admission/runtime_boundary.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary.rs
@@ -2,7 +2,7 @@ use super::{
     callee_identity::callee_identity_call_evidence, push_unique, visit_subtree, AdmissionContext,
 };
 use async_runtime::push_async_runtime_call_missing_evidence;
-use nose_il::{Interner, NodeId, NodeKind, Payload};
+use nose_il::{Interner, Lang, NodeId, NodeKind, Payload};
 
 mod async_runtime;
 
@@ -90,8 +90,12 @@ fn push_source_protocol_missing_evidence(
             push_unique(labels, "async-await-scheduling-contract");
         }
         nose_il::SourceProtocolKind::Yield => {
-            push_unique(labels, "generator-yield-lifecycle-contract");
-            push_unique(labels, "generator-yield-protocol-contract");
+            if il.meta.lang == Lang::Ruby {
+                push_unique(labels, "ruby-yield-callback-demand-effect-contract");
+            } else {
+                push_unique(labels, "generator-yield-lifecycle-contract");
+                push_unique(labels, "generator-yield-protocol-contract");
+            }
         }
         nose_il::SourceProtocolKind::ChannelReceive | nose_il::SourceProtocolKind::ChannelSend => {
             push_go_channel_send_receive_missing_evidence(il, interner, node, labels);
@@ -492,14 +496,10 @@ fn promise_then_has_callback_slot(il: &nose_il::Il, call: NodeId) -> bool {
     il.children(call).len() > 1
 }
 
-fn js_like_runtime_lang(lang: nose_il::Lang) -> bool {
+fn js_like_runtime_lang(lang: Lang) -> bool {
     matches!(
         lang,
-        nose_il::Lang::JavaScript
-            | nose_il::Lang::TypeScript
-            | nose_il::Lang::Vue
-            | nose_il::Lang::Svelte
-            | nose_il::Lang::Html
+        Lang::JavaScript | Lang::TypeScript | Lang::Vue | Lang::Svelte | Lang::Html
     )
 }
 

--- a/crates/nose-cli/src/verify_admission/runtime_boundary.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary.rs
@@ -90,12 +90,11 @@ fn push_source_protocol_missing_evidence(
             push_unique(labels, "async-await-scheduling-contract");
         }
         nose_il::SourceProtocolKind::Yield => {
-            if il.meta.lang == Lang::Ruby {
-                push_unique(labels, "ruby-yield-callback-demand-effect-contract");
-            } else {
-                push_unique(labels, "generator-yield-lifecycle-contract");
-                push_unique(labels, "generator-yield-protocol-contract");
-            }
+            push_unique(labels, "generator-yield-lifecycle-contract");
+            push_unique(labels, "generator-yield-protocol-contract");
+        }
+        nose_il::SourceProtocolKind::BlockYield => {
+            push_unique(labels, "ruby-yield-callback-demand-effect-contract");
         }
         nose_il::SourceProtocolKind::ChannelReceive | nose_il::SourceProtocolKind::ChannelSend => {
             push_go_channel_send_receive_missing_evidence(il, interner, node, labels);

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
@@ -134,7 +134,7 @@ fn yield_protocol_missing_evidence_is_language_specific() {
         "yield.rb",
         "def render(value)\n  yield value\nend\n",
         Lang::Ruby,
-        nose_il::SourceProtocolKind::Yield,
+        nose_il::SourceProtocolKind::BlockYield,
     );
     assert!(ruby.contains(&"ruby-yield-callback-demand-effect-contract"));
     assert!(!ruby.contains(&"generator-yield-lifecycle-contract"));

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
@@ -129,6 +129,29 @@ fn await_protocol_missing_evidence_is_language_neutral() {
 }
 
 #[test]
+fn yield_protocol_missing_evidence_is_language_specific() {
+    let ruby = missing_evidence_for_protocol(
+        "yield.rb",
+        "def render(value)\n  yield value\nend\n",
+        Lang::Ruby,
+        nose_il::SourceProtocolKind::Yield,
+    );
+    assert!(ruby.contains(&"ruby-yield-callback-demand-effect-contract"));
+    assert!(!ruby.contains(&"generator-yield-lifecycle-contract"));
+    assert!(!ruby.contains(&"generator-yield-protocol-contract"));
+
+    let python = missing_evidence_for_protocol(
+        "yield.py",
+        "def values(x):\n    yield x\n",
+        Lang::Python,
+        nose_il::SourceProtocolKind::Yield,
+    );
+    assert!(python.contains(&"generator-yield-lifecycle-contract"));
+    assert!(python.contains(&"generator-yield-protocol-contract"));
+    assert!(!python.contains(&"ruby-yield-callback-demand-effect-contract"));
+}
+
+#[test]
 fn go_channel_protocol_boundaries_report_specific_obligations() {
     let send = missing_evidence_for_raw_tag(
         "channel.go",

--- a/crates/nose-cli/tests/cli/semantic_boundaries.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[path = "semantic_boundaries/python_async_protocol.rs"]
 mod python_async_protocol;
+#[path = "semantic_boundaries/ruby_yield_protocol.rs"]
+mod ruby_yield_protocol;
 
 #[test]
 fn query_mode_semantic_rejects_cross_receiver_field_state() {

--- a/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
@@ -8,10 +8,19 @@ fn query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence() {
     let project = TempProject::new("ruby_yield_protocol_boundary");
     project.write("return_pair.rb", "def produce(a, b)\n  return a, b\nend\n");
     project.write("yield_pair.rb", "def produce(a, b)\n  yield a, b\nend\n");
+    project.write(
+        "block_call_pair.rb",
+        "def produce(block, a, b)\n  block.call(a, b)\nend\n",
+    );
 
     let json = project.query_json("semantic", &["--min-size", "1", "--min-lines", "1"]);
-    assert!(
-        !family_contains_all(&json, &["return_pair.rb", "yield_pair.rb"]),
-        "Ruby yield must not be erased into ordinary multiple-value return without callback demand/effect proof: {json}"
-    );
+    for pair in [
+        ["return_pair.rb", "yield_pair.rb"],
+        ["block_call_pair.rb", "yield_pair.rb"],
+    ] {
+        assert!(
+            !family_contains_all(&json, &pair),
+            "Ruby yield must not be erased into ordinary return or direct block call without callback demand/effect proof for {pair:?}: {json}"
+        );
+    }
 }

--- a/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
@@ -6,11 +6,17 @@ use super::*;
 #[test]
 fn query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence() {
     let project = TempProject::new("ruby_yield_protocol_boundary");
-    project.write("return_pair.rb", "def produce(a, b)\n  return a, b\nend\n");
-    project.write("yield_pair.rb", "def produce(a, b)\n  yield a, b\nend\n");
+    project.write(
+        "return_pair.rb",
+        "def produce(a, b, &block)\n  return a, b\nend\n",
+    );
+    project.write(
+        "yield_pair.rb",
+        "def produce(a, b, &block)\n  yield a, b\nend\n",
+    );
     project.write(
         "block_call_pair.rb",
-        "def produce(block, a, b)\n  block.call(a, b)\nend\n",
+        "def produce(a, b, &block)\n  block.call(a, b)\nend\n",
     );
 
     let json = project.query_json("semantic", &["--min-size", "1", "--min-lines", "1"]);

--- a/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
+++ b/crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+/// Ruby `yield a, b` invokes the current method block and may run arbitrary
+/// callback effects. It must not collapse into Ruby's ordinary multiple-value
+/// return shape until a block-yield protocol contract exists.
+#[test]
+fn query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence() {
+    let project = TempProject::new("ruby_yield_protocol_boundary");
+    project.write("return_pair.rb", "def produce(a, b)\n  return a, b\nend\n");
+    project.write("yield_pair.rb", "def produce(a, b)\n  yield a, b\nend\n");
+
+    let json = project.query_json("semantic", &["--min-size", "1", "--min-lines", "1"]);
+    assert!(
+        !family_contains_all(&json, &["return_pair.rb", "yield_pair.rb"]),
+        "Ruby yield must not be erased into ordinary multiple-value return without callback demand/effect proof: {json}"
+    );
+}

--- a/crates/nose-frontend/src/ruby.rs
+++ b/crates/nose-frontend/src/ruby.rs
@@ -8,8 +8,8 @@
 
 use crate::lower::{common_bin_op, Lowering};
 use nose_il::{
-    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload, Span, Symbol,
-    UnitKind,
+    FileId, Il, Interner, Lang, LitClass, LoopKind, NodeId, NodeKind, Op, Payload,
+    SourceProtocolKind, Span, Symbol, UnitKind,
 };
 use tree_sitter::Node as TsNode;
 

--- a/crates/nose-frontend/src/ruby/expressions.rs
+++ b/crates/nose-frontend/src/ruby/expressions.rs
@@ -158,7 +158,7 @@ pub(super) fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .into_iter()
                 .map(|c| lower_expr(lo, c))
                 .collect();
-            lo.protocol_boundary(span, SourceProtocolKind::Yield, "yield", &kids)
+            lo.protocol_boundary(span, SourceProtocolKind::BlockYield, "yield", &kids)
         }
         "super" | "forward_argument" => lo.var(lo.text(node), span),
         _ => raw_kids(lo, node),

--- a/crates/nose-frontend/src/ruby/expressions.rs
+++ b/crates/nose-frontend/src/ruby/expressions.rs
@@ -151,13 +151,14 @@ pub(super) fn lower_expr(lo: &mut Lowering, node: TsNode) -> NodeId {
                 .collect();
             lo.add(NodeKind::Seq, Payload::None, span, &kids)
         }
-        // `yield x` — the yielded values.
+        // `yield x` invokes the method's block with demand/effect semantics,
+        // so keep it as a source protocol boundary instead of an ordinary value.
         "yield" => {
             let kids: Vec<NodeId> = Lowering::named_children(node)
                 .into_iter()
                 .map(|c| lower_expr(lo, c))
                 .collect();
-            lo.add(NodeKind::Seq, Payload::None, span, &kids)
+            lo.protocol_boundary(span, SourceProtocolKind::Yield, "yield", &kids)
         }
         "super" | "forward_argument" => lo.var(lo.text(node), span),
         _ => raw_kids(lo, node),

--- a/crates/nose-frontend/src/ruby/tests.rs
+++ b/crates/nose-frontend/src/ruby/tests.rs
@@ -144,7 +144,7 @@ fn yield_preserves_source_backed_protocol_boundary() {
         &il,
         &interner,
         "yield",
-        SourceProtocolKind::Yield,
+        SourceProtocolKind::BlockYield,
     );
 }
 

--- a/crates/nose-frontend/src/ruby/tests.rs
+++ b/crates/nose-frontend/src/ruby/tests.rs
@@ -129,6 +129,25 @@ fn raw_names_without_errors(src: &str) -> Vec<String> {
         .collect()
 }
 
+#[test]
+fn yield_preserves_source_backed_protocol_boundary() {
+    let interner = Interner::new();
+    let il = lower(
+        FileId(0),
+        "t.rb",
+        b"def render(value)\n  yield value, value + 1\nend\n",
+        &interner,
+    )
+    .expect("lower");
+
+    crate::test_helpers::expect_raw_protocol_boundary(
+        &il,
+        &interner,
+        "yield",
+        SourceProtocolKind::Yield,
+    );
+}
+
 fn expr_stmt_ints(src: &str) -> Vec<i64> {
     let interner = Interner::new();
     let il = lower(FileId(0), "t.rb", src.as_bytes(), &interner).expect("lower");

--- a/crates/nose-il/src/node/source.rs
+++ b/crates/nose-il/src/node/source.rs
@@ -62,6 +62,7 @@ pub enum SourceProtocolKind {
     AsyncFunction,
     AsyncContext,
     AsyncIteration,
+    BlockYield,
     ChannelReceive,
     ChannelSelect,
     ChannelSelectCase,

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -17,6 +17,7 @@ pub enum DemandOperation {
     PullLazyHof,
     CallByNeedThunk,
     AsyncContinuation,
+    CallbackInvocation,
     GeneratorSuspension,
     ChannelOperation,
     ProtocolBoundary,
@@ -253,6 +254,7 @@ pub enum CallbackInvocationDemand {
     PerElementPull,
     LeftFoldStep,
     AsyncContinuation,
+    SourceOrderCallback,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -260,6 +262,7 @@ pub enum CallbackArgumentDemand {
     Element,
     AccumulatorAndElement,
     SettledValue,
+    PassedArguments,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -270,6 +273,7 @@ pub enum CallbackResultDemand {
     Predicate,
     Accumulator,
     ContinuationValue,
+    CallbackReturnValue,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -301,6 +305,14 @@ impl CallbackDemandProfile {
             invocation: CallbackInvocationDemand::AsyncContinuation,
             arguments: CallbackArgumentDemand::SettledValue,
             result: CallbackResultDemand::ContinuationValue,
+        }
+    }
+
+    pub const fn source_callback() -> Self {
+        Self {
+            invocation: CallbackInvocationDemand::SourceOrderCallback,
+            arguments: CallbackArgumentDemand::PassedArguments,
+            result: CallbackResultDemand::CallbackReturnValue,
         }
     }
 }
@@ -489,11 +501,18 @@ pub fn source_protocol_demand_effect_profile(protocol: SourceProtocolKind) -> De
             }
         }
         SourceProtocolKind::Yield => DemandEffectProfile {
-            operation: DemandOperation::ProtocolBoundary,
-            order: EvaluationOrder::ProtocolDefined,
-            child_demand: ChildDemand::ProtocolBoundary,
+            operation: DemandOperation::GeneratorSuspension,
+            order: EvaluationOrder::DeferredUntilObserved,
+            child_demand: ChildDemand::SuspendedUntilObserved,
             callback: None,
-            effect_visibility: EffectVisibility::ProtocolBoundary,
+            effect_visibility: EffectVisibility::YieldBoundary,
+        },
+        SourceProtocolKind::BlockYield => DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::SourceOrder,
+            child_demand: ChildDemand::Always,
+            callback: Some(CallbackDemandProfile::source_callback()),
+            effect_visibility: EffectVisibility::Immediate,
         },
         SourceProtocolKind::ChannelReceive
         | SourceProtocolKind::ChannelSelect

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -489,11 +489,11 @@ pub fn source_protocol_demand_effect_profile(protocol: SourceProtocolKind) -> De
             }
         }
         SourceProtocolKind::Yield => DemandEffectProfile {
-            operation: DemandOperation::GeneratorSuspension,
-            order: EvaluationOrder::DeferredUntilObserved,
-            child_demand: ChildDemand::SuspendedUntilObserved,
+            operation: DemandOperation::ProtocolBoundary,
+            order: EvaluationOrder::ProtocolDefined,
+            child_demand: ChildDemand::ProtocolBoundary,
             callback: None,
-            effect_visibility: EffectVisibility::YieldBoundary,
+            effect_visibility: EffectVisibility::ProtocolBoundary,
         },
         SourceProtocolKind::ChannelReceive
         | SourceProtocolKind::ChannelSelect

--- a/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
@@ -273,6 +273,10 @@ fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
         source_protocol_demand_effect_profile(SourceProtocolKind::Defer).effect_visibility,
         EffectVisibility::ProtocolBoundary
     );
+    assert_eq!(
+        source_protocol_demand_effect_profile(SourceProtocolKind::Yield).operation,
+        DemandOperation::ProtocolBoundary
+    );
 }
 
 #[test]

--- a/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
@@ -275,7 +275,17 @@ fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
     );
     assert_eq!(
         source_protocol_demand_effect_profile(SourceProtocolKind::Yield).operation,
-        DemandOperation::ProtocolBoundary
+        DemandOperation::GeneratorSuspension
+    );
+    assert_eq!(
+        source_protocol_demand_effect_profile(SourceProtocolKind::BlockYield),
+        DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::SourceOrder,
+            child_demand: ChildDemand::Always,
+            callback: Some(CallbackDemandProfile::source_callback()),
+            effect_visibility: EffectVisibility::Immediate,
+        }
     );
 }
 

--- a/docs/demand-effect-semantics.md
+++ b/docs/demand-effect-semantics.md
@@ -12,23 +12,24 @@ axes:
 
 - operation class: eager, fold reduction, short-circuit quantifier, append
   mutation, nullish default, per-element HOF, pull-lazy HOF, call-by-need thunk,
-  async continuation, generator suspension, channel operation, or protocol
-  boundary;
+  async continuation, generator suspension, source-order callback invocation,
+  channel operation, or protocol boundary;
 - evaluation order: source order, short-circuit, per-element source order,
   deferred until observation, runtime scheduled, or protocol-defined;
 - child demand: always, never, conditional, short-circuit-until-known,
   per-element-pull, maybe repeated, call-by-need memoized, suspended until
   observed, async continuation, channel boundary, or protocol boundary;
-- callback demand, when present: per-element callback, fold step, or async
-  continuation, with argument/result roles;
+- callback demand, when present: per-element callback, fold step, async
+  continuation, or source callback invocation, with argument/result roles;
 - effect visibility: immediate, only-if-demanded, delayed-until-pull,
   memoized-first-demand, async boundary, yield boundary, channel boundary, or
   protocol boundary.
 
 This is a contract model for admitted operations, not an evidence record family.
-Source protocol facts such as `Source::Protocol(Await)` and
-`Source::Protocol(Yield)` are proof anchors. The demand/effect profile says what
-a contract would need to prove before exact consumers may use that anchor.
+Source protocol facts such as `Source::Protocol(Await)`,
+`Source::Protocol(Yield)`, and `Source::Protocol(BlockYield)` are proof
+anchors. The demand/effect profile says what a contract would need to prove
+before exact consumers may use that anchor.
 
 ## Implemented profiles
 
@@ -102,7 +103,8 @@ Source protocol boundaries have internal profiles for future contracts:
   boundaries even when their body has no `await`; JS/TS Promise producer proof
   remains a separate Promise-specific recovery obligation;
 - `async {}` is suspended until observation;
-- `yield` is a generator suspension boundary;
+- JS/TS and Python generator `yield` is a generator suspension boundary;
+- Ruby block `yield` is a source-order callback invocation boundary;
 - Go channel/select surfaces are channel boundaries;
 - Go goroutine/defer surfaces are protocol boundaries, not channel operations;
 - Rust `?` is a conditional short-circuit boundary.

--- a/docs/evidence-records.md
+++ b/docs/evidence-records.md
@@ -590,7 +590,8 @@ First-party frontends now emit these facts as `EvidenceRecord`:
 - source-origin facts become `Source` evidence. JS/TS, Python, and Rust `await`
   expressions preserve a raw async boundary and emit
   `Source::Protocol(Await)` at that source span. JS/TS and Python `yield`
-  expressions emit `Source::Protocol(Yield)`. Rust `async {}` and `?` emit
+  expressions emit `Source::Protocol(Yield)`, while Ruby block `yield` emits
+  `Source::Protocol(BlockYield)`. Rust `async {}` and `?` emit
   `Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. Rust
   and Swift async closures reuse `Source::Protocol(AsyncFunction)`, Swift plain
   and typed throwing functions/closures reuse

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -86,7 +86,7 @@ They do not change exact admission.
 
 | obligation family | typical subreason | meaning |
 |---|---|---|
-| `callback-demand-effect` | `callback-member-call-effect-proof-missing`, `callback-rust-macro-call-effect-proof-missing`, `callback-direct-function-call-effect-contract-missing`, `callback-imported-function-call-effect-contract-missing`, `callback-assignment-effect-proof-missing`, `callback-runtime-boundary-proof-missing`, `callback-identity-or-shape-proof-missing`, `promise-then-callback-demand-effect-contract-missing`, `future-callback-demand-effect-contract-missing`, `goroutine-callback-effect-contract-missing`, `defer-callback-effect-contract-missing`, `mapping-callback-demand-effect-profile-missing`, `predicate-callback-demand-effect-profile-missing`, `flattening-callback-demand-effect-profile-missing`, `optional-callback-demand-effect-profile-missing`, or `reduction-callback-demand-effect-profile-missing` | A HOF/callback surface lacks timing, callback identity, effect visibility, result role, call-shape proof, or materialization proof. |
+| `callback-demand-effect` | `callback-member-call-effect-proof-missing`, `callback-rust-macro-call-effect-proof-missing`, `callback-direct-function-call-effect-contract-missing`, `callback-imported-function-call-effect-contract-missing`, `callback-assignment-effect-proof-missing`, `callback-runtime-boundary-proof-missing`, `callback-identity-or-shape-proof-missing`, `promise-then-callback-demand-effect-contract-missing`, `future-callback-demand-effect-contract-missing`, `ruby-yield-callback-demand-effect-contract-missing`, `goroutine-callback-effect-contract-missing`, `defer-callback-effect-contract-missing`, `mapping-callback-demand-effect-profile-missing`, `predicate-callback-demand-effect-profile-missing`, `flattening-callback-demand-effect-profile-missing`, `optional-callback-demand-effect-profile-missing`, or `reduction-callback-demand-effect-profile-missing` | A HOF/callback surface lacks timing, callback identity, effect visibility, result role, call-shape proof, or materialization proof. |
 | `executor-callback` | `promise-executor-timing-contract-missing`, `promise-executor-resolve-reject-callback-contract-missing`, `promise-executor-throw-to-rejection-contract-missing`, or `promise-executor-callback-effect-contract-missing` | A Promise/Future-like constructor callback needs executor timing, resolve/reject callback identity, thrown-to-rejected outcome, and callback-effect proof before exact use. |
 | `receiver-mutation` | `effect-preserving-contract-missing` | A mutation/place/effect boundary blocks exact admission. |
 | `rejection-channel` | `promise-reject-rejected-value-channel-contract-missing`, `promise-catch-rejection-continuation-contract-missing`, `promise-finally-settlement-continuation-contract-missing`, `promise-then-rejection-continuation-contract-missing`, legacy `promise-rejection-channel-contract-missing`/`promise-rejection-continuation-contract-missing`, or `exception-channel-contract-missing` | Rejection, catch/finally settlement, throw, rescue, or non-local error flow must remain distinct from ordinary return values. |
@@ -291,6 +291,12 @@ remain closed. The matching
 [120-repo pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-thread-fiber-runtime-2026-07-01.v1.json) marks the Ruby Thread/Fiber row
 reporting-supported, prices `74` occurrences across `11` repos, and raises
 total source prevalence from `146,987` to `146,988`.
+The follow-up [Ruby yield source-protocol artifact](../bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
+keeps exact admission closed while preserving Ruby block `yield` as a
+source-backed callback demand/effect protocol boundary. The matching [120-repo
+pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
+marks `ruby.generator.yield` reporting-supported, prices `801` occurrences
+across `17` repos, and the checked `crates` gate reports `0` false merges.
 The
 checked [promise-protocol diagnostics](../bench/recall_loss/promise-protocol-diagnostics-2026-06-28.v1.json)
 connect the JS/TS source-prevalence group (`29,094` Promise/async occurrences)

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -296,7 +296,7 @@ keeps exact admission closed while preserving Ruby block `yield` as a
 source-backed `BlockYield` callback demand/effect protocol boundary. The
 matching [120-repo
 pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
-marks `ruby.generator.yield` reporting-supported, prices `801` occurrences
+marks `ruby.block.yield` reporting-supported, prices `801` occurrences
 across `17` repos, and the checked `crates` gate reports `0` false merges.
 The
 checked [promise-protocol diagnostics](../bench/recall_loss/promise-protocol-diagnostics-2026-06-28.v1.json)

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -293,7 +293,8 @@ reporting-supported, prices `74` occurrences across `11` repos, and raises
 total source prevalence from `146,987` to `146,988`.
 The follow-up [Ruby yield source-protocol artifact](../bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
 keeps exact admission closed while preserving Ruby block `yield` as a
-source-backed callback demand/effect protocol boundary. The matching [120-repo
+source-backed `BlockYield` callback demand/effect protocol boundary. The
+matching [120-repo
 pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
 marks `ruby.generator.yield` reporting-supported, prices `801` occurrences
 across `17` repos, and the checked `crates` gate reports `0` false merges.

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -222,6 +222,13 @@ matching
 [120-repo pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-thread-fiber-runtime-2026-07-01.v1.json) marks the Ruby Thread/Fiber row
 reporting-supported, prices `74` occurrences across `11` repos, and raises
 total source prevalence from `146,987` to `146,988` by adding `Thread.start`.
+The follow-up [Ruby yield source-protocol artifact](../bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
+reuses the source-protocol boundary capability for Ruby block `yield` without
+adding a Ruby-specific exact admission path. `yield a, b` now stays distinct
+from ordinary multiple-value `return a, b` until block identity, callback
+argument/result role, effect visibility, non-local control, and exception
+behavior are proven. The 120-repo audit prices `801` Ruby yield occurrences
+across `17` repos and marks the row reporting-supported closed-boundary.
 The follow-up [non-JS async runtime scope-shadowing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
 keeps the same reporting-only boundary while making Python/Rust runtime
 attribution scope-aware. Python `asyncio` aliases/imported bindings and Rust

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -224,11 +224,13 @@ reporting-supported, prices `74` occurrences across `11` repos, and raises
 total source prevalence from `146,987` to `146,988` by adding `Thread.start`.
 The follow-up [Ruby yield source-protocol artifact](../bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
 reuses the source-protocol boundary capability for Ruby block `yield` without
-adding a Ruby-specific exact admission path. `yield a, b` now stays distinct
-from ordinary multiple-value `return a, b` until block identity, callback
-argument/result role, effect visibility, non-local control, and exception
-behavior are proven. The 120-repo audit prices `801` Ruby yield occurrences
-across `17` repos and marks the row reporting-supported closed-boundary.
+adding a Ruby-specific exact admission path or widening generator-yield
+semantics. `yield a, b` now uses `Source::Protocol(BlockYield)` and stays
+distinct from ordinary multiple-value `return a, b` until block identity,
+callback argument/result role, effect visibility, non-local control, and
+exception behavior are proven. The 120-repo audit prices `801` Ruby yield
+occurrences across `17` repos and marks the row reporting-supported
+closed-boundary.
 The follow-up [non-JS async runtime scope-shadowing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
 keeps the same reporting-only boundary while making Python/Rust runtime
 attribution scope-aware. Python `asyncio` aliases/imported bindings and Rust

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1628,13 +1628,14 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   until an explicit async/sync protocol evidence path exists.
 - JS/TS, Python, Rust, and Swift `await` expressions now preserve a raw async protocol
   boundary and emit `Source::Protocol(Await)` evidence instead of lowering
-  directly to the operand. JS/TS and Python `yield` expressions preserve raw
-  generator protocol boundaries with `Source::Protocol(Yield)`. Rust `async {}`
+  directly to the operand. JS/TS and Python generator `yield` expressions and
+  Ruby block `yield` expressions preserve raw protocol boundaries with
+  `Source::Protocol(Yield)`. Rust `async {}`
   and `?` also preserve raw protocol boundaries with
   `Source::Protocol(AsyncBlock)` and
   `Source::Protocol(TryPropagation)`, and Rust async closures reuse
   `Source::Protocol(AsyncFunction)`. This closes the old exact async/sync and
-  error-propagation convergence paths, plus generator/body erasure, until
+  error-propagation convergence paths, plus generator/body and block-callback erasure, until
   language/runtime-specific protocol contracts can prove receiver, demand,
   scheduling, suspension, exception, and effect obligations.
 - Go concurrency/channel surfaces now preserve source-backed protocol

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1259,8 +1259,9 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   nullish defaulting, per-element callback demand for
   map/flat-map/filter-map/filter/reduce, pull-lazy Python generator expressions,
   eager JS-like/Ruby library HOFs, pull-lazy Rust iterator/Java Stream HOFs,
-  async continuation boundaries, generator suspension, channel boundaries, and
-  non-channel protocol boundaries. The oracle consumes those profiles for
+  async continuation boundaries, generator suspension, source-order callback
+  invocation, channel boundaries, and non-channel protocol boundaries. The
+  oracle consumes those profiles for
   admitted builtins instead of matching local demand enums; value-graph HOF
   callback exception timing, HOF materialization gates, strict-exact HOF gates,
   and Promise `.then` beta-reduction also read shared profiles. API admission
@@ -1628,9 +1629,10 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   until an explicit async/sync protocol evidence path exists.
 - JS/TS, Python, Rust, and Swift `await` expressions now preserve a raw async protocol
   boundary and emit `Source::Protocol(Await)` evidence instead of lowering
-  directly to the operand. JS/TS and Python generator `yield` expressions and
-  Ruby block `yield` expressions preserve raw protocol boundaries with
-  `Source::Protocol(Yield)`. Rust `async {}`
+  directly to the operand. JS/TS and Python generator `yield` expressions
+  preserve raw protocol boundaries with `Source::Protocol(Yield)`, while Ruby
+  block `yield` expressions preserve callback protocol boundaries with
+  `Source::Protocol(BlockYield)`. Rust `async {}`
   and `?` also preserve raw protocol boundaries with
   `Source::Protocol(AsyncBlock)` and
   `Source::Protocol(TryPropagation)`, and Rust async closures reuse
@@ -2406,6 +2408,16 @@ Rust async closure occurrences, so this is a parity and hard-negative slice;
 the same audit now prices `1,342` Rust async blocks across `4` repos without
 letting closure syntax inflate the block row. The checked `crates` gate remains
 at `0` false merges and `0` canon preservation violations.
+
+2026-07-01 Ruby block-yield source-protocol note:
+The [ruby-yield-source-protocol-reporting-2026-07-01.v1.json](../bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json)
+artifact extends source protocol reporting without widening generator-yield
+semantics. Ruby block `yield` now uses the separate `BlockYield` source
+protocol and maps to a source-order callback invocation demand/effect profile.
+Exact admission remains closed until block identity, callback argument/result
+roles, effect visibility, non-local control, and exception behavior are proven.
+The 120-repo audit prices `801` Ruby yield occurrences across `17` repos, and
+the checked `crates` gate remains at `0` false merges.
 
 ## See also
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -28,9 +28,10 @@ boundaries while the graded-witness build keeps an explicit protocol wrapper, so
 async/sync twins can surface as `async-mirror` transformation leads without
 opening exact admission.
 JS/TS and Python `yield` expressions are preserved as generator protocol
-boundaries with `Source::Protocol(Yield)`. Rust `async {}` and `?` are likewise
-preserved as protocol boundaries with `Source::Protocol(AsyncBlock)` and
-`Source::Protocol(TryPropagation)`. Go
+boundaries with `Source::Protocol(Yield)`, while Ruby block `yield` uses the
+separate callback protocol boundary `Source::Protocol(BlockYield)`. Rust
+`async {}` and `?` are likewise preserved as protocol boundaries with
+`Source::Protocol(AsyncBlock)` and `Source::Protocol(TryPropagation)`. Go
 goroutine spawn, deferred calls, channel send/receive, receive-status
 projections, and `select` boundaries are also preserved as raw source-backed
 protocol anchors rather than ordinary calls, values, or sequence tags. Their
@@ -53,7 +54,8 @@ applying materialization or demand-sensitive laws. Admitted builtin and HOF
 operations now also have internal `DemandEffectProfile` contracts for the
 currently supported eager, short-circuit, append, nullish-default, reduction,
 per-element callback, pull-lazy generator, async-continuation, generator
-suspension, channel-boundary, and protocol-boundary shapes; these profiles
+suspension, source-order callback invocation, channel-boundary, and
+protocol-boundary shapes; these profiles
 describe how an already-admitted operation is consumed, not which source API is
 admitted. HOF callback timing comes from an explicit source or API demand source,
 not from the raw HOF kind alone. The node-level HOF resolver distinguishes

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -680,8 +680,8 @@ migrated.
   strict/loose inequality, and `instanceof` facts. Python emits async `await`,
   async function and generator `yield` boundaries, list/set/dict/generator
   comprehension surfaces, value equality/inequality, and identity
-  equality/inequality facts. Swift emits async function, async `await`, and
-  `try` boundaries. Go emits
+  equality/inequality facts. Ruby emits block `yield` callback protocol
+  boundaries. Swift emits async function, async `await`, and `try` boundaries. Go emits
   protocol facts for `go`, `defer`, channel send/receive, receive-status
   projection, `select`, and select cases/defaults. C emits source-cast facts
   for explicit unsigned 32-bit byte-lane casts, with alias-based casts depending
@@ -692,8 +692,8 @@ migrated.
   `EvidenceRecord::Source`; there is no source-fact side-table fallback.
   Normalize and detect consume source facts only where a semantic contract
   requires that exact source surface. Current JS/TS/Python/Rust/Swift async
-  function/closure and `await` nodes, JS/TS/Python `yield` nodes, Rust `async`/`?` nodes,
-  Swift `try` nodes, and Go concurrency/channel
+  function/closure and `await` nodes, JS/TS/Python generator `yield` nodes,
+  Ruby block `yield` nodes, Rust `async`/`?` nodes, Swift `try` nodes, and Go concurrency/channel
   nodes remain raw exact-closed protocol anchors until such a contract exists.
   Python returned generator/set comprehensions and unsupported cardinality
   surfaces stay exact-closed; supported list/generator terminal reductions can
@@ -1447,8 +1447,9 @@ Semantic knowledge still appears in several forms outside the facade:
   as `aread` no longer rewrite to sync names without an explicit protocol/API
   evidence path, JS/TS/Python/Rust/Swift async function/closure and `await` expressions
   no longer erase to their body or operand without async protocol proof,
-  JS/TS/Python `yield` no longer erases to its yielded expression without
-  generator protocol proof, and Rust `async {}`/`?` no longer erase to their body
+  JS/TS/Python generator `yield` and Ruby block `yield` no longer erase to
+  their yielded expression or callback arguments without protocol proof, and
+  Rust `async {}`/`?` no longer erase to their body
   or operand without async/error protocol proof. Swift `try` similarly keeps the
   error channel explicit. Go `go`/`defer`/channel receive no longer erase to ordinary
   calls or operands, Go channel send no longer relies on an untyped

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -202,12 +202,13 @@ Examples:
 The implemented builtin substrate now names these as
 `DemandEffectProfile` contracts for admitted operations. The profiles cover
 current eager, short-circuit, eager HOF, pull-lazy HOF/generator, async
-continuation, generator suspension, channel-boundary, and protocol-boundary
-classes. HOF timing must come from an explicit source or API demand source; the
-node-level resolver distinguishes source comprehensions, eager JS-like/Ruby
-library HOFs, and pull-lazy Rust/Java library HOFs. The profiles describe how an
-already-proven operation is consumed; they do not prove that a selector or raw
-source protocol anchor has that meaning.
+continuation, generator suspension, source-order callback invocation,
+channel-boundary, and protocol-boundary classes. HOF timing must come from an
+explicit source or API demand source; the node-level resolver distinguishes
+source comprehensions, eager JS-like/Ruby library HOFs, and pull-lazy Rust/Java
+library HOFs. The profiles describe how an already-proven operation is consumed;
+they do not prove that a selector or raw source protocol anchor has that
+meaning.
 
 ### Values and domains
 

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -143,8 +143,9 @@ fall back to a side-table mirror when source evidence is missing.
   and async context-manager lifecycle obligations. Swift `async let` preserves
   `Raw("task_spawn", assign)`, and Swift throwing callables preserve
   `Raw("throwing_function" | "throwing_closure", body)`. JS/TS and Python
-  generator `yield` and Ruby block `yield` preserve
-  `Raw("yield", value...)`. Rust
+  generator `yield` preserve `Raw("yield", value...)` with
+  `Source::Protocol(Yield)`, while Ruby block `yield` preserves the same raw
+  tag with `Source::Protocol(BlockYield)`. Rust
   `async {}` and `?` are preserved as
   `Raw("async_block", body)` and `Raw("try", value)`. Exact async/sync,
   generator, and error-propagation convergence stays closed until a future

--- a/docs/source-facts.md
+++ b/docs/source-facts.md
@@ -110,6 +110,9 @@ fall back to a side-table mirror when source evidence is missing.
   `async for` statements, async comprehensions, and `async with` boundaries,
   generator `yield` boundaries, list/set/dict/generator comprehension surfaces,
   value equality/inequality, and identity equality/inequality.
+- Ruby lowering emits source facts for block `yield` callback boundaries, so a
+  method that invokes its caller-provided block does not erase into an ordinary
+  multiple-value return before callback demand/effect proof exists.
 - Go lowering emits source facts for goroutine spawn, deferred calls, channel
   send/receive, select, and select case/default protocol boundaries. These
   surfaces remain raw protocol anchors; `v, ok := <-ch` preserves both the
@@ -140,7 +143,8 @@ fall back to a side-table mirror when source evidence is missing.
   and async context-manager lifecycle obligations. Swift `async let` preserves
   `Raw("task_spawn", assign)`, and Swift throwing callables preserve
   `Raw("throwing_function" | "throwing_closure", body)`. JS/TS and Python
-  `yield` preserves `Raw("yield", value)`. Rust
+  generator `yield` and Ruby block `yield` preserve
+  `Raw("yield", value...)`. Rust
   `async {}` and `?` are preserved as
   `Raw("async_block", body)` and `Raw("try", value)`. Exact async/sync,
   generator, and error-propagation convergence stays closed until a future

--- a/scripts/query-regression-harness.py
+++ b/scripts/query-regression-harness.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run alternating product-query regressions for two nose binaries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_QUERY_ARGS = ("query", "{repo}", "all", "top=0", "--mode", "semantic", "--format", "json")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git_output(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        return f"<git {' '.join(args)} failed: {result.stderr.strip()}>"
+    return result.stdout.strip()
+
+
+def parse_query_args(raw: str) -> tuple[str, ...]:
+    if not raw:
+        return DEFAULT_QUERY_ARGS
+    args = tuple(part for part in raw.split(" ") if part)
+    if "{repo}" not in args:
+        raise SystemExit("--query-args must contain {repo}")
+    return args
+
+
+def command_for(binary: Path, repo: Path, query_args: tuple[str, ...]) -> list[str]:
+    return [str(binary), *[repo.as_posix() if arg == "{repo}" else arg for arg in query_args]]
+
+
+def family_count(stdout: bytes) -> int:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return 0
+    if isinstance(payload, dict) and isinstance(payload.get("families"), list):
+        return len(payload["families"])
+    if isinstance(payload, list):
+        return len(payload)
+    return 0
+
+
+def run_once(
+    *,
+    binary: Path,
+    label: str,
+    repo_name: str,
+    repo_path: Path,
+    iteration: int,
+    query_args: tuple[str, ...],
+) -> dict[str, Any]:
+    command = command_for(binary, repo_path, query_args)
+    start = time.perf_counter()
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if result.returncode != 0:
+        raise SystemExit(
+            f"{label} {repo_name} iteration {iteration} failed: "
+            f"{result.stderr.decode(errors='replace')}"
+        )
+    return {
+        "bytes": len(result.stdout),
+        "elapsed_ms": elapsed_ms,
+        "families": family_count(result.stdout),
+        "iteration": iteration,
+        "label": label,
+        "repo": repo_name,
+        "sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def warmup(
+    *,
+    binary: Path,
+    label: str,
+    repos: list[tuple[str, Path]],
+    warmups: int,
+    query_args: tuple[str, ...],
+) -> None:
+    for iteration in range(1, warmups + 1):
+        for repo_name, repo_path in repos:
+            run_once(
+                binary=binary,
+                label=label,
+                repo_name=repo_name,
+                repo_path=repo_path,
+                iteration=-iteration,
+                query_args=query_args,
+            )
+
+
+def summarize(runs: list[dict[str, Any]], repos: list[str]) -> dict[str, Any]:
+    by_repo: dict[str, dict[str, dict[str, Any]]] = {}
+    for repo in repos:
+        by_repo[repo] = {}
+        for label in ("baseline", "current"):
+            rows = [row for row in runs if row["repo"] == repo and row["label"] == label]
+            by_repo[repo][label] = {
+                "bytes": sorted({row["bytes"] for row in rows}),
+                "families": sorted({row["families"] for row in rows}),
+                "hashes": sorted({row["sha256"] for row in rows}),
+                "median_ms": statistics.median(row["elapsed_ms"] for row in rows),
+            }
+
+    aggregate_baseline = sum(by_repo[repo]["baseline"]["median_ms"] for repo in repos)
+    aggregate_current = sum(by_repo[repo]["current"]["median_ms"] for repo in repos)
+    delta_pct = (
+        ((aggregate_current - aggregate_baseline) / aggregate_baseline) * 100.0
+        if aggregate_baseline
+        else 0.0
+    )
+    return {
+        "aggregate_baseline_median_ms": aggregate_baseline,
+        "aggregate_current_median_ms": aggregate_current,
+        "aggregate_delta_pct": delta_pct,
+        "by_repo": by_repo,
+        "hashes_identical_by_repo": {
+            repo: by_repo[repo]["baseline"]["hashes"] == by_repo[repo]["current"]["hashes"]
+            for repo in repos
+        },
+    }
+
+
+def run_self_test() -> None:
+    rows = [
+        {"repo": "a", "label": "baseline", "elapsed_ms": 10.0, "bytes": 1, "families": 1, "sha256": "x"},
+        {"repo": "a", "label": "current", "elapsed_ms": 12.0, "bytes": 1, "families": 1, "sha256": "x"},
+        {"repo": "b", "label": "baseline", "elapsed_ms": 20.0, "bytes": 2, "families": 2, "sha256": "y"},
+        {"repo": "b", "label": "current", "elapsed_ms": 18.0, "bytes": 2, "families": 2, "sha256": "y"},
+    ]
+    summary = summarize(rows, ["a", "b"])
+    assert summary["aggregate_baseline_median_ms"] == 30.0
+    assert summary["aggregate_current_median_ms"] == 30.0
+    assert summary["hashes_identical_by_repo"] == {"a": True, "b": True}
+    print("query regression harness self-test passed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-binary", type=Path)
+    parser.add_argument("--current-binary", type=Path)
+    parser.add_argument("--baseline-source-ref", default="origin/main")
+    parser.add_argument("--current-source-ref", default="HEAD")
+    parser.add_argument("--baseline-source-sha")
+    parser.add_argument("--current-source-sha")
+    parser.add_argument("--repos-root", type=Path, default=Path("bench/repos"))
+    parser.add_argument("--repo", action="append", dest="repos", default=[])
+    parser.add_argument("--iterations", type=int, default=9)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--query-args", default=" ".join(DEFAULT_QUERY_ARGS))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+    if not args.baseline_binary or not args.current_binary or not args.output or not args.repos:
+        raise SystemExit("--baseline-binary, --current-binary, --repo, and --output are required")
+    if args.iterations <= 0 or args.warmups < 0:
+        raise SystemExit("--iterations must be positive and --warmups must be non-negative")
+
+    baseline_binary = args.baseline_binary.resolve()
+    current_binary = args.current_binary.resolve()
+    repos = [(repo, (args.repos_root / repo).resolve()) for repo in args.repos]
+    missing = [path for _, path in repos if not path.exists()]
+    if missing:
+        raise SystemExit(f"missing repo paths: {', '.join(path.as_posix() for path in missing)}")
+    query_args = parse_query_args(args.query_args)
+
+    warmup(binary=baseline_binary, label="baseline", repos=repos, warmups=args.warmups, query_args=query_args)
+    warmup(binary=current_binary, label="current", repos=repos, warmups=args.warmups, query_args=query_args)
+
+    runs: list[dict[str, Any]] = []
+    for iteration in range(1, args.iterations + 1):
+        order = ("baseline", "current") if iteration % 2 else ("current", "baseline")
+        binaries = {"baseline": baseline_binary, "current": current_binary}
+        for label in order:
+            for repo_name, repo_path in repos:
+                runs.append(
+                    run_once(
+                        binary=binaries[label],
+                        label=label,
+                        repo_name=repo_name,
+                        repo_path=repo_path,
+                        iteration=iteration,
+                        query_args=query_args,
+                    )
+                )
+
+    repo_names = [repo for repo, _ in repos]
+    output = {
+        "command": "nose " + " ".join(query_args).replace("{repo}", "<repo>"),
+        "provenance": {
+            "baseline_binary": baseline_binary.as_posix(),
+            "baseline_binary_sha256": sha256_file(baseline_binary),
+            "baseline_source_ref": args.baseline_source_ref,
+            "baseline_source_sha": args.baseline_source_sha or git_output(["rev-parse", args.baseline_source_ref]),
+            "current_binary": current_binary.as_posix(),
+            "current_binary_sha256": sha256_file(current_binary),
+            "current_source_ref": args.current_source_ref,
+            "current_source_sha": args.current_source_sha or git_output(["rev-parse", args.current_source_ref]),
+            "harness": "scripts/query-regression-harness.py",
+            "harness_command": " ".join(sys.argv),
+            "working_tree_status": git_output(["status", "--short"]),
+        },
+        "repos": repo_names,
+        "runs": runs,
+        "summary": summarize(runs, repo_names),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/query-regression-harness.py
+++ b/scripts/query-regression-harness.py
@@ -198,6 +198,7 @@ def main() -> int:
     if missing:
         raise SystemExit(f"missing repo paths: {', '.join(path.as_posix() for path in missing)}")
     query_args = parse_query_args(args.query_args)
+    working_tree_status_before_measurement = git_output(["status", "--short"])
 
     warmup(binary=baseline_binary, label="baseline", repos=repos, warmups=args.warmups, query_args=query_args)
     warmup(binary=current_binary, label="current", repos=repos, warmups=args.warmups, query_args=query_args)
@@ -233,7 +234,7 @@ def main() -> int:
             "current_source_sha": args.current_source_sha or git_output(["rev-parse", args.current_source_ref]),
             "harness": "scripts/query-regression-harness.py",
             "harness_command": " ".join(sys.argv),
-            "working_tree_status": git_output(["status", "--short"]),
+            "working_tree_status_before_measurement": working_tree_status_before_measurement,
         },
         "repos": repo_names,
         "runs": runs,

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -139,7 +139,7 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("swift", "swift.continuation.throwing", "withCheckedThrowingContinuation/withUnsafeThrowingContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift throwing continuation bridge", "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels", re.compile(r"\bwith(?:Checked|Unsafe)ThrowingContinuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.thread.fiber", "Thread/Fiber", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "thread/fiber scheduling", "Thread/Fiber APIs create scheduler and lifecycle boundaries", re.compile(r"\b(?:Thread\s*\.\s*(?:new|start|fork)|Fiber\s*\.\s*(?:new|schedule))\b"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.exception", "raise/rescue", "exception-channel", "ruby-exception-channel-contract-missing", "exception channel", "raise/rescue changes error channels and non-local control", re.compile(r"\b(?:raise|rescue)\b")),
-    Pattern("ruby", "ruby.generator.yield", "yield", "callback-demand-effect", "ruby-yield-callback-demand-effect-contract-missing", "block callback", "Ruby yield invokes a block with demand/effect obligations", re.compile(r"\byield\b")),
+    Pattern("ruby", "ruby.generator.yield", "yield", "callback-demand-effect", "ruby-yield-callback-demand-effect-contract-missing", "block callback", "Ruby yield invokes a block with demand/effect obligations", re.compile(r"\byield\b"), "reporting-supported-closed-boundary"),
     Pattern("c", "c.thread.pthread", "pthread_create", "scheduling-boundary", "c-pthread-scheduling-contract-missing", "thread scheduling", "pthread_create introduces thread scheduling and lifetime boundaries", re.compile(r"\bpthread_create\s*\(")),
     Pattern("c", "c.nonlocal_jump", "setjmp/longjmp", "exception-channel", "c-nonlocal-jump-contract-missing", "non-local jump", "setjmp/longjmp is non-local control flow, not ordinary return", re.compile(r"\b(?:setjmp|longjmp)\s*\(")),
 )
@@ -734,6 +734,17 @@ def self_test() -> None:
     )
     assert SWIFT_THROWING_FUNCTION not in swift_type_only
     assert SWIFT_THROWING_CLOSURE not in swift_type_only
+
+    ruby_yield = count_file(
+        "def render(value)\n"
+        "  yield value\n"
+        "end\n"
+        "text = 'yield ignored in strings'\n",
+        "ruby",
+    )
+    ruby_yield_pattern = next(item for item in PATTERNS if item.surface == "ruby.generator.yield")
+    assert ruby_yield.get(ruby_yield_pattern) == 1
+    assert ruby_yield_pattern.status == "reporting-supported-closed-boundary"
 
 
 def load_repos(manifest: Path) -> list[dict[str, Any]]:
@@ -2098,6 +2109,11 @@ def hard_negative_inventory() -> list[dict[str, Any]]:
         {
             "class": "Python async iterator and async context-manager protocol boundaries versus synchronous loops, comprehensions, and with-blocks",
             "evidence": "crates/nose-cli/tests/cli/semantic_boundaries/python_async_protocol.rs::query_mode_semantic_rejects_unproven_python_async_protocol_lifecycle_convergence, ::query_mode_semantic_rejects_unproven_python_async_comprehension_convergence, crates/nose-frontend/src/python/tests.rs::async_for_preserves_source_backed_iteration_boundary, ::async_comprehension_preserves_source_backed_iteration_boundary, ::multi_clause_async_comprehension_preserves_source_backed_iteration_boundary, ::async_with_preserves_source_backed_context_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::python_async_lifecycle_protocols_report_specific_obligations",
+            "status": "expanded-this-slice",
+        },
+        {
+            "class": "Ruby block yield callback demand/effect versus ordinary value return or direct call",
+            "evidence": "crates/nose-frontend/src/ruby/tests.rs::yield_preserves_source_backed_protocol_boundary, crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::yield_protocol_missing_evidence_is_language_specific, and crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs::query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence",
             "status": "expanded-this-slice",
         },
         {

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -139,7 +139,7 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("swift", "swift.continuation.throwing", "withCheckedThrowingContinuation/withUnsafeThrowingContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift throwing continuation bridge", "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels", re.compile(r"\bwith(?:Checked|Unsafe)ThrowingContinuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.thread.fiber", "Thread/Fiber", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "thread/fiber scheduling", "Thread/Fiber APIs create scheduler and lifecycle boundaries", re.compile(r"\b(?:Thread\s*\.\s*(?:new|start|fork)|Fiber\s*\.\s*(?:new|schedule))\b"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.exception", "raise/rescue", "exception-channel", "ruby-exception-channel-contract-missing", "exception channel", "raise/rescue changes error channels and non-local control", re.compile(r"\b(?:raise|rescue)\b")),
-    Pattern("ruby", "ruby.generator.yield", "yield", "callback-demand-effect", "ruby-yield-callback-demand-effect-contract-missing", "block callback", "Ruby yield invokes a block with demand/effect obligations", re.compile(r"\byield\b"), "reporting-supported-closed-boundary"),
+    Pattern("ruby", "ruby.block.yield", "yield", "callback-demand-effect", "ruby-yield-callback-demand-effect-contract-missing", "block callback", "Ruby yield invokes a block with demand/effect obligations", re.compile(r"\byield\b"), "reporting-supported-closed-boundary"),
     Pattern("c", "c.thread.pthread", "pthread_create", "scheduling-boundary", "c-pthread-scheduling-contract-missing", "thread scheduling", "pthread_create introduces thread scheduling and lifetime boundaries", re.compile(r"\bpthread_create\s*\(")),
     Pattern("c", "c.nonlocal_jump", "setjmp/longjmp", "exception-channel", "c-nonlocal-jump-contract-missing", "non-local jump", "setjmp/longjmp is non-local control flow, not ordinary return", re.compile(r"\b(?:setjmp|longjmp)\s*\(")),
 )
@@ -742,7 +742,7 @@ def self_test() -> None:
         "text = 'yield ignored in strings'\n",
         "ruby",
     )
-    ruby_yield_pattern = next(item for item in PATTERNS if item.surface == "ruby.generator.yield")
+    ruby_yield_pattern = next(item for item in PATTERNS if item.surface == "ruby.block.yield")
     assert ruby_yield.get(ruby_yield_pattern) == 1
     assert ruby_yield_pattern.status == "reporting-supported-closed-boundary"
 


### PR DESCRIPTION
## Summary
- Preserve Ruby block `yield` as a source-backed `BlockYield` protocol boundary instead of erasing it into an ordinary `Seq` value or widening generator `Yield` semantics.
- Report Ruby yield under `ruby-yield-callback-demand-effect-contract` while keeping JS/Python generator yield diagnostics under generator-specific obligations.
- Add focused frontend/verifier/demand-profile/recall-loss/CLI hard-negative tests plus checked recall-loss, 120-repo audit, query-regression provenance, docs, and changelog.

## Quantification
- 120-repo audit marks `ruby.block.yield` reporting-supported closed-boundary: 801 occurrences across 17 repos.
- `nose verify crates --max-violations 0` remains at 0 false merges and 0 canon preservation violations across 6960 units.
- Ruby-heavy product query regression over rubocop, rspec-core, sidekiq, rack, fastlane, sinatra: alternating r15 aggregate median 2504.55ms -> 2574.79ms (+2.80%).
- Product output hashes are identical for 5/6 repos; `rspec-core` keeps 8 families, with one same-location 3-member HTML family representative label changing from `pre` to `code`.

## Validation
- `git diff --check`
- `cargo fmt --check`
- `(cd docs && awiki lint)`
- `./scripts/check-duplication.sh`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py`
- `python3 scripts/query-regression-harness.py --self-test`
- `python3 -m py_compile scripts/query-regression-harness.py`
- focused Ruby yield frontend/verifier/demand-profile/recall-loss/CLI tests
- `cargo test --release -p nose-cli --test cli query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence -- --nocapture`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-yield-source-protocol.crates.json`
- `python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-yield-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-yield-source-protocol --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-yield-source-protocol-query-regression-2026-07-01.v1.json`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --release`