### PR TITLE
Report Go protocol callback demand profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,9 @@ break.
   are marked reporting-supported closed-boundaries in the 120-repo audit.
   Exact admission remains closed; the Go protocol slice covers `31,500`
   occurrences across the pinned corpus and keeps the checked `crates`
-  recall-loss gate at `0` false merges.
+  recall-loss gate at `0` false merges. The Go-heavy query regression measured
+  `3757.82ms -> 3674.17ms` (`-2.23%`) with identical product hashes on all six
+  measured repos.
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust
   async blocks in near/witness builds, so Rust `async fn`/`.await` and Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,13 @@ break.
   `17` repos, the checked `crates` recall-loss gate stays at `0` false merges,
   and the Ruby-heavy query regression measured `2504.55ms -> 2574.79ms`
   (`+2.80%`) with one stable-count `rspec-core` representative-label drift.
+- Added Go protocol reporting-support alignment. `go` statements now carry a
+  runtime-scheduled callback demand/effect profile and `defer` statements carry
+  a scope-exit deferred callback profile, while channel/select protocol rows
+  are marked reporting-supported closed-boundaries in the 120-repo audit.
+  Exact admission remains closed; the Go protocol slice covers `31,500`
+  occurrences across the pinned corpus and keeps the checked `crates`
+  recall-loss gate at `0` false merges.
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust
   async blocks in near/witness builds, so Rust `async fn`/`.await` and Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,7 @@ break.
   Exact admission remains closed; the Go protocol slice covers `31,500`
   occurrences across the pinned corpus and keeps the checked `crates`
   recall-loss gate at `0` false merges. The Go-heavy query regression measured
-  `3757.82ms -> 3674.17ms` (`-2.23%`) with identical product hashes on all six
+  `3560.13ms -> 3563.06ms` (`+0.08%`) with identical product hashes on all six
   measured repos.
 - Added non-JS async protocol near-channel mirror support. The dual-view async
   protocol capability now covers `await`, async-function boundaries, and Rust

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -339,6 +339,15 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json \
   --output target/scheduling-lifecycle-boundary-audit.go-protocol-reporting-support.json \
   --generated-on 2026-07-01
+
+python3 scripts/query-regression-harness.py \
+  --baseline-binary /tmp/nose-go-protocol-main-target/release/nose \
+  --current-binary target/release/nose \
+  --baseline-source-ref origin/main \
+  --current-source-ref go-protocol-reporting-support \
+  --repo nats-server --repo etcd --repo minio \
+  --repo prometheus --repo badger --repo delve \
+  --output target/go-protocol-reporting-support-query-regression.json
 ```
 
 Build the first #602 `Promise.all` exact aggregate slice audit with:
@@ -715,6 +724,11 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   select, goroutine, and defer protocol rows reporting-supported. Go
   `go`/`defer` now also have scheduled/deferred callback demand/effect
   profiles in the shared kernel.
+- [go-protocol-reporting-support-2026-07-01.v1.json](go-protocol-reporting-support-2026-07-01.v1.json)
+  records the compact Go protocol closeout. It prices `31,500` Go protocol
+  occurrences, keeps the checked `crates` gate at `0` false merges, and records
+  a Go-heavy r9 query regression of `3757.82ms -> 3674.17ms` (`-2.23%`) with
+  identical product hashes on all six measured repos.
 - [scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json)
   records the Python async protocol lifecycle reporting slice. It keeps exact
   admission closed while splitting `async for` statements/comprehensions and

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -727,7 +727,7 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
 - [go-protocol-reporting-support-2026-07-01.v1.json](go-protocol-reporting-support-2026-07-01.v1.json)
   records the compact Go protocol closeout. It prices `31,500` Go protocol
   occurrences, keeps the checked `crates` gate at `0` false merges, and records
-  a Go-heavy r9 query regression of `3757.82ms -> 3674.17ms` (`-2.23%`) with
+  a Go-heavy r9 query regression of `3560.13ms -> 3563.06ms` (`+0.08%`) with
   identical product hashes on all six measured repos.
 - [scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json)
   records the Python async protocol lifecycle reporting slice. It keeps exact

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -328,6 +328,19 @@ python3 scripts/scheduling-lifecycle-boundary-audit.py \
   --generated-on 2026-06-30
 ```
 
+Build the Go protocol reporting-support audit with:
+
+```sh
+cargo run -q -p nose-cli -- verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json
+
+python3 scripts/scheduling-lifecycle-boundary-audit.py \
+  --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json \
+  --output target/scheduling-lifecycle-boundary-audit.go-protocol-reporting-support.json \
+  --generated-on 2026-07-01
+```
+
 Build the first #602 `Promise.all` exact aggregate slice audit with:
 
 ```sh
@@ -696,6 +709,12 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   parents, `3,590` select cases, `546` select defaults, `1,949` goroutines,
   and `17,521` defers. Select parents and arms are counted separately because
   they are distinct source-backed protocol boundaries in lowering.
+- [scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
+  records the Go protocol reporting-support follow-up. It keeps exact
+  admission closed while marking the already source-backed Go channel,
+  select, goroutine, and defer protocol rows reporting-supported. Go
+  `go`/`defer` now also have scheduled/deferred callback demand/effect
+  profiles in the shared kernel.
 - [scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json](scheduling-lifecycle-boundary-audit-python-async-lifecycle-2026-07-01.v1.json)
   records the Python async protocol lifecycle reporting slice. It keeps exact
   admission closed while splitting `async for` statements/comprehensions and

--- a/bench/recall_loss/go-protocol-reporting-support-2026-07-01.v1.json
+++ b/bench/recall_loss/go-protocol-reporting-support-2026-07-01.v1.json
@@ -1,0 +1,130 @@
+{
+  "capability_alignment": {
+    "capability": "source-backed scheduled/deferred callback protocol boundary",
+    "not_a_feature_list": [
+      "No Go exact admission was opened.",
+      "No public semantic-pack API was added.",
+      "Existing Go source protocol lowering and runtime-boundary obligations are reused."
+    ],
+    "principle": "Capabilities over features",
+    "reused_capabilities": [
+      "SourceProtocolKind::GoRoutine",
+      "SourceProtocolKind::Defer",
+      "SourceProtocolKind::ChannelReceive",
+      "SourceProtocolKind::ChannelSend",
+      "SourceProtocolKind::ChannelSelect",
+      "DemandEffectProfile",
+      "runtime-boundary-model",
+      "recall-loss oracle_exclusions/by_obligation rollups"
+    ]
+  },
+  "corpus_pricing": {
+    "source": "bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json",
+    "status": "reporting-supported-closed-boundary",
+    "surfaces": [
+      {
+        "occurrences": 17521,
+        "repos": 16,
+        "surface": "go.concurrent.defer"
+      },
+      {
+        "occurrences": 4294,
+        "repos": 13,
+        "surface": "go.channel.receive"
+      },
+      {
+        "occurrences": 3590,
+        "repos": 13,
+        "surface": "go.channel.select.case"
+      },
+      {
+        "occurrences": 1949,
+        "repos": 14,
+        "surface": "go.concurrent.goroutine"
+      },
+      {
+        "occurrences": 1920,
+        "repos": 13,
+        "surface": "go.channel.select"
+      },
+      {
+        "occurrences": 1525,
+        "repos": 12,
+        "surface": "go.channel.send"
+      },
+      {
+        "occurrences": 546,
+        "repos": 10,
+        "surface": "go.channel.select.default"
+      },
+      {
+        "occurrences": 155,
+        "repos": 9,
+        "surface": "go.channel.receive_status"
+      }
+    ],
+    "total_go_protocol_occurrences": 31500
+  },
+  "current_crates_gate": {
+    "admission_rejections": 811,
+    "advisory_disagreements": 4,
+    "canon_checked": 99,
+    "canon_preservation_violations": 0,
+    "excluded_units": 5993,
+    "false_merges": 0,
+    "fingerprint_groups": 38,
+    "gate_passed": true,
+    "interpretable_units": 969,
+    "lossy_fingerprint_collisions": 0,
+    "max_violations": 0,
+    "report": "target/recall-loss.go-protocol-reporting-support.crates.json",
+    "total_units": 6962
+  },
+  "generated_on": "2026-07-01",
+  "next_exact_work_policy": {
+    "status": "closed_until_evidence",
+    "summary": "Exact Go channel/goroutine/defer convergence still needs blocking, synchronization, close/status, select readiness, callback effects, panic/defer ordering, scheduling, and liveness proof."
+  },
+  "product_query_regression": {
+    "aggregate_baseline_median_ms": 3757.8219156712294,
+    "aggregate_current_median_ms": 3674.1729178465903,
+    "aggregate_delta_pct": -2.2259968593987387,
+    "hashes_identical_by_repo": {
+      "badger": true,
+      "delve": true,
+      "etcd": true,
+      "minio": true,
+      "nats-server": true,
+      "prometheus": true
+    },
+    "method": "1 warmup per binary/repo, then 9 alternating measured runs over Go protocol-heavy repos",
+    "source": "bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json",
+    "subset": [
+      "nats-server",
+      "etcd",
+      "minio",
+      "prometheus",
+      "badger",
+      "delve"
+    ]
+  },
+  "report_kind": "go-protocol-reporting-support",
+  "schema_version": 1,
+  "scope": {
+    "exact_admission_opened": false,
+    "kind": "reporting-and-profile-only",
+    "semantic_admission_delta": 0,
+    "summary": "Go go/defer now have scheduled/deferred callback demand/effect profiles and Go channel/goroutine/defer/select rows are reporting-supported closed boundaries."
+  },
+  "validation_commands": [
+    "cargo test -p nose-semantics promise_and_protocol_demand_profiles_keep_async_boundaries --lib -- --nocapture",
+    "cargo test -p nose-frontend go::tests::go_defer_and_channel_operations_preserve_source_backed_protocol_boundaries --lib -- --nocapture",
+    "cargo test -p nose-cli go_select_defer_and_goroutine_boundaries_report_specific_obligations --lib -- --nocapture",
+    "cargo test -p nose-cli goroutine_and_defer_labels_have_specific_obligations --lib -- --nocapture",
+    "cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence -- --nocapture",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json --generated-on 2026-07-01",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-go-protocol-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref go-protocol-reporting-support --repo nats-server --repo etcd --repo minio --repo prometheus --repo badger --repo delve --output bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json"
+  ]
+}

--- a/bench/recall_loss/go-protocol-reporting-support-2026-07-01.v1.json
+++ b/bench/recall_loss/go-protocol-reporting-support-2026-07-01.v1.json
@@ -86,9 +86,9 @@
     "summary": "Exact Go channel/goroutine/defer convergence still needs blocking, synchronization, close/status, select readiness, callback effects, panic/defer ordering, scheduling, and liveness proof."
   },
   "product_query_regression": {
-    "aggregate_baseline_median_ms": 3757.8219156712294,
-    "aggregate_current_median_ms": 3674.1729178465903,
-    "aggregate_delta_pct": -2.2259968593987387,
+    "aggregate_baseline_median_ms": 3560.1316671818495,
+    "aggregate_current_median_ms": 3563.0643751937896,
+    "aggregate_delta_pct": 0.08237639183332823,
     "hashes_identical_by_repo": {
       "badger": true,
       "delve": true,

--- a/bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json
+++ b/bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json
@@ -1,0 +1,1169 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-go-protocol-main-target/release/nose",
+    "baseline_binary_sha256": "08f48b950731694c695d02711094f7ce47d23554695e74df873848a45f8f038d",
+    "baseline_source_ref": "origin/main",
+    "baseline_source_sha": "6002e57397fdf005de5bd181e20cdffc0712f581",
+    "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "current_binary_sha256": "1ae5c9bbe0ce5d564e74afb71a723e83d4ac7923f976b03f700930edf6a4ad7b",
+    "current_source_ref": "go-protocol-reporting-support",
+    "current_source_sha": "dc3a622179b7a516539b6d68d32a4205d2202a00",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-go-protocol-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref go-protocol-reporting-support --repo nats-server --repo etcd --repo minio --repo prometheus --repo badger --repo delve --output bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json",
+    "working_tree_status_before_measurement": ""
+  },
+  "repos": [
+    "nats-server",
+    "etcd",
+    "minio",
+    "prometheus",
+    "badger",
+    "delve"
+  ],
+  "runs": [
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1162.7379171550274,
+      "families": 27,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 415.5155420303345,
+      "families": 32,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 700.2789578400552,
+      "families": 54,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 819.5239580236375,
+      "families": 67,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 88.45037501305342,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 369.16333297267556,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1271.5191249735653,
+      "families": 27,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 380.8552920818329,
+      "families": 32,
+      "iteration": 1,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 751.6098329797387,
+      "families": 54,
+      "iteration": 1,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 754.5036659575999,
+      "families": 67,
+      "iteration": 1,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 108.45866613090038,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 342.5934580154717,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1171.1053329054266,
+      "families": 27,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 441.9457500334829,
+      "families": 32,
+      "iteration": 2,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 753.2711669337004,
+      "families": 54,
+      "iteration": 2,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 757.5495410710573,
+      "families": 67,
+      "iteration": 2,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 126.28804217092693,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 372.70816694945097,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1235.403792001307,
+      "families": 27,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 377.4082080926746,
+      "families": 32,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 736.3559999503195,
+      "families": 54,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 831.9686250761151,
+      "families": 67,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 91.49495791643858,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 305.39141595363617,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1311.6912499535829,
+      "families": 27,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 420.9559999871999,
+      "families": 32,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 758.2178749144077,
+      "families": 54,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 839.4325419794768,
+      "families": 67,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 98.39495806954801,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 343.90504099428654,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1157.8782501164824,
+      "families": 27,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 475.56874994188547,
+      "families": 32,
+      "iteration": 3,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 719.5974588394165,
+      "families": 54,
+      "iteration": 3,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 759.1244999784976,
+      "families": 67,
+      "iteration": 3,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 90.5242080334574,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 418.2450419757515,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1243.2681659702212,
+      "families": 27,
+      "iteration": 4,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 360.6850409414619,
+      "families": 32,
+      "iteration": 4,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 775.5940000060946,
+      "families": 54,
+      "iteration": 4,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 821.5456667821854,
+      "families": 67,
+      "iteration": 4,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 92.70879183895886,
+      "families": 8,
+      "iteration": 4,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 302.7718330267817,
+      "families": 29,
+      "iteration": 4,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1345.721042016521,
+      "families": 27,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 406.06645797379315,
+      "families": 32,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 749.8001668136567,
+      "families": 54,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 726.9945421721786,
+      "families": 67,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 110.89270794764161,
+      "families": 8,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 405.37895797751844,
+      "families": 29,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1180.927542038262,
+      "families": 27,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 486.0265839379281,
+      "families": 32,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 767.0567079912871,
+      "families": 54,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 770.6804999615997,
+      "families": 67,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 135.07908396422863,
+      "families": 8,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 367.49933287501335,
+      "families": 29,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1271.7395829968154,
+      "families": 27,
+      "iteration": 5,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 410.7015000190586,
+      "families": 32,
+      "iteration": 5,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 721.0837919265032,
+      "families": 54,
+      "iteration": 5,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 875.1620419789106,
+      "families": 67,
+      "iteration": 5,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 88.53754214942455,
+      "families": 8,
+      "iteration": 5,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 379.5942079741508,
+      "families": 29,
+      "iteration": 5,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1268.5357918962836,
+      "families": 27,
+      "iteration": 6,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 388.42858420684934,
+      "families": 32,
+      "iteration": 6,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 766.0229590255767,
+      "families": 54,
+      "iteration": 6,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 765.8058749511838,
+      "families": 67,
+      "iteration": 6,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 117.68750008195639,
+      "families": 8,
+      "iteration": 6,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 337.05537486821413,
+      "families": 29,
+      "iteration": 6,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1264.2817911691964,
+      "families": 27,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 454.24620900303125,
+      "families": 32,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 745.3173329122365,
+      "families": 54,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 793.9247919712216,
+      "families": 67,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 116.77195900119841,
+      "families": 8,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 392.6047079730779,
+      "families": 29,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1186.9657919742167,
+      "families": 27,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 437.0463329833001,
+      "families": 32,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 712.9243751987815,
+      "families": 54,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 902.2035838570446,
+      "families": 67,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 82.66329183243215,
+      "families": 8,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 432.7021250501275,
+      "families": 29,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1242.7525410894305,
+      "families": 27,
+      "iteration": 7,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 347.61837497353554,
+      "families": 32,
+      "iteration": 7,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 781.4663341268897,
+      "families": 54,
+      "iteration": 7,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 827.7624580077827,
+      "families": 67,
+      "iteration": 7,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 92.95454202219844,
+      "families": 8,
+      "iteration": 7,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 297.2815001849085,
+      "families": 29,
+      "iteration": 7,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1330.6118750479072,
+      "families": 27,
+      "iteration": 8,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 436.00391619838774,
+      "families": 32,
+      "iteration": 8,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 764.728375012055,
+      "families": 54,
+      "iteration": 8,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 791.6306250263005,
+      "families": 67,
+      "iteration": 8,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 110.64816592261195,
+      "families": 8,
+      "iteration": 8,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 357.07929194904864,
+      "families": 29,
+      "iteration": 8,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1255.6953330058604,
+      "families": 27,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 456.1393749900162,
+      "families": 32,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 782.1527919732034,
+      "families": 54,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 760.1458330173045,
+      "families": 67,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 116.42866604961455,
+      "families": 8,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 395.4774171579629,
+      "families": 29,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1306.699875043705,
+      "families": 27,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 442.0789999421686,
+      "families": 32,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 779.3532500509173,
+      "families": 54,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 835.0734580308199,
+      "families": 67,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 103.15141687169671,
+      "families": 8,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 403.3715829718858,
+      "families": 29,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1307.9147080425173,
+      "families": 27,
+      "iteration": 9,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 415.4251669533551,
+      "families": 32,
+      "iteration": 9,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 749.0016249939799,
+      "families": 54,
+      "iteration": 9,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+    },
+    {
+      "bytes": 149292,
+      "elapsed_ms": 908.9371250011027,
+      "families": 67,
+      "iteration": 9,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 79.80399997904897,
+      "families": 8,
+      "iteration": 9,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 405.30170896090567,
+      "families": 29,
+      "iteration": 9,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 3757.8219156712294,
+    "aggregate_current_median_ms": 3674.1729178465903,
+    "aggregate_delta_pct": -2.2259968593987387,
+    "by_repo": {
+      "badger": {
+        "baseline": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+          ],
+          "median_ms": 103.15141687169671
+        },
+        "current": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
+          ],
+          "median_ms": 92.95454202219844
+        }
+      },
+      "delve": {
+        "baseline": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+          ],
+          "median_ms": 392.6047079730779
+        },
+        "current": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
+          ],
+          "median_ms": 357.07929194904864
+        }
+      },
+      "etcd": {
+        "baseline": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+          ],
+          "median_ms": 437.0463329833001
+        },
+        "current": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
+          ],
+          "median_ms": 410.7015000190586
+        }
+      },
+      "minio": {
+        "baseline": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+          ],
+          "median_ms": 749.8001668136567
+        },
+        "current": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
+          ],
+          "median_ms": 753.2711669337004
+        }
+      },
+      "nats-server": {
+        "baseline": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+          ],
+          "median_ms": 1255.6953330058604
+        },
+        "current": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
+          ],
+          "median_ms": 1268.5357918962836
+        }
+      },
+      "prometheus": {
+        "baseline": {
+          "bytes": [
+            149292
+          ],
+          "families": [
+            67
+          ],
+          "hashes": [
+            "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+          ],
+          "median_ms": 819.5239580236375
+        },
+        "current": {
+          "bytes": [
+            149292
+          ],
+          "families": [
+            67
+          ],
+          "hashes": [
+            "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
+          ],
+          "median_ms": 791.6306250263005
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "badger": true,
+      "delve": true,
+      "etcd": true,
+      "minio": true,
+      "nats-server": true,
+      "prometheus": true
+    }
+  }
+}

--- a/bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json
+++ b/bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json
@@ -6,9 +6,9 @@
     "baseline_source_ref": "origin/main",
     "baseline_source_sha": "6002e57397fdf005de5bd181e20cdffc0712f581",
     "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
-    "current_binary_sha256": "1ae5c9bbe0ce5d564e74afb71a723e83d4ac7923f976b03f700930edf6a4ad7b",
+    "current_binary_sha256": "492bd35b0efc72f5a9b592fa8f308f8a6b4e48f0037fd1caac281ef22ef44755",
     "current_source_ref": "go-protocol-reporting-support",
-    "current_source_sha": "dc3a622179b7a516539b6d68d32a4205d2202a00",
+    "current_source_sha": "20a4c68a3058d142b6178498adb0bb7fbcd55990",
     "harness": "scripts/query-regression-harness.py",
     "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-go-protocol-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref go-protocol-reporting-support --repo nats-server --repo etcd --repo minio --repo prometheus --repo badger --repo delve --output bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json",
     "working_tree_status_before_measurement": ""
@@ -24,7 +24,7 @@
   "runs": [
     {
       "bytes": 64019,
-      "elapsed_ms": 1162.7379171550274,
+      "elapsed_ms": 1111.3802089821547,
       "families": 27,
       "iteration": 1,
       "label": "baseline",
@@ -33,7 +33,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 415.5155420303345,
+      "elapsed_ms": 413.29041705466807,
       "families": 32,
       "iteration": 1,
       "label": "baseline",
@@ -42,7 +42,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 700.2789578400552,
+      "elapsed_ms": 631.0549590270966,
       "families": 54,
       "iteration": 1,
       "label": "baseline",
@@ -51,7 +51,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 819.5239580236375,
+      "elapsed_ms": 818.908124929294,
       "families": 67,
       "iteration": 1,
       "label": "baseline",
@@ -60,7 +60,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 88.45037501305342,
+      "elapsed_ms": 79.42254189401865,
       "families": 8,
       "iteration": 1,
       "label": "baseline",
@@ -69,7 +69,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 369.16333297267556,
+      "elapsed_ms": 372.81591608189046,
       "families": 29,
       "iteration": 1,
       "label": "baseline",
@@ -78,7 +78,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1271.5191249735653,
+      "elapsed_ms": 1198.3852081466466,
       "families": 27,
       "iteration": 1,
       "label": "current",
@@ -87,7 +87,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 380.8552920818329,
+      "elapsed_ms": 368.893374921754,
       "families": 32,
       "iteration": 1,
       "label": "current",
@@ -96,7 +96,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 751.6098329797387,
+      "elapsed_ms": 692.5863330252469,
       "families": 54,
       "iteration": 1,
       "label": "current",
@@ -105,7 +105,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 754.5036659575999,
+      "elapsed_ms": 781.0547498520464,
       "families": 67,
       "iteration": 1,
       "label": "current",
@@ -114,7 +114,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 108.45866613090038,
+      "elapsed_ms": 106.220250017941,
       "families": 8,
       "iteration": 1,
       "label": "current",
@@ -123,7 +123,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 342.5934580154717,
+      "elapsed_ms": 337.29312499053776,
       "families": 29,
       "iteration": 1,
       "label": "current",
@@ -132,7 +132,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1171.1053329054266,
+      "elapsed_ms": 1113.3847089949995,
       "families": 27,
       "iteration": 2,
       "label": "current",
@@ -141,7 +141,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 441.9457500334829,
+      "elapsed_ms": 433.98549989797175,
       "families": 32,
       "iteration": 2,
       "label": "current",
@@ -150,7 +150,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 753.2711669337004,
+      "elapsed_ms": 655.8767920359969,
       "families": 54,
       "iteration": 2,
       "label": "current",
@@ -159,7 +159,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 757.5495410710573,
+      "elapsed_ms": 815.3534589800984,
       "families": 67,
       "iteration": 2,
       "label": "current",
@@ -168,7 +168,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 126.28804217092693,
+      "elapsed_ms": 80.7365421205759,
       "families": 8,
       "iteration": 2,
       "label": "current",
@@ -177,7 +177,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 372.70816694945097,
+      "elapsed_ms": 342.20020892098546,
       "families": 29,
       "iteration": 2,
       "label": "current",
@@ -186,7 +186,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1235.403792001307,
+      "elapsed_ms": 1195.4737501218915,
       "families": 27,
       "iteration": 2,
       "label": "baseline",
@@ -195,7 +195,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 377.4082080926746,
+      "elapsed_ms": 394.45437490940094,
       "families": 32,
       "iteration": 2,
       "label": "baseline",
@@ -204,7 +204,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 736.3559999503195,
+      "elapsed_ms": 723.3352079056203,
       "families": 54,
       "iteration": 2,
       "label": "baseline",
@@ -213,7 +213,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 831.9686250761151,
+      "elapsed_ms": 745.3816661145538,
       "families": 67,
       "iteration": 2,
       "label": "baseline",
@@ -222,7 +222,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 91.49495791643858,
+      "elapsed_ms": 98.34183310158551,
       "families": 8,
       "iteration": 2,
       "label": "baseline",
@@ -231,7 +231,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 305.39141595363617,
+      "elapsed_ms": 344.6042500436306,
       "families": 29,
       "iteration": 2,
       "label": "baseline",
@@ -240,7 +240,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1311.6912499535829,
+      "elapsed_ms": 1154.711834155023,
       "families": 27,
       "iteration": 3,
       "label": "baseline",
@@ -249,7 +249,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 420.9559999871999,
+      "elapsed_ms": 446.8513331376016,
       "families": 32,
       "iteration": 3,
       "label": "baseline",
@@ -258,7 +258,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 758.2178749144077,
+      "elapsed_ms": 655.2272089757025,
       "families": 54,
       "iteration": 3,
       "label": "baseline",
@@ -267,7 +267,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 839.4325419794768,
+      "elapsed_ms": 817.0927090104669,
       "families": 67,
       "iteration": 3,
       "label": "baseline",
@@ -276,7 +276,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 98.39495806954801,
+      "elapsed_ms": 83.16079201176763,
       "families": 8,
       "iteration": 3,
       "label": "baseline",
@@ -285,7 +285,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 343.90504099428654,
+      "elapsed_ms": 359.9262919742614,
       "families": 29,
       "iteration": 3,
       "label": "baseline",
@@ -294,7 +294,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1157.8782501164824,
+      "elapsed_ms": 1244.1323748789728,
       "families": 27,
       "iteration": 3,
       "label": "current",
@@ -303,7 +303,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 475.56874994188547,
+      "elapsed_ms": 380.82849979400635,
       "families": 32,
       "iteration": 3,
       "label": "current",
@@ -312,7 +312,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 719.5974588394165,
+      "elapsed_ms": 720.0599580537528,
       "families": 54,
       "iteration": 3,
       "label": "current",
@@ -321,7 +321,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 759.1244999784976,
+      "elapsed_ms": 764.6691249683499,
       "families": 67,
       "iteration": 3,
       "label": "current",
@@ -330,7 +330,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 90.5242080334574,
+      "elapsed_ms": 112.95941704884171,
       "families": 8,
       "iteration": 3,
       "label": "current",
@@ -339,7 +339,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 418.2450419757515,
+      "elapsed_ms": 346.46912501193583,
       "families": 29,
       "iteration": 3,
       "label": "current",
@@ -348,7 +348,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1243.2681659702212,
+      "elapsed_ms": 1154.872874962166,
       "families": 27,
       "iteration": 4,
       "label": "current",
@@ -357,7 +357,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 360.6850409414619,
+      "elapsed_ms": 460.0974579807371,
       "families": 32,
       "iteration": 4,
       "label": "current",
@@ -366,7 +366,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 775.5940000060946,
+      "elapsed_ms": 669.3463751580566,
       "families": 54,
       "iteration": 4,
       "label": "current",
@@ -375,7 +375,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 821.5456667821854,
+      "elapsed_ms": 791.0189998801798,
       "families": 67,
       "iteration": 4,
       "label": "current",
@@ -384,7 +384,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 92.70879183895886,
+      "elapsed_ms": 84.39616695977747,
       "families": 8,
       "iteration": 4,
       "label": "current",
@@ -393,7 +393,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 302.7718330267817,
+      "elapsed_ms": 406.0864169150591,
       "families": 29,
       "iteration": 4,
       "label": "current",
@@ -402,7 +402,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1345.721042016521,
+      "elapsed_ms": 1186.6407501511276,
       "families": 27,
       "iteration": 4,
       "label": "baseline",
@@ -411,7 +411,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 406.06645797379315,
+      "elapsed_ms": 359.40800001844764,
       "families": 32,
       "iteration": 4,
       "label": "baseline",
@@ -420,7 +420,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 749.8001668136567,
+      "elapsed_ms": 756.1049580108374,
       "families": 54,
       "iteration": 4,
       "label": "baseline",
@@ -429,7 +429,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 726.9945421721786,
+      "elapsed_ms": 780.3405828308314,
       "families": 67,
       "iteration": 4,
       "label": "baseline",
@@ -438,7 +438,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 110.89270794764161,
+      "elapsed_ms": 117.56291682831943,
       "families": 8,
       "iteration": 4,
       "label": "baseline",
@@ -447,7 +447,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 405.37895797751844,
+      "elapsed_ms": 326.0815420653671,
       "families": 29,
       "iteration": 4,
       "label": "baseline",
@@ -456,7 +456,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1180.927542038262,
+      "elapsed_ms": 1210.538167040795,
       "families": 27,
       "iteration": 5,
       "label": "baseline",
@@ -465,7 +465,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 486.0265839379281,
+      "elapsed_ms": 433.8157079182565,
       "families": 32,
       "iteration": 5,
       "label": "baseline",
@@ -474,7 +474,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 767.0567079912871,
+      "elapsed_ms": 734.1736250091344,
       "families": 54,
       "iteration": 5,
       "label": "baseline",
@@ -483,7 +483,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 770.6804999615997,
+      "elapsed_ms": 720.8085421007127,
       "families": 67,
       "iteration": 5,
       "label": "baseline",
@@ -492,7 +492,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 135.07908396422863,
+      "elapsed_ms": 99.91999994963408,
       "families": 8,
       "iteration": 5,
       "label": "baseline",
@@ -501,7 +501,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 367.49933287501335,
+      "elapsed_ms": 419.98791694641113,
       "families": 29,
       "iteration": 5,
       "label": "baseline",
@@ -510,7 +510,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1271.7395829968154,
+      "elapsed_ms": 1193.3458328712732,
       "families": 27,
       "iteration": 5,
       "label": "current",
@@ -519,7 +519,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 410.7015000190586,
+      "elapsed_ms": 350.12575006112456,
       "families": 32,
       "iteration": 5,
       "label": "current",
@@ -528,7 +528,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 721.0837919265032,
+      "elapsed_ms": 761.9306659325957,
       "families": 54,
       "iteration": 5,
       "label": "current",
@@ -537,7 +537,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 875.1620419789106,
+      "elapsed_ms": 735.743333818391,
       "families": 67,
       "iteration": 5,
       "label": "current",
@@ -546,7 +546,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 88.53754214942455,
+      "elapsed_ms": 102.62008314020932,
       "families": 8,
       "iteration": 5,
       "label": "current",
@@ -555,7 +555,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 379.5942079741508,
+      "elapsed_ms": 327.38299993798137,
       "families": 29,
       "iteration": 5,
       "label": "current",
@@ -564,7 +564,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1268.5357918962836,
+      "elapsed_ms": 1262.6870828680694,
       "families": 27,
       "iteration": 6,
       "label": "current",
@@ -573,7 +573,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 388.42858420684934,
+      "elapsed_ms": 445.12495887465775,
       "families": 32,
       "iteration": 6,
       "label": "current",
@@ -582,7 +582,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 766.0229590255767,
+      "elapsed_ms": 698.334458982572,
       "families": 54,
       "iteration": 6,
       "label": "current",
@@ -591,7 +591,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 765.8058749511838,
+      "elapsed_ms": 736.8934999685735,
       "families": 67,
       "iteration": 6,
       "label": "current",
@@ -600,7 +600,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 117.68750008195639,
+      "elapsed_ms": 108.5854999255389,
       "families": 8,
       "iteration": 6,
       "label": "current",
@@ -609,7 +609,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 337.05537486821413,
+      "elapsed_ms": 382.8074170742184,
       "families": 29,
       "iteration": 6,
       "label": "current",
@@ -618,7 +618,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1264.2817911691964,
+      "elapsed_ms": 1205.0383749883622,
       "families": 27,
       "iteration": 6,
       "label": "baseline",
@@ -627,7 +627,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 454.24620900303125,
+      "elapsed_ms": 400.4945419728756,
       "families": 32,
       "iteration": 6,
       "label": "baseline",
@@ -636,7 +636,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 745.3173329122365,
+      "elapsed_ms": 718.1286250706762,
       "families": 54,
       "iteration": 6,
       "label": "baseline",
@@ -645,7 +645,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 793.9247919712216,
+      "elapsed_ms": 848.4416659921408,
       "families": 67,
       "iteration": 6,
       "label": "baseline",
@@ -654,7 +654,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 116.77195900119841,
+      "elapsed_ms": 82.35366689041257,
       "families": 8,
       "iteration": 6,
       "label": "baseline",
@@ -663,7 +663,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 392.6047079730779,
+      "elapsed_ms": 340.3840831015259,
       "families": 29,
       "iteration": 6,
       "label": "baseline",
@@ -672,7 +672,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1186.9657919742167,
+      "elapsed_ms": 1288.711708970368,
       "families": 27,
       "iteration": 7,
       "label": "baseline",
@@ -681,7 +681,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 437.0463329833001,
+      "elapsed_ms": 393.4057499282062,
       "families": 32,
       "iteration": 7,
       "label": "baseline",
@@ -690,7 +690,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 712.9243751987815,
+      "elapsed_ms": 759.1394169721752,
       "families": 54,
       "iteration": 7,
       "label": "baseline",
@@ -699,7 +699,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 902.2035838570446,
+      "elapsed_ms": 783.6930421181023,
       "families": 67,
       "iteration": 7,
       "label": "baseline",
@@ -708,7 +708,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 82.66329183243215,
+      "elapsed_ms": 109.62666594423354,
       "families": 8,
       "iteration": 7,
       "label": "baseline",
@@ -717,7 +717,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 432.7021250501275,
+      "elapsed_ms": 323.36987485177815,
       "families": 29,
       "iteration": 7,
       "label": "baseline",
@@ -726,7 +726,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1242.7525410894305,
+      "elapsed_ms": 1237.6212500967085,
       "families": 27,
       "iteration": 7,
       "label": "current",
@@ -735,7 +735,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 347.61837497353554,
+      "elapsed_ms": 435.4094169102609,
       "families": 32,
       "iteration": 7,
       "label": "current",
@@ -744,7 +744,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 781.4663341268897,
+      "elapsed_ms": 748.9903329405934,
       "families": 54,
       "iteration": 7,
       "label": "current",
@@ -753,7 +753,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 827.7624580077827,
+      "elapsed_ms": 746.7017089948058,
       "families": 67,
       "iteration": 7,
       "label": "current",
@@ -762,7 +762,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 92.95454202219844,
+      "elapsed_ms": 134.6470827702433,
       "families": 8,
       "iteration": 7,
       "label": "current",
@@ -771,7 +771,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 297.2815001849085,
+      "elapsed_ms": 349.46404211223125,
       "families": 29,
       "iteration": 7,
       "label": "current",
@@ -780,7 +780,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1330.6118750479072,
+      "elapsed_ms": 1199.0908330772072,
       "families": 27,
       "iteration": 8,
       "label": "current",
@@ -789,7 +789,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 436.00391619838774,
+      "elapsed_ms": 377.0299169700593,
       "families": 32,
       "iteration": 8,
       "label": "current",
@@ -798,7 +798,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 764.728375012055,
+      "elapsed_ms": 722.4160418845713,
       "families": 54,
       "iteration": 8,
       "label": "current",
@@ -807,7 +807,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 791.6306250263005,
+      "elapsed_ms": 817.6253337878734,
       "families": 67,
       "iteration": 8,
       "label": "current",
@@ -816,7 +816,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 110.64816592261195,
+      "elapsed_ms": 97.88495814427733,
       "families": 8,
       "iteration": 8,
       "label": "current",
@@ -825,7 +825,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 357.07929194904864,
+      "elapsed_ms": 300.5466249305755,
       "families": 29,
       "iteration": 8,
       "label": "current",
@@ -834,7 +834,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1255.6953330058604,
+      "elapsed_ms": 1387.7622080035508,
       "families": 27,
       "iteration": 8,
       "label": "baseline",
@@ -843,7 +843,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 456.1393749900162,
+      "elapsed_ms": 403.54079217649996,
       "families": 32,
       "iteration": 8,
       "label": "baseline",
@@ -852,7 +852,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 782.1527919732034,
+      "elapsed_ms": 787.3877498786896,
       "families": 54,
       "iteration": 8,
       "label": "baseline",
@@ -861,7 +861,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 760.1458330173045,
+      "elapsed_ms": 766.3699160329998,
       "families": 67,
       "iteration": 8,
       "label": "baseline",
@@ -870,7 +870,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 116.42866604961455,
+      "elapsed_ms": 117.71270888857543,
       "families": 8,
       "iteration": 8,
       "label": "baseline",
@@ -879,7 +879,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 395.4774171579629,
+      "elapsed_ms": 342.4502080306411,
       "families": 29,
       "iteration": 8,
       "label": "baseline",
@@ -888,7 +888,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1306.699875043705,
+      "elapsed_ms": 1261.105583049357,
       "families": 27,
       "iteration": 9,
       "label": "baseline",
@@ -897,7 +897,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 442.0789999421686,
+      "elapsed_ms": 461.455250158906,
       "families": 32,
       "iteration": 9,
       "label": "baseline",
@@ -906,7 +906,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 779.3532500509173,
+      "elapsed_ms": 710.7147499918938,
       "families": 54,
       "iteration": 9,
       "label": "baseline",
@@ -915,7 +915,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 835.0734580308199,
+      "elapsed_ms": 831.2432081438601,
       "families": 67,
       "iteration": 9,
       "label": "baseline",
@@ -924,7 +924,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 103.15141687169671,
+      "elapsed_ms": 106.99175018817186,
       "families": 8,
       "iteration": 9,
       "label": "baseline",
@@ -933,7 +933,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 403.3715829718858,
+      "elapsed_ms": 390.271499985829,
       "families": 29,
       "iteration": 9,
       "label": "baseline",
@@ -942,7 +942,7 @@
     },
     {
       "bytes": 64019,
-      "elapsed_ms": 1307.9147080425173,
+      "elapsed_ms": 1167.1251670923084,
       "families": 27,
       "iteration": 9,
       "label": "current",
@@ -951,7 +951,7 @@
     },
     {
       "bytes": 63385,
-      "elapsed_ms": 415.4251669533551,
+      "elapsed_ms": 416.3579170126468,
       "families": 32,
       "iteration": 9,
       "label": "current",
@@ -960,7 +960,7 @@
     },
     {
       "bytes": 84761,
-      "elapsed_ms": 749.0016249939799,
+      "elapsed_ms": 718.1772920303047,
       "families": 54,
       "iteration": 9,
       "label": "current",
@@ -969,7 +969,7 @@
     },
     {
       "bytes": 149292,
-      "elapsed_ms": 908.9371250011027,
+      "elapsed_ms": 832.0782908704132,
       "families": 67,
       "iteration": 9,
       "label": "current",
@@ -978,7 +978,7 @@
     },
     {
       "bytes": 32276,
-      "elapsed_ms": 79.80399997904897,
+      "elapsed_ms": 80.41541697457433,
       "families": 8,
       "iteration": 9,
       "label": "current",
@@ -987,7 +987,7 @@
     },
     {
       "bytes": 65064,
-      "elapsed_ms": 405.30170896090567,
+      "elapsed_ms": 404.27966602146626,
       "families": 29,
       "iteration": 9,
       "label": "current",
@@ -996,9 +996,9 @@
     }
   ],
   "summary": {
-    "aggregate_baseline_median_ms": 3757.8219156712294,
-    "aggregate_current_median_ms": 3674.1729178465903,
-    "aggregate_delta_pct": -2.2259968593987387,
+    "aggregate_baseline_median_ms": 3560.1316671818495,
+    "aggregate_current_median_ms": 3563.0643751937896,
+    "aggregate_delta_pct": 0.08237639183332823,
     "by_repo": {
       "badger": {
         "baseline": {
@@ -1011,7 +1011,7 @@
           "hashes": [
             "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
           ],
-          "median_ms": 103.15141687169671
+          "median_ms": 99.91999994963408
         },
         "current": {
           "bytes": [
@@ -1023,7 +1023,7 @@
           "hashes": [
             "f49db7a70c4ec415042a905b62ab619e6ba4c630916ce9d6642b0d2a7344f426"
           ],
-          "median_ms": 92.95454202219844
+          "median_ms": 102.62008314020932
         }
       },
       "delve": {
@@ -1037,7 +1037,7 @@
           "hashes": [
             "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
           ],
-          "median_ms": 392.6047079730779
+          "median_ms": 344.6042500436306
         },
         "current": {
           "bytes": [
@@ -1049,7 +1049,7 @@
           "hashes": [
             "67d339dbcf426d7ca8f8ed38c8476e0411f3af8ee789b5d9d92145321d8eb65f"
           ],
-          "median_ms": 357.07929194904864
+          "median_ms": 346.46912501193583
         }
       },
       "etcd": {
@@ -1063,7 +1063,7 @@
           "hashes": [
             "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
           ],
-          "median_ms": 437.0463329833001
+          "median_ms": 403.54079217649996
         },
         "current": {
           "bytes": [
@@ -1075,7 +1075,7 @@
           "hashes": [
             "4e09b17c4cd320355e213ca780ffe691674f1706536ef0f375803dfe452e663e"
           ],
-          "median_ms": 410.7015000190586
+          "median_ms": 416.3579170126468
         }
       },
       "minio": {
@@ -1089,7 +1089,7 @@
           "hashes": [
             "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
           ],
-          "median_ms": 749.8001668136567
+          "median_ms": 723.3352079056203
         },
         "current": {
           "bytes": [
@@ -1101,7 +1101,7 @@
           "hashes": [
             "04938a6530487d1e48954e655e87b6228d05e8525bee172d13872269b3b66dde"
           ],
-          "median_ms": 753.2711669337004
+          "median_ms": 718.1772920303047
         }
       },
       "nats-server": {
@@ -1115,7 +1115,7 @@
           "hashes": [
             "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
           ],
-          "median_ms": 1255.6953330058604
+          "median_ms": 1205.0383749883622
         },
         "current": {
           "bytes": [
@@ -1127,7 +1127,7 @@
           "hashes": [
             "bab54b3294eb4da36462a81c44b57d9e792b01760a96fc03199b31eaa3b57edf"
           ],
-          "median_ms": 1268.5357918962836
+          "median_ms": 1198.3852081466466
         }
       },
       "prometheus": {
@@ -1141,7 +1141,7 @@
           "hashes": [
             "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
           ],
-          "median_ms": 819.5239580236375
+          "median_ms": 783.6930421181023
         },
         "current": {
           "bytes": [
@@ -1153,7 +1153,7 @@
           "hashes": [
             "d1a8152da9dc31ed184e8e6911f4b00f4c2e5b841aed0d1b3c1fd3c17ef997e0"
           ],
-          "median_ms": 791.6306250263005
+          "median_ms": 781.0547498520464
         }
       }
     },

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json
@@ -1,0 +1,5410 @@
+{
+  "current_recall_loss": {
+    "relevant_obligations": [
+      {
+        "count": 17,
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_interpretable": 17
+      },
+      {
+        "count": 10,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-rust-macro-call-effect-proof-missing",
+        "oracle_interpretable": 10
+      },
+      {
+        "count": 9,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-member-call-effect-proof-missing",
+        "oracle_interpretable": 9
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-assignment-effect-proof-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-direct-function-call-effect-contract-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 2,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-identity-or-shape-proof-missing",
+        "oracle_interpretable": 2
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-imported-function-call-effect-contract-missing",
+        "oracle_interpretable": 1
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "predicate-callback-demand-effect-profile-missing",
+        "oracle_interpretable": 1
+      }
+    ],
+    "relevant_oracle_exclusion_obligations": [
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 576,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_excluded": 576
+      },
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 3,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "oracle_excluded": 3
+      }
+    ],
+    "report": "target/recall-loss.go-protocol-reporting-support.crates.json",
+    "soundness_gate": {
+      "advisory_disagreements": 4,
+      "canon_preservation_violations": 0,
+      "false_merges": 0,
+      "fingerprint_groups": 38,
+      "gate_passed": true,
+      "lossy_fingerprint_collisions": 0,
+      "max_violations": 0
+    },
+    "summary": {
+      "admission_rejections": 811,
+      "canon_checked": 99,
+      "canon_preservation_violations": 0,
+      "excluded_units": 5993,
+      "interpretable_units": 969,
+      "total_units": 6962
+    }
+  },
+  "generated_on": "2026-07-01",
+  "hard_negative_inventory": [
+    {
+      "class": "thenable assimilation and custom Promise-like receivers",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "first-settled versus all-settled aggregate semantics",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "executor callback timing and thrown executor errors",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::promise_constructor_missing_evidence_splits_executor_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "scheduler/microtask ordering versus synchronous evaluation",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::scheduler_and_interval_calls_report_timing_and_lifecycle_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "interval stream liveness/cardinality",
+      "evidence": "crates/nose-cli/tests/cli/commands/recall_loss_report.rs::recall_loss_report_splits_promise_protocol_boundaries",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
+      "evidence": "docs/scheduling-channel-callback-obligations-594.md",
+      "status": "mapped-doc-policy"
+    },
+    {
+      "class": "Go direct call versus goroutine/defer scheduling and callback effects",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_select_defer_and_goroutine_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Go channel receive value/status, channel send, and select/default readiness boundaries",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_channel_protocol_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Python async iterator and async context-manager protocol boundaries versus synchronous loops, comprehensions, and with-blocks",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries/python_async_protocol.rs::query_mode_semantic_rejects_unproven_python_async_protocol_lifecycle_convergence, ::query_mode_semantic_rejects_unproven_python_async_comprehension_convergence, crates/nose-frontend/src/python/tests.rs::async_for_preserves_source_backed_iteration_boundary, ::async_comprehension_preserves_source_backed_iteration_boundary, ::multi_clause_async_comprehension_preserves_source_backed_iteration_boundary, ::async_with_preserves_source_backed_context_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::python_async_lifecycle_protocols_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Ruby block yield callback demand/effect versus ordinary value return or direct call",
+      "evidence": "crates/nose-frontend/src/ruby/tests.rs::yield_preserves_source_backed_protocol_boundary, crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::yield_protocol_missing_evidence_is_language_specific, and crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs::query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Rust async closures versus synchronous closures and async blocks",
+      "evidence": "crates/nose-frontend/src/rust/tests/async_protocols.rs::async_closure_preserves_source_backed_protocol_boundary, ::sync_closure_does_not_create_async_protocol_boundary, and crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Swift structured-concurrency runtime names shadowed by local Task bindings, Task extensions, same-file task-group functions, or project-visible task-group functions",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_structured_concurrency_rejects_local_runtime_shadows",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Swift throwing functions and closures versus non-throwing callables, plus async throwing callables that must retain both scheduling and exception-channel obligations",
+      "evidence": "crates/nose-frontend/src/swift/tests/async_protocols.rs::async_throwing_function_preserves_scheduling_and_exception_boundaries, ::async_throwing_closure_keeps_exception_boundary_inside_async_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_throwing_callables_report_exception_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletableFuture static calls without exact stdlib type identity, or with local/conflicting type names",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completable_future_static_attribution_requires_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletionStage-style receiver continuations without import-backed java.util.concurrent type-domain evidence",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completion_stage_receiver_methods_require_import_backed_type_domain",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future local receivers with reassignment, local shadows, or conflicting imports, plus conflicting Executor local receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future field receivers that are implicit, non-this, member-shadowed, duplicate, or conflicting, plus conflicting Executor field receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    }
+  ],
+  "policy": {
+    "go_channel_operation_pricing": "Directional channel type arrows such as <-chan and chan<- are excluded from send/receive operation counts.",
+    "note": "Counts price boundary surfaces; they do not prove exact semantics.",
+    "raw_source_snippets_included": false,
+    "semantic_admission_delta": 0,
+    "source_prevalence_only": true
+  },
+  "recommended_order": [
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "rank": 1,
+      "repos": 17,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "rank": 2,
+      "repos": 8,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "rank": 3,
+      "repos": 18,
+      "why": "new Promise is high-risk because timing, resolve/reject callback, and throw-to-rejection behavior interact."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "rank": 4,
+      "repos": 7,
+      "why": "Cancellation appears across JS/TS scheduling APIs and must stay separate from fulfillment/rejection recovery."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "rank": 5,
+      "repos": 11,
+      "why": "Repeated emission/liveness needs lifecycle proof before interval streams can be compared exactly."
+    },
+    {
+      "language": "rust",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "rank": 6,
+      "repos": 3,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "swift",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 215,
+      "operation": "Task/Task.detached",
+      "rank": 7,
+      "repos": 12,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "python",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "rank": 8,
+      "repos": 3,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "rust",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "rank": 9,
+      "repos": 2,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    },
+    {
+      "language": "python",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "rank": 10,
+      "repos": 4,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    }
+  ],
+  "regenerate": [
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json --generated-on 2026-07-01"
+  ],
+  "report_kind": "scheduling-lifecycle-boundary-audit",
+  "schema_version": 1,
+  "summary": {
+    "languages": {
+      "c": 81,
+      "go": 31500,
+      "java": 6702,
+      "javascript-typescript": 45382,
+      "python": 6439,
+      "ruby": 4885,
+      "rust": 13228,
+      "swift": 47385
+    },
+    "obligation_families": {
+      "callback-demand-effect": 801,
+      "cancellation-liveness-boundary": 547,
+      "channel-boundary": 12030,
+      "exception-channel": 37808,
+      "executor-callback": 795,
+      "lifecycle-materialization-boundary": 22811,
+      "scheduling-boundary": 79498,
+      "success-error-result-channel": 1312
+    },
+    "repos_in_manifest": 120,
+    "total_source_prevalence": 155602
+  },
+  "surfaces": [
+    {
+      "boundary": "await scheduling",
+      "language": "javascript-typescript",
+      "note": "await is scheduling and thenable assimilation, not sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 29305,
+      "operation": "await",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.await",
+      "top_files": [
+        {
+          "occurrences": 1058,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 689,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 673,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 635,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 615,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 615,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 487,
+          "path": "drizzle-orm/integration-tests/tests/sqlite/sqlite-common.ts"
+        },
+        {
+          "occurrences": 484,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12136,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3321,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 2666,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2413,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1604,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 1592,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 1171,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 1164,
+          "repo": "swr"
+        }
+      ]
+    },
+    {
+      "boundary": "throws channel",
+      "language": "swift",
+      "note": "Swift throws/try is an explicit error channel",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "swift-throws-exception-channel-contract-missing",
+      "occurrences": 26608,
+      "operation": "throws/try",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "swift.error.throws",
+      "top_files": [
+        {
+          "occurrences": 664,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 489,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 450,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 406,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 396,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 364,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 344,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 304,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14760,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2508,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1466,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 1356,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 1107,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 914,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 805,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "defer lifecycle",
+      "language": "go",
+      "note": "defer has scope-exit ordering and panic interaction semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "defer-lifecycle-ordering-contract-missing",
+      "occurrences": 17521,
+      "operation": "defer statement",
+      "repos": 16,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.defer",
+      "top_files": [
+        {
+          "occurrences": 1001,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 560,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 494,
+          "path": "nats-server/server/jetstream_consumer_test.go"
+        },
+        {
+          "occurrences": 461,
+          "path": "nats-server/server/filestore_test.go"
+        },
+        {
+          "occurrences": 420,
+          "path": "nats-server/server/mqtt_test.go"
+        },
+        {
+          "occurrences": 396,
+          "path": "nats-server/server/jetstream_cluster_3_test.go"
+        },
+        {
+          "occurrences": 394,
+          "path": "nats-server/server/jetstream_cluster_1_test.go"
+        },
+        {
+          "occurrences": 379,
+          "path": "nats-server/server/gateway_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10073,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 2461,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1797,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 1151,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 581,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 449,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 422,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 161,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "javascript-typescript",
+      "note": "async functions have scheduling and rejection boundaries even without explicit await",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 14491,
+      "operation": "async function",
+      "repos": 22,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.function",
+      "top_files": [
+        {
+          "occurrences": 352,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 314,
+          "path": "ky/test/hooks.ts"
+        },
+        {
+          "occurrences": 278,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 278,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 210,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 207,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 198,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 192,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4595,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 1621,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1607,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 1079,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 883,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 814,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 688,
+          "repo": "axios"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "swift",
+      "note": "Swift await has task scheduling and actor/lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8689,
+      "operation": "await",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "swift.async.await",
+      "top_files": [
+        {
+          "occurrences": 612,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 556,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 263,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 257,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 251,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 221,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 153,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 150,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3169,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2261,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 969,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 944,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 724,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 155,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 139,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 96,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "future await",
+      "language": "rust",
+      "note": "Rust .await polls a Future and must keep wake/scheduling effects explicit",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8647,
+      "operation": ".await",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.await",
+      "top_files": [
+        {
+          "occurrences": 545,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/proxy.rs"
+        },
+        {
+          "occurrences": 255,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 227,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 221,
+          "path": "meilisearch/crates/meilisearch/tests/dumps/mod.rs"
+        },
+        {
+          "occurrences": 193,
+          "path": "meilisearch/crates/meilisearch/tests/search/mod.rs"
+        },
+        {
+          "occurrences": 147,
+          "path": "meilisearch/crates/meilisearch/tests/tasks/mod.rs"
+        },
+        {
+          "occurrences": 141,
+          "path": "meilisearch/crates/meilisearch/tests/batches/mod.rs"
+        },
+        {
+          "occurrences": 138,
+          "path": "meilisearch/crates/meilisearch/tests/documents/get_documents.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5632,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 2942,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 39,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 34,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing callable error channel",
+      "language": "swift",
+      "note": "Swift body-bearing throwing functions expose an error channel even when the body has no explicit try expression",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 7008,
+      "operation": "func/init/subscript throws/rethrows",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_function",
+      "top_files": [
+        {
+          "occurrences": 135,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 133,
+          "path": "swift-nio/Tests/NIOCoreTests/ByteBufferTest.swift"
+        },
+        {
+          "occurrences": 82,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 76,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 74,
+          "path": "swift-nio/Tests/NIOPosixTests/CodecTest.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 64,
+          "path": "swift-collections/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3459,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 864,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 518,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 445,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 387,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 284,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 219,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 165,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive value",
+      "language": "go",
+      "note": "Go channel receives have blocking, synchronization, and close/zero-value channel semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-value-channel-contract-missing",
+      "occurrences": 4294,
+      "operation": "channel receive",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive",
+      "top_files": [
+        {
+          "occurrences": 126,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 102,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 98,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "delve/service/test/integration2_test.go"
+        },
+        {
+          "occurrences": 82,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 73,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 68,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 65,
+          "path": "nats-server/server/norace_2_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1476,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1354,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 541,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 537,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 175,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 85,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 17,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "exception channel",
+      "language": "ruby",
+      "note": "raise/rescue changes error channels and non-local control",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 4010,
+      "operation": "raise/rescue",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "ruby.exception",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 71,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 67,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 53,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 50,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1334,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 699,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 343,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 264,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 226,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 155,
+          "repo": "sinatra"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "swift",
+      "note": "Swift async surfaces create task/future-like protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 3953,
+      "operation": "async",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "swift.async.function",
+      "top_files": [
+        {
+          "occurrences": 134,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 71,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 62,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 54,
+          "path": "vapor/Tests/VaporMacroTests/HTTPMethodMacroTests.swift"
+        },
+        {
+          "occurrences": 53,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 50,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 47,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1379,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 680,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 670,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 334,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 226,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 179,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 131,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 115,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "select case selection",
+      "language": "go",
+      "note": "Go select cases require readiness, case-selection, and send/receive side-effect proof",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-case-selection-contract-missing",
+      "occurrences": 3590,
+      "operation": "select case",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.case",
+      "top_files": [
+        {
+          "occurrences": 110,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 106,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 71,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 67,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 63,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 62,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 61,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1342,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1086,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 533,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 430,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 82,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 29,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 15,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "executor scheduling",
+      "language": "java",
+      "note": "Executor/Future APIs introduce scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "java-executor-scheduling-contract-missing",
+      "occurrences": 3297,
+      "operation": "Executor/Future",
+      "repos": 16,
+      "status": "closed-boundary",
+      "surface": "java.future.executor",
+      "top_files": [
+        {
+          "occurrences": 59,
+          "path": "netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 33,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1338,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 1173,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 343,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 107,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 86,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 84,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 57,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 44,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "rust",
+      "note": "async fn creates a suspended async function boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2806,
+      "operation": "async fn",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 67,
+          "path": "meilisearch/crates/meilisearch/tests/common/index.rs"
+        },
+        {
+          "occurrences": 60,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 56,
+          "path": "meilisearch/crates/meilisearch/tests/common/server.rs"
+        },
+        {
+          "occurrences": 49,
+          "path": "meilisearch/crates/meilisearch/tests/search/errors.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 37,
+          "path": "meilisearch/crates/meilisearch/tests/auth/api_keys.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1405,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 1352,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 28,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 21,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "generator lifecycle",
+      "language": "python",
+      "note": "yield has suspension and iterator lifecycle semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "generator-yield-lifecycle-contract-missing",
+      "occurrences": 2404,
+      "operation": "yield",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "python.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 86,
+          "path": "sympy/sympy/utilities/iterables.py"
+        },
+        {
+          "occurrences": 83,
+          "path": "black/src/black/linegen.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "scrapy/tests/test_crawl.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sympy/sympy/core/facts.py"
+        },
+        {
+          "occurrences": 39,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 37,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 31,
+          "path": "packaging/src/packaging/tags.py"
+        },
+        {
+          "occurrences": 29,
+          "path": "rich/rich/segment.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 540,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 446,
+          "repo": "sympy"
+        },
+        {
+          "occurrences": 367,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 339,
+          "repo": "rich"
+        },
+        {
+          "occurrences": 172,
+          "repo": "black"
+        },
+        {
+          "occurrences": 139,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 76,
+          "repo": "poetry"
+        },
+        {
+          "occurrences": 64,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Java streams need lazy/eager lifecycle and terminal materialization proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 1996,
+      "operation": "stream/parallelStream",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "java.stream.lifecycle",
+      "top_files": [
+        {
+          "occurrences": 137,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/GeoPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 124,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java"
+        },
+        {
+          "occurrences": 80,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGeospatialCommandsTest.java"
+        },
+        {
+          "occurrences": 75,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 60,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "netty/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java"
+        },
+        {
+          "occurrences": 24,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 535,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 508,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 385,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 280,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 102,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 88,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 29,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 24,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "goroutine scheduling",
+      "language": "go",
+      "note": "go statements spawn concurrent execution",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "repos": 14,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.goroutine",
+      "top_files": [
+        {
+          "occurrences": 52,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "prometheus/discovery/kubernetes/kubernetes.go"
+        },
+        {
+          "occurrences": 23,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 22,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 20,
+          "path": "nats-server/server/jwt_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 501,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 439,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 364,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 253,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 126,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 91,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 60,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 36,
+          "repo": "hugo"
+        }
+      ]
+    },
+    {
+      "boundary": "channel select",
+      "language": "go",
+      "note": "select has readiness, default, and scheduling semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-readiness-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select",
+      "top_files": [
+        {
+          "occurrences": 62,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 58,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 45,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 33,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 31,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "nats-server/server/routes_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "prometheus/scrape/scrape_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 706,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 574,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 279,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 250,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 47,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 25,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 21,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "python",
+      "note": "Python await has coroutine scheduling and exception channel semantics",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 1789,
+      "operation": "await",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "python.async.await",
+      "top_files": [
+        {
+          "occurrences": 145,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 122,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 78,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 72,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 62,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 54,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 50,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 716,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 661,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 200,
+          "repo": "black"
+        },
+        {
+          "occurrences": 196,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 5,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "python",
+      "note": "async def creates coroutine protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 1596,
+      "operation": "async def",
+      "repos": 9,
+      "status": "closed-boundary",
+      "surface": "python.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 75,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 57,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/result.py"
+        },
+        {
+          "occurrences": 53,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "scrapy/tests/test_spidermiddleware.py"
+        },
+        {
+          "occurrences": 40,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 790,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 424,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 209,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 144,
+          "repo": "black"
+        },
+        {
+          "occurrences": 19,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 3,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "channel send synchronization",
+      "language": "go",
+      "note": "Go channel sends have blocking and synchronization semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-synchronization-contract-missing",
+      "occurrences": 1525,
+      "operation": "channel send",
+      "repos": 12,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.send",
+      "top_files": [
+        {
+          "occurrences": 43,
+          "path": "nats-server/server/filestore.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jwt_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "minio/cmd/metrics.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "prometheus/tsdb/head_wal.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/reload_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "etcd/server/etcdserver/server_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "nats-server/server/leafnode_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 474,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 436,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 275,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 189,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 39,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 33,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 28,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 18,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async block construction",
+      "language": "rust",
+      "note": "async blocks create suspended async boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-block-scheduling-contract-missing",
+      "occurrences": 1342,
+      "operation": "async block",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "rust.async.block",
+      "top_files": [
+        {
+          "occurrences": 109,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 86,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 57,
+          "path": "tokio/tokio/tests/task_local_set.rs"
+        },
+        {
+          "occurrences": 43,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 42,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio-util/tests/task_join_map.rs"
+        },
+        {
+          "occurrences": 33,
+          "path": "tokio/tokio/tests/rt_basic.rs"
+        },
+        {
+          "occurrences": 31,
+          "path": "tokio/tokio/tests/task_join_set.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1273,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 5,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "block callback",
+      "language": "ruby",
+      "note": "Ruby yield invokes a block with demand/effect obligations",
+      "obligation_family": "callback-demand-effect",
+      "obligation_subreason": "ruby-yield-callback-demand-effect-contract-missing",
+      "occurrences": 801,
+      "operation": "yield",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.block.yield",
+      "top_files": [
+        {
+          "occurrences": 26,
+          "path": "rubocop/spec/rubocop/cop/style/explicit_block_argument_spec.rb"
+        },
+        {
+          "occurrences": 22,
+          "path": "rspec-core/benchmarks/capture_block_vs_yield.rb"
+        },
+        {
+          "occurrences": 18,
+          "path": "rack/test/spec_deflater.rb"
+        },
+        {
+          "occurrences": 16,
+          "path": "sinatra/lib/sinatra/base.rb"
+        },
+        {
+          "occurrences": 12,
+          "path": "rubocop/spec/rubocop/cop/layout/hash_alignment_spec.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "faraday/lib/faraday/connection.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "rack/test/spec_lint.rb"
+        },
+        {
+          "occurrences": 8,
+          "path": "rspec-core/lib/rspec/core/configuration.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 228,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 98,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 55,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 38,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 36,
+          "repo": "devise"
+        },
+        {
+          "occurrences": 34,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "executor timing",
+      "language": "javascript-typescript",
+      "note": "new Promise needs executor timing, resolve/reject callback, and throw-to-rejection contracts",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.executor",
+      "top_files": [
+        {
+          "occurrences": 46,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 28,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 20,
+          "path": "axios/tests/unit/prototypePollution.test.js"
+        },
+        {
+          "occurrences": 20,
+          "path": "trpc/packages/tests/server/websockets.test.ts"
+        },
+        {
+          "occurrences": 12,
+          "path": "esbuild/scripts/plugin-tests.js"
+        },
+        {
+          "occurrences": 12,
+          "path": "prettier/tests/format/flow/flow-repo/promises/promise.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 151,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 135,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 96,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 89,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 80,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 61,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 55,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 50,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "select default liveness",
+      "language": "go",
+      "note": "Go select defaults change blocking and liveness behavior",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-default-liveness-contract-missing",
+      "occurrences": 546,
+      "operation": "select default",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.default",
+      "top_files": [
+        {
+          "occurrences": 14,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/gateway_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 11,
+          "path": "prometheus/storage/remote/queue_manager.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "etcd/pkg/proxy/server.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "prometheus/tsdb/db.go"
+        },
+        {
+          "occurrences": 9,
+          "path": "nats-server/server/jetstream_cluster_long_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 195,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 144,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 94,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 71,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 13,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 2,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "all-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.all needs ordered all-fulfilled value and first rejection semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "execa/test/convert/concurrent.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 12,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 11,
+          "path": "zod/packages/zod/src/v4/core/schemas.ts"
+        },
+        {
+          "occurrences": 9,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "date-fns/pkgs/docs/src/bin.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "execa/test/pipe/streaming.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 79,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 62,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 60,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 56,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 29,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 17,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 17,
+          "repo": "zod"
+        },
+        {
+          "occurrences": 16,
+          "repo": "date-fns"
+        }
+      ]
+    },
+    {
+      "boundary": "async context lifecycle",
+      "language": "python",
+      "note": "async with needs async enter/exit cleanup, exception-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-context-lifecycle-contract-missing",
+      "occurrences": 361,
+      "operation": "async with",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.context",
+      "top_files": [
+        {
+          "occurrences": 66,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 59,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 33,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 27,
+          "path": "httpx/tests/client/test_auth.py"
+        },
+        {
+          "occurrences": 26,
+          "path": "httpx/tests/client/test_async_client.py"
+        },
+        {
+          "occurrences": 14,
+          "path": "scrapy/tests/test_scheduler.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "scrapy/tests/test_downloadermiddleware.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 169,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 95,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 77,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 19,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "task spawn",
+      "language": "rust",
+      "note": "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "rust.async.spawn",
+      "top_files": [
+        {
+          "occurrences": 32,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 18,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 16,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 12,
+          "path": "tokio/tokio/tests/task_abort.rs"
+        },
+        {
+          "occurrences": 11,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "meilisearch/crates/meilisearch/src/routes/indexes/documents.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/net_named_pipe.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 284,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 62,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "future channel",
+      "language": "java",
+      "note": "CompletableFuture needs success/error channel and scheduling proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 276,
+      "operation": "CompletableFuture",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "java.future.completable",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "retrofit/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 112,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 64,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 55,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 29,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 7,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 6,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "cancellation signal",
+      "language": "javascript-typescript",
+      "note": "AbortSignal/AbortController can change scheduling and rejection outcomes",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "js-ts.cancellation.abort",
+      "top_files": [
+        {
+          "occurrences": 18,
+          "path": "execa/test/terminate/cancel.js"
+        },
+        {
+          "occurrences": 18,
+          "path": "execa/test/ipc/graceful.js"
+        },
+        {
+          "occurrences": 14,
+          "path": "execa/test/terminate/graceful.js"
+        },
+        {
+          "occurrences": 13,
+          "path": "trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test-d/arguments/options.test-d.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test/pipe/abort.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "trpc/packages/client/src/internals/signals.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 108,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 87,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 30,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 17,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 8,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 4,
+          "repo": "pixijs"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle get",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose blocking settled-value and exception channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 249,
+      "operation": "Future.get",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.get",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 83,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 28,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 23,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 13,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 11,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 8,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle cancellation",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose cancellation and task-handle liveness boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 239,
+      "operation": "Future.cancel/isCancelled",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.cancel",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 104,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 101,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 14,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 3,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service future scheduling",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService receivers schedule callbacks and return Future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 222,
+      "operation": "ExecutorService.submit",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.submit",
+      "top_files": [
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 90,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 72,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 27,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 6,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 5,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 4,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 4,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task scheduling",
+      "language": "swift",
+      "note": "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 215,
+      "operation": "Task/Task.detached",
+      "repos": 12,
+      "status": "closed-boundary",
+      "surface": "swift.task.spawn",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift"
+        },
+        {
+          "occurrences": 21,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "rxswift/Sources/AllTestz/PrimitiveSequence+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 63,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 35,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 31,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 23,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 23,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 16,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 6,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "swift",
+      "note": "Swift async sequence loops need async iterator lifecycle, value-channel, scheduling, and throwing-channel proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 193,
+      "operation": "for await/for try await",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Sources/ServiceLifecycle/ServiceGroup.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxswift/Sources/AllTestz/Observable+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 72,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 67,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 13,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "executor runnable scheduling",
+      "language": "java",
+      "note": "Import-backed Java Executor receivers schedule callback execution without returning a task handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 180,
+      "operation": "Executor.execute",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor.execute",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "netty/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "mockito/mockito-core/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 114,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 38,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 2,
+          "repo": "gson"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing closure error channel",
+      "language": "swift",
+      "note": "Swift throwing closures expose the same error-channel obligation as throwing functions and async throwing closures",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 169,
+      "operation": "closure throws/rethrows",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_closure",
+      "top_files": [
+        {
+          "occurrences": 16,
+          "path": "swift-collections/Tests/DequeTests/RigidDequeTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "vapor/Tests/VaporTests/QueryTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "vapor/Tests/VaporTests/ContentTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Sources/AllTestz/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Tests/VaporMacroTests/AuthMiddlewareMacroTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 58,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 52,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 38,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "task sleep timer",
+      "language": "swift",
+      "note": "Swift Task.sleep creates a timer-backed scheduling boundary and cancellation/liveness boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 161,
+      "operation": "Task.sleep",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.sleep",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-nio/Tests/NIOPosixTests/EventLoopTest.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Tests/KingfisherTests/KingfisherManagerTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "nimble/Tests/NimbleTests/AsyncAwaitTest.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 71,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 32,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 10,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive status",
+      "language": "go",
+      "note": "Go comma-ok receives expose the channel close status as an additional protocol result",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-status-contract-missing",
+      "occurrences": 155,
+      "operation": "comma-ok channel receive",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive_status",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 12,
+          "path": "etcd/tests/integration/clientv3/lease/lease_test.go"
+        },
+        {
+          "occurrences": 6,
+          "path": "etcd/tests/integration/cache_test.go"
+        },
+        {
+          "occurrences": 5,
+          "path": "etcd/tests/integration/v3_election_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "etcd/cache/cache_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/admin-handlers.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/internal/grid/muxclient.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 84,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 48,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 11,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 5,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 1,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "task-group aggregate",
+      "language": "swift",
+      "note": "Swift task groups need all-completion, result-channel, cancellation/liveness, and throwing error-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 153,
+      "operation": "withTaskGroup/withThrowingTaskGroup/withDiscardingTaskGroup/withThrowingDiscardingTaskGroup",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.group",
+      "top_files": [
+        {
+          "occurrences": 31,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 18,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 14,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 9,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/CancellationTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 68,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 4,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 3,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 1,
+          "repo": "fastlane"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle lifecycle",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose task-handle lifecycle status",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "task-handle-lifecycle-contract-missing",
+      "occurrences": 127,
+      "operation": "Future.isDone",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.status",
+      "top_files": [
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 61,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 49,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 10,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "python",
+      "note": "async for statements and comprehensions need async iterator lifecycle, value-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 114,
+      "operation": "async for",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "httpx/tests/test_content.py"
+        },
+        {
+          "occurrences": 16,
+          "path": "httpx/tests/models/test_responses.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "black/tests/data/cases/python37.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "httpx/httpx/_models.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_spidermiddleware_referer.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/starred_for_target.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 48,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 30,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 20,
+          "repo": "black"
+        },
+        {
+          "occurrences": 15,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timer",
+      "language": "python",
+      "note": "asyncio sleep creates a timer-backed scheduling boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 104,
+      "operation": "asyncio.sleep",
+      "repos": 6,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.sleep",
+      "top_files": [
+        {
+          "occurrences": 48,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 9,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "flask/tests/test_async.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_command_parse.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_utils_defer.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 3,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 59,
+          "repo": "black"
+        },
+        {
+          "occurrences": 32,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "async closure scheduling",
+      "language": "swift",
+      "note": "Swift async closures create async callable protocol boundaries even when the surrounding function is synchronous",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 100,
+      "operation": "async closure",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.closure",
+      "top_files": [
+        {
+          "occurrences": 29,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "vapor/Tests/VaporTests/AuthenticationTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "swift-composable-architecture/Benchmarks/Benchmarks/swift-composable-architecture-benchmark/Benchmarks.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "vapor/Tests/VaporTests/MiddlewareTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "vapor/Tests/VaporTests/RouteTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "nimble/Tests/NimbleTests/Matchers/EqualTest.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 86,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-nio"
+        }
+      ]
+    },
+    {
+      "boundary": "thread/fiber scheduling",
+      "language": "ruby",
+      "note": "Thread/Fiber APIs create scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 74,
+      "operation": "Thread/Fiber",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.thread.fiber",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "puma/test/test_cli.rb"
+        },
+        {
+          "occurrences": 6,
+          "path": "rack/test/spec_multipart.rb"
+        },
+        {
+          "occurrences": 4,
+          "path": "puma/test/test_pumactl.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/test/test_thread_pool.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/lib/puma/cluster/worker.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/benchmarks/local/response_time_wrk.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "fastlane/fastlane/lib/fastlane/swift_lane_manager.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "puma/test/test_puma_server_ssl.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 36,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 10,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 10,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jekyll"
+        },
+        {
+          "occurrences": 2,
+          "repo": "asciidoctor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rspec-core"
+        }
+      ]
+    },
+    {
+      "boundary": "interval lifecycle",
+      "language": "javascript-typescript",
+      "note": "setInterval and timers interval streams have repeated emission, cancellation, and liveness semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.interval",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjs/packages/rxjs/spec/Observable-spec.ts"
+        },
+        {
+          "occurrences": 4,
+          "path": "swr/test/use-swr-subscription.test.tsx"
+        },
+        {
+          "occurrences": 3,
+          "path": "drizzle-orm/drizzle-kit/src/cli/views.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/example/src/main/resources/io/netty/example/stomp/websocket/stomp.js"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/src/internal/scheduler/intervalProvider.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/spec/schedulers/TestScheduler-spec.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 16,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 7,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 7,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 6,
+          "repo": "swr"
+        },
+        {
+          "occurrences": 3,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "thread scheduling",
+      "language": "c",
+      "note": "pthread_create introduces thread scheduling and lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "c-pthread-scheduling-contract-missing",
+      "occurrences": 68,
+      "operation": "pthread_create",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "c.thread.pthread",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "redis/tests/modules/blockedclient.c"
+        },
+        {
+          "occurrences": 3,
+          "path": "redis/tests/modules/blockonbackground.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/name-hash.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/transport-helper.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/read-cache.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/fsmonitor--daemon.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/pack-objects.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/helper/test-trace2.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 23,
+          "repo": "git"
+        },
+        {
+          "occurrences": 7,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 5,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 3,
+          "repo": "libuv"
+        },
+        {
+          "occurrences": 2,
+          "repo": "raylib"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jq"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nginx"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime join style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "repos": 2,
+      "status": "closed-boundary",
+      "surface": "rust.async.join",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_try_join.rs"
+        },
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_try_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_join.rs"
+        },
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "meilisearch/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 67,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 1,
+          "repo": "meilisearch"
+        }
+      ]
+    },
+    {
+      "boundary": "structured task binding",
+      "language": "swift",
+      "note": "Swift async let creates a child task with scheduling, handle lifecycle, cancellation/liveness, and awaited result boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 51,
+      "operation": "async let",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.let",
+      "top_files": [
+        {
+          "occurrences": 17,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 16,
+          "path": "alamofire/Tests/OfflineRetrierTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "vapor/Tests/VaporTests/EndpointCacheTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 33,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 5,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift throwing continuation bridge",
+      "language": "swift",
+      "note": "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 43,
+      "operation": "withCheckedThrowingContinuation/withUnsafeThrowingContinuation",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.throwing",
+      "top_files": [
+        {
+          "occurrences": 8,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-nio/Sources/NIOCore/AsyncAwaitSupport.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/Sources/RxSwift/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOPosix/NIOThreadPool.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingChannel.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/BufferedStream.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOFS/Internal/BufferedStream.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 18,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 13,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 1,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "first-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.race needs first-settled ordering and liveness proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "execa/test/convert/iterable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/setup/server.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/convert/readable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "ky/source/core/Ky.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/client/src/links/localLink.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/mysql2/session.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/singlestore/session.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 15,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 4,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 3,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 3,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 2,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift continuation bridge",
+      "language": "swift",
+      "note": "Swift continuation bridges suspend and resume through a callback-settled future-like result channel",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 30,
+      "operation": "withCheckedContinuation/withUnsafeContinuation",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.checked",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "alamofire/Tests/RequestInterceptorTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingEventLoop.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NIOThreadPoolTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "alamofire/Source/Features/Concurrency.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/Concurrency Primitives/TokenBucket.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/NIOFS/Internal/Concurrency Primitives/TokenBucket.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 7,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor timer",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService schedule calls add timer-backed task scheduling and Future result channels",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 27,
+      "operation": "ScheduledExecutorService.schedule",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.schedule",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadWorker.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio future drive",
+      "language": "python",
+      "note": "asyncio.run drives a coroutine to completion with scheduling, result-channel, and exception boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "future-drive-scheduling-contract-missing",
+      "occurrences": 23,
+      "operation": "asyncio.run",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/_concurrency_fixtures.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/tests/test_concurrency_manager_shutdown.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "curl/tests/http/testenv/ws_echo_server.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/AsyncCrawlerRunner/reactorless_simple.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor interval lifecycle",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService repeating schedules expose interval lifecycle and cancellation boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 22,
+      "operation": "ScheduledExecutorService.scheduleAtFixedRate/scheduleWithFixedDelay",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.interval",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "jedis/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "commons-lang"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service all-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAll waits for all submitted tasks and returns Future result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 21,
+      "operation": "ExecutorService.invokeAll",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_all",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "all-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.allSettled needs settled-record channel and shape proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-settled-contract-missing",
+      "occurrences": 17,
+      "operation": "Promise.allSettled",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/lib/resolve/wait-subprocess.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "jest/packages/jest-haste-map/src/watchers/index.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/streaming.test.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/adapters/standalone.test.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/pipe/setup.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/resolve/exit-async.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/buffer-messages.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/convert/concurrent.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 5,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 2,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio all-completion aggregate",
+      "language": "python",
+      "note": "asyncio gather needs all-completion, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "repos": 4,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.gather",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/examples/asyncio/gather_orm_statements.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_downloadermiddleware_robotstxt.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/pipelines/media.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "black"
+        },
+        {
+          "occurrences": 6,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "future settled value",
+      "language": "java",
+      "note": "CompletableFuture settled factories create fulfilled or exceptional future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 14,
+      "operation": "CompletableFuture.completedFuture/failedFuture",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.factory",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 13,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio task spawn",
+      "language": "python",
+      "note": "asyncio task APIs create scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.task",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/core/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/defer.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "black"
+        }
+      ]
+    },
+    {
+      "boundary": "non-local jump",
+      "language": "c",
+      "note": "setjmp/longjmp is non-local control flow, not ordinary return",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "c-nonlocal-jump-contract-missing",
+      "occurrences": 13,
+      "operation": "setjmp/longjmp",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "c.nonlocal_jump",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "sqlite/autosetup/jimsh0.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/unit-tests/clar/clar.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "lua/ltests.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "redis/modules/vector-sets/fastjson_test.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "vim/src/if_python3.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 2,
+          "repo": "git"
+        },
+        {
+          "occurrences": 2,
+          "repo": "lua"
+        },
+        {
+          "occurrences": 2,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vim"
+        }
+      ]
+    },
+    {
+      "boundary": "future task spawn",
+      "language": "java",
+      "note": "CompletableFuture async factories schedule executor callbacks and return future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "CompletableFuture.supplyAsync/runAsync",
+      "repos": 4,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.spawn",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task yield",
+      "language": "swift",
+      "note": "Swift Task.yield yields to the task scheduler and must not collapse into sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-yield-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "Task.yield",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.yield",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-composable-architecture/Sources/ComposableArchitecture/TestStore.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/DebugTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduler yield",
+      "language": "javascript-typescript",
+      "note": "scheduler.yield needs microtask/order proof",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "scheduler-yield-microtask-order-contract-missing",
+      "occurrences": 11,
+      "operation": "scheduler.yield",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.scheduler",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/generator.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/web-transform.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/duplex.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/graceful.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/incoming.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/ipc/get-each.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/transform/generator-main.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/convert/writable.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 11,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "future settlement continuation",
+      "language": "java",
+      "note": "Future-like receivers need settlement continuation and callback demand/effect proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settlement-continuation-contract-missing",
+      "occurrences": 10,
+      "operation": "FutureLike.handle/whenComplete",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completion_stage.settlement",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 9,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "imported future all-completion aggregate",
+      "language": "rust",
+      "note": "import-backed tokio/futures/futures_util join-style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 8,
+      "operation": "use runtime::join; join!",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join.imported",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "tokio/tokio/tests/tcp_connect.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tests-integration/tests/process_stdio.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/tcp_stream.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service first-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAny exposes first-success completion, cancellation, and exception boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 6,
+      "operation": "ExecutorService.invokeAny",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_any",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio cancellation shield",
+      "language": "python",
+      "note": "asyncio.shield changes cancellation propagation while preserving an awaitable result channel",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 5,
+      "operation": "asyncio.shield",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.shield",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "sqlalchemy/lib/sqlalchemy/connectors/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlalchemy"
+        }
+      ]
+    },
+    {
+      "boundary": "future first-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime select style macros need first-completion, cancellation, and result-channel proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 5,
+      "operation": "tokio/futures/futures_util select",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "rust.async.select",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/examples/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "java",
+      "note": "CompletableFuture.allOf needs all-completion and exceptional completion proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "CompletableFuture.allOf",
+      "repos": 2,
+      "status": "reporting-candidate-closed-boundary",
+      "surface": "java.future.completable.all",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio completion aggregate",
+      "language": "python",
+      "note": "asyncio wait needs completion-selection, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "asyncio.wait",
+      "repos": 3,
+      "status": "closed-boundary",
+      "surface": "python.asyncio.wait",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/extensions/feedexport.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timeout wait",
+      "language": "python",
+      "note": "asyncio.wait_for adds timer and cancellation/liveness boundaries around an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "asyncio.wait_for",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait_for",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/util/queue.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "imported task spawn",
+      "language": "rust",
+      "note": "import-backed tokio/async-std spawn bindings introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn.imported",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_handle_block_on.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread-safe task submission",
+      "language": "python",
+      "note": "asyncio.run_coroutine_threadsafe schedules a coroutine onto another loop and returns a future handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "asyncio.run_coroutine_threadsafe",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run_coroutine_threadsafe",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/shell.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/commands/shell.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "imported asyncio timer",
+      "language": "python",
+      "note": "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "from asyncio import sleep; binding",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.imported.sleep",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spider_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "first-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.any needs first-fulfilled and AggregateError rejection proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-first-fulfilled-contract-missing",
+      "occurrences": 1,
+      "operation": "Promise.any",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "jest/packages/expect/src/__tests__/toThrowMatchers.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "jest"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread offload",
+      "language": "python",
+      "note": "asyncio.to_thread schedules a callback on a worker thread and returns an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 1,
+      "operation": "asyncio.to_thread",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.to_thread",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "scrapy"
+        }
+      ]
+    }
+  ],
+  "tracking_issue": {
+    "number": 602,
+    "url": "https://github.com/corca-ai/nose/issues/602"
+  }
+}

--- a/crates/nose-semantics/src/demand.rs
+++ b/crates/nose-semantics/src/demand.rs
@@ -29,6 +29,7 @@ pub enum EvaluationOrder {
     ShortCircuit,
     PerElementSourceOrder,
     DeferredUntilObserved,
+    DeferredUntilScopeExit,
     RuntimeScheduled,
     ProtocolDefined,
 }
@@ -255,6 +256,8 @@ pub enum CallbackInvocationDemand {
     LeftFoldStep,
     AsyncContinuation,
     SourceOrderCallback,
+    ScheduledCallback,
+    DeferredCallback,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -274,6 +277,7 @@ pub enum CallbackResultDemand {
     Accumulator,
     ContinuationValue,
     CallbackReturnValue,
+    Ignored,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -313,6 +317,22 @@ impl CallbackDemandProfile {
             invocation: CallbackInvocationDemand::SourceOrderCallback,
             arguments: CallbackArgumentDemand::PassedArguments,
             result: CallbackResultDemand::CallbackReturnValue,
+        }
+    }
+
+    pub const fn scheduled_callback() -> Self {
+        Self {
+            invocation: CallbackInvocationDemand::ScheduledCallback,
+            arguments: CallbackArgumentDemand::PassedArguments,
+            result: CallbackResultDemand::Ignored,
+        }
+    }
+
+    pub const fn deferred_callback() -> Self {
+        Self {
+            invocation: CallbackInvocationDemand::DeferredCallback,
+            arguments: CallbackArgumentDemand::PassedArguments,
+            result: CallbackResultDemand::Ignored,
         }
     }
 }
@@ -525,9 +545,21 @@ pub fn source_protocol_demand_effect_profile(protocol: SourceProtocolKind) -> De
             callback: None,
             effect_visibility: EffectVisibility::ChannelBoundary,
         },
-        SourceProtocolKind::Defer
-        | SourceProtocolKind::GoRoutine
-        | SourceProtocolKind::TaskSpawn => DemandEffectProfile {
+        SourceProtocolKind::Defer => DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::DeferredUntilScopeExit,
+            child_demand: ChildDemand::ProtocolBoundary,
+            callback: Some(CallbackDemandProfile::deferred_callback()),
+            effect_visibility: EffectVisibility::ProtocolBoundary,
+        },
+        SourceProtocolKind::GoRoutine => DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::RuntimeScheduled,
+            child_demand: ChildDemand::ProtocolBoundary,
+            callback: Some(CallbackDemandProfile::scheduled_callback()),
+            effect_visibility: EffectVisibility::ProtocolBoundary,
+        },
+        SourceProtocolKind::TaskSpawn => DemandEffectProfile {
             operation: DemandOperation::ProtocolBoundary,
             order: EvaluationOrder::ProtocolDefined,
             child_demand: ChildDemand::ProtocolBoundary,

--- a/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
+++ b/crates/nose-semantics/src/tests/library_api_contracts/demand_effect.rs
@@ -254,8 +254,14 @@ fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
         EffectVisibility::ChannelBoundary
     );
     assert_eq!(
-        source_protocol_demand_effect_profile(SourceProtocolKind::GoRoutine).operation,
-        DemandOperation::ProtocolBoundary
+        source_protocol_demand_effect_profile(SourceProtocolKind::GoRoutine),
+        DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::RuntimeScheduled,
+            child_demand: ChildDemand::ProtocolBoundary,
+            callback: Some(CallbackDemandProfile::scheduled_callback()),
+            effect_visibility: EffectVisibility::ProtocolBoundary,
+        }
     );
     assert_eq!(
         source_protocol_demand_effect_profile(SourceProtocolKind::TaskSpawn).effect_visibility,
@@ -270,8 +276,14 @@ fn promise_and_protocol_demand_profiles_keep_async_boundaries() {
         ChildDemand::ProtocolBoundary
     );
     assert_eq!(
-        source_protocol_demand_effect_profile(SourceProtocolKind::Defer).effect_visibility,
-        EffectVisibility::ProtocolBoundary
+        source_protocol_demand_effect_profile(SourceProtocolKind::Defer),
+        DemandEffectProfile {
+            operation: DemandOperation::CallbackInvocation,
+            order: EvaluationOrder::DeferredUntilScopeExit,
+            child_demand: ChildDemand::ProtocolBoundary,
+            callback: Some(CallbackDemandProfile::deferred_callback()),
+            effect_visibility: EffectVisibility::ProtocolBoundary,
+        }
     );
     assert_eq!(
         source_protocol_demand_effect_profile(SourceProtocolKind::Yield).operation,

--- a/docs/demand-effect-semantics.md
+++ b/docs/demand-effect-semantics.md
@@ -13,14 +13,16 @@ axes:
 - operation class: eager, fold reduction, short-circuit quantifier, append
   mutation, nullish default, per-element HOF, pull-lazy HOF, call-by-need thunk,
   async continuation, generator suspension, source-order callback invocation,
-  channel operation, or protocol boundary;
+  scheduled/deferred callback invocation, channel operation, or protocol
+  boundary;
 - evaluation order: source order, short-circuit, per-element source order,
   deferred until observation, runtime scheduled, or protocol-defined;
 - child demand: always, never, conditional, short-circuit-until-known,
   per-element-pull, maybe repeated, call-by-need memoized, suspended until
   observed, async continuation, channel boundary, or protocol boundary;
 - callback demand, when present: per-element callback, fold step, async
-  continuation, or source callback invocation, with argument/result roles;
+  continuation, source callback invocation, scheduled callback, or deferred
+  callback, with argument/result roles;
 - effect visibility: immediate, only-if-demanded, delayed-until-pull,
   memoized-first-demand, async boundary, yield boundary, channel boundary, or
   protocol boundary.
@@ -106,7 +108,8 @@ Source protocol boundaries have internal profiles for future contracts:
 - JS/TS and Python generator `yield` is a generator suspension boundary;
 - Ruby block `yield` is a source-order callback invocation boundary;
 - Go channel/select surfaces are channel boundaries;
-- Go goroutine/defer surfaces are protocol boundaries, not channel operations;
+- Go goroutine surfaces are scheduled callback protocol boundaries, while
+  `defer` surfaces are scope-exit deferred callback protocol boundaries;
 - Rust `?` is a conditional short-circuit boundary.
 
 ## Current consumers

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -298,6 +298,9 @@ matching [120-repo
 pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
 marks `ruby.block.yield` reporting-supported, prices `801` occurrences
 across `17` repos, and the checked `crates` gate reports `0` false merges.
+The follow-up [Go protocol reporting-support artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
+marks Go channel/send/receive/select, goroutine, and defer source-protocol rows
+reporting-supported while keeping exact admission closed.
 The
 checked [promise-protocol diagnostics](../bench/recall_loss/promise-protocol-diagnostics-2026-06-28.v1.json)
 connect the JS/TS source-prevalence group (`29,094` Promise/async occurrences)

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -231,6 +231,16 @@ callback argument/result role, effect visibility, non-local control, and
 exception behavior are proven. The 120-repo audit prices `801` Ruby yield
 occurrences across `17` repos and marks the row reporting-supported
 closed-boundary.
+
+The follow-up [Go protocol reporting-support artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
+keeps exact admission closed while aligning Go protocol reporting with the
+existing source-backed lowering and runtime obligations. Go `go` now carries a
+scheduled callback demand/effect profile, `defer` carries a scope-exit deferred
+callback profile, and channel/select protocol rows are marked
+reporting-supported closed-boundaries. The 120-repo audit keeps the same Go
+source prevalence: `17,521` defers, `4,294` channel receives, `3,590` select
+cases, `1,949` goroutines, `1,920` select parents, `1,525` channel sends, `546`
+select defaults, and `155` comma-ok receives.
 The follow-up [non-JS async runtime scope-shadowing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
 keeps the same reporting-only boundary while making Python/Rust runtime
 attribution scope-aware. Python `asyncio` aliases/imported bindings and Rust
@@ -516,7 +526,7 @@ cardinality, and cancellation cleanup are dependency-closed obligations.
 | success/error result channel | `Domain(Option/Result/FutureLike/PromiseLike)`, constructor/predicate rows, default contracts | success, empty, default, error, panic, and rejection channels must remain distinct |
 | exception channel | `Source::Protocol`, static-error control, effect-free throw checks | thrown/rescued/non-local control must not be collapsed into ordinary return values |
 | rejection channel | Promise/Future-like contracts and async demand profiles | rejected values, catch/then continuations, finally settlement, aggregate rejection, and thenable assimilation stay closed until proven |
-| scheduling boundary | `DemandOperation::AsyncContinuation`, `GeneratorSuspension`, `ChannelOperation`, `ProtocolBoundary` | task/thread/goroutine/microtask timing is not synchronous equivalence proof |
+| scheduling boundary | `DemandOperation::AsyncContinuation`, `GeneratorSuspension`, `CallbackInvocation`, `ChannelOperation`, `ProtocolBoundary` | task/thread/goroutine/microtask timing is not synchronous equivalence proof |
 | cancellation/early exit | short-circuit demand profiles and future protocol facts | cancellation, stop, break, first-settled, and early-exit behavior must be explicit |
 | lifecycle/materialization | `SequenceSurface`, `Domain`, iterator adapter/materializer rows | one-shot views, reusable collections, type-directed materializers, and allocation/lifetime are separate |
 | receiver mutation | `Effect(ReceiverMutation)`, place/effect contracts | mutation can close later exact receiver use; it does not create pure value equality |
@@ -525,8 +535,8 @@ cardinality, and cancellation cleanup are dependency-closed obligations.
 ## Existing Mapping
 
 - `DemandEffectProfile` already carries eager, fold, short-circuit, lazy HOF,
-  async continuation, generator, channel, and protocol-boundary timing. This is
-  the contract side of the vocabulary.
+  async continuation, generator, scheduled/deferred callback, channel, and
+  protocol-boundary timing. This is the contract side of the vocabulary.
 - `Source` facts anchor syntax/protocol distinctions such as await, async
   functions, yield, casts, calls, comprehensions, ranges, and patterns. They do
   not approve exact clones by themselves.

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -1260,8 +1260,8 @@ repeated registry walks on hot paths. Binary size changed 20,181,712 ->
   map/flat-map/filter-map/filter/reduce, pull-lazy Python generator expressions,
   eager JS-like/Ruby library HOFs, pull-lazy Rust iterator/Java Stream HOFs,
   async continuation boundaries, generator suspension, source-order callback
-  invocation, channel boundaries, and non-channel protocol boundaries. The
-  oracle consumes those profiles for
+  invocation, scheduled/deferred callback invocation, channel boundaries, and
+  non-channel protocol boundaries. The oracle consumes those profiles for
   admitted builtins instead of matching local demand enums; value-graph HOF
   callback exception timing, HOF materialization gates, strict-exact HOF gates,
   and Promise `.then` beta-reduction also read shared profiles. API admission
@@ -2418,6 +2418,17 @@ Exact admission remains closed until block identity, callback argument/result
 roles, effect visibility, non-local control, and exception behavior are proven.
 The 120-repo audit prices `801` Ruby yield occurrences across `17` repos, and
 the checked `crates` gate remains at `0` false merges.
+
+2026-07-01 Go protocol reporting-support note:
+The [scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
+artifact aligns the existing Go source protocol support with the shared
+demand/effect vocabulary. `go` statements now profile as runtime-scheduled
+callbacks and `defer` statements as scope-exit deferred callbacks. Channel
+send/receive, receive-status, select, select-case, select-default, goroutine,
+and defer rows are reporting-supported closed-boundaries in the 120-repo audit.
+Exact channel/goroutine/defer admission remains closed until scheduling,
+blocking, close/status, readiness, callback effect, panic/defer ordering, and
+liveness contracts are proven.
 
 ## See also
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -54,8 +54,8 @@ applying materialization or demand-sensitive laws. Admitted builtin and HOF
 operations now also have internal `DemandEffectProfile` contracts for the
 currently supported eager, short-circuit, append, nullish-default, reduction,
 per-element callback, pull-lazy generator, async-continuation, generator
-suspension, source-order callback invocation, channel-boundary, and
-protocol-boundary shapes; these profiles
+suspension, source-order callback invocation, scheduled/deferred callback
+invocation, channel-boundary, and protocol-boundary shapes; these profiles
 describe how an already-admitted operation is consumed, not which source API is
 admitted. HOF callback timing comes from an explicit source or API demand source,
 not from the raw HOF kind alone. The node-level HOF resolver distinguishes

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -203,12 +203,12 @@ The implemented builtin substrate now names these as
 `DemandEffectProfile` contracts for admitted operations. The profiles cover
 current eager, short-circuit, eager HOF, pull-lazy HOF/generator, async
 continuation, generator suspension, source-order callback invocation,
-channel-boundary, and protocol-boundary classes. HOF timing must come from an
-explicit source or API demand source; the node-level resolver distinguishes
-source comprehensions, eager JS-like/Ruby library HOFs, and pull-lazy Rust/Java
-library HOFs. The profiles describe how an already-proven operation is consumed;
-they do not prove that a selector or raw source protocol anchor has that
-meaning.
+scheduled/deferred callback invocation, channel-boundary, and
+protocol-boundary classes. HOF timing must come from an explicit source or API
+demand source; the node-level resolver distinguishes source comprehensions,
+eager JS-like/Ruby library HOFs, and pull-lazy Rust/Java library HOFs. The
+profiles describe how an already-proven operation is consumed; they do not
+prove that a selector or raw source protocol anchor has that meaning.
 
 ### Values and domains
 

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -114,10 +114,10 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("rust", "rust.async.spawn", "tokio/async-std spawn", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "task spawn", "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries", re.compile(r"\b(?:tokio(?:::task)?|async_std::task)\s*::\s*spawn(?:_blocking)?\s*\(")),
     Pattern("rust", "rust.async.join", "tokio/futures/futures_util join/try_join", "success-error-result-channel", "async-aggregate-all-completion-contract-missing", "future all-completion aggregate", "qualified runtime join style macros need all-completion result-channel proof", re.compile(r"\b(?:tokio|futures|futures_util)::(?:join|try_join)!\s*\(")),
     Pattern("rust", "rust.async.select", "tokio/futures/futures_util select", "cancellation-liveness-boundary", "async-aggregate-first-completion-contract-missing", "future first-completion aggregate", "qualified runtime select style macros need first-completion, cancellation, and result-channel proof", re.compile(r"\b(?:tokio|futures|futures_util)::select!\s*\(")),
-    Pattern("go", "go.concurrent.goroutine", "go statement", "scheduling-boundary", "goroutine-scheduling-contract-missing", "goroutine scheduling", "go statements spawn concurrent execution", re.compile(r"\bgo\s+[A-Za-z_{(]")),
-    Pattern("go", "go.concurrent.defer", "defer statement", "lifecycle-materialization-boundary", "defer-lifecycle-ordering-contract-missing", "defer lifecycle", "defer has scope-exit ordering and panic interaction semantics", re.compile(r"\bdefer\s+")),
+    Pattern("go", "go.concurrent.goroutine", "go statement", "scheduling-boundary", "goroutine-scheduling-contract-missing", "goroutine scheduling", "go statements spawn concurrent execution", re.compile(r"\bgo\s+[A-Za-z_{(]"), "reporting-supported-closed-boundary"),
+    Pattern("go", "go.concurrent.defer", "defer statement", "lifecycle-materialization-boundary", "defer-lifecycle-ordering-contract-missing", "defer lifecycle", "defer has scope-exit ordering and panic interaction semantics", re.compile(r"\bdefer\s+"), "reporting-supported-closed-boundary"),
     Pattern("go", "go.channel.send_receive", "channel send/receive", "channel-boundary", "channel-send-receive-protocol-contract-missing", "channel protocol", "channel send/receive has blocking and synchronization semantics", re.compile(r"<-")),
-    Pattern("go", "go.channel.select", "select", "channel-boundary", "channel-select-readiness-contract-missing", "channel select", "select has readiness, default, and scheduling semantics", re.compile(r"\bselect\s*\{")),
+    Pattern("go", "go.channel.select", "select", "channel-boundary", "channel-select-readiness-contract-missing", "channel select", "select has readiness, default, and scheduling semantics", re.compile(r"\bselect\s*\{"), "reporting-supported-closed-boundary"),
     Pattern("java", "java.future.completable", "CompletableFuture", "success-error-result-channel", "future-settled-value-channel-contract-missing", "future channel", "CompletableFuture needs success/error channel and scheduling proof", re.compile(r"\bCompletableFuture\b(?!\s*\.\s*(?:supplyAsync|runAsync|completedFuture|completedStage|failedFuture|failedStage|allOf|anyOf)\s*\()")),
     Pattern("java", "java.future.completable.spawn", "CompletableFuture.supplyAsync/runAsync", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "future task spawn", "CompletableFuture async factories schedule executor callbacks and return future handles", re.compile(r"\bCompletableFuture\s*\.\s*(?:supplyAsync|runAsync)\s*\("), "reporting-candidate-closed-boundary"),
     Pattern("java", "java.future.completable.factory", "CompletableFuture.completedFuture/failedFuture", "success-error-result-channel", "future-settled-value-channel-contract-missing", "future settled value", "CompletableFuture settled factories create fulfilled or exceptional future channels", re.compile(r"\bCompletableFuture\s*\.\s*(?:completedFuture|completedStage|failedFuture|failedStage)\s*\("), "reporting-candidate-closed-boundary"),
@@ -539,6 +539,7 @@ GO_CHANNEL_SEND = Pattern(
     "channel send synchronization",
     "Go channel sends have blocking and synchronization semantics",
     re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
 )
 GO_CHANNEL_RECEIVE = Pattern(
     "go",
@@ -549,6 +550,7 @@ GO_CHANNEL_RECEIVE = Pattern(
     "channel receive value",
     "Go channel receives have blocking, synchronization, and close/zero-value channel semantics",
     re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
 )
 GO_CHANNEL_RECEIVE_STATUS = Pattern(
     "go",
@@ -559,6 +561,7 @@ GO_CHANNEL_RECEIVE_STATUS = Pattern(
     "channel receive status",
     "Go comma-ok receives expose the channel close status as an additional protocol result",
     re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
 )
 GO_CHANNEL_SELECT_CASE = Pattern(
     "go",
@@ -569,6 +572,7 @@ GO_CHANNEL_SELECT_CASE = Pattern(
     "select case selection",
     "Go select cases require readiness, case-selection, and send/receive side-effect proof",
     re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
 )
 GO_CHANNEL_SELECT_DEFAULT = Pattern(
     "go",
@@ -579,6 +583,7 @@ GO_CHANNEL_SELECT_DEFAULT = Pattern(
     "select default liveness",
     "Go select defaults change blocking and liveness behavior",
     re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
 )
 SWIFT_THROWING_FUNCTION = Pattern(
     "swift",


### PR DESCRIPTION
## Summary
- model Go `go` and `defer` as scheduled/deferred callback demand profiles instead of generic protocol boundaries
- mark Go goroutine/defer/channel/select protocol rows as reporting-supported closed boundaries in the lifecycle audit
- record Go protocol audit, query-regression evidence, changelog, and semantic-kernel docs

## Evidence
- Go protocol corpus rows now reporting-supported: 31,500 occurrences
  - `go.concurrent.defer`: 17,521 occurrences / 16 repos
  - `go.channel.receive`: 4,294 / 13
  - `go.channel.select.case`: 3,590 / 13
  - `go.concurrent.goroutine`: 1,949 / 14
  - `go.channel.select`: 1,920 / 13
  - `go.channel.send`: 1,525 / 12
  - `go.channel.select.default`: 546 / 10
  - `go.channel.receive_status`: 155 / 9
- `verify crates`: 6,962 total units, 969 interpretable, 5,993 excluded, 811 admission rejections, 0 false merges, 0 canon violations
- Go-heavy query regression subset (`nats-server`, `etcd`, `minio`, `prometheus`, `badger`, `delve`): 3,560.13ms -> 3,563.06ms (`+0.08%`), 6/6 product hashes identical

## Validation
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py`
- `cargo test -p nose-semantics promise_and_protocol_demand_profiles_keep_async_boundaries --lib -- --nocapture`
- `cargo test -p nose-frontend go::tests::go_defer_and_channel_operations_preserve_source_backed_protocol_boundaries --lib -- --nocapture`
- `cargo test -p nose-cli go_select_defer_and_goroutine_boundaries_report_specific_obligations --lib -- --nocapture`
- `cargo test -p nose-cli goroutine_and_defer_labels_have_specific_obligations --lib -- --nocapture`
- `cargo test -p nose-cli --test cli query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence -- --nocapture`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.go-protocol-reporting-support.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json --generated-on 2026-07-01`
- `python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-go-protocol-main-target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref go-protocol-reporting-support --repo nats-server --repo etcd --repo minio --repo prometheus --repo badger --repo delve --output bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json`
- `jq empty bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json bench/recall_loss/go-protocol-reporting-support-2026-07-01.v1.json bench/recall_loss/go-protocol-reporting-support-query-regression-2026-07-01.v1.json`
- `(cd docs && awiki format && awiki lint)`
- `python3 scripts/query-regression-harness.py --self-test`
- `python3 -m py_compile scripts/query-regression-harness.py`
- `python3 scripts/check-file-lengths.py --self-test`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `./scripts/check-duplication.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --release`