### PR TITLE
Report Ruby exception boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,16 @@ break.
   raising the total to `90,979` occurrences across `61` rows and leaving no
   Python closed-boundary rows in the scheduling/lifecycle audit; exact
   admission remains closed.
+- Added Ruby exception-channel reporting for unqualified `raise`/`fail` calls
+  by lowering them to the existing `Throw` boundary, while keeping `rescue` on
+  the existing `Try` boundary. The 120-repo audit splits the broad
+  `raise/rescue` bucket into `2,065` `raise` and `1,933` `rescue`
+  reporting-supported occurrences, reclassifies the old `4,010`-occurrence
+  broad bucket as a superseded overlap row, and makes Java Stream lifecycle
+  (`1,996`) the largest non-JS actionable closed boundary. The Ruby-heavy
+  query regression measured `2778.68ms -> 2670.37ms` (`-3.90%`) and the output
+  drift is intentional: `fastlane` and `rspec-core` gain exact families for
+  repeated Ruby `raise` guard clauses.
 - Added Java `Executor`/`Future` receiver-method reporting for
   exact- or wildcard-import-backed `CompletableFuture`, `Future`,
   `ScheduledFuture`, `Executor`, `ExecutorService`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@ break.
   `raise/rescue` bucket as a superseded overlap row, and leaves the 12
   receiver-qualified broad-only overlaps outside the concrete rows. Java Stream
   lifecycle (`1,996`) becomes the largest non-JS actionable closed boundary.
-  The Ruby-heavy query regression measured `3326.98ms -> 3354.09ms` (`+0.81%`);
+  The Ruby-heavy query regression measured `3295.78ms -> 3330.24ms` (`+1.05%`);
   family counts stayed stable across all 6 repos, with metadata/hash drift only
   in `rubocop` and `rspec-core`.
 - Added Java `Executor`/`Future` receiver-method reporting for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,16 +129,17 @@ break.
   raising the total to `90,979` occurrences across `61` rows and leaving no
   Python closed-boundary rows in the scheduling/lifecycle audit; exact
   admission remains closed.
-- Added Ruby exception-channel reporting for unqualified `raise`/`fail` calls
-  by lowering them to the existing `Throw` boundary, while keeping `rescue` on
-  the existing `Try` boundary. The 120-repo audit splits the broad
-  `raise/rescue` bucket into `2,065` `raise` and `1,933` `rescue`
-  reporting-supported occurrences, reclassifies the old `4,010`-occurrence
-  broad bucket as a superseded overlap row, and makes Java Stream lifecycle
-  (`1,996`) the largest non-JS actionable closed boundary. The Ruby-heavy
-  query regression measured `2778.68ms -> 2670.37ms` (`-3.90%`) and the output
-  drift is intentional: `fastlane` and `rspec-core` gain exact families for
-  repeated Ruby `raise` guard clauses.
+- Added Ruby exception-channel reporting for unqualified `raise` calls by
+  lowering them to the existing `Throw` boundary, while keeping `rescue` on the
+  existing `Try` boundary. The 120-repo audit prices `2,065` source-backed
+  `raise` and `1,933` `rescue` occurrences as reporting-supported
+  closed-boundaries, reclassifies the old `4,010`-occurrence broad
+  `raise/rescue` bucket as a superseded overlap row, and leaves the 12
+  receiver-qualified broad-only overlaps outside the concrete rows. Java Stream
+  lifecycle (`1,996`) becomes the largest non-JS actionable closed boundary.
+  The Ruby-heavy query regression measured `3326.98ms -> 3354.09ms` (`+0.81%`);
+  family counts stayed stable across all 6 repos, with metadata/hash drift only
+  in `rubocop` and `rspec-core`.
 - Added Java `Executor`/`Future` receiver-method reporting for
   exact- or wildcard-import-backed `CompletableFuture`, `Future`,
   `ScheduledFuture`, `Executor`, `ExecutorService`, and

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -305,6 +305,7 @@ python3 scripts/query-regression-harness.py \
   --current-binary target/release/nose \
   --baseline-source-ref origin/main \
   --current-source-ref ruby-exception-reporting-alignment \
+  --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 \
   --iterations 15 \
   --repo rubocop --repo rspec-core --repo sidekiq \
   --repo rack --repo fastlane --repo sinatra \
@@ -1073,11 +1074,12 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   changed one same-location 3-member HTML family's representative label from
   `pre` to `code` while keeping the family count stable.
 - [scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json](scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json)
-  records the Ruby exception-channel reporting audit. It splits the historical
-  broad `raise/rescue` bucket into `2,065` source-backed `raise` occurrences
-  and `1,933` source-backed `rescue` occurrences, both reporting-supported
-  closed-boundaries, while the broad `4,010`-occurrence overlap bucket remains
-  visible as superseded.
+  records the Ruby exception-channel reporting audit. It prices `2,065`
+  source-backed unqualified `raise` occurrences and `1,933` source-backed
+  `rescue` occurrences as reporting-supported closed-boundaries, while the
+  broad `4,010`-occurrence `raise/rescue` overlap bucket remains visible as
+  superseded. The 12 broad-only occurrences are receiver-qualified `.raise`
+  overlaps that stay outside the concrete reporting-supported rows.
 - [ruby-exception-reporting-2026-07-02.v1.json](ruby-exception-reporting-2026-07-02.v1.json)
   records the compact closeout for the same slice. Reporting-supported
   closed-boundary rows rise to `94,977` occurrences across `63` rows, exact
@@ -1085,11 +1087,12 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   non-JS actionable closed boundary at `1,996` occurrences.
 - [ruby-exception-reporting-query-regression-2026-07-02.v1.json](ruby-exception-reporting-query-regression-2026-07-02.v1.json)
   records the Ruby-heavy product query regression. The 6-repo alternating r15
-  aggregate median was `2778.68ms -> 2670.37ms` (`-3.90%`). Output hashes stay
-  identical on `rack`, `rubocop`, `sidekiq`, and `sinatra`; `fastlane`
-  increases from `28` to `34` families and `rspec-core` from `8` to `9`
-  because repeated Ruby `raise` guard clauses are now preserved as exact
-  exception-boundary clones.
+  aggregate median was `3326.98ms -> 3354.09ms` (`+0.81%`). Family counts stay
+  stable across all 6 repos. Output hashes stay identical on `fastlane`,
+  `rack`, `sidekiq`, and `sinatra`; `rubocop` changes only
+  `value_nodes`/`mean_sem` metadata on one Ruby helper family, and `rspec-core`
+  changes one stable-count HTML hidden family's representative from `code` to
+  `pre` with `static-attrs-only` origin evidence.
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -305,7 +305,7 @@ python3 scripts/query-regression-harness.py \
   --current-binary target/release/nose \
   --baseline-source-ref origin/main \
   --current-source-ref ruby-exception-reporting-alignment \
-  --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 \
+  --current-source-sha 8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3 \
   --iterations 15 \
   --repo rubocop --repo rspec-core --repo sidekiq \
   --repo rack --repo fastlane --repo sinatra \
@@ -1087,7 +1087,7 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   non-JS actionable closed boundary at `1,996` occurrences.
 - [ruby-exception-reporting-query-regression-2026-07-02.v1.json](ruby-exception-reporting-query-regression-2026-07-02.v1.json)
   records the Ruby-heavy product query regression. The 6-repo alternating r15
-  aggregate median was `3326.98ms -> 3354.09ms` (`+0.81%`). Family counts stay
+  aggregate median was `3295.78ms -> 3330.24ms` (`+1.05%`). Family counts stay
   stable across all 6 repos. Output hashes stay identical on `fastlane`,
   `rack`, `sidekiq`, and `sinatra`; `rubocop` changes only
   `value_nodes`/`mean_sem` metadata on one Ruby helper family, and `rspec-core`

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -288,6 +288,29 @@ python3 scripts/query-regression-harness.py \
   --output target/ruby-yield-source-protocol-query-regression.json
 ```
 
+Build the Ruby exception-channel reporting audit with:
+
+```sh
+cargo run -q -p nose-cli -- verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json
+
+python3 scripts/scheduling-lifecycle-boundary-audit.py \
+  --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json \
+  --output target/scheduling-lifecycle-boundary-audit.ruby-exception-reporting.json \
+  --generated-on 2026-07-02
+
+python3 scripts/query-regression-harness.py \
+  --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose \
+  --current-binary target/release/nose \
+  --baseline-source-ref origin/main \
+  --current-source-ref ruby-exception-reporting-alignment \
+  --iterations 15 \
+  --repo rubocop --repo rspec-core --repo sidekiq \
+  --repo rack --repo fastlane --repo sinatra \
+  --output target/ruby-exception-reporting-query-regression.json
+```
+
 Build the Java `CompletableFuture`/FutureLike obligation audit with:
 
 ```sh
@@ -1049,6 +1072,24 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   aggregate median was `2504.55ms -> 2574.79ms` (`+2.80%`). `rspec-core`
   changed one same-location 3-member HTML family's representative label from
   `pre` to `code` while keeping the family count stable.
+- [scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json](scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json)
+  records the Ruby exception-channel reporting audit. It splits the historical
+  broad `raise/rescue` bucket into `2,065` source-backed `raise` occurrences
+  and `1,933` source-backed `rescue` occurrences, both reporting-supported
+  closed-boundaries, while the broad `4,010`-occurrence overlap bucket remains
+  visible as superseded.
+- [ruby-exception-reporting-2026-07-02.v1.json](ruby-exception-reporting-2026-07-02.v1.json)
+  records the compact closeout for the same slice. Reporting-supported
+  closed-boundary rows rise to `94,977` occurrences across `63` rows, exact
+  admission remains closed, and Java Stream lifecycle becomes the largest
+  non-JS actionable closed boundary at `1,996` occurrences.
+- [ruby-exception-reporting-query-regression-2026-07-02.v1.json](ruby-exception-reporting-query-regression-2026-07-02.v1.json)
+  records the Ruby-heavy product query regression. The 6-repo alternating r15
+  aggregate median was `2778.68ms -> 2670.37ms` (`-3.90%`). Output hashes stay
+  identical on `rack`, `rubocop`, `sidekiq`, and `sinatra`; `fastlane`
+  increases from `28` to `34` families and `rspec-core` from `8` to `9`
+  because repeated Ruby `raise` guard clauses are now preserved as exact
+  exception-boundary clones.
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
@@ -1,0 +1,133 @@
+{
+  "artifact_kind": "recall-loss-follow-up",
+  "branch": "ruby-exception-reporting-alignment",
+  "generated_on": "2026-07-02",
+  "goal": "Map Ruby raise/rescue exception surfaces onto existing Throw/Try runtime-boundary reporting while keeping exact admission closed.",
+  "source_baseline": {
+    "ref": "origin/main",
+    "sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2"
+  },
+  "implementation_commit": "f85ebcce4b7fc5c48a36b4f20e8678bc49d59770",
+  "newly_aligned_reporting_supported_rows": [
+    {
+      "language": "ruby",
+      "surface": "ruby.exception.raise",
+      "operation": "raise",
+      "occurrences": 2065,
+      "repos": 18,
+      "before_status": "covered_by_broad_closed_boundary",
+      "after_status": "reporting-supported-closed-boundary"
+    },
+    {
+      "language": "ruby",
+      "surface": "ruby.exception.rescue",
+      "operation": "rescue",
+      "occurrences": 1933,
+      "repos": 18,
+      "before_status": "covered_by_broad_closed_boundary",
+      "after_status": "reporting-supported-closed-boundary"
+    }
+  ],
+  "newly_aligned_reporting_supported_occurrences": 3998,
+  "superseded_overlap_rows": [
+    {
+      "language": "ruby",
+      "surface": "ruby.exception",
+      "operation": "raise/rescue",
+      "occurrences": 4010,
+      "repos": 18,
+      "before_status": "closed-boundary",
+      "after_status": "superseded-overlap-boundary"
+    }
+  ],
+  "tracking_delta": {
+    "reporting_supported_total": {
+      "before": {
+        "artifact": "bench/recall_loss/scheduling-lifecycle-boundary-audit-python-asyncio-sleep-reporting-2026-07-02.v1.json",
+        "occurrences": 90979,
+        "rows": 61
+      },
+      "after": {
+        "artifact": "bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json",
+        "occurrences": 94977,
+        "rows": 63
+      }
+    },
+    "largest_actionable_non_js_closed_boundary_after": {
+      "surface": "java.stream.lifecycle",
+      "operation": "stream/parallelStream",
+      "occurrences": 1996,
+      "repos": 15
+    },
+    "summary": "Ruby raise/fail now lower to the existing Throw boundary and rescue already lowers to Try. The broad lexical raise/rescue row is retained as a superseded overlap row so residual ordering moves to concrete operation rows."
+  },
+  "exact_admission_policy": {
+    "semantic_admission_delta": 0,
+    "status": "closed_until_evidence",
+    "summary": "The change reports Ruby exception-channel obligations and closes exact admission for throw/try runtime boundaries. It does not make raising/rescuing exact-equivalent to ordinary returns."
+  },
+  "current_recall_loss": {
+    "report": "target/recall-loss.ruby-exception-reporting.crates.json",
+    "total_units": 6991,
+    "interpretable_units": 970,
+    "excluded_units": 6021,
+    "admission_rejections": 812,
+    "fingerprint_groups": 38,
+    "false_merges": 0,
+    "canon_checked": 99,
+    "canon_preservation_violations": 0,
+    "advisory_disagreements": 4,
+    "gate_passed": true
+  },
+  "query_regression": {
+    "artifact": "bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "repos": ["rubocop", "rspec-core", "sidekiq", "rack", "fastlane", "sinatra"],
+    "iterations": 15,
+    "aggregate_baseline_median_ms": 2778.6843322683126,
+    "aggregate_current_median_ms": 2670.3669177368283,
+    "aggregate_delta_pct": -3.898154722852664,
+    "hashes_identical_by_repo": {
+      "fastlane": false,
+      "rack": true,
+      "rspec-core": false,
+      "rubocop": true,
+      "sidekiq": true,
+      "sinatra": true
+    },
+    "intentional_output_changes": [
+      {
+        "repo": "fastlane",
+        "baseline_families": 28,
+        "current_families": 34,
+        "summary": "New exact families are repeated Ruby raise guard clauses such as duplicate group_id, app_id, capability_type, profile_id, and sort_order checks."
+      },
+      {
+        "repo": "rspec-core",
+        "baseline_families": 8,
+        "current_families": 9,
+        "summary": "The new exact family is the repeated '#let or #subject called without a block' raise guard."
+      }
+    ]
+  },
+  "related_artifacts": [
+    "bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json",
+    "bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "bench/recall_loss/ruby-yield-source-protocol-reporting-2026-07-01.v1.json",
+    "bench/recall_loss/python-asyncio-sleep-reporting-2026-07-02.v1.json"
+  ],
+  "validation": [
+    "jq empty bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
+    "cargo test -p nose-frontend ruby::tests -- --nocapture",
+    "cargo test -p nose-cli --lib ruby_raise_reports_exception_channel_boundary -- --nocapture",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json --generated-on 2026-07-02",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "scripts/check-docs.sh",
+    "cargo fmt --check",
+    "python3 scripts/check-file-lengths.py --ratchet-base origin/main",
+    "git diff --check",
+    "./scripts/check-duplication.sh"
+  ]
+}

--- a/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
@@ -8,7 +8,7 @@
     "sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2"
   },
   "implementation_commit": "e189b1f4aa2c996aa75cc187f3629df06e017df4",
-  "measured_source_commit": "524a6726156caa550a185e52544da41d365e55d1",
+  "measured_source_commit": "8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3",
   "newly_aligned_reporting_supported_rows": [
     {
       "language": "ruby",
@@ -65,7 +65,7 @@
   "exact_admission_policy": {
     "new_exact_admissions": 0,
     "status": "closed_until_evidence",
-    "summary": "The change reports Ruby exception-channel obligations and explicitly keeps Try/Throw runtime boundaries closed in strict exact. It does not make raising/rescuing exact-equivalent to ordinary returns."
+    "summary": "The change reports Ruby exception-channel obligations and explicitly keeps Ruby Try/Throw runtime boundaries closed in strict exact. It does not make raising/rescuing exact-equivalent to ordinary returns, while preserving existing non-Ruby exact fragment contracts."
   },
   "current_recall_loss": {
     "report": "target/recall-loss.ruby-exception-reporting.crates.json",
@@ -84,9 +84,9 @@
     "artifact": "bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "repos": ["rubocop", "rspec-core", "sidekiq", "rack", "fastlane", "sinatra"],
     "iterations": 15,
-    "aggregate_baseline_median_ms": 3326.981251593679,
-    "aggregate_current_median_ms": 3354.0852514561266,
-    "aggregate_delta_pct": 0.814672455682283,
+    "aggregate_baseline_median_ms": 3295.7787909545004,
+    "aggregate_current_median_ms": 3330.240792129189,
+    "aggregate_delta_pct": 1.045640601525556,
     "hashes_identical_by_repo": {
       "fastlane": true,
       "rack": true,
@@ -125,7 +125,7 @@
     "cargo test -p nose-detect strict_exact_closes_ruby_exception_boundaries -- --nocapture",
     "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json",
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json --generated-on 2026-07-02",
-    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "scripts/check-docs.sh",
     "cargo fmt --check",
     "python3 scripts/check-file-lengths.py --ratchet-base origin/main",

--- a/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json
@@ -7,7 +7,8 @@
     "ref": "origin/main",
     "sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2"
   },
-  "implementation_commit": "f85ebcce4b7fc5c48a36b4f20e8678bc49d59770",
+  "implementation_commit": "e189b1f4aa2c996aa75cc187f3629df06e017df4",
+  "measured_source_commit": "524a6726156caa550a185e52544da41d365e55d1",
   "newly_aligned_reporting_supported_rows": [
     {
       "language": "ruby",
@@ -59,18 +60,18 @@
       "occurrences": 1996,
       "repos": 15
     },
-    "summary": "Ruby raise/fail now lower to the existing Throw boundary and rescue already lowers to Try. The broad lexical raise/rescue row is retained as a superseded overlap row so residual ordering moves to concrete operation rows."
+    "summary": "Unqualified Ruby raise now lowers to the existing Throw boundary and rescue already lowers to Try. The broad lexical raise/rescue row is retained as a superseded overlap row; the 12 broad-only occurrences are receiver-qualified raise overlaps that remain outside the concrete reporting-supported rows."
   },
   "exact_admission_policy": {
-    "semantic_admission_delta": 0,
+    "new_exact_admissions": 0,
     "status": "closed_until_evidence",
-    "summary": "The change reports Ruby exception-channel obligations and closes exact admission for throw/try runtime boundaries. It does not make raising/rescuing exact-equivalent to ordinary returns."
+    "summary": "The change reports Ruby exception-channel obligations and explicitly keeps Try/Throw runtime boundaries closed in strict exact. It does not make raising/rescuing exact-equivalent to ordinary returns."
   },
   "current_recall_loss": {
     "report": "target/recall-loss.ruby-exception-reporting.crates.json",
-    "total_units": 6991,
+    "total_units": 6993,
     "interpretable_units": 970,
-    "excluded_units": 6021,
+    "excluded_units": 6023,
     "admission_rejections": 812,
     "fingerprint_groups": 38,
     "false_merges": 0,
@@ -83,29 +84,29 @@
     "artifact": "bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "repos": ["rubocop", "rspec-core", "sidekiq", "rack", "fastlane", "sinatra"],
     "iterations": 15,
-    "aggregate_baseline_median_ms": 2778.6843322683126,
-    "aggregate_current_median_ms": 2670.3669177368283,
-    "aggregate_delta_pct": -3.898154722852664,
+    "aggregate_baseline_median_ms": 3326.981251593679,
+    "aggregate_current_median_ms": 3354.0852514561266,
+    "aggregate_delta_pct": 0.814672455682283,
     "hashes_identical_by_repo": {
-      "fastlane": false,
+      "fastlane": true,
       "rack": true,
       "rspec-core": false,
-      "rubocop": true,
+      "rubocop": false,
       "sidekiq": true,
       "sinatra": true
     },
-    "intentional_output_changes": [
+    "output_changes": [
       {
-        "repo": "fastlane",
-        "baseline_families": 28,
-        "current_families": 34,
-        "summary": "New exact families are repeated Ruby raise guard clauses such as duplicate group_id, app_id, capability_type, profile_id, and sort_order checks."
+        "repo": "rubocop",
+        "baseline_families": 104,
+        "current_families": 104,
+        "summary": "Family count and bytes are stable; the hash changes because the repeated Ruby kind helper family reports value_nodes/mean_sem 6 -> 7 after raise is represented as a closed Throw boundary."
       },
       {
         "repo": "rspec-core",
         "baseline_families": 8,
-        "current_families": 9,
-        "summary": "The new exact family is the repeated '#let or #subject called without a block' raise guard."
+        "current_families": 8,
+        "summary": "Family count stays stable; the hash changes in one HTML hidden family whose representative moves from code elements to pre elements with static-attrs-only origin evidence."
       }
     ]
   },
@@ -121,9 +122,10 @@
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
     "cargo test -p nose-frontend ruby::tests -- --nocapture",
     "cargo test -p nose-cli --lib ruby_raise_reports_exception_channel_boundary -- --nocapture",
+    "cargo test -p nose-detect strict_exact_closes_ruby_exception_boundaries -- --nocapture",
     "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json",
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json --generated-on 2026-07-02",
-    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "scripts/check-docs.sh",
     "cargo fmt --check",
     "python3 scripts/check-file-lengths.py --ratchet-base origin/main",

--- a/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
@@ -6,11 +6,11 @@
     "baseline_source_ref": "origin/main",
     "baseline_source_sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2",
     "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
-    "current_binary_sha256": "a67b1efb6df12ee55ce8fd255c6655e48a8f6e0a5f9dd5fdb9ef1a332982ef4b",
+    "current_binary_sha256": "9fa50c8b2954de750db8c7c81893af97d4144a0dd2f44c549b89163b0c685e70",
     "current_source_ref": "ruby-exception-reporting-alignment",
-    "current_source_sha": "f85ebcce4b7fc5c48a36b4f20e8678bc49d59770",
+    "current_source_sha": "524a6726156caa550a185e52544da41d365e55d1",
     "harness": "scripts/query-regression-harness.py",
-    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "working_tree_status_before_measurement": ""
   },
   "repos": [
@@ -24,7 +24,7 @@
   "runs": [
     {
       "bytes": 138988,
-      "elapsed_ms": 520.5945409834385,
+      "elapsed_ms": 404.90299998782575,
       "families": 104,
       "iteration": 1,
       "label": "baseline",
@@ -33,7 +33,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 152.74933399632573,
+      "elapsed_ms": 121.71645811758935,
       "families": 8,
       "iteration": 1,
       "label": "baseline",
@@ -42,7 +42,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 81.81599993258715,
+      "elapsed_ms": 121.10237521119416,
       "families": 6,
       "iteration": 1,
       "label": "baseline",
@@ -51,7 +51,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 63.6939590331167,
+      "elapsed_ms": 86.19329193606973,
       "families": 3,
       "iteration": 1,
       "label": "baseline",
@@ -60,7 +60,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1514.5891250576824,
+      "elapsed_ms": 1830.82979102619,
       "families": 28,
       "iteration": 1,
       "label": "baseline",
@@ -69,7 +69,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 85.82950010895729,
+      "elapsed_ms": 100.48912488855422,
       "families": 1,
       "iteration": 1,
       "label": "baseline",
@@ -78,25 +78,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 409.23449979163706,
+      "elapsed_ms": 624.2268329951912,
       "families": 104,
       "iteration": 1,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 116.64083413779736,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 157.27370791137218,
+      "families": 8,
       "iteration": 1,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 117.34145786613226,
+      "elapsed_ms": 156.8943748716265,
       "families": 6,
       "iteration": 1,
       "label": "current",
@@ -105,7 +105,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 86.24837500974536,
+      "elapsed_ms": 93.71891594491899,
       "families": 3,
       "iteration": 1,
       "label": "current",
@@ -113,17 +113,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1581.4587499480695,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2162.690791999921,
+      "families": 28,
       "iteration": 1,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 65.37766708061099,
+      "elapsed_ms": 100.50462512299418,
       "families": 1,
       "iteration": 1,
       "label": "current",
@@ -132,25 +132,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 517.9152090568095,
+      "elapsed_ms": 510.87612519040704,
       "families": 104,
       "iteration": 2,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 136.7780000437051,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 209.23083391971886,
+      "families": 8,
       "iteration": 2,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 95.73941701091826,
+      "elapsed_ms": 114.90716598927975,
       "families": 6,
       "iteration": 2,
       "label": "current",
@@ -159,7 +159,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 86.22262487187982,
+      "elapsed_ms": 93.49970798939466,
       "families": 3,
       "iteration": 2,
       "label": "current",
@@ -167,17 +167,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1538.0744168069214,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2040.0640829466283,
+      "families": 28,
       "iteration": 2,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 81.67649991810322,
+      "elapsed_ms": 99.41566688939929,
       "families": 1,
       "iteration": 2,
       "label": "current",
@@ -186,7 +186,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 488.10795904137194,
+      "elapsed_ms": 517.3602919094265,
       "families": 104,
       "iteration": 2,
       "label": "baseline",
@@ -195,7 +195,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 123.90537490136921,
+      "elapsed_ms": 190.43275015428662,
       "families": 8,
       "iteration": 2,
       "label": "baseline",
@@ -204,7 +204,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 99.24429096281528,
+      "elapsed_ms": 111.13808280788362,
       "families": 6,
       "iteration": 2,
       "label": "baseline",
@@ -213,7 +213,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 94.67325010336936,
+      "elapsed_ms": 105.55825009942055,
       "families": 3,
       "iteration": 2,
       "label": "baseline",
@@ -222,7 +222,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1633.993374882266,
+      "elapsed_ms": 2091.6134170256555,
       "families": 28,
       "iteration": 2,
       "label": "baseline",
@@ -231,7 +231,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 68.50904203020036,
+      "elapsed_ms": 79.33358405716717,
       "families": 1,
       "iteration": 2,
       "label": "baseline",
@@ -240,7 +240,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 431.69983313418925,
+      "elapsed_ms": 562.4480410479009,
       "families": 104,
       "iteration": 3,
       "label": "baseline",
@@ -249,7 +249,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 160.32849997282028,
+      "elapsed_ms": 209.20141716487706,
       "families": 8,
       "iteration": 3,
       "label": "baseline",
@@ -258,7 +258,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 115.30849989503622,
+      "elapsed_ms": 144.4564580451697,
       "families": 6,
       "iteration": 3,
       "label": "baseline",
@@ -267,7 +267,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 87.28312514722347,
+      "elapsed_ms": 107.33108315616846,
       "families": 3,
       "iteration": 3,
       "label": "baseline",
@@ -276,7 +276,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1611.2462079618126,
+      "elapsed_ms": 2122.590082930401,
       "families": 28,
       "iteration": 3,
       "label": "baseline",
@@ -285,7 +285,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 82.35491602681577,
+      "elapsed_ms": 75.78937523066998,
       "families": 1,
       "iteration": 3,
       "label": "baseline",
@@ -294,25 +294,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 498.92075010575354,
+      "elapsed_ms": 623.5511670820415,
       "families": 104,
       "iteration": 3,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 118.29270888119936,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 164.8642080835998,
+      "families": 8,
       "iteration": 3,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 94.2119169048965,
+      "elapsed_ms": 119.08304202370346,
       "families": 6,
       "iteration": 3,
       "label": "current",
@@ -321,7 +321,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 99.76608399301767,
+      "elapsed_ms": 96.81570809334517,
       "families": 3,
       "iteration": 3,
       "label": "current",
@@ -329,17 +329,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1583.5396249312907,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2082.7935829292983,
+      "families": 28,
       "iteration": 3,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 66.14300003275275,
+      "elapsed_ms": 114.26791595295072,
       "families": 1,
       "iteration": 3,
       "label": "current",
@@ -348,25 +348,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 485.91983411461115,
+      "elapsed_ms": 617.4134591128677,
       "families": 104,
       "iteration": 4,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 141.2927908822894,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 182.14075011201203,
+      "families": 8,
       "iteration": 4,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 96.53137507848442,
+      "elapsed_ms": 108.13324991613626,
       "families": 6,
       "iteration": 4,
       "label": "current",
@@ -375,7 +375,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 79.60291602648795,
+      "elapsed_ms": 112.40758304484189,
       "families": 3,
       "iteration": 4,
       "label": "current",
@@ -383,17 +383,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1671.655457932502,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2261.3473751116544,
+      "families": 28,
       "iteration": 4,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 89.46725004352629,
+      "elapsed_ms": 101.26587492413819,
       "families": 1,
       "iteration": 4,
       "label": "current",
@@ -402,7 +402,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 490.0594169739634,
+      "elapsed_ms": 533.9424591511488,
       "families": 104,
       "iteration": 4,
       "label": "baseline",
@@ -411,7 +411,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 113.40216593816876,
+      "elapsed_ms": 223.47579197958112,
       "families": 8,
       "iteration": 4,
       "label": "baseline",
@@ -420,7 +420,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 79.50637489557266,
+      "elapsed_ms": 136.42545812763274,
       "families": 6,
       "iteration": 4,
       "label": "baseline",
@@ -429,7 +429,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 71.97620812803507,
+      "elapsed_ms": 106.50120908394456,
       "families": 3,
       "iteration": 4,
       "label": "baseline",
@@ -438,7 +438,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1752.3879590444267,
+      "elapsed_ms": 2193.174249958247,
       "families": 28,
       "iteration": 4,
       "label": "baseline",
@@ -447,7 +447,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 64.63179201819003,
+      "elapsed_ms": 77.04491703771055,
       "families": 1,
       "iteration": 4,
       "label": "baseline",
@@ -456,7 +456,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 480.24616693146527,
+      "elapsed_ms": 658.1928750965744,
       "families": 104,
       "iteration": 5,
       "label": "baseline",
@@ -465,7 +465,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 162.95458399690688,
+      "elapsed_ms": 181.21254118159413,
       "families": 8,
       "iteration": 5,
       "label": "baseline",
@@ -474,7 +474,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 99.27224996499717,
+      "elapsed_ms": 138.6728750076145,
       "families": 6,
       "iteration": 5,
       "label": "baseline",
@@ -483,7 +483,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 81.75704092718661,
+      "elapsed_ms": 97.42895909585059,
       "families": 3,
       "iteration": 5,
       "label": "baseline",
@@ -492,7 +492,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1697.3213329911232,
+      "elapsed_ms": 2189.5434588659555,
       "families": 28,
       "iteration": 5,
       "label": "baseline",
@@ -501,7 +501,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 86.94170787930489,
+      "elapsed_ms": 89.08995799720287,
       "families": 1,
       "iteration": 5,
       "label": "baseline",
@@ -510,25 +510,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 479.0580829139799,
+      "elapsed_ms": 635.7992079574615,
       "families": 104,
       "iteration": 5,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 146.78295911289752,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 156.97124996222556,
+      "families": 8,
       "iteration": 5,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 100.58404179289937,
+      "elapsed_ms": 119.3061659578234,
       "families": 6,
       "iteration": 5,
       "label": "current",
@@ -537,7 +537,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 84.2759998049587,
+      "elapsed_ms": 120.35291595384479,
       "families": 3,
       "iteration": 5,
       "label": "current",
@@ -545,17 +545,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1746.8800419010222,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2250.5405419506133,
+      "families": 28,
       "iteration": 5,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 111.21379095129669,
+      "elapsed_ms": 112.47091693803668,
       "families": 1,
       "iteration": 5,
       "label": "current",
@@ -564,25 +564,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 587.9798328969628,
+      "elapsed_ms": 554.9430830869824,
       "families": 104,
       "iteration": 6,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 133.31800000742078,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 218.80983281880617,
+      "families": 8,
       "iteration": 6,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 108.92941593192518,
+      "elapsed_ms": 128.14112496562302,
       "families": 6,
       "iteration": 6,
       "label": "current",
@@ -591,7 +591,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 86.49741695262492,
+      "elapsed_ms": 97.07920788787305,
       "families": 3,
       "iteration": 6,
       "label": "current",
@@ -599,17 +599,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1707.2546670679003,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2204.124125186354,
+      "families": 28,
       "iteration": 6,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 64.51724981889129,
+      "elapsed_ms": 81.85079088434577,
       "families": 1,
       "iteration": 6,
       "label": "current",
@@ -618,7 +618,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 590.3253750875592,
+      "elapsed_ms": 635.3474999777973,
       "families": 104,
       "iteration": 6,
       "label": "baseline",
@@ -627,7 +627,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 155.1304159220308,
+      "elapsed_ms": 208.1250420305878,
       "families": 8,
       "iteration": 6,
       "label": "baseline",
@@ -636,7 +636,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 100.23645800538361,
+      "elapsed_ms": 134.62829194031656,
       "families": 6,
       "iteration": 6,
       "label": "baseline",
@@ -645,7 +645,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 87.9738749936223,
+      "elapsed_ms": 103.08116697706282,
       "families": 3,
       "iteration": 6,
       "label": "baseline",
@@ -654,7 +654,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1785.089915851131,
+      "elapsed_ms": 2125.1297499984503,
       "families": 28,
       "iteration": 6,
       "label": "baseline",
@@ -663,7 +663,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 73.28308303840458,
+      "elapsed_ms": 97.11770806461573,
       "families": 1,
       "iteration": 6,
       "label": "baseline",
@@ -672,7 +672,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 503.0956659466028,
+      "elapsed_ms": 658.4287080913782,
       "families": 104,
       "iteration": 7,
       "label": "baseline",
@@ -681,7 +681,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 171.02833301760256,
+      "elapsed_ms": 186.350499978289,
       "families": 8,
       "iteration": 7,
       "label": "baseline",
@@ -690,7 +690,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 115.6962919048965,
+      "elapsed_ms": 133.86545912362635,
       "families": 6,
       "iteration": 7,
       "label": "baseline",
@@ -699,7 +699,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 103.31354197114706,
+      "elapsed_ms": 118.18516603671014,
       "families": 3,
       "iteration": 7,
       "label": "baseline",
@@ -708,7 +708,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1735.8057498931885,
+      "elapsed_ms": 2251.170708797872,
       "families": 28,
       "iteration": 7,
       "label": "baseline",
@@ -717,7 +717,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 87.87620812654495,
+      "elapsed_ms": 101.92279191687703,
       "families": 1,
       "iteration": 7,
       "label": "baseline",
@@ -726,25 +726,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 558.0206250306219,
+      "elapsed_ms": 559.0964169241488,
       "families": 104,
       "iteration": 7,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 172.0643751323223,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 182.17983283102512,
+      "families": 8,
       "iteration": 7,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 103.8053329102695,
+      "elapsed_ms": 147.15041709132493,
       "families": 6,
       "iteration": 7,
       "label": "current",
@@ -753,7 +753,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 101.41695803031325,
+      "elapsed_ms": 119.20287483371794,
       "families": 3,
       "iteration": 7,
       "label": "current",
@@ -761,17 +761,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1721.5661669615656,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2263.768707867712,
+      "families": 28,
       "iteration": 7,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 92.6617500372231,
+      "elapsed_ms": 76.21666695922613,
       "families": 1,
       "iteration": 7,
       "label": "current",
@@ -780,25 +780,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 610.8132919762284,
+      "elapsed_ms": 620.8587919827551,
       "families": 104,
       "iteration": 8,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 127.52058287151158,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 194.90391621366143,
+      "families": 8,
       "iteration": 8,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 93.66708295419812,
+      "elapsed_ms": 119.72104106098413,
       "families": 6,
       "iteration": 8,
       "label": "current",
@@ -807,7 +807,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 70.78816695138812,
+      "elapsed_ms": 107.03854192979634,
       "families": 3,
       "iteration": 8,
       "label": "current",
@@ -815,17 +815,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1818.5228749644011,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2167.2699579503387,
+      "families": 28,
       "iteration": 8,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 69.67899994924664,
+      "elapsed_ms": 106.62420885637403,
       "families": 1,
       "iteration": 8,
       "label": "current",
@@ -834,7 +834,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 574.965207837522,
+      "elapsed_ms": 645.2823327854276,
       "families": 104,
       "iteration": 8,
       "label": "baseline",
@@ -843,7 +843,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 157.81249990686774,
+      "elapsed_ms": 160.64095916226506,
       "families": 8,
       "iteration": 8,
       "label": "baseline",
@@ -852,7 +852,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 101.30654205568135,
+      "elapsed_ms": 159.39374989829957,
       "families": 6,
       "iteration": 8,
       "label": "baseline",
@@ -861,7 +861,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 87.51791692338884,
+      "elapsed_ms": 108.23179199360311,
       "families": 3,
       "iteration": 8,
       "label": "baseline",
@@ -870,7 +870,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1845.8951250649989,
+      "elapsed_ms": 2331.710333004594,
       "families": 28,
       "iteration": 8,
       "label": "baseline",
@@ -879,7 +879,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 66.28374988213181,
+      "elapsed_ms": 80.2926670294255,
       "families": 1,
       "iteration": 8,
       "label": "baseline",
@@ -888,7 +888,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 513.835959136486,
+      "elapsed_ms": 639.0081669669598,
       "families": 104,
       "iteration": 9,
       "label": "baseline",
@@ -897,7 +897,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 156.9780830759555,
+      "elapsed_ms": 191.2080841138959,
       "families": 8,
       "iteration": 9,
       "label": "baseline",
@@ -906,7 +906,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 106.18187487125397,
+      "elapsed_ms": 126.92804192192852,
       "families": 6,
       "iteration": 9,
       "label": "baseline",
@@ -915,7 +915,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 92.18270797282457,
+      "elapsed_ms": 114.25662506371737,
       "families": 3,
       "iteration": 9,
       "label": "baseline",
@@ -924,7 +924,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1906.7560411058366,
+      "elapsed_ms": 2201.3483338523656,
       "families": 28,
       "iteration": 9,
       "label": "baseline",
@@ -933,7 +933,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 69.43933316506445,
+      "elapsed_ms": 80.05616697482765,
       "families": 1,
       "iteration": 9,
       "label": "baseline",
@@ -942,25 +942,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 448.2509170193225,
+      "elapsed_ms": 669.7634998708963,
       "families": 104,
       "iteration": 9,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 180.69404200650752,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 189.86441707238555,
+      "families": 8,
       "iteration": 9,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 109.28595787845552,
+      "elapsed_ms": 110.92179198749363,
       "families": 6,
       "iteration": 9,
       "label": "current",
@@ -969,7 +969,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 88.8839999679476,
+      "elapsed_ms": 130.41849993169308,
       "families": 3,
       "iteration": 9,
       "label": "current",
@@ -977,17 +977,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1718.5873328708112,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2281.487707979977,
+      "families": 28,
       "iteration": 9,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 78.85154196992517,
+      "elapsed_ms": 108.26770798303187,
       "families": 1,
       "iteration": 9,
       "label": "current",
@@ -996,25 +996,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 565.3300411067903,
+      "elapsed_ms": 593.5069168917835,
       "families": 104,
       "iteration": 10,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 133.35454207845032,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 209.41500016488135,
+      "families": 8,
       "iteration": 10,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 94.12183403037488,
+      "elapsed_ms": 125.05754199810326,
       "families": 6,
       "iteration": 10,
       "label": "current",
@@ -1023,7 +1023,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 110.07604212500155,
+      "elapsed_ms": 97.82162494957447,
       "families": 3,
       "iteration": 10,
       "label": "current",
@@ -1031,17 +1031,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1806.8643331062049,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2205.263457959518,
+      "families": 28,
       "iteration": 10,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 69.83341695740819,
+      "elapsed_ms": 81.40437491238117,
       "families": 1,
       "iteration": 10,
       "label": "current",
@@ -1050,7 +1050,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 578.2174998894334,
+      "elapsed_ms": 670.5777498427778,
       "families": 104,
       "iteration": 10,
       "label": "baseline",
@@ -1059,7 +1059,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 145.8101668395102,
+      "elapsed_ms": 179.48974994942546,
       "families": 8,
       "iteration": 10,
       "label": "baseline",
@@ -1068,7 +1068,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 107.62525000609457,
+      "elapsed_ms": 143.77162512391806,
       "families": 6,
       "iteration": 10,
       "label": "baseline",
@@ -1077,7 +1077,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 79.9531249795109,
+      "elapsed_ms": 103.12874987721443,
       "families": 3,
       "iteration": 10,
       "label": "baseline",
@@ -1086,7 +1086,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1833.485416136682,
+      "elapsed_ms": 2314.482167130336,
       "families": 28,
       "iteration": 10,
       "label": "baseline",
@@ -1095,7 +1095,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 68.22291691787541,
+      "elapsed_ms": 114.78816694580019,
       "families": 1,
       "iteration": 10,
       "label": "baseline",
@@ -1104,7 +1104,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 525.0154591631144,
+      "elapsed_ms": 603.8280420470983,
       "families": 104,
       "iteration": 11,
       "label": "baseline",
@@ -1113,7 +1113,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 140.87124983780086,
+      "elapsed_ms": 205.240709008649,
       "families": 8,
       "iteration": 11,
       "label": "baseline",
@@ -1122,7 +1122,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 119.97579201124609,
+      "elapsed_ms": 130.24145807139575,
       "families": 6,
       "iteration": 11,
       "label": "baseline",
@@ -1131,7 +1131,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 100.30616587027907,
+      "elapsed_ms": 121.68341712094843,
       "families": 3,
       "iteration": 11,
       "label": "baseline",
@@ -1140,7 +1140,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1883.4691250231117,
+      "elapsed_ms": 2232.458416139707,
       "families": 28,
       "iteration": 11,
       "label": "baseline",
@@ -1149,7 +1149,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 70.20587497390807,
+      "elapsed_ms": 74.86424990929663,
       "families": 1,
       "iteration": 11,
       "label": "baseline",
@@ -1158,25 +1158,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 481.4730421639979,
+      "elapsed_ms": 615.1641251053661,
       "families": 104,
       "iteration": 11,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 175.41945888660848,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 205.57133294641972,
+      "families": 8,
       "iteration": 11,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 105.23041686974466,
+      "elapsed_ms": 139.6032499615103,
       "families": 6,
       "iteration": 11,
       "label": "current",
@@ -1185,7 +1185,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 85.98704100586474,
+      "elapsed_ms": 119.69370883889496,
       "families": 3,
       "iteration": 11,
       "label": "current",
@@ -1193,17 +1193,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1825.596584007144,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2181.442917091772,
+      "families": 28,
       "iteration": 11,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 94.62716593407094,
+      "elapsed_ms": 92.87725016474724,
       "families": 1,
       "iteration": 11,
       "label": "current",
@@ -1212,25 +1212,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 491.0299580078572,
+      "elapsed_ms": 635.6337910983711,
       "families": 104,
       "iteration": 12,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 175.81320903263986,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 172.38070792518556,
+      "families": 8,
       "iteration": 12,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 102.65541705302894,
+      "elapsed_ms": 159.53291696496308,
       "families": 6,
       "iteration": 12,
       "label": "current",
@@ -1239,7 +1239,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 88.23070907965302,
+      "elapsed_ms": 131.13004202023149,
       "families": 3,
       "iteration": 12,
       "label": "current",
@@ -1247,17 +1247,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1851.6720838379115,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2245.3977910336107,
+      "families": 28,
       "iteration": 12,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 91.28149994648993,
+      "elapsed_ms": 98.36533316411078,
       "families": 1,
       "iteration": 12,
       "label": "current",
@@ -1266,7 +1266,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 592.3959158826619,
+      "elapsed_ms": 597.9432910680771,
       "families": 104,
       "iteration": 12,
       "label": "baseline",
@@ -1275,7 +1275,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 123.98799997754395,
+      "elapsed_ms": 192.37658311612904,
       "families": 8,
       "iteration": 12,
       "label": "baseline",
@@ -1284,7 +1284,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 151.40400012023747,
+      "elapsed_ms": 138.3378750178963,
       "families": 6,
       "iteration": 12,
       "label": "baseline",
@@ -1293,7 +1293,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 100.63479212112725,
+      "elapsed_ms": 115.90283294208348,
       "families": 3,
       "iteration": 12,
       "label": "baseline",
@@ -1302,7 +1302,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1884.2594581656158,
+      "elapsed_ms": 2207.264000084251,
       "families": 28,
       "iteration": 12,
       "label": "baseline",
@@ -1311,7 +1311,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 81.83108316734433,
+      "elapsed_ms": 75.90679218992591,
       "families": 1,
       "iteration": 12,
       "label": "baseline",
@@ -1320,7 +1320,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 588.0736249964684,
+      "elapsed_ms": 609.568125102669,
       "families": 104,
       "iteration": 13,
       "label": "baseline",
@@ -1329,7 +1329,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 150.0910420436412,
+      "elapsed_ms": 184.1642081271857,
       "families": 8,
       "iteration": 13,
       "label": "baseline",
@@ -1338,7 +1338,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 126.95533293299377,
+      "elapsed_ms": 119.73316594958305,
       "families": 6,
       "iteration": 13,
       "label": "baseline",
@@ -1347,7 +1347,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 97.79033297672868,
+      "elapsed_ms": 97.33283310197294,
       "families": 3,
       "iteration": 13,
       "label": "baseline",
@@ -1356,7 +1356,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1904.1640418581665,
+      "elapsed_ms": 2253.6430000327528,
       "families": 28,
       "iteration": 13,
       "label": "baseline",
@@ -1365,7 +1365,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 105.31000001356006,
+      "elapsed_ms": 107.44866612367332,
       "families": 1,
       "iteration": 13,
       "label": "baseline",
@@ -1374,25 +1374,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 611.88037507236,
+      "elapsed_ms": 630.6539999786764,
       "families": 104,
       "iteration": 13,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 142.15383399277925,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 202.57929200306535,
+      "families": 8,
       "iteration": 13,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 127.28887493722141,
+      "elapsed_ms": 132.93466717004776,
       "families": 6,
       "iteration": 13,
       "label": "current",
@@ -1401,7 +1401,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 98.07391604408622,
+      "elapsed_ms": 107.42862499319017,
       "families": 3,
       "iteration": 13,
       "label": "current",
@@ -1409,17 +1409,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1810.676374938339,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2205.754042137414,
+      "families": 28,
       "iteration": 13,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 71.81133306585252,
+      "elapsed_ms": 94.39283283427358,
       "families": 1,
       "iteration": 13,
       "label": "current",
@@ -1428,25 +1428,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 605.3936660755426,
+      "elapsed_ms": 590.6499170232564,
       "families": 104,
       "iteration": 14,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 155.87183297611773,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 184.38287498429418,
+      "families": 8,
       "iteration": 14,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 113.35437512025237,
+      "elapsed_ms": 136.71233388595283,
       "families": 6,
       "iteration": 14,
       "label": "current",
@@ -1455,7 +1455,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 83.37387489154935,
+      "elapsed_ms": 115.33033405430615,
       "families": 3,
       "iteration": 14,
       "label": "current",
@@ -1463,17 +1463,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1922.751666046679,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2222.2167919389904,
+      "families": 28,
       "iteration": 14,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 68.39620787650347,
+      "elapsed_ms": 112.61316714808345,
       "families": 1,
       "iteration": 14,
       "label": "current",
@@ -1482,7 +1482,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 613.5638749692589,
+      "elapsed_ms": 661.7954999674112,
       "families": 104,
       "iteration": 14,
       "label": "baseline",
@@ -1491,7 +1491,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 166.05370794422925,
+      "elapsed_ms": 180.00712501816452,
       "families": 8,
       "iteration": 14,
       "label": "baseline",
@@ -1500,7 +1500,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 104.25204108469188,
+      "elapsed_ms": 114.74770889617503,
       "families": 6,
       "iteration": 14,
       "label": "baseline",
@@ -1509,7 +1509,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 82.65916700474918,
+      "elapsed_ms": 105.5386250372976,
       "families": 3,
       "iteration": 14,
       "label": "baseline",
@@ -1518,7 +1518,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1964.7789171431214,
+      "elapsed_ms": 2243.056375067681,
       "families": 28,
       "iteration": 14,
       "label": "baseline",
@@ -1527,7 +1527,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 97.7379169780761,
+      "elapsed_ms": 104.69158389605582,
       "families": 1,
       "iteration": 14,
       "label": "baseline",
@@ -1536,7 +1536,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 584.3573750462383,
+      "elapsed_ms": 563.2505419198424,
       "families": 104,
       "iteration": 15,
       "label": "baseline",
@@ -1545,7 +1545,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 170.00354221090674,
+      "elapsed_ms": 201.6484159976244,
       "families": 8,
       "iteration": 15,
       "label": "baseline",
@@ -1554,7 +1554,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 98.48124999552965,
+      "elapsed_ms": 130.2955828141421,
       "families": 6,
       "iteration": 15,
       "label": "baseline",
@@ -1563,7 +1563,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 71.05041691102087,
+      "elapsed_ms": 101.99024993926287,
       "families": 3,
       "iteration": 15,
       "label": "baseline",
@@ -1572,7 +1572,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1930.2377081476152,
+      "elapsed_ms": 2293.4672080446035,
       "families": 28,
       "iteration": 15,
       "label": "baseline",
@@ -1581,7 +1581,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 65.64433313906193,
+      "elapsed_ms": 78.59375001862645,
       "families": 1,
       "iteration": 15,
       "label": "baseline",
@@ -1590,25 +1590,25 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 675.4708748776466,
+      "elapsed_ms": 613.4114998858422,
       "families": 104,
       "iteration": 15,
       "label": "current",
       "repo": "rubocop",
-      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+      "sha256": "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
     },
     {
-      "bytes": 36246,
-      "elapsed_ms": 171.13108304329216,
-      "families": 9,
+      "bytes": 35566,
+      "elapsed_ms": 202.942208154127,
+      "families": 8,
       "iteration": 15,
       "label": "current",
       "repo": "rspec-core",
-      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+      "sha256": "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 104.45216600783169,
+      "elapsed_ms": 128.25662503018975,
       "families": 6,
       "iteration": 15,
       "label": "current",
@@ -1617,7 +1617,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 83.63816607743502,
+      "elapsed_ms": 112.74008289910853,
       "families": 3,
       "iteration": 15,
       "label": "current",
@@ -1625,17 +1625,17 @@
       "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
     },
     {
-      "bytes": 76801,
-      "elapsed_ms": 1935.8829578850418,
-      "families": 34,
+      "bytes": 71641,
+      "elapsed_ms": 2221.1911249905825,
+      "families": 28,
       "iteration": 15,
       "label": "current",
       "repo": "fastlane",
-      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 73.36412486620247,
+      "elapsed_ms": 111.0206248704344,
       "families": 1,
       "iteration": 15,
       "label": "current",
@@ -1644,9 +1644,9 @@
     }
   ],
   "summary": {
-    "aggregate_baseline_median_ms": 2778.6843322683126,
-    "aggregate_current_median_ms": 2670.3669177368283,
-    "aggregate_delta_pct": -3.898154722852664,
+    "aggregate_baseline_median_ms": 3326.981251593679,
+    "aggregate_current_median_ms": 3354.0852514561266,
+    "aggregate_delta_pct": 0.814672455682283,
     "by_repo": {
       "fastlane": {
         "baseline": {
@@ -1659,19 +1659,19 @@
           "hashes": [
             "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 1833.485416136682
+          "median_ms": 2207.264000084251
         },
         "current": {
           "bytes": [
-            76801
+            71641
           ],
           "families": [
-            34
+            28
           ],
           "hashes": [
-            "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+            "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 1746.8800419010222
+          "median_ms": 2205.754042137414
         }
       },
       "rack": {
@@ -1685,7 +1685,7 @@
           "hashes": [
             "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 87.51791692338884
+          "median_ms": 105.55825009942055
         },
         "current": {
           "bytes": [
@@ -1697,7 +1697,7 @@
           "hashes": [
             "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 86.24837500974536
+          "median_ms": 112.40758304484189
         }
       },
       "rspec-core": {
@@ -1711,19 +1711,19 @@
           "hashes": [
             "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
           ],
-          "median_ms": 155.1304159220308
+          "median_ms": 190.43275015428662
         },
         "current": {
           "bytes": [
-            36246
+            35566
           ],
           "families": [
-            9
+            8
           ],
           "hashes": [
-            "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+            "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
           ],
-          "median_ms": 142.15383399277925
+          "median_ms": 189.86441707238555
         }
       },
       "rubocop": {
@@ -1737,7 +1737,7 @@
           "hashes": [
             "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
           ],
-          "median_ms": 525.0154591631144
+          "median_ms": 609.568125102669
         },
         "current": {
           "bytes": [
@@ -1747,9 +1747,9 @@
             104
           ],
           "hashes": [
-            "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+            "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
           ],
-          "median_ms": 517.9152090568095
+          "median_ms": 617.4134591128677
         }
       },
       "sidekiq": {
@@ -1763,7 +1763,7 @@
           "hashes": [
             "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 104.25204108469188
+          "median_ms": 133.86545912362635
         },
         "current": {
           "bytes": [
@@ -1775,7 +1775,7 @@
           "hashes": [
             "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 103.8053329102695
+          "median_ms": 128.14112496562302
         }
       },
       "sinatra": {
@@ -1789,7 +1789,7 @@
           "hashes": [
             "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 73.28308303840458
+          "median_ms": 80.2926670294255
         },
         "current": {
           "bytes": [
@@ -1801,15 +1801,15 @@
           "hashes": [
             "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 73.36412486620247
+          "median_ms": 100.50462512299418
         }
       }
     },
     "hashes_identical_by_repo": {
-      "fastlane": false,
+      "fastlane": true,
       "rack": true,
       "rspec-core": false,
-      "rubocop": true,
+      "rubocop": false,
       "sidekiq": true,
       "sinatra": true
     }

--- a/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
@@ -1,0 +1,1817 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-ruby-exception-main/target/release/nose",
+    "baseline_binary_sha256": "403e02c5738dcaceddc32e8dfdb043e76f7bbc3786ef42f0a44338c3a0fb6199",
+    "baseline_source_ref": "origin/main",
+    "baseline_source_sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2",
+    "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "current_binary_sha256": "a67b1efb6df12ee55ce8fd255c6655e48a8f6e0a5f9dd5fdb9ef1a332982ef4b",
+    "current_source_ref": "ruby-exception-reporting-alignment",
+    "current_source_sha": "f85ebcce4b7fc5c48a36b4f20e8678bc49d59770",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "working_tree_status_before_measurement": ""
+  },
+  "repos": [
+    "rubocop",
+    "rspec-core",
+    "sidekiq",
+    "rack",
+    "fastlane",
+    "sinatra"
+  ],
+  "runs": [
+    {
+      "bytes": 138988,
+      "elapsed_ms": 520.5945409834385,
+      "families": 104,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 152.74933399632573,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 81.81599993258715,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 63.6939590331167,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1514.5891250576824,
+      "families": 28,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 85.82950010895729,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 409.23449979163706,
+      "families": 104,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 116.64083413779736,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 117.34145786613226,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.24837500974536,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1581.4587499480695,
+      "families": 34,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 65.37766708061099,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 517.9152090568095,
+      "families": 104,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 136.7780000437051,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 95.73941701091826,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.22262487187982,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1538.0744168069214,
+      "families": 34,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 81.67649991810322,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 488.10795904137194,
+      "families": 104,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 123.90537490136921,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.24429096281528,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 94.67325010336936,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1633.993374882266,
+      "families": 28,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 68.50904203020036,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 431.69983313418925,
+      "families": 104,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 160.32849997282028,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 115.30849989503622,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 87.28312514722347,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1611.2462079618126,
+      "families": 28,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 82.35491602681577,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 498.92075010575354,
+      "families": 104,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 118.29270888119936,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 94.2119169048965,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 99.76608399301767,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1583.5396249312907,
+      "families": 34,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 66.14300003275275,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 485.91983411461115,
+      "families": 104,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 141.2927908822894,
+      "families": 9,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 96.53137507848442,
+      "families": 6,
+      "iteration": 4,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 79.60291602648795,
+      "families": 3,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1671.655457932502,
+      "families": 34,
+      "iteration": 4,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 89.46725004352629,
+      "families": 1,
+      "iteration": 4,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 490.0594169739634,
+      "families": 104,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 113.40216593816876,
+      "families": 8,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 79.50637489557266,
+      "families": 6,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 71.97620812803507,
+      "families": 3,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1752.3879590444267,
+      "families": 28,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 64.63179201819003,
+      "families": 1,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 480.24616693146527,
+      "families": 104,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 162.95458399690688,
+      "families": 8,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.27224996499717,
+      "families": 6,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 81.75704092718661,
+      "families": 3,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1697.3213329911232,
+      "families": 28,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 86.94170787930489,
+      "families": 1,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 479.0580829139799,
+      "families": 104,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 146.78295911289752,
+      "families": 9,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 100.58404179289937,
+      "families": 6,
+      "iteration": 5,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 84.2759998049587,
+      "families": 3,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1746.8800419010222,
+      "families": 34,
+      "iteration": 5,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 111.21379095129669,
+      "families": 1,
+      "iteration": 5,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 587.9798328969628,
+      "families": 104,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 133.31800000742078,
+      "families": 9,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 108.92941593192518,
+      "families": 6,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.49741695262492,
+      "families": 3,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1707.2546670679003,
+      "families": 34,
+      "iteration": 6,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 64.51724981889129,
+      "families": 1,
+      "iteration": 6,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 590.3253750875592,
+      "families": 104,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 155.1304159220308,
+      "families": 8,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 100.23645800538361,
+      "families": 6,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 87.9738749936223,
+      "families": 3,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1785.089915851131,
+      "families": 28,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 73.28308303840458,
+      "families": 1,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 503.0956659466028,
+      "families": 104,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 171.02833301760256,
+      "families": 8,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 115.6962919048965,
+      "families": 6,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 103.31354197114706,
+      "families": 3,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1735.8057498931885,
+      "families": 28,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 87.87620812654495,
+      "families": 1,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 558.0206250306219,
+      "families": 104,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 172.0643751323223,
+      "families": 9,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 103.8053329102695,
+      "families": 6,
+      "iteration": 7,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 101.41695803031325,
+      "families": 3,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1721.5661669615656,
+      "families": 34,
+      "iteration": 7,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 92.6617500372231,
+      "families": 1,
+      "iteration": 7,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 610.8132919762284,
+      "families": 104,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 127.52058287151158,
+      "families": 9,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 93.66708295419812,
+      "families": 6,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 70.78816695138812,
+      "families": 3,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1818.5228749644011,
+      "families": 34,
+      "iteration": 8,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 69.67899994924664,
+      "families": 1,
+      "iteration": 8,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 574.965207837522,
+      "families": 104,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 157.81249990686774,
+      "families": 8,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 101.30654205568135,
+      "families": 6,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 87.51791692338884,
+      "families": 3,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1845.8951250649989,
+      "families": 28,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 66.28374988213181,
+      "families": 1,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 513.835959136486,
+      "families": 104,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 156.9780830759555,
+      "families": 8,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 106.18187487125397,
+      "families": 6,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 92.18270797282457,
+      "families": 3,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1906.7560411058366,
+      "families": 28,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 69.43933316506445,
+      "families": 1,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 448.2509170193225,
+      "families": 104,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 180.69404200650752,
+      "families": 9,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 109.28595787845552,
+      "families": 6,
+      "iteration": 9,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 88.8839999679476,
+      "families": 3,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1718.5873328708112,
+      "families": 34,
+      "iteration": 9,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 78.85154196992517,
+      "families": 1,
+      "iteration": 9,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 565.3300411067903,
+      "families": 104,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 133.35454207845032,
+      "families": 9,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 94.12183403037488,
+      "families": 6,
+      "iteration": 10,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 110.07604212500155,
+      "families": 3,
+      "iteration": 10,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1806.8643331062049,
+      "families": 34,
+      "iteration": 10,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 69.83341695740819,
+      "families": 1,
+      "iteration": 10,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 578.2174998894334,
+      "families": 104,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 145.8101668395102,
+      "families": 8,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 107.62525000609457,
+      "families": 6,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 79.9531249795109,
+      "families": 3,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1833.485416136682,
+      "families": 28,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 68.22291691787541,
+      "families": 1,
+      "iteration": 10,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 525.0154591631144,
+      "families": 104,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 140.87124983780086,
+      "families": 8,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 119.97579201124609,
+      "families": 6,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 100.30616587027907,
+      "families": 3,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1883.4691250231117,
+      "families": 28,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 70.20587497390807,
+      "families": 1,
+      "iteration": 11,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 481.4730421639979,
+      "families": 104,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 175.41945888660848,
+      "families": 9,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 105.23041686974466,
+      "families": 6,
+      "iteration": 11,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 85.98704100586474,
+      "families": 3,
+      "iteration": 11,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1825.596584007144,
+      "families": 34,
+      "iteration": 11,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 94.62716593407094,
+      "families": 1,
+      "iteration": 11,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 491.0299580078572,
+      "families": 104,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 175.81320903263986,
+      "families": 9,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 102.65541705302894,
+      "families": 6,
+      "iteration": 12,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 88.23070907965302,
+      "families": 3,
+      "iteration": 12,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1851.6720838379115,
+      "families": 34,
+      "iteration": 12,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 91.28149994648993,
+      "families": 1,
+      "iteration": 12,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 592.3959158826619,
+      "families": 104,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 123.98799997754395,
+      "families": 8,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 151.40400012023747,
+      "families": 6,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 100.63479212112725,
+      "families": 3,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1884.2594581656158,
+      "families": 28,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 81.83108316734433,
+      "families": 1,
+      "iteration": 12,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 588.0736249964684,
+      "families": 104,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 150.0910420436412,
+      "families": 8,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 126.95533293299377,
+      "families": 6,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 97.79033297672868,
+      "families": 3,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1904.1640418581665,
+      "families": 28,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 105.31000001356006,
+      "families": 1,
+      "iteration": 13,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 611.88037507236,
+      "families": 104,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 142.15383399277925,
+      "families": 9,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 127.28887493722141,
+      "families": 6,
+      "iteration": 13,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 98.07391604408622,
+      "families": 3,
+      "iteration": 13,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1810.676374938339,
+      "families": 34,
+      "iteration": 13,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 71.81133306585252,
+      "families": 1,
+      "iteration": 13,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 605.3936660755426,
+      "families": 104,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 155.87183297611773,
+      "families": 9,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 113.35437512025237,
+      "families": 6,
+      "iteration": 14,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 83.37387489154935,
+      "families": 3,
+      "iteration": 14,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1922.751666046679,
+      "families": 34,
+      "iteration": 14,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 68.39620787650347,
+      "families": 1,
+      "iteration": 14,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 613.5638749692589,
+      "families": 104,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 166.05370794422925,
+      "families": 8,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 104.25204108469188,
+      "families": 6,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 82.65916700474918,
+      "families": 3,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1964.7789171431214,
+      "families": 28,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 97.7379169780761,
+      "families": 1,
+      "iteration": 14,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 584.3573750462383,
+      "families": 104,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 35452,
+      "elapsed_ms": 170.00354221090674,
+      "families": 8,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 98.48124999552965,
+      "families": 6,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 71.05041691102087,
+      "families": 3,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 1930.2377081476152,
+      "families": 28,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 65.64433313906193,
+      "families": 1,
+      "iteration": 15,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 675.4708748776466,
+      "families": 104,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+    },
+    {
+      "bytes": 36246,
+      "elapsed_ms": 171.13108304329216,
+      "families": 9,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 104.45216600783169,
+      "families": 6,
+      "iteration": 15,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 83.63816607743502,
+      "families": 3,
+      "iteration": 15,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+    },
+    {
+      "bytes": 76801,
+      "elapsed_ms": 1935.8829578850418,
+      "families": 34,
+      "iteration": 15,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 73.36412486620247,
+      "families": 1,
+      "iteration": 15,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 2778.6843322683126,
+    "aggregate_current_median_ms": 2670.3669177368283,
+    "aggregate_delta_pct": -3.898154722852664,
+    "by_repo": {
+      "fastlane": {
+        "baseline": {
+          "bytes": [
+            71641
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
+          ],
+          "median_ms": 1833.485416136682
+        },
+        "current": {
+          "bytes": [
+            76801
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "ab2f319e852806b8676033bdfbb81f072b8edd9124121007d23d553212b25565"
+          ],
+          "median_ms": 1746.8800419010222
+        }
+      },
+      "rack": {
+        "baseline": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+          ],
+          "median_ms": 87.51791692338884
+        },
+        "current": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
+          ],
+          "median_ms": 86.24837500974536
+        }
+      },
+      "rspec-core": {
+        "baseline": {
+          "bytes": [
+            35452
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
+          ],
+          "median_ms": 155.1304159220308
+        },
+        "current": {
+          "bytes": [
+            36246
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "a1db47438e7e2531fd0b0ff083acc9a8519606f1f90cdb6bcb49c482c204fc73"
+          ],
+          "median_ms": 142.15383399277925
+        }
+      },
+      "rubocop": {
+        "baseline": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+          ],
+          "median_ms": 525.0154591631144
+        },
+        "current": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
+          ],
+          "median_ms": 517.9152090568095
+        }
+      },
+      "sidekiq": {
+        "baseline": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+          ],
+          "median_ms": 104.25204108469188
+        },
+        "current": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
+          ],
+          "median_ms": 103.8053329102695
+        }
+      },
+      "sinatra": {
+        "baseline": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+          ],
+          "median_ms": 73.28308303840458
+        },
+        "current": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
+          ],
+          "median_ms": 73.36412486620247
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "fastlane": false,
+      "rack": true,
+      "rspec-core": false,
+      "rubocop": true,
+      "sidekiq": true,
+      "sinatra": true
+    }
+  }
+}

--- a/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
+++ b/bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json
@@ -6,11 +6,11 @@
     "baseline_source_ref": "origin/main",
     "baseline_source_sha": "6a58c16eea0cd037b1772a7d0318bdbd2a2f75a2",
     "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
-    "current_binary_sha256": "9fa50c8b2954de750db8c7c81893af97d4144a0dd2f44c549b89163b0c685e70",
+    "current_binary_sha256": "92d09fafc3470b9cc9ac6d3cc634b30f32e3f95516d217fa6345d1f37edc46a6",
     "current_source_ref": "ruby-exception-reporting-alignment",
-    "current_source_sha": "524a6726156caa550a185e52544da41d365e55d1",
+    "current_source_sha": "8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3",
     "harness": "scripts/query-regression-harness.py",
-    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 524a6726156caa550a185e52544da41d365e55d1 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json",
     "working_tree_status_before_measurement": ""
   },
   "repos": [
@@ -24,7 +24,7 @@
   "runs": [
     {
       "bytes": 138988,
-      "elapsed_ms": 404.90299998782575,
+      "elapsed_ms": 656.9576670881361,
       "families": 104,
       "iteration": 1,
       "label": "baseline",
@@ -33,7 +33,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 121.71645811758935,
+      "elapsed_ms": 187.9395409487188,
       "families": 8,
       "iteration": 1,
       "label": "baseline",
@@ -42,7 +42,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 121.10237521119416,
+      "elapsed_ms": 119.92966593243182,
       "families": 6,
       "iteration": 1,
       "label": "baseline",
@@ -51,7 +51,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 86.19329193606973,
+      "elapsed_ms": 112.96900012530386,
       "families": 3,
       "iteration": 1,
       "label": "baseline",
@@ -60,7 +60,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 1830.82979102619,
+      "elapsed_ms": 2194.8795411735773,
       "families": 28,
       "iteration": 1,
       "label": "baseline",
@@ -69,7 +69,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 100.48912488855422,
+      "elapsed_ms": 87.94466592371464,
       "families": 1,
       "iteration": 1,
       "label": "baseline",
@@ -78,7 +78,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 624.2268329951912,
+      "elapsed_ms": 559.1879580169916,
       "families": 104,
       "iteration": 1,
       "label": "current",
@@ -87,7 +87,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 157.27370791137218,
+      "elapsed_ms": 181.60645803436637,
       "families": 8,
       "iteration": 1,
       "label": "current",
@@ -96,7 +96,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 156.8943748716265,
+      "elapsed_ms": 136.07733300887048,
       "families": 6,
       "iteration": 1,
       "label": "current",
@@ -105,7 +105,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 93.71891594491899,
+      "elapsed_ms": 109.5240421127528,
       "families": 3,
       "iteration": 1,
       "label": "current",
@@ -114,7 +114,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2162.690791999921,
+      "elapsed_ms": 2158.7476250715554,
       "families": 28,
       "iteration": 1,
       "label": "current",
@@ -123,7 +123,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 100.50462512299418,
+      "elapsed_ms": 77.58383406326175,
       "families": 1,
       "iteration": 1,
       "label": "current",
@@ -132,7 +132,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 510.87612519040704,
+      "elapsed_ms": 602.2261250764132,
       "families": 104,
       "iteration": 2,
       "label": "current",
@@ -141,7 +141,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 209.23083391971886,
+      "elapsed_ms": 171.08487500809133,
       "families": 8,
       "iteration": 2,
       "label": "current",
@@ -150,7 +150,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 114.90716598927975,
+      "elapsed_ms": 132.28533300571144,
       "families": 6,
       "iteration": 2,
       "label": "current",
@@ -159,7 +159,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 93.49970798939466,
+      "elapsed_ms": 115.46354205347598,
       "families": 3,
       "iteration": 2,
       "label": "current",
@@ -168,7 +168,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2040.0640829466283,
+      "elapsed_ms": 2182.600958039984,
       "families": 28,
       "iteration": 2,
       "label": "current",
@@ -177,7 +177,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 99.41566688939929,
+      "elapsed_ms": 94.79225007817149,
       "families": 1,
       "iteration": 2,
       "label": "current",
@@ -186,7 +186,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 517.3602919094265,
+      "elapsed_ms": 614.9474170524627,
       "families": 104,
       "iteration": 2,
       "label": "baseline",
@@ -195,7 +195,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 190.43275015428662,
+      "elapsed_ms": 155.8869588188827,
       "families": 8,
       "iteration": 2,
       "label": "baseline",
@@ -204,7 +204,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 111.13808280788362,
+      "elapsed_ms": 145.44216613285244,
       "families": 6,
       "iteration": 2,
       "label": "baseline",
@@ -213,7 +213,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 105.55825009942055,
+      "elapsed_ms": 110.34524999558926,
       "families": 3,
       "iteration": 2,
       "label": "baseline",
@@ -222,7 +222,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2091.6134170256555,
+      "elapsed_ms": 2077.5862080045044,
       "families": 28,
       "iteration": 2,
       "label": "baseline",
@@ -231,7 +231,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 79.33358405716717,
+      "elapsed_ms": 97.27958403527737,
       "families": 1,
       "iteration": 2,
       "label": "baseline",
@@ -240,7 +240,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 562.4480410479009,
+      "elapsed_ms": 593.6977090314031,
       "families": 104,
       "iteration": 3,
       "label": "baseline",
@@ -249,7 +249,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 209.20141716487706,
+      "elapsed_ms": 208.32229196093976,
       "families": 8,
       "iteration": 3,
       "label": "baseline",
@@ -258,7 +258,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 144.4564580451697,
+      "elapsed_ms": 121.65599991567433,
       "families": 6,
       "iteration": 3,
       "label": "baseline",
@@ -267,7 +267,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 107.33108315616846,
+      "elapsed_ms": 114.20474993065,
       "families": 3,
       "iteration": 3,
       "label": "baseline",
@@ -276,7 +276,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2122.590082930401,
+      "elapsed_ms": 2147.1964998636395,
       "families": 28,
       "iteration": 3,
       "label": "baseline",
@@ -285,7 +285,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 75.78937523066998,
+      "elapsed_ms": 86.18104201741517,
       "families": 1,
       "iteration": 3,
       "label": "baseline",
@@ -294,7 +294,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 623.5511670820415,
+      "elapsed_ms": 612.3479579109699,
       "families": 104,
       "iteration": 3,
       "label": "current",
@@ -303,7 +303,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 164.8642080835998,
+      "elapsed_ms": 159.92970811203122,
       "families": 8,
       "iteration": 3,
       "label": "current",
@@ -312,7 +312,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 119.08304202370346,
+      "elapsed_ms": 132.11720809340477,
       "families": 6,
       "iteration": 3,
       "label": "current",
@@ -321,7 +321,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 96.81570809334517,
+      "elapsed_ms": 111.48654203861952,
       "families": 3,
       "iteration": 3,
       "label": "current",
@@ -330,7 +330,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2082.7935829292983,
+      "elapsed_ms": 2183.0966668203473,
       "families": 28,
       "iteration": 3,
       "label": "current",
@@ -339,7 +339,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 114.26791595295072,
+      "elapsed_ms": 73.32891691476107,
       "families": 1,
       "iteration": 3,
       "label": "current",
@@ -348,7 +348,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 617.4134591128677,
+      "elapsed_ms": 645.8960000891238,
       "families": 104,
       "iteration": 4,
       "label": "current",
@@ -357,7 +357,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 182.14075011201203,
+      "elapsed_ms": 173.18020784296095,
       "families": 8,
       "iteration": 4,
       "label": "current",
@@ -366,7 +366,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 108.13324991613626,
+      "elapsed_ms": 122.89745802991092,
       "families": 6,
       "iteration": 4,
       "label": "current",
@@ -375,7 +375,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 112.40758304484189,
+      "elapsed_ms": 101.10275004990399,
       "families": 3,
       "iteration": 4,
       "label": "current",
@@ -384,7 +384,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2261.3473751116544,
+      "elapsed_ms": 2315.214958973229,
       "families": 28,
       "iteration": 4,
       "label": "current",
@@ -393,7 +393,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 101.26587492413819,
+      "elapsed_ms": 108.53562504053116,
       "families": 1,
       "iteration": 4,
       "label": "current",
@@ -402,7 +402,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 533.9424591511488,
+      "elapsed_ms": 657.375292154029,
       "families": 104,
       "iteration": 4,
       "label": "baseline",
@@ -411,7 +411,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 223.47579197958112,
+      "elapsed_ms": 222.2342500463128,
       "families": 8,
       "iteration": 4,
       "label": "baseline",
@@ -420,7 +420,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 136.42545812763274,
+      "elapsed_ms": 121.47925002500415,
       "families": 6,
       "iteration": 4,
       "label": "baseline",
@@ -429,7 +429,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 106.50120908394456,
+      "elapsed_ms": 117.37966700457036,
       "families": 3,
       "iteration": 4,
       "label": "baseline",
@@ -438,7 +438,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2193.174249958247,
+      "elapsed_ms": 2225.693041924387,
       "families": 28,
       "iteration": 4,
       "label": "baseline",
@@ -447,7 +447,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 77.04491703771055,
+      "elapsed_ms": 76.34474989026785,
       "families": 1,
       "iteration": 4,
       "label": "baseline",
@@ -456,7 +456,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 658.1928750965744,
+      "elapsed_ms": 638.316041091457,
       "families": 104,
       "iteration": 5,
       "label": "baseline",
@@ -465,7 +465,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 181.21254118159413,
+      "elapsed_ms": 181.308374973014,
       "families": 8,
       "iteration": 5,
       "label": "baseline",
@@ -474,7 +474,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 138.6728750076145,
+      "elapsed_ms": 126.60224991850555,
       "families": 6,
       "iteration": 5,
       "label": "baseline",
@@ -483,7 +483,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 97.42895909585059,
+      "elapsed_ms": 108.11804211698472,
       "families": 3,
       "iteration": 5,
       "label": "baseline",
@@ -492,7 +492,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2189.5434588659555,
+      "elapsed_ms": 2076.9868749193847,
       "families": 28,
       "iteration": 5,
       "label": "baseline",
@@ -501,7 +501,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 89.08995799720287,
+      "elapsed_ms": 71.69879204593599,
       "families": 1,
       "iteration": 5,
       "label": "baseline",
@@ -510,7 +510,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 635.7992079574615,
+      "elapsed_ms": 648.8949579652399,
       "families": 104,
       "iteration": 5,
       "label": "current",
@@ -519,7 +519,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 156.97124996222556,
+      "elapsed_ms": 169.15370803326368,
       "families": 8,
       "iteration": 5,
       "label": "current",
@@ -528,7 +528,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 119.3061659578234,
+      "elapsed_ms": 127.21716589294374,
       "families": 6,
       "iteration": 5,
       "label": "current",
@@ -537,7 +537,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 120.35291595384479,
+      "elapsed_ms": 103.97866717539728,
       "families": 3,
       "iteration": 5,
       "label": "current",
@@ -546,7 +546,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2250.5405419506133,
+      "elapsed_ms": 2176.021915860474,
       "families": 28,
       "iteration": 5,
       "label": "current",
@@ -555,7 +555,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 112.47091693803668,
+      "elapsed_ms": 105.10562499985099,
       "families": 1,
       "iteration": 5,
       "label": "current",
@@ -564,7 +564,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 554.9430830869824,
+      "elapsed_ms": 613.092957995832,
       "families": 104,
       "iteration": 6,
       "label": "current",
@@ -573,7 +573,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 218.80983281880617,
+      "elapsed_ms": 195.65241714008152,
       "families": 8,
       "iteration": 6,
       "label": "current",
@@ -582,7 +582,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 128.14112496562302,
+      "elapsed_ms": 114.911749958992,
       "families": 6,
       "iteration": 6,
       "label": "current",
@@ -591,7 +591,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 97.07920788787305,
+      "elapsed_ms": 115.64441700465977,
       "families": 3,
       "iteration": 6,
       "label": "current",
@@ -600,7 +600,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2204.124125186354,
+      "elapsed_ms": 2190.3840410523117,
       "families": 28,
       "iteration": 6,
       "label": "current",
@@ -609,7 +609,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 81.85079088434577,
+      "elapsed_ms": 83.66991695947945,
       "families": 1,
       "iteration": 6,
       "label": "current",
@@ -618,7 +618,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 635.3474999777973,
+      "elapsed_ms": 574.4004999287426,
       "families": 104,
       "iteration": 6,
       "label": "baseline",
@@ -627,7 +627,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 208.1250420305878,
+      "elapsed_ms": 185.7494581490755,
       "families": 8,
       "iteration": 6,
       "label": "baseline",
@@ -636,7 +636,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 134.62829194031656,
+      "elapsed_ms": 118.5015409719199,
       "families": 6,
       "iteration": 6,
       "label": "baseline",
@@ -645,7 +645,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 103.08116697706282,
+      "elapsed_ms": 100.96562490798533,
       "families": 3,
       "iteration": 6,
       "label": "baseline",
@@ -654,7 +654,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2125.1297499984503,
+      "elapsed_ms": 2167.8641659673303,
       "families": 28,
       "iteration": 6,
       "label": "baseline",
@@ -663,7 +663,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 97.11770806461573,
+      "elapsed_ms": 75.66283293999732,
       "families": 1,
       "iteration": 6,
       "label": "baseline",
@@ -672,7 +672,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 658.4287080913782,
+      "elapsed_ms": 616.1093339323997,
       "families": 104,
       "iteration": 7,
       "label": "baseline",
@@ -681,7 +681,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 186.350499978289,
+      "elapsed_ms": 196.26533286646008,
       "families": 8,
       "iteration": 7,
       "label": "baseline",
@@ -690,7 +690,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 133.86545912362635,
+      "elapsed_ms": 135.90691704303026,
       "families": 6,
       "iteration": 7,
       "label": "baseline",
@@ -699,7 +699,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 118.18516603671014,
+      "elapsed_ms": 93.25441694818437,
       "families": 3,
       "iteration": 7,
       "label": "baseline",
@@ -708,7 +708,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2251.170708797872,
+      "elapsed_ms": 2171.08983383514,
       "families": 28,
       "iteration": 7,
       "label": "baseline",
@@ -717,7 +717,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 101.92279191687703,
+      "elapsed_ms": 91.97233291342854,
       "families": 1,
       "iteration": 7,
       "label": "baseline",
@@ -726,7 +726,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 559.0964169241488,
+      "elapsed_ms": 642.4587080255151,
       "families": 104,
       "iteration": 7,
       "label": "current",
@@ -735,7 +735,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 182.17983283102512,
+      "elapsed_ms": 138.33679212257266,
       "families": 8,
       "iteration": 7,
       "label": "current",
@@ -744,7 +744,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 147.15041709132493,
+      "elapsed_ms": 151.10704209655523,
       "families": 6,
       "iteration": 7,
       "label": "current",
@@ -753,7 +753,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 119.20287483371794,
+      "elapsed_ms": 102.7651249896735,
       "families": 3,
       "iteration": 7,
       "label": "current",
@@ -762,7 +762,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2263.768707867712,
+      "elapsed_ms": 2221.1074579972774,
       "families": 28,
       "iteration": 7,
       "label": "current",
@@ -771,7 +771,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 76.21666695922613,
+      "elapsed_ms": 110.97383312880993,
       "families": 1,
       "iteration": 7,
       "label": "current",
@@ -780,7 +780,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 620.8587919827551,
+      "elapsed_ms": 541.9145419728011,
       "families": 104,
       "iteration": 8,
       "label": "current",
@@ -789,7 +789,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 194.90391621366143,
+      "elapsed_ms": 189.08679205924273,
       "families": 8,
       "iteration": 8,
       "label": "current",
@@ -798,7 +798,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 119.72104106098413,
+      "elapsed_ms": 116.87283287756145,
       "families": 6,
       "iteration": 8,
       "label": "current",
@@ -807,7 +807,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 107.03854192979634,
+      "elapsed_ms": 100.48229107633233,
       "families": 3,
       "iteration": 8,
       "label": "current",
@@ -816,7 +816,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2167.2699579503387,
+      "elapsed_ms": 2181.8254999816418,
       "families": 28,
       "iteration": 8,
       "label": "current",
@@ -825,7 +825,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 106.62420885637403,
+      "elapsed_ms": 79.84300004318357,
       "families": 1,
       "iteration": 8,
       "label": "current",
@@ -834,7 +834,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 645.2823327854276,
+      "elapsed_ms": 625.3516250289977,
       "families": 104,
       "iteration": 8,
       "label": "baseline",
@@ -843,7 +843,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 160.64095916226506,
+      "elapsed_ms": 177.64666699804366,
       "families": 8,
       "iteration": 8,
       "label": "baseline",
@@ -852,7 +852,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 159.39374989829957,
+      "elapsed_ms": 118.04704205133021,
       "families": 6,
       "iteration": 8,
       "label": "baseline",
@@ -861,7 +861,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 108.23179199360311,
+      "elapsed_ms": 100.51658400334418,
       "families": 3,
       "iteration": 8,
       "label": "baseline",
@@ -870,7 +870,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2331.710333004594,
+      "elapsed_ms": 2259.0442090295255,
       "families": 28,
       "iteration": 8,
       "label": "baseline",
@@ -879,7 +879,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 80.2926670294255,
+      "elapsed_ms": 101.3061658013612,
       "families": 1,
       "iteration": 8,
       "label": "baseline",
@@ -888,7 +888,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 639.0081669669598,
+      "elapsed_ms": 639.3547500483692,
       "families": 104,
       "iteration": 9,
       "label": "baseline",
@@ -897,7 +897,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 191.2080841138959,
+      "elapsed_ms": 156.87095909379423,
       "families": 8,
       "iteration": 9,
       "label": "baseline",
@@ -906,7 +906,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 126.92804192192852,
+      "elapsed_ms": 151.77837503142655,
       "families": 6,
       "iteration": 9,
       "label": "baseline",
@@ -915,7 +915,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 114.25662506371737,
+      "elapsed_ms": 115.28900009579957,
       "families": 3,
       "iteration": 9,
       "label": "baseline",
@@ -924,7 +924,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2201.3483338523656,
+      "elapsed_ms": 2134.965999983251,
       "families": 28,
       "iteration": 9,
       "label": "baseline",
@@ -933,7 +933,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 80.05616697482765,
+      "elapsed_ms": 99.80683401226997,
       "families": 1,
       "iteration": 9,
       "label": "baseline",
@@ -942,7 +942,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 669.7634998708963,
+      "elapsed_ms": 592.2148341778666,
       "families": 104,
       "iteration": 9,
       "label": "current",
@@ -951,7 +951,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 189.86441707238555,
+      "elapsed_ms": 183.33829194307327,
       "families": 8,
       "iteration": 9,
       "label": "current",
@@ -960,7 +960,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 110.92179198749363,
+      "elapsed_ms": 129.60729096084833,
       "families": 6,
       "iteration": 9,
       "label": "current",
@@ -969,7 +969,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 130.41849993169308,
+      "elapsed_ms": 116.78074998781085,
       "families": 3,
       "iteration": 9,
       "label": "current",
@@ -978,7 +978,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2281.487707979977,
+      "elapsed_ms": 2243.4007078409195,
       "families": 28,
       "iteration": 9,
       "label": "current",
@@ -987,7 +987,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 108.26770798303187,
+      "elapsed_ms": 81.29020920023322,
       "families": 1,
       "iteration": 9,
       "label": "current",
@@ -996,7 +996,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 593.5069168917835,
+      "elapsed_ms": 630.684542004019,
       "families": 104,
       "iteration": 10,
       "label": "current",
@@ -1005,7 +1005,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 209.41500016488135,
+      "elapsed_ms": 185.9863749705255,
       "families": 8,
       "iteration": 10,
       "label": "current",
@@ -1014,7 +1014,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 125.05754199810326,
+      "elapsed_ms": 131.38420903123915,
       "families": 6,
       "iteration": 10,
       "label": "current",
@@ -1023,7 +1023,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 97.82162494957447,
+      "elapsed_ms": 94.65904114767909,
       "families": 3,
       "iteration": 10,
       "label": "current",
@@ -1032,7 +1032,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2205.263457959518,
+      "elapsed_ms": 2172.363999998197,
       "families": 28,
       "iteration": 10,
       "label": "current",
@@ -1041,7 +1041,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 81.40437491238117,
+      "elapsed_ms": 106.89900000579655,
       "families": 1,
       "iteration": 10,
       "label": "current",
@@ -1050,7 +1050,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 670.5777498427778,
+      "elapsed_ms": 634.600582998246,
       "families": 104,
       "iteration": 10,
       "label": "baseline",
@@ -1059,7 +1059,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 179.48974994942546,
+      "elapsed_ms": 166.81220778264105,
       "families": 8,
       "iteration": 10,
       "label": "baseline",
@@ -1068,7 +1068,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 143.77162512391806,
+      "elapsed_ms": 133.18958296440542,
       "families": 6,
       "iteration": 10,
       "label": "baseline",
@@ -1077,7 +1077,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 103.12874987721443,
+      "elapsed_ms": 99.43770780228078,
       "families": 3,
       "iteration": 10,
       "label": "baseline",
@@ -1086,7 +1086,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2314.482167130336,
+      "elapsed_ms": 2128.2019580248743,
       "families": 28,
       "iteration": 10,
       "label": "baseline",
@@ -1095,7 +1095,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 114.78816694580019,
+      "elapsed_ms": 103.37408306077123,
       "families": 1,
       "iteration": 10,
       "label": "baseline",
@@ -1104,7 +1104,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 603.8280420470983,
+      "elapsed_ms": 575.63954195939,
       "families": 104,
       "iteration": 11,
       "label": "baseline",
@@ -1113,7 +1113,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 205.240709008649,
+      "elapsed_ms": 214.11649999208748,
       "families": 8,
       "iteration": 11,
       "label": "baseline",
@@ -1122,7 +1122,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 130.24145807139575,
+      "elapsed_ms": 108.78604091703892,
       "families": 6,
       "iteration": 11,
       "label": "baseline",
@@ -1131,7 +1131,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 121.68341712094843,
+      "elapsed_ms": 111.74233304336667,
       "families": 3,
       "iteration": 11,
       "label": "baseline",
@@ -1140,7 +1140,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2232.458416139707,
+      "elapsed_ms": 2256.049082847312,
       "families": 28,
       "iteration": 11,
       "label": "baseline",
@@ -1149,7 +1149,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 74.86424990929663,
+      "elapsed_ms": 79.15833406150341,
       "families": 1,
       "iteration": 11,
       "label": "baseline",
@@ -1158,7 +1158,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 615.1641251053661,
+      "elapsed_ms": 588.4386661928147,
       "families": 104,
       "iteration": 11,
       "label": "current",
@@ -1167,7 +1167,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 205.57133294641972,
+      "elapsed_ms": 185.25850004516542,
       "families": 8,
       "iteration": 11,
       "label": "current",
@@ -1176,7 +1176,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 139.6032499615103,
+      "elapsed_ms": 130.68466586992145,
       "families": 6,
       "iteration": 11,
       "label": "current",
@@ -1185,7 +1185,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 119.69370883889496,
+      "elapsed_ms": 113.43441694043577,
       "families": 3,
       "iteration": 11,
       "label": "current",
@@ -1194,7 +1194,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2181.442917091772,
+      "elapsed_ms": 2153.6276668775827,
       "families": 28,
       "iteration": 11,
       "label": "current",
@@ -1203,7 +1203,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 92.87725016474724,
+      "elapsed_ms": 77.5535840075463,
       "families": 1,
       "iteration": 11,
       "label": "current",
@@ -1212,7 +1212,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 635.6337910983711,
+      "elapsed_ms": 667.4305410124362,
       "families": 104,
       "iteration": 12,
       "label": "current",
@@ -1221,7 +1221,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 172.38070792518556,
+      "elapsed_ms": 180.21287489682436,
       "families": 8,
       "iteration": 12,
       "label": "current",
@@ -1230,7 +1230,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 159.53291696496308,
+      "elapsed_ms": 102.96391695737839,
       "families": 6,
       "iteration": 12,
       "label": "current",
@@ -1239,7 +1239,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 131.13004202023149,
+      "elapsed_ms": 121.55583291314542,
       "families": 3,
       "iteration": 12,
       "label": "current",
@@ -1248,7 +1248,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2245.3977910336107,
+      "elapsed_ms": 2143.564708996564,
       "families": 28,
       "iteration": 12,
       "label": "current",
@@ -1257,7 +1257,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 98.36533316411078,
+      "elapsed_ms": 108.5674581117928,
       "families": 1,
       "iteration": 12,
       "label": "current",
@@ -1266,7 +1266,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 597.9432910680771,
+      "elapsed_ms": 599.3277500383556,
       "families": 104,
       "iteration": 12,
       "label": "baseline",
@@ -1275,7 +1275,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 192.37658311612904,
+      "elapsed_ms": 206.95387502200902,
       "families": 8,
       "iteration": 12,
       "label": "baseline",
@@ -1284,7 +1284,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 138.3378750178963,
+      "elapsed_ms": 112.08079103380442,
       "families": 6,
       "iteration": 12,
       "label": "baseline",
@@ -1293,7 +1293,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 115.90283294208348,
+      "elapsed_ms": 107.82983293756843,
       "families": 3,
       "iteration": 12,
       "label": "baseline",
@@ -1302,7 +1302,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2207.264000084251,
+      "elapsed_ms": 2219.0268749836832,
       "families": 28,
       "iteration": 12,
       "label": "baseline",
@@ -1311,7 +1311,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 75.90679218992591,
+      "elapsed_ms": 84.42891691811383,
       "families": 1,
       "iteration": 12,
       "label": "baseline",
@@ -1320,7 +1320,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 609.568125102669,
+      "elapsed_ms": 644.8536668904126,
       "families": 104,
       "iteration": 13,
       "label": "baseline",
@@ -1329,7 +1329,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 184.1642081271857,
+      "elapsed_ms": 195.8769999910146,
       "families": 8,
       "iteration": 13,
       "label": "baseline",
@@ -1338,7 +1338,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 119.73316594958305,
+      "elapsed_ms": 125.36458298563957,
       "families": 6,
       "iteration": 13,
       "label": "baseline",
@@ -1347,7 +1347,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 97.33283310197294,
+      "elapsed_ms": 111.86312511563301,
       "families": 3,
       "iteration": 13,
       "label": "baseline",
@@ -1356,7 +1356,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2253.6430000327528,
+      "elapsed_ms": 2118.272916879505,
       "families": 28,
       "iteration": 13,
       "label": "baseline",
@@ -1365,7 +1365,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 107.44866612367332,
+      "elapsed_ms": 70.27374999597669,
       "families": 1,
       "iteration": 13,
       "label": "baseline",
@@ -1374,7 +1374,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 630.6539999786764,
+      "elapsed_ms": 627.3572500795126,
       "families": 104,
       "iteration": 13,
       "label": "current",
@@ -1383,7 +1383,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 202.57929200306535,
+      "elapsed_ms": 189.60624979808927,
       "families": 8,
       "iteration": 13,
       "label": "current",
@@ -1392,7 +1392,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 132.93466717004776,
+      "elapsed_ms": 109.08841714262962,
       "families": 6,
       "iteration": 13,
       "label": "current",
@@ -1401,7 +1401,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 107.42862499319017,
+      "elapsed_ms": 95.15670780092478,
       "families": 3,
       "iteration": 13,
       "label": "current",
@@ -1410,7 +1410,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2205.754042137414,
+      "elapsed_ms": 2152.8404999990016,
       "families": 28,
       "iteration": 13,
       "label": "current",
@@ -1419,7 +1419,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 94.39283283427358,
+      "elapsed_ms": 101.71383409760892,
       "families": 1,
       "iteration": 13,
       "label": "current",
@@ -1428,7 +1428,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 590.6499170232564,
+      "elapsed_ms": 660.2585839573294,
       "families": 104,
       "iteration": 14,
       "label": "current",
@@ -1437,7 +1437,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 184.38287498429418,
+      "elapsed_ms": 156.31420817226171,
       "families": 8,
       "iteration": 14,
       "label": "current",
@@ -1446,7 +1446,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 136.71233388595283,
+      "elapsed_ms": 133.7897500488907,
       "families": 6,
       "iteration": 14,
       "label": "current",
@@ -1455,7 +1455,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 115.33033405430615,
+      "elapsed_ms": 103.01987477578223,
       "families": 3,
       "iteration": 14,
       "label": "current",
@@ -1464,7 +1464,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2222.2167919389904,
+      "elapsed_ms": 2165.957042016089,
       "families": 28,
       "iteration": 14,
       "label": "current",
@@ -1473,7 +1473,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 112.61316714808345,
+      "elapsed_ms": 102.8140839189291,
       "families": 1,
       "iteration": 14,
       "label": "current",
@@ -1482,7 +1482,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 661.7954999674112,
+      "elapsed_ms": 555.9222081210464,
       "families": 104,
       "iteration": 14,
       "label": "baseline",
@@ -1491,7 +1491,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 180.00712501816452,
+      "elapsed_ms": 191.89524999819696,
       "families": 8,
       "iteration": 14,
       "label": "baseline",
@@ -1500,7 +1500,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 114.74770889617503,
+      "elapsed_ms": 109.14283315651119,
       "families": 6,
       "iteration": 14,
       "label": "baseline",
@@ -1509,7 +1509,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 105.5386250372976,
+      "elapsed_ms": 98.89116697013378,
       "families": 3,
       "iteration": 14,
       "label": "baseline",
@@ -1518,7 +1518,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2243.056375067681,
+      "elapsed_ms": 2169.3348749540746,
       "families": 28,
       "iteration": 14,
       "label": "baseline",
@@ -1527,7 +1527,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 104.69158389605582,
+      "elapsed_ms": 83.75812484882772,
       "families": 1,
       "iteration": 14,
       "label": "baseline",
@@ -1536,7 +1536,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 563.2505419198424,
+      "elapsed_ms": 624.0199999883771,
       "families": 104,
       "iteration": 15,
       "label": "baseline",
@@ -1545,7 +1545,7 @@
     },
     {
       "bytes": 35452,
-      "elapsed_ms": 201.6484159976244,
+      "elapsed_ms": 186.62975006736815,
       "families": 8,
       "iteration": 15,
       "label": "baseline",
@@ -1554,7 +1554,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 130.2955828141421,
+      "elapsed_ms": 132.0439581759274,
       "families": 6,
       "iteration": 15,
       "label": "baseline",
@@ -1563,7 +1563,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 101.99024993926287,
+      "elapsed_ms": 106.63520800881088,
       "families": 3,
       "iteration": 15,
       "label": "baseline",
@@ -1572,7 +1572,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2293.4672080446035,
+      "elapsed_ms": 2149.6969170402735,
       "families": 28,
       "iteration": 15,
       "label": "baseline",
@@ -1581,7 +1581,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 78.59375001862645,
+      "elapsed_ms": 101.56041709706187,
       "families": 1,
       "iteration": 15,
       "label": "baseline",
@@ -1590,7 +1590,7 @@
     },
     {
       "bytes": 138988,
-      "elapsed_ms": 613.4114998858422,
+      "elapsed_ms": 644.9694579932839,
       "families": 104,
       "iteration": 15,
       "label": "current",
@@ -1599,7 +1599,7 @@
     },
     {
       "bytes": 35566,
-      "elapsed_ms": 202.942208154127,
+      "elapsed_ms": 165.8049589022994,
       "families": 8,
       "iteration": 15,
       "label": "current",
@@ -1608,7 +1608,7 @@
     },
     {
       "bytes": 32237,
-      "elapsed_ms": 128.25662503018975,
+      "elapsed_ms": 105.22683407180011,
       "families": 6,
       "iteration": 15,
       "label": "current",
@@ -1617,7 +1617,7 @@
     },
     {
       "bytes": 28232,
-      "elapsed_ms": 112.74008289910853,
+      "elapsed_ms": 114.76949998177588,
       "families": 3,
       "iteration": 15,
       "label": "current",
@@ -1626,7 +1626,7 @@
     },
     {
       "bytes": 71641,
-      "elapsed_ms": 2221.1911249905825,
+      "elapsed_ms": 2262.204583035782,
       "families": 28,
       "iteration": 15,
       "label": "current",
@@ -1635,7 +1635,7 @@
     },
     {
       "bytes": 27177,
-      "elapsed_ms": 111.0206248704344,
+      "elapsed_ms": 110.94687506556511,
       "families": 1,
       "iteration": 15,
       "label": "current",
@@ -1644,9 +1644,9 @@
     }
   ],
   "summary": {
-    "aggregate_baseline_median_ms": 3326.981251593679,
-    "aggregate_current_median_ms": 3354.0852514561266,
-    "aggregate_delta_pct": 0.814672455682283,
+    "aggregate_baseline_median_ms": 3295.7787909545004,
+    "aggregate_current_median_ms": 3330.240792129189,
+    "aggregate_delta_pct": 1.045640601525556,
     "by_repo": {
       "fastlane": {
         "baseline": {
@@ -1659,7 +1659,7 @@
           "hashes": [
             "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 2207.264000084251
+          "median_ms": 2167.8641659673303
         },
         "current": {
           "bytes": [
@@ -1671,7 +1671,7 @@
           "hashes": [
             "2480bcc49a82e097ba3ba81d42820581c9ee766d850e32de89e4d094d12e6da8"
           ],
-          "median_ms": 2205.754042137414
+          "median_ms": 2181.8254999816418
         }
       },
       "rack": {
@@ -1685,7 +1685,7 @@
           "hashes": [
             "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 105.55825009942055
+          "median_ms": 108.11804211698472
         },
         "current": {
           "bytes": [
@@ -1697,7 +1697,7 @@
           "hashes": [
             "0ba5ea138badceb1ba9d770cde1152d468fec82b51995b5ed067b9b5b0a6d345"
           ],
-          "median_ms": 112.40758304484189
+          "median_ms": 109.5240421127528
         }
       },
       "rspec-core": {
@@ -1711,7 +1711,7 @@
           "hashes": [
             "9a3a14775e369e095ff60d55a32ac7c09cf2ef16919fab22b0b3c862779523a2"
           ],
-          "median_ms": 190.43275015428662
+          "median_ms": 187.9395409487188
         },
         "current": {
           "bytes": [
@@ -1723,7 +1723,7 @@
           "hashes": [
             "d79cb4c42029903b2fe1f84847a84634f9cb737fae00dfd383ac4624d65c3714"
           ],
-          "median_ms": 189.86441707238555
+          "median_ms": 180.21287489682436
         }
       },
       "rubocop": {
@@ -1737,7 +1737,7 @@
           "hashes": [
             "20ed571d60a124512ade42c7c5bcbbfd1765d3eda9f3ea44275b1f4401bfecb4"
           ],
-          "median_ms": 609.568125102669
+          "median_ms": 624.0199999883771
         },
         "current": {
           "bytes": [
@@ -1749,7 +1749,7 @@
           "hashes": [
             "9332e563fe0a6f730ad8cf4c42a90184b8ddac8294ea5e01b58320620e88f3af"
           ],
-          "median_ms": 617.4134591128677
+          "median_ms": 627.3572500795126
         }
       },
       "sidekiq": {
@@ -1763,7 +1763,7 @@
           "hashes": [
             "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 133.86545912362635
+          "median_ms": 121.65599991567433
         },
         "current": {
           "bytes": [
@@ -1775,7 +1775,7 @@
           "hashes": [
             "ccdbfe3c0dd364af6e521cc24b647de2786bce0ffcd9a94f067ec70e84a0eab5"
           ],
-          "median_ms": 128.14112496562302
+          "median_ms": 129.60729096084833
         }
       },
       "sinatra": {
@@ -1789,7 +1789,7 @@
           "hashes": [
             "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 80.2926670294255
+          "median_ms": 86.18104201741517
         },
         "current": {
           "bytes": [
@@ -1801,7 +1801,7 @@
           "hashes": [
             "8da5b06729f145969c4fb3083af11ba78130db8b83bd7a384adc586d60485c39"
           ],
-          "median_ms": 100.50462512299418
+          "median_ms": 101.71383409760892
         }
       }
     },

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json
@@ -82,9 +82,9 @@
       "admission_rejections": 812,
       "canon_checked": 99,
       "canon_preservation_violations": 0,
-      "excluded_units": 6021,
+      "excluded_units": 6023,
       "interpretable_units": 970,
-      "total_units": 6991
+      "total_units": 6993
     }
   },
   "generated_on": "2026-07-02",

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json
@@ -1,0 +1,5674 @@
+{
+  "current_recall_loss": {
+    "relevant_obligations": [
+      {
+        "count": 17,
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_interpretable": 17
+      },
+      {
+        "count": 10,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-rust-macro-call-effect-proof-missing",
+        "oracle_interpretable": 10
+      },
+      {
+        "count": 9,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-member-call-effect-proof-missing",
+        "oracle_interpretable": 9
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-assignment-effect-proof-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-direct-function-call-effect-contract-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 2,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-identity-or-shape-proof-missing",
+        "oracle_interpretable": 2
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-imported-function-call-effect-contract-missing",
+        "oracle_interpretable": 1
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "predicate-callback-demand-effect-profile-missing",
+        "oracle_interpretable": 1
+      }
+    ],
+    "relevant_oracle_exclusion_obligations": [
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 580,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_excluded": 580
+      },
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 3,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "oracle_excluded": 3
+      }
+    ],
+    "report": "target/recall-loss.ruby-exception-reporting.crates.json",
+    "soundness_gate": {
+      "advisory_disagreements": 4,
+      "canon_preservation_violations": 0,
+      "false_merges": 0,
+      "fingerprint_groups": 38,
+      "gate_passed": true,
+      "lossy_fingerprint_collisions": 0,
+      "max_violations": 0
+    },
+    "summary": {
+      "admission_rejections": 812,
+      "canon_checked": 99,
+      "canon_preservation_violations": 0,
+      "excluded_units": 6021,
+      "interpretable_units": 970,
+      "total_units": 6991
+    }
+  },
+  "generated_on": "2026-07-02",
+  "hard_negative_inventory": [
+    {
+      "class": "thenable assimilation and custom Promise-like receivers",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "first-settled versus all-settled aggregate semantics",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "executor callback timing and thrown executor errors",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::promise_constructor_missing_evidence_splits_executor_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "scheduler/microtask ordering versus synchronous evaluation",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::scheduler_and_interval_calls_report_timing_and_lifecycle_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "interval stream liveness/cardinality",
+      "evidence": "crates/nose-cli/tests/cli/commands/recall_loss_report.rs::recall_loss_report_splits_promise_protocol_boundaries",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
+      "evidence": "docs/scheduling-channel-callback-obligations-594.md",
+      "status": "mapped-doc-policy"
+    },
+    {
+      "class": "Go direct call versus goroutine/defer scheduling and callback effects",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_select_defer_and_goroutine_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Go channel receive value/status, channel send, and select/default readiness boundaries",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_channel_protocol_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Python async iterator and async context-manager protocol boundaries versus synchronous loops, comprehensions, and with-blocks",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries/python_async_protocol.rs::query_mode_semantic_rejects_unproven_python_async_protocol_lifecycle_convergence, ::query_mode_semantic_rejects_unproven_python_async_comprehension_convergence, crates/nose-frontend/src/python/tests.rs::async_for_preserves_source_backed_iteration_boundary, ::async_comprehension_preserves_source_backed_iteration_boundary, ::multi_clause_async_comprehension_preserves_source_backed_iteration_boundary, ::async_with_preserves_source_backed_context_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::python_async_lifecycle_protocols_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Ruby block yield callback demand/effect versus ordinary value return or direct call",
+      "evidence": "crates/nose-frontend/src/ruby/tests.rs::yield_preserves_source_backed_protocol_boundary, crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::yield_protocol_missing_evidence_is_language_specific, and crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs::query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Rust async closures versus synchronous closures and async blocks",
+      "evidence": "crates/nose-frontend/src/rust/tests/async_protocols.rs::async_closure_preserves_source_backed_protocol_boundary, ::sync_closure_does_not_create_async_protocol_boundary, and crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Swift structured-concurrency runtime names shadowed by local Task bindings, Task extensions, same-file task-group functions, or project-visible task-group functions",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_structured_concurrency_rejects_local_runtime_shadows",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Swift throwing functions and closures versus non-throwing callables, plus async throwing callables that must retain both scheduling and exception-channel obligations",
+      "evidence": "crates/nose-frontend/src/swift/tests/async_protocols.rs::async_throwing_function_preserves_scheduling_and_exception_boundaries, ::async_throwing_closure_keeps_exception_boundary_inside_async_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_throwing_callables_report_exception_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletableFuture static calls without exact stdlib type identity, or with local/conflicting type names",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_static_wildcard.rs::java_completable_future_static_attribution_requires_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletionStage-style receiver continuations without import-backed java.util.concurrent type-domain evidence",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completion_stage_receiver_methods_require_import_backed_type_domain",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future local receivers with reassignment, local shadows, or conflicting imports, plus conflicting Executor local receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future field receivers that are implicit, non-this, member-shadowed, duplicate, or conflicting, plus conflicting Executor field receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    }
+  ],
+  "policy": {
+    "go_channel_operation_pricing": "Directional channel type arrows such as <-chan and chan<- are excluded from send/receive operation counts.",
+    "note": "Counts price boundary surfaces; they do not prove exact semantics.",
+    "raw_source_snippets_included": false,
+    "semantic_admission_delta": 0,
+    "source_prevalence_only": true
+  },
+  "recommended_order": [
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "rank": 1,
+      "repos": 17,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "rank": 2,
+      "repos": 8,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "rank": 3,
+      "repos": 18,
+      "why": "new Promise is high-risk because timing, resolve/reject callback, and throw-to-rejection behavior interact."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "rank": 4,
+      "repos": 7,
+      "why": "Cancellation appears across JS/TS scheduling APIs and must stay separate from fulfillment/rejection recovery."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "rank": 5,
+      "repos": 11,
+      "why": "Repeated emission/liveness needs lifecycle proof before interval streams can be compared exactly."
+    },
+    {
+      "language": "java",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 230,
+      "operation": "CompletableFuture",
+      "rank": 6,
+      "repos": 7,
+      "why": "High-prevalence boundary surface with reusable obligation vocabulary."
+    }
+  ],
+  "regenerate": [
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json --generated-on 2026-07-02"
+  ],
+  "report_kind": "scheduling-lifecycle-boundary-audit",
+  "schema_version": 1,
+  "summary": {
+    "languages": {
+      "c": 81,
+      "go": 31500,
+      "java": 6702,
+      "javascript-typescript": 45382,
+      "python": 6439,
+      "ruby": 8883,
+      "rust": 13228,
+      "swift": 64366
+    },
+    "obligation_families": {
+      "callback-demand-effect": 801,
+      "cancellation-liveness-boundary": 547,
+      "channel-boundary": 12030,
+      "exception-channel": 59776,
+      "executor-callback": 795,
+      "lifecycle-materialization-boundary": 22811,
+      "scheduling-boundary": 78509,
+      "success-error-result-channel": 1312
+    },
+    "repos_in_manifest": 120,
+    "total_source_prevalence": 176581
+  },
+  "surfaces": [
+    {
+      "boundary": "await scheduling",
+      "language": "javascript-typescript",
+      "note": "await is scheduling and thenable assimilation, not sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 29305,
+      "operation": "await",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.await",
+      "top_files": [
+        {
+          "occurrences": 1058,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 689,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 673,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 635,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 615,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 615,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 487,
+          "path": "drizzle-orm/integration-tests/tests/sqlite/sqlite-common.ts"
+        },
+        {
+          "occurrences": 484,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12136,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3321,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 2666,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2413,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1604,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 1592,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 1171,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 1164,
+          "repo": "swr"
+        }
+      ]
+    },
+    {
+      "boundary": "throws channel",
+      "language": "swift",
+      "note": "Historical lexical overlap bucket; use source-backed Swift try and throwing-callable rows as actionable exception-channel surfaces",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "swift-throws-exception-channel-contract-missing",
+      "occurrences": 26608,
+      "operation": "throws/try",
+      "repos": 18,
+      "status": "superseded-overlap-boundary",
+      "surface": "swift.error.throws",
+      "top_files": [
+        {
+          "occurrences": 664,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 489,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 450,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 406,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 396,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 364,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 344,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 304,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14760,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2508,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1466,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 1356,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 1107,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 914,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 805,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "try propagation error channel",
+      "language": "swift",
+      "note": "Swift try expressions and for-try-await loops expose source-backed TryPropagation boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 17970,
+      "operation": "try/try?/try!",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.try_expression",
+      "top_files": [
+        {
+          "occurrences": 529,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 411,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 391,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 357,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 337,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 282,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 273,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 259,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10831,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 1460,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 760,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 758,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 722,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 635,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 610,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 562,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "defer lifecycle",
+      "language": "go",
+      "note": "defer has scope-exit ordering and panic interaction semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "defer-lifecycle-ordering-contract-missing",
+      "occurrences": 17521,
+      "operation": "defer statement",
+      "repos": 16,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.defer",
+      "top_files": [
+        {
+          "occurrences": 1001,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 560,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 494,
+          "path": "nats-server/server/jetstream_consumer_test.go"
+        },
+        {
+          "occurrences": 461,
+          "path": "nats-server/server/filestore_test.go"
+        },
+        {
+          "occurrences": 420,
+          "path": "nats-server/server/mqtt_test.go"
+        },
+        {
+          "occurrences": 396,
+          "path": "nats-server/server/jetstream_cluster_3_test.go"
+        },
+        {
+          "occurrences": 394,
+          "path": "nats-server/server/jetstream_cluster_1_test.go"
+        },
+        {
+          "occurrences": 379,
+          "path": "nats-server/server/gateway_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10073,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 2461,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1797,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 1151,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 581,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 449,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 422,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 161,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "javascript-typescript",
+      "note": "async functions have scheduling and rejection boundaries even without explicit await",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 14491,
+      "operation": "async function",
+      "repos": 22,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.function",
+      "top_files": [
+        {
+          "occurrences": 352,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 314,
+          "path": "ky/test/hooks.ts"
+        },
+        {
+          "occurrences": 278,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 278,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 210,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 207,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 198,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 192,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4595,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 1621,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1607,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 1079,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 883,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 814,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 688,
+          "repo": "axios"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "swift",
+      "note": "Swift await has task scheduling and actor/lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8689,
+      "operation": "await",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.await",
+      "top_files": [
+        {
+          "occurrences": 612,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 556,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 263,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 257,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 251,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 221,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 153,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 150,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3169,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2261,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 969,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 944,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 724,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 155,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 139,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 96,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "future await",
+      "language": "rust",
+      "note": "Rust .await polls a Future and must keep wake/scheduling effects explicit",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8647,
+      "operation": ".await",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.await",
+      "top_files": [
+        {
+          "occurrences": 545,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/proxy.rs"
+        },
+        {
+          "occurrences": 255,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 227,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 221,
+          "path": "meilisearch/crates/meilisearch/tests/dumps/mod.rs"
+        },
+        {
+          "occurrences": 193,
+          "path": "meilisearch/crates/meilisearch/tests/search/mod.rs"
+        },
+        {
+          "occurrences": 147,
+          "path": "meilisearch/crates/meilisearch/tests/tasks/mod.rs"
+        },
+        {
+          "occurrences": 141,
+          "path": "meilisearch/crates/meilisearch/tests/batches/mod.rs"
+        },
+        {
+          "occurrences": 138,
+          "path": "meilisearch/crates/meilisearch/tests/documents/get_documents.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5632,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 2942,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 39,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 34,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing callable error channel",
+      "language": "swift",
+      "note": "Swift body-bearing throwing functions expose an error channel even when the body has no explicit try expression",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 7008,
+      "operation": "func/init/subscript throws/rethrows",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_function",
+      "top_files": [
+        {
+          "occurrences": 135,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 133,
+          "path": "swift-nio/Tests/NIOCoreTests/ByteBufferTest.swift"
+        },
+        {
+          "occurrences": 82,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 76,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 74,
+          "path": "swift-nio/Tests/NIOPosixTests/CodecTest.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 64,
+          "path": "swift-collections/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3459,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 864,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 518,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 445,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 387,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 284,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 219,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 165,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive value",
+      "language": "go",
+      "note": "Go channel receives have blocking, synchronization, and close/zero-value channel semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-value-channel-contract-missing",
+      "occurrences": 4294,
+      "operation": "channel receive",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive",
+      "top_files": [
+        {
+          "occurrences": 126,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 102,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 98,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "delve/service/test/integration2_test.go"
+        },
+        {
+          "occurrences": 82,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 73,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 68,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 65,
+          "path": "nats-server/server/norace_2_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1476,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1354,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 541,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 537,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 175,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 85,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 17,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "exception channel",
+      "language": "ruby",
+      "note": "Historical lexical overlap bucket; use source-backed Ruby raise and rescue rows as actionable exception-channel surfaces",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 4010,
+      "operation": "raise/rescue",
+      "repos": 18,
+      "status": "superseded-overlap-boundary",
+      "surface": "ruby.exception",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 71,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 67,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 53,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 50,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1334,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 699,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 343,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 264,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 226,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 155,
+          "repo": "sinatra"
+        }
+      ]
+    },
+    {
+      "boundary": "select case selection",
+      "language": "go",
+      "note": "Go select cases require readiness, case-selection, and send/receive side-effect proof",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-case-selection-contract-missing",
+      "occurrences": 3590,
+      "operation": "select case",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.case",
+      "top_files": [
+        {
+          "occurrences": 110,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 106,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 71,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 67,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 63,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 62,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 61,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1342,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1086,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 533,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 430,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 82,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 29,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 15,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "executor scheduling",
+      "language": "java",
+      "note": "Historical lexical type-name bucket; use proof-backed Java Future, CompletionStage, Executor, and ScheduledExecutor receiver-method rows as actionable surfaces",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "java-executor-scheduling-contract-missing",
+      "occurrences": 3297,
+      "operation": "Executor/Future",
+      "repos": 16,
+      "status": "superseded-overlap-boundary",
+      "surface": "java.future.executor",
+      "top_files": [
+        {
+          "occurrences": 59,
+          "path": "netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 33,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1338,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 1173,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 343,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 107,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 86,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 84,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 57,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 44,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "swift",
+      "note": "Swift async surfaces create task/future-like protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2964,
+      "operation": "async",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.function",
+      "top_files": [
+        {
+          "occurrences": 134,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 54,
+          "path": "vapor/Tests/VaporMacroTests/HTTPMethodMacroTests.swift"
+        },
+        {
+          "occurrences": 45,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 45,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 44,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 42,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 41,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1119,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 605,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 507,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 265,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 99,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 97,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 79,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 76,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "rust",
+      "note": "async fn creates a suspended async function boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2806,
+      "operation": "async fn",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 67,
+          "path": "meilisearch/crates/meilisearch/tests/common/index.rs"
+        },
+        {
+          "occurrences": 60,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 56,
+          "path": "meilisearch/crates/meilisearch/tests/common/server.rs"
+        },
+        {
+          "occurrences": 49,
+          "path": "meilisearch/crates/meilisearch/tests/search/errors.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 37,
+          "path": "meilisearch/crates/meilisearch/tests/auth/api_keys.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1405,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 1352,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 28,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 21,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "generator lifecycle",
+      "language": "python",
+      "note": "Python yield expressions expose source-backed generator lifecycle and protocol boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "generator-yield-lifecycle-contract-missing",
+      "occurrences": 2404,
+      "operation": "yield",
+      "repos": 21,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 86,
+          "path": "sympy/sympy/utilities/iterables.py"
+        },
+        {
+          "occurrences": 83,
+          "path": "black/src/black/linegen.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "scrapy/tests/test_crawl.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sympy/sympy/core/facts.py"
+        },
+        {
+          "occurrences": 39,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 37,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 31,
+          "path": "packaging/src/packaging/tags.py"
+        },
+        {
+          "occurrences": 29,
+          "path": "rich/rich/segment.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 540,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 446,
+          "repo": "sympy"
+        },
+        {
+          "occurrences": 367,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 339,
+          "repo": "rich"
+        },
+        {
+          "occurrences": 172,
+          "repo": "black"
+        },
+        {
+          "occurrences": 139,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 76,
+          "repo": "poetry"
+        },
+        {
+          "occurrences": 64,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "raise exception channel",
+      "language": "ruby",
+      "note": "Ruby raise calls expose source-backed Throw exception-channel boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 2065,
+      "operation": "raise",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.exception.raise",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 49,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 45,
+          "path": "rubocop/spec/rubocop/cop/style/raise_args_spec.rb"
+        },
+        {
+          "occurrences": 38,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        },
+        {
+          "occurrences": 30,
+          "path": "sidekiq/test/retry_test.rb"
+        },
+        {
+          "occurrences": 29,
+          "path": "puma/lib/puma/client.rb"
+        },
+        {
+          "occurrences": 27,
+          "path": "asciidoctor/lib/asciidoctor/extensions.rb"
+        },
+        {
+          "occurrences": 27,
+          "path": "rubocop/spec/rubocop/cop/style/guard_clause_spec.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 425,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 373,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 182,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 174,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 155,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 138,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 126,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 112,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Java streams need lazy/eager lifecycle and terminal materialization proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 1996,
+      "operation": "stream/parallelStream",
+      "repos": 15,
+      "status": "closed-boundary",
+      "surface": "java.stream.lifecycle",
+      "top_files": [
+        {
+          "occurrences": 137,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/GeoPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 124,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java"
+        },
+        {
+          "occurrences": 80,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGeospatialCommandsTest.java"
+        },
+        {
+          "occurrences": 75,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 60,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "netty/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java"
+        },
+        {
+          "occurrences": 24,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 535,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 508,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 385,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 280,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 102,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 88,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 29,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 24,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "goroutine scheduling",
+      "language": "go",
+      "note": "go statements spawn concurrent execution",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "repos": 14,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.goroutine",
+      "top_files": [
+        {
+          "occurrences": 52,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "prometheus/discovery/kubernetes/kubernetes.go"
+        },
+        {
+          "occurrences": 23,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 22,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 20,
+          "path": "nats-server/server/jwt_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 501,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 439,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 364,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 253,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 126,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 91,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 60,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 36,
+          "repo": "hugo"
+        }
+      ]
+    },
+    {
+      "boundary": "rescue exception channel",
+      "language": "ruby",
+      "note": "Ruby rescue clauses lower to Try exception-channel boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 1933,
+      "operation": "rescue",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.exception.rescue",
+      "top_files": [
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 40,
+          "path": "rubocop/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb"
+        },
+        {
+          "occurrences": 39,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_modifier_spec.rb"
+        },
+        {
+          "occurrences": 37,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 31,
+          "path": "rubocop/spec/rubocop/cop/layout/else_alignment_spec.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 901,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 326,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 186,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 99,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 63,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 44,
+          "repo": "jekyll"
+        }
+      ]
+    },
+    {
+      "boundary": "channel select",
+      "language": "go",
+      "note": "select has readiness, default, and scheduling semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-readiness-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select",
+      "top_files": [
+        {
+          "occurrences": 62,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 58,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 45,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 33,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 31,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "nats-server/server/routes_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "prometheus/scrape/scrape_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 706,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 574,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 279,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 250,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 47,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 25,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 21,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "python",
+      "note": "Python await has coroutine scheduling and exception channel semantics",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 1789,
+      "operation": "await",
+      "repos": 8,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.await",
+      "top_files": [
+        {
+          "occurrences": 145,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 122,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 78,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 72,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 62,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 54,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 50,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 716,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 661,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 200,
+          "repo": "black"
+        },
+        {
+          "occurrences": 196,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 5,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "python",
+      "note": "async def creates coroutine protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 1596,
+      "operation": "async def",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 75,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 57,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/result.py"
+        },
+        {
+          "occurrences": 53,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "scrapy/tests/test_spidermiddleware.py"
+        },
+        {
+          "occurrences": 40,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 790,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 424,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 209,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 144,
+          "repo": "black"
+        },
+        {
+          "occurrences": 19,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 3,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "channel send synchronization",
+      "language": "go",
+      "note": "Go channel sends have blocking and synchronization semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-synchronization-contract-missing",
+      "occurrences": 1525,
+      "operation": "channel send",
+      "repos": 12,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.send",
+      "top_files": [
+        {
+          "occurrences": 43,
+          "path": "nats-server/server/filestore.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jwt_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "minio/cmd/metrics.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "prometheus/tsdb/head_wal.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/reload_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "etcd/server/etcdserver/server_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "nats-server/server/leafnode_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 474,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 436,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 275,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 189,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 39,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 33,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 28,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 18,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async block construction",
+      "language": "rust",
+      "note": "async blocks create suspended async boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-block-scheduling-contract-missing",
+      "occurrences": 1342,
+      "operation": "async block",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.block",
+      "top_files": [
+        {
+          "occurrences": 109,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 86,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 57,
+          "path": "tokio/tokio/tests/task_local_set.rs"
+        },
+        {
+          "occurrences": 43,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 42,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio-util/tests/task_join_map.rs"
+        },
+        {
+          "occurrences": 33,
+          "path": "tokio/tokio/tests/rt_basic.rs"
+        },
+        {
+          "occurrences": 31,
+          "path": "tokio/tokio/tests/task_join_set.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1273,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 5,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "block callback",
+      "language": "ruby",
+      "note": "Ruby yield invokes a block with demand/effect obligations",
+      "obligation_family": "callback-demand-effect",
+      "obligation_subreason": "ruby-yield-callback-demand-effect-contract-missing",
+      "occurrences": 801,
+      "operation": "yield",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.block.yield",
+      "top_files": [
+        {
+          "occurrences": 26,
+          "path": "rubocop/spec/rubocop/cop/style/explicit_block_argument_spec.rb"
+        },
+        {
+          "occurrences": 22,
+          "path": "rspec-core/benchmarks/capture_block_vs_yield.rb"
+        },
+        {
+          "occurrences": 18,
+          "path": "rack/test/spec_deflater.rb"
+        },
+        {
+          "occurrences": 16,
+          "path": "sinatra/lib/sinatra/base.rb"
+        },
+        {
+          "occurrences": 12,
+          "path": "rubocop/spec/rubocop/cop/layout/hash_alignment_spec.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "faraday/lib/faraday/connection.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "rack/test/spec_lint.rb"
+        },
+        {
+          "occurrences": 8,
+          "path": "rspec-core/lib/rspec/core/configuration.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 228,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 98,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 55,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 38,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 36,
+          "repo": "devise"
+        },
+        {
+          "occurrences": 34,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "executor timing",
+      "language": "javascript-typescript",
+      "note": "new Promise needs executor timing, resolve/reject callback, and throw-to-rejection contracts",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.executor",
+      "top_files": [
+        {
+          "occurrences": 46,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 28,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 20,
+          "path": "axios/tests/unit/prototypePollution.test.js"
+        },
+        {
+          "occurrences": 20,
+          "path": "trpc/packages/tests/server/websockets.test.ts"
+        },
+        {
+          "occurrences": 12,
+          "path": "esbuild/scripts/plugin-tests.js"
+        },
+        {
+          "occurrences": 12,
+          "path": "prettier/tests/format/flow/flow-repo/promises/promise.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 151,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 135,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 96,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 89,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 80,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 61,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 55,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 50,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "select default liveness",
+      "language": "go",
+      "note": "Go select defaults change blocking and liveness behavior",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-default-liveness-contract-missing",
+      "occurrences": 546,
+      "operation": "select default",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.default",
+      "top_files": [
+        {
+          "occurrences": 14,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/gateway_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 11,
+          "path": "prometheus/storage/remote/queue_manager.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "etcd/pkg/proxy/server.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "prometheus/tsdb/db.go"
+        },
+        {
+          "occurrences": 9,
+          "path": "nats-server/server/jetstream_cluster_long_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 195,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 144,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 94,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 71,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 13,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 2,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "all-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.all needs ordered all-fulfilled value and first rejection semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "execa/test/convert/concurrent.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 12,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 11,
+          "path": "zod/packages/zod/src/v4/core/schemas.ts"
+        },
+        {
+          "occurrences": 9,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "date-fns/pkgs/docs/src/bin.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "execa/test/pipe/streaming.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 79,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 62,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 60,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 56,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 29,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 17,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 17,
+          "repo": "zod"
+        },
+        {
+          "occurrences": 16,
+          "repo": "date-fns"
+        }
+      ]
+    },
+    {
+      "boundary": "async context lifecycle",
+      "language": "python",
+      "note": "async with needs async enter/exit cleanup, exception-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-context-lifecycle-contract-missing",
+      "occurrences": 361,
+      "operation": "async with",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.context",
+      "top_files": [
+        {
+          "occurrences": 66,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 59,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 33,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 27,
+          "path": "httpx/tests/client/test_auth.py"
+        },
+        {
+          "occurrences": 26,
+          "path": "httpx/tests/client/test_async_client.py"
+        },
+        {
+          "occurrences": 14,
+          "path": "scrapy/tests/test_scheduler.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "scrapy/tests/test_downloadermiddleware.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 169,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 95,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 77,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 19,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "task spawn",
+      "language": "rust",
+      "note": "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn",
+      "top_files": [
+        {
+          "occurrences": 32,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 18,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 16,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 12,
+          "path": "tokio/tokio/tests/task_abort.rs"
+        },
+        {
+          "occurrences": 11,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "meilisearch/crates/meilisearch/src/routes/indexes/documents.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/net_named_pipe.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 284,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 62,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "cancellation signal",
+      "language": "javascript-typescript",
+      "note": "AbortSignal/AbortController can change scheduling and rejection outcomes",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "js-ts.cancellation.abort",
+      "top_files": [
+        {
+          "occurrences": 18,
+          "path": "execa/test/terminate/cancel.js"
+        },
+        {
+          "occurrences": 18,
+          "path": "execa/test/ipc/graceful.js"
+        },
+        {
+          "occurrences": 14,
+          "path": "execa/test/terminate/graceful.js"
+        },
+        {
+          "occurrences": 13,
+          "path": "trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test-d/arguments/options.test-d.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test/pipe/abort.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "trpc/packages/client/src/internals/signals.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 108,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 87,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 30,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 17,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 8,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 4,
+          "repo": "pixijs"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle get",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose blocking settled-value and exception channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 249,
+      "operation": "Future.get",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.get",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 83,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 28,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 23,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 13,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 11,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 8,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle cancellation",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose cancellation and task-handle liveness boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 239,
+      "operation": "Future.cancel/isCancelled",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.cancel",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 104,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 101,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 14,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 3,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "future channel",
+      "language": "java",
+      "note": "CompletableFuture needs success/error channel and scheduling proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 230,
+      "operation": "CompletableFuture",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "java.future.completable",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "retrofit/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureCallAdapterFactoryTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 94,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 62,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 35,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 24,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 7,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 6,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service future scheduling",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService receivers schedule callbacks and return Future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 222,
+      "operation": "ExecutorService.submit",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.submit",
+      "top_files": [
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 90,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 72,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 27,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 6,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 5,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 4,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 4,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task scheduling",
+      "language": "swift",
+      "note": "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 215,
+      "operation": "Task/Task.detached",
+      "repos": 12,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.spawn",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift"
+        },
+        {
+          "occurrences": 21,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "rxswift/Sources/AllTestz/PrimitiveSequence+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 63,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 35,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 31,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 23,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 23,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 16,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 6,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "swift",
+      "note": "Swift async sequence loops need async iterator lifecycle, value-channel, scheduling, and throwing-channel proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 193,
+      "operation": "for await/for try await",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Sources/ServiceLifecycle/ServiceGroup.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxswift/Sources/AllTestz/Observable+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 72,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 67,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 13,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "executor runnable scheduling",
+      "language": "java",
+      "note": "Import-backed Java Executor receivers schedule callback execution without returning a task handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 180,
+      "operation": "Executor.execute",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor.execute",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "netty/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "mockito/mockito-core/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 114,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 38,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 2,
+          "repo": "gson"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing closure error channel",
+      "language": "swift",
+      "note": "Swift throwing closures expose the same error-channel obligation as throwing functions and async throwing closures",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 169,
+      "operation": "closure throws/rethrows",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_closure",
+      "top_files": [
+        {
+          "occurrences": 16,
+          "path": "swift-collections/Tests/DequeTests/RigidDequeTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "vapor/Tests/VaporTests/QueryTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "vapor/Tests/VaporTests/ContentTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Sources/AllTestz/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Tests/VaporMacroTests/AuthMiddlewareMacroTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 58,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 52,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 38,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "task sleep timer",
+      "language": "swift",
+      "note": "Swift Task.sleep creates a timer-backed scheduling boundary and cancellation/liveness boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 161,
+      "operation": "Task.sleep",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.sleep",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-nio/Tests/NIOPosixTests/EventLoopTest.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Tests/KingfisherTests/KingfisherManagerTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "nimble/Tests/NimbleTests/AsyncAwaitTest.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 71,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 32,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 10,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive status",
+      "language": "go",
+      "note": "Go comma-ok receives expose the channel close status as an additional protocol result",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-status-contract-missing",
+      "occurrences": 155,
+      "operation": "comma-ok channel receive",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive_status",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 12,
+          "path": "etcd/tests/integration/clientv3/lease/lease_test.go"
+        },
+        {
+          "occurrences": 6,
+          "path": "etcd/tests/integration/cache_test.go"
+        },
+        {
+          "occurrences": 5,
+          "path": "etcd/tests/integration/v3_election_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "etcd/cache/cache_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/admin-handlers.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/internal/grid/muxclient.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 84,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 48,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 11,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 5,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 1,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "task-group aggregate",
+      "language": "swift",
+      "note": "Swift task groups need all-completion, result-channel, cancellation/liveness, and throwing error-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 153,
+      "operation": "withTaskGroup/withThrowingTaskGroup/withDiscardingTaskGroup/withThrowingDiscardingTaskGroup",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.group",
+      "top_files": [
+        {
+          "occurrences": 31,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 18,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 14,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 9,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/CancellationTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 68,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 4,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 3,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 1,
+          "repo": "fastlane"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle lifecycle",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose task-handle lifecycle status",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "task-handle-lifecycle-contract-missing",
+      "occurrences": 127,
+      "operation": "Future.isDone",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.status",
+      "top_files": [
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 61,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 49,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 10,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "python",
+      "note": "async for statements and comprehensions need async iterator lifecycle, value-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 114,
+      "operation": "async for",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "httpx/tests/test_content.py"
+        },
+        {
+          "occurrences": 16,
+          "path": "httpx/tests/models/test_responses.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "black/tests/data/cases/python37.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "httpx/httpx/_models.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_spidermiddleware_referer.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/starred_for_target.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 48,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 30,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 20,
+          "repo": "black"
+        },
+        {
+          "occurrences": 15,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timer",
+      "language": "python",
+      "note": "asyncio sleep creates a timer-backed scheduling boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 104,
+      "operation": "asyncio.sleep",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.sleep",
+      "top_files": [
+        {
+          "occurrences": 48,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 9,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "flask/tests/test_async.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_command_parse.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_utils_defer.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 3,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 59,
+          "repo": "black"
+        },
+        {
+          "occurrences": 32,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "async closure scheduling",
+      "language": "swift",
+      "note": "Swift async closures create async callable protocol boundaries even when the surrounding function is synchronous",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 100,
+      "operation": "async closure",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.closure",
+      "top_files": [
+        {
+          "occurrences": 29,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "vapor/Tests/VaporTests/AuthenticationTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "swift-composable-architecture/Benchmarks/Benchmarks/swift-composable-architecture-benchmark/Benchmarks.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "vapor/Tests/VaporTests/MiddlewareTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "vapor/Tests/VaporTests/RouteTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "nimble/Tests/NimbleTests/Matchers/EqualTest.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 86,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-nio"
+        }
+      ]
+    },
+    {
+      "boundary": "thread/fiber scheduling",
+      "language": "ruby",
+      "note": "Thread/Fiber APIs create scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 74,
+      "operation": "Thread/Fiber",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.thread.fiber",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "puma/test/test_cli.rb"
+        },
+        {
+          "occurrences": 6,
+          "path": "rack/test/spec_multipart.rb"
+        },
+        {
+          "occurrences": 4,
+          "path": "puma/test/test_pumactl.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/test/test_thread_pool.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/lib/puma/cluster/worker.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/benchmarks/local/response_time_wrk.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "fastlane/fastlane/lib/fastlane/swift_lane_manager.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "puma/test/test_puma_server_ssl.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 36,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 10,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 10,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jekyll"
+        },
+        {
+          "occurrences": 2,
+          "repo": "asciidoctor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rspec-core"
+        }
+      ]
+    },
+    {
+      "boundary": "interval lifecycle",
+      "language": "javascript-typescript",
+      "note": "setInterval and timers interval streams have repeated emission, cancellation, and liveness semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.interval",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjs/packages/rxjs/spec/Observable-spec.ts"
+        },
+        {
+          "occurrences": 4,
+          "path": "swr/test/use-swr-subscription.test.tsx"
+        },
+        {
+          "occurrences": 3,
+          "path": "drizzle-orm/drizzle-kit/src/cli/views.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/example/src/main/resources/io/netty/example/stomp/websocket/stomp.js"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/src/internal/scheduler/intervalProvider.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/spec/schedulers/TestScheduler-spec.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 16,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 7,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 7,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 6,
+          "repo": "swr"
+        },
+        {
+          "occurrences": 3,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "thread scheduling",
+      "language": "c",
+      "note": "pthread_create introduces thread scheduling and lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "c-pthread-scheduling-contract-missing",
+      "occurrences": 68,
+      "operation": "pthread_create",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "c.thread.pthread",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "redis/tests/modules/blockedclient.c"
+        },
+        {
+          "occurrences": 3,
+          "path": "redis/tests/modules/blockonbackground.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/name-hash.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/transport-helper.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/read-cache.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/fsmonitor--daemon.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/pack-objects.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/helper/test-trace2.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 23,
+          "repo": "git"
+        },
+        {
+          "occurrences": 7,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 5,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 3,
+          "repo": "libuv"
+        },
+        {
+          "occurrences": 2,
+          "repo": "raylib"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jq"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nginx"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime join style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_try_join.rs"
+        },
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_try_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_join.rs"
+        },
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "meilisearch/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 67,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 1,
+          "repo": "meilisearch"
+        }
+      ]
+    },
+    {
+      "boundary": "structured task binding",
+      "language": "swift",
+      "note": "Swift async let creates a child task with scheduling, handle lifecycle, cancellation/liveness, and awaited result boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 51,
+      "operation": "async let",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.let",
+      "top_files": [
+        {
+          "occurrences": 17,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 16,
+          "path": "alamofire/Tests/OfflineRetrierTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "vapor/Tests/VaporTests/EndpointCacheTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 33,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 5,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "future constructor channel",
+      "language": "java",
+      "note": "Import- or qualified-name-backed Java CompletableFuture constructors create manual settlement future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 46,
+      "operation": "new CompletableFuture",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.constructor",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "retrofit/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 20,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 18,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift throwing continuation bridge",
+      "language": "swift",
+      "note": "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 43,
+      "operation": "withCheckedThrowingContinuation/withUnsafeThrowingContinuation",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.throwing",
+      "top_files": [
+        {
+          "occurrences": 8,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-nio/Sources/NIOCore/AsyncAwaitSupport.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/Sources/RxSwift/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOPosix/NIOThreadPool.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingChannel.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/BufferedStream.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOFS/Internal/BufferedStream.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 18,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 13,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 1,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "first-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.race needs first-settled ordering and liveness proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "execa/test/convert/iterable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/setup/server.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/convert/readable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "ky/source/core/Ky.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/client/src/links/localLink.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/mysql2/session.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/singlestore/session.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 15,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 4,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 3,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 3,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 2,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift continuation bridge",
+      "language": "swift",
+      "note": "Swift continuation bridges suspend and resume through a callback-settled future-like result channel",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 30,
+      "operation": "withCheckedContinuation/withUnsafeContinuation",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.checked",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "alamofire/Tests/RequestInterceptorTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingEventLoop.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NIOThreadPoolTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "alamofire/Source/Features/Concurrency.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/Concurrency Primitives/TokenBucket.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/NIOFS/Internal/Concurrency Primitives/TokenBucket.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 7,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor timer",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService schedule calls add timer-backed task scheduling and Future result channels",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 27,
+      "operation": "ScheduledExecutorService.schedule",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.schedule",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadWorker.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio future drive",
+      "language": "python",
+      "note": "asyncio.run drives a coroutine to completion with scheduling, result-channel, and exception boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "future-drive-scheduling-contract-missing",
+      "occurrences": 23,
+      "operation": "asyncio.run",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/_concurrency_fixtures.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/tests/test_concurrency_manager_shutdown.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "curl/tests/http/testenv/ws_echo_server.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/AsyncCrawlerRunner/reactorless_simple.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor interval lifecycle",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService repeating schedules expose interval lifecycle and cancellation boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 22,
+      "operation": "ScheduledExecutorService.scheduleAtFixedRate/scheduleWithFixedDelay",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.interval",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "jedis/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "commons-lang"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service all-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAll waits for all submitted tasks and returns Future result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 21,
+      "operation": "ExecutorService.invokeAll",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_all",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "all-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.allSettled needs settled-record channel and shape proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-settled-contract-missing",
+      "occurrences": 17,
+      "operation": "Promise.allSettled",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/lib/resolve/wait-subprocess.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "jest/packages/jest-haste-map/src/watchers/index.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/streaming.test.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/adapters/standalone.test.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/pipe/setup.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/resolve/exit-async.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/buffer-messages.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/convert/concurrent.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 5,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 2,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio all-completion aggregate",
+      "language": "python",
+      "note": "asyncio gather needs all-completion, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.gather",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/examples/asyncio/gather_orm_statements.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_downloadermiddleware_robotstxt.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/pipelines/media.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "black"
+        },
+        {
+          "occurrences": 6,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "future settled value",
+      "language": "java",
+      "note": "CompletableFuture settled factories create fulfilled or exceptional future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 14,
+      "operation": "CompletableFuture.completedFuture/failedFuture",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.factory",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 13,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio task spawn",
+      "language": "python",
+      "note": "asyncio task APIs create scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.task",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/core/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/defer.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "black"
+        }
+      ]
+    },
+    {
+      "boundary": "non-local jump",
+      "language": "c",
+      "note": "setjmp/longjmp is non-local control flow, not ordinary return",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "c-nonlocal-jump-contract-missing",
+      "occurrences": 13,
+      "operation": "setjmp/longjmp",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "c.nonlocal_jump",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "sqlite/autosetup/jimsh0.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/unit-tests/clar/clar.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "lua/ltests.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "redis/modules/vector-sets/fastjson_test.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "vim/src/if_python3.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 2,
+          "repo": "git"
+        },
+        {
+          "occurrences": 2,
+          "repo": "lua"
+        },
+        {
+          "occurrences": 2,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vim"
+        }
+      ]
+    },
+    {
+      "boundary": "future task spawn",
+      "language": "java",
+      "note": "CompletableFuture async factories schedule executor callbacks and return future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "CompletableFuture.supplyAsync/runAsync",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.spawn",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task yield",
+      "language": "swift",
+      "note": "Swift Task.yield yields to the task scheduler and must not collapse into sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-yield-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "Task.yield",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.yield",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-composable-architecture/Sources/ComposableArchitecture/TestStore.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/DebugTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduler yield",
+      "language": "javascript-typescript",
+      "note": "scheduler.yield needs microtask/order proof",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "scheduler-yield-microtask-order-contract-missing",
+      "occurrences": 11,
+      "operation": "scheduler.yield",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.scheduler",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/generator.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/web-transform.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/duplex.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/graceful.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/incoming.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/ipc/get-each.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/transform/generator-main.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/convert/writable.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 11,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "future settlement continuation",
+      "language": "java",
+      "note": "Future-like receivers need settlement continuation and callback demand/effect proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settlement-continuation-contract-missing",
+      "occurrences": 10,
+      "operation": "FutureLike.handle/whenComplete",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completion_stage.settlement",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 9,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "imported future all-completion aggregate",
+      "language": "rust",
+      "note": "import-backed tokio/futures/futures_util join-style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 8,
+      "operation": "use runtime::join; join!",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join.imported",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "tokio/tokio/tests/tcp_connect.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tests-integration/tests/process_stdio.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/tcp_stream.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service first-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAny exposes first-success completion, cancellation, and exception boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 6,
+      "operation": "ExecutorService.invokeAny",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_any",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio cancellation shield",
+      "language": "python",
+      "note": "asyncio.shield changes cancellation propagation while preserving an awaitable result channel",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 5,
+      "operation": "asyncio.shield",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.shield",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "sqlalchemy/lib/sqlalchemy/connectors/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlalchemy"
+        }
+      ]
+    },
+    {
+      "boundary": "future first-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime select style macros need first-completion, cancellation, and result-channel proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 5,
+      "operation": "tokio/futures/futures_util select",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.select",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/examples/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "java",
+      "note": "CompletableFuture.allOf needs all-completion and exceptional completion proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "CompletableFuture.allOf",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.all",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio completion aggregate",
+      "language": "python",
+      "note": "asyncio wait needs completion-selection, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "asyncio.wait",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/extensions/feedexport.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timeout wait",
+      "language": "python",
+      "note": "asyncio.wait_for adds timer and cancellation/liveness boundaries around an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "asyncio.wait_for",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait_for",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/util/queue.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "imported task spawn",
+      "language": "rust",
+      "note": "import-backed tokio/async-std spawn bindings introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn.imported",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_handle_block_on.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread-safe task submission",
+      "language": "python",
+      "note": "asyncio.run_coroutine_threadsafe schedules a coroutine onto another loop and returns a future handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "asyncio.run_coroutine_threadsafe",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run_coroutine_threadsafe",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/shell.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/commands/shell.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "imported asyncio timer",
+      "language": "python",
+      "note": "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "from asyncio import sleep; binding",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.imported.sleep",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spider_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "first-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.any needs first-fulfilled and AggregateError rejection proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-first-fulfilled-contract-missing",
+      "occurrences": 1,
+      "operation": "Promise.any",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "jest/packages/expect/src/__tests__/toThrowMatchers.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "jest"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread offload",
+      "language": "python",
+      "note": "asyncio.to_thread schedules a callback on a worker thread and returns an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 1,
+      "operation": "asyncio.to_thread",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.to_thread",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "scrapy"
+        }
+      ]
+    }
+  ],
+  "tracking_issue": {
+    "number": 602,
+    "url": "https://github.com/corca-ai/nose/issues/602"
+  }
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs
@@ -152,6 +152,22 @@ fn yield_protocol_missing_evidence_is_language_specific() {
 }
 
 #[test]
+fn ruby_raise_reports_exception_channel_boundary() {
+    let (il, interner) = lowered_source(
+        "raise.rb",
+        "def fail_fast(error)\n  raise error\nend\n",
+        Lang::Ruby,
+    );
+    let node = (0..il.nodes.len())
+        .map(|idx| NodeId(idx as u32))
+        .find(|&node| il.kind(node) == NodeKind::Throw)
+        .expect("expected Ruby raise to lower to Throw");
+    let labels = runtime_boundary_missing_evidence(&il, &interner, node)
+        .expect("expected exception-channel runtime boundary evidence");
+    assert!(labels.contains(&"exception-channel-contract"));
+}
+
+#[test]
 fn go_channel_protocol_boundaries_report_specific_obligations() {
     let send = missing_evidence_for_raw_tag(
         "channel.go",

--- a/crates/nose-detect/src/strict_exact/tree.rs
+++ b/crates/nose-detect/src/strict_exact/tree.rs
@@ -48,7 +48,12 @@ pub(crate) fn strict_exact_safe_tree(
         return false;
     }
     match il.kind(node) {
-        NodeKind::Raw | NodeKind::Try | NodeKind::Throw => false,
+        NodeKind::Raw => false,
+        // Ruby `raise`/`rescue` exact recovery needs exception propagation,
+        // rescue matching, ensure ordering, and non-local-control semantics.
+        // Keep those boundaries closed without disabling existing exact
+        // fragment contracts for other languages' direct throw/exit shapes.
+        NodeKind::Try | NodeKind::Throw if il.meta.lang == Lang::Ruby => false,
         // Declarative (CSS) units are constant, deterministic, effect-free data. A rule
         // is exact-safe iff it has no unparsed (`Raw`) construct, so recurse into the
         // rule but treat a declaration / selector (whose leaves are constant value

--- a/crates/nose-detect/src/strict_exact/tree.rs
+++ b/crates/nose-detect/src/strict_exact/tree.rs
@@ -48,7 +48,7 @@ pub(crate) fn strict_exact_safe_tree(
         return false;
     }
     match il.kind(node) {
-        NodeKind::Raw => false,
+        NodeKind::Raw | NodeKind::Try | NodeKind::Throw => false,
         // Declarative (CSS) units are constant, deterministic, effect-free data. A rule
         // is exact-safe iff it has no unparsed (`Raw`) construct, so recurse into the
         // rule but treat a declaration / selector (whose leaves are constant value

--- a/crates/nose-detect/src/units/tests/strict_exact_surfaces.rs
+++ b/crates/nose-detect/src/units/tests/strict_exact_surfaces.rs
@@ -573,3 +573,20 @@ fn lowered_function_exact_safe(path: &str, source: &str, lang: Lang) -> bool {
         .expect("callable unit");
     strict_exact_safe_tree(&il, &interner, &facts, function.root)
 }
+
+#[test]
+fn strict_exact_closes_ruby_exception_boundaries() {
+    for (name, source) in [
+        ("raise", "def f(error)\n  raise error\nend\n"),
+        (
+            "guarded raise",
+            "def f(error, bad)\n  raise error if bad\n  1\nend\n",
+        ),
+        ("rescue", "def f\n  work\nrescue Error\n  recover\nend\n"),
+    ] {
+        assert!(
+            !lowered_function_exact_safe("exception.rb", source, Lang::Ruby),
+            "{name} must stay closed in strict exact until Ruby exception-channel semantics are proven"
+        );
+    }
+}

--- a/crates/nose-frontend/src/ruby/blocks_calls.rs
+++ b/crates/nose-frontend/src/ruby/blocks_calls.rs
@@ -129,7 +129,7 @@ pub(super) fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
 }
 
 pub(super) fn is_unqualified_raise_call(node: TsNode, method_name: Option<&str>) -> bool {
-    node.child_by_field_name("receiver").is_none() && matches!(method_name, Some("raise" | "fail"))
+    node.child_by_field_name("receiver").is_none() && method_name == Some("raise")
 }
 
 pub(super) fn lower_raise_call(lo: &mut Lowering, node: TsNode, span: Span) -> NodeId {

--- a/crates/nose-frontend/src/ruby/blocks_calls.rs
+++ b/crates/nose-frontend/src/ruby/blocks_calls.rs
@@ -84,6 +84,9 @@ pub(super) fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
     let method_name = node
         .child_by_field_name("method")
         .map(|m| lo.text(m).to_string());
+    if is_unqualified_raise_call(node, method_name.as_deref()) {
+        return lower_raise_call(lo, node, span);
+    }
     let method = method_name.as_deref().map(|m| lo.sym(m));
     let recv = node.child_by_field_name("receiver");
     let block = Lowering::named_children(node)
@@ -123,4 +126,22 @@ pub(super) fn lower_call(lo: &mut Lowering, node: TsNode) -> NodeId {
         kids.push(block_expr);
     }
     lo.add(NodeKind::Call, Payload::None, span, &kids)
+}
+
+pub(super) fn is_unqualified_raise_call(node: TsNode, method_name: Option<&str>) -> bool {
+    node.child_by_field_name("receiver").is_none() && matches!(method_name, Some("raise" | "fail"))
+}
+
+pub(super) fn lower_raise_call(lo: &mut Lowering, node: TsNode, span: Span) -> NodeId {
+    let mut args = Vec::new();
+    if let Some(arguments) = node.child_by_field_name("arguments") {
+        for arg in Lowering::named_children(arguments) {
+            args.push(lower_expr(lo, arg));
+        }
+    }
+    let kids = match args.len() {
+        0 | 1 => args,
+        _ => vec![lo.add(NodeKind::Seq, Payload::None, span, &args)],
+    };
+    lo.add(NodeKind::Throw, Payload::None, span, &kids)
 }

--- a/crates/nose-frontend/src/ruby/statements.rs
+++ b/crates/nose-frontend/src/ruby/statements.rs
@@ -48,7 +48,10 @@ pub(super) fn body_children_with_return(
     let n = children.len();
     let mut stmts = Vec::new();
     for (idx, c) in children.into_iter().enumerate() {
-        if idx + 1 == n && is_tail_expr(c.kind()) {
+        let method_name = c.child_by_field_name("method").map(|m| lo.text(m));
+        if is_unqualified_raise_call(c, method_name) {
+            stmts.push(lower_raise_call(lo, c, lo.span(c)));
+        } else if idx + 1 == n && is_tail_expr(c.kind()) {
             let e = lower_expr(lo, c);
             stmts.push(lo.add(NodeKind::Return, Payload::None, lo.span(c), &[e]));
         } else if let Some(id) = lower_stmt(lo, c) {
@@ -135,6 +138,14 @@ pub(super) fn lower_stmt(lo: &mut Lowering, node: TsNode) -> Option<NodeId> {
                 kids.push(lower_return_value(lo, v));
             }
             Some(lo.add(NodeKind::Return, Payload::None, span, &kids))
+        }
+        "call" | "method_call"
+            if is_unqualified_raise_call(
+                node,
+                node.child_by_field_name("method").map(|m| lo.text(m)),
+            ) =>
+        {
+            Some(lower_raise_call(lo, node, span))
         }
         "break" => Some(lo.add(NodeKind::Break, Payload::None, span, &[])),
         "next" => Some(lo.add(NodeKind::Continue, Payload::None, span, &[])),

--- a/crates/nose-frontend/src/ruby/statements.rs
+++ b/crates/nose-frontend/src/ruby/statements.rs
@@ -116,6 +116,8 @@ pub(super) fn is_tail_expr(k: &str) -> bool {
             | "unless"
             | "while"
             | "until"
+            | "if_modifier"
+            | "unless_modifier"
             | "while_modifier"
             | "until_modifier"
             | "case"

--- a/crates/nose-frontend/src/ruby/tests.rs
+++ b/crates/nose-frontend/src/ruby/tests.rs
@@ -129,6 +129,32 @@ fn raw_names_without_errors(src: &str) -> Vec<String> {
         .collect()
 }
 
+fn throw_has_return_ancestor(src: &str) -> bool {
+    let interner = Interner::new();
+    let il = lower(FileId(0), "t.rb", src.as_bytes(), &interner).expect("lower");
+    let mut parents: Vec<Option<NodeId>> = vec![None; il.nodes.len()];
+    for idx in 0..il.nodes.len() {
+        let parent = NodeId(idx as u32);
+        for &child in il.children(parent) {
+            parents[child.0 as usize] = Some(parent);
+        }
+    }
+    for idx in 0..il.nodes.len() {
+        let node = NodeId(idx as u32);
+        if il.kind(node) != NodeKind::Throw {
+            continue;
+        }
+        let mut current = parents[idx];
+        while let Some(parent) = current {
+            if il.kind(parent) == NodeKind::Return {
+                return true;
+            }
+            current = parents[parent.0 as usize];
+        }
+    }
+    false
+}
+
 #[test]
 fn yield_preserves_source_backed_protocol_boundary() {
     let interner = Interner::new();
@@ -196,23 +222,22 @@ fn method_body_rescue_and_ensure_lower_as_try_without_clause_raw() {
 }
 
 #[test]
-fn unqualified_raise_and_fail_lower_as_throw() {
+fn unqualified_raise_lowers_as_throw_without_tail_return_wrapping() {
     let kinds =
-        node_kinds("def f(error)\n  raise error\nend\n\ndef g\n  value || fail('missing')\nend\n");
+        node_kinds("def f(error, bad)\n  raise error\n  raise 'guarded' if bad\n  1\nend\n");
     assert_eq!(
         kinds
             .iter()
             .filter(|&&kind| kind == NodeKind::Throw)
             .count(),
         2,
-        "bare raise/fail calls should lower to Throw boundaries: {kinds:?}"
+        "bare raise calls should lower to Throw boundaries: {kinds:?}"
     );
     assert!(
-        !kinds.windows(2).any(|window| matches!(
-            window,
-            [NodeKind::Return, NodeKind::Throw] | [NodeKind::Throw, NodeKind::Return]
-        )),
-        "tail-position raise/fail should not be wrapped as ordinary returns: {kinds:?}"
+        !throw_has_return_ancestor(
+            "def f(error, bad)\n  raise error\n  raise 'guarded' if bad\n  1\nend\n"
+        ),
+        "raise and guarded raise must not be wrapped as ordinary returns"
     );
 }
 

--- a/crates/nose-frontend/src/ruby/tests.rs
+++ b/crates/nose-frontend/src/ruby/tests.rs
@@ -196,6 +196,27 @@ fn method_body_rescue_and_ensure_lower_as_try_without_clause_raw() {
 }
 
 #[test]
+fn unqualified_raise_and_fail_lower_as_throw() {
+    let kinds =
+        node_kinds("def f(error)\n  raise error\nend\n\ndef g\n  value || fail('missing')\nend\n");
+    assert_eq!(
+        kinds
+            .iter()
+            .filter(|&&kind| kind == NodeKind::Throw)
+            .count(),
+        2,
+        "bare raise/fail calls should lower to Throw boundaries: {kinds:?}"
+    );
+    assert!(
+        !kinds.windows(2).any(|window| matches!(
+            window,
+            [NodeKind::Return, NodeKind::Throw] | [NodeKind::Throw, NodeKind::Return]
+        )),
+        "tail-position raise/fail should not be wrapped as ordinary returns: {kinds:?}"
+    );
+}
+
+#[test]
 fn block_body_rescue_else_and_ensure_lower_as_try_without_clause_raw() {
     let src = "it 'defaults' do\n  res = options.instrumenter\nrescue NameError => e then recover(e)\nelse\n  verify(res)\nensure\n  cleanup\nend\n";
     let raw = raw_names(src);

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -346,6 +346,14 @@ matching [120-repo
 pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-yield-source-protocol-2026-07-01.v1.json)
 marks `ruby.block.yield` reporting-supported, prices `801` occurrences
 across `17` repos, and the checked `crates` gate reports `0` false merges.
+The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
+keeps exact admission closed while lowering unqualified Ruby `raise`/`fail` to
+the existing `Throw` boundary and retaining `rescue` on the existing `Try`
+boundary. Its 120-repo audit splits the historical broad `raise/rescue` bucket
+into `2,065` `raise` and `1,933` `rescue` reporting-supported occurrences, then
+marks the old `4,010`-occurrence broad row as superseded overlap. The Ruby-heavy
+query regression records no performance degradation and intentionally adds exact
+families for repeated Ruby `raise` guard clauses in `fastlane` and `rspec-core`.
 The follow-up [Go protocol reporting-support artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
 marks Go channel/send/receive/select, goroutine, and defer source-protocol rows
 reporting-supported while keeping exact admission closed.

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -353,7 +353,7 @@ boundary. Its 120-repo audit prices `2,065` unqualified `raise` and `1,933`
 `rescue` occurrences as reporting-supported, then marks the old
 `4,010`-occurrence broad row as superseded overlap; the 12 broad-only
 occurrences are receiver-qualified `.raise` overlaps. The Ruby-heavy query
-regression records a `+0.81%` aggregate median change, stable family counts
+regression records a `+1.05%` aggregate median change, stable family counts
 across all 6 repos, and metadata/hash drift only in `rubocop` and `rspec-core`.
 The follow-up [Go protocol reporting-support artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
 marks Go channel/send/receive/select, goroutine, and defer source-protocol rows

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -347,13 +347,14 @@ pricing artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-
 marks `ruby.block.yield` reporting-supported, prices `801` occurrences
 across `17` repos, and the checked `crates` gate reports `0` false merges.
 The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
-keeps exact admission closed while lowering unqualified Ruby `raise`/`fail` to
-the existing `Throw` boundary and retaining `rescue` on the existing `Try`
-boundary. Its 120-repo audit splits the historical broad `raise/rescue` bucket
-into `2,065` `raise` and `1,933` `rescue` reporting-supported occurrences, then
-marks the old `4,010`-occurrence broad row as superseded overlap. The Ruby-heavy
-query regression records no performance degradation and intentionally adds exact
-families for repeated Ruby `raise` guard clauses in `fastlane` and `rspec-core`.
+keeps exact admission closed while lowering unqualified Ruby `raise` to the
+existing `Throw` boundary and retaining `rescue` on the existing `Try`
+boundary. Its 120-repo audit prices `2,065` unqualified `raise` and `1,933`
+`rescue` occurrences as reporting-supported, then marks the old
+`4,010`-occurrence broad row as superseded overlap; the 12 broad-only
+occurrences are receiver-qualified `.raise` overlaps. The Ruby-heavy query
+regression records a `+0.81%` aggregate median change, stable family counts
+across all 6 repos, and metadata/hash drift only in `rubocop` and `rspec-core`.
 The follow-up [Go protocol reporting-support artifact](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
 marks Go channel/send/receive/select, goroutine, and defer source-protocol rows
 reporting-supported while keeping exact admission closed.

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -137,7 +137,7 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   occurrences while reclassifying the broad `4,010`-occurrence `raise/rescue`
   row as superseded overlap. The 12 broad-only occurrences are
   receiver-qualified `.raise` overlaps. The Ruby-heavy query regression records
-  `3326.98ms -> 3354.09ms` (`+0.81%`) with stable family counts across all 6
+  `3295.78ms -> 3330.24ms` (`+1.05%`) with stable family counts across all 6
   repos and metadata/hash drift limited to `rubocop` and `rspec-core`.
 - [Swift try-expression reporting alignment](../bench/recall_loss/swift-try-expression-reporting-2026-07-02.v1.json) records the source-backed `TryPropagation` audit closeout for `try`, `try?`,
   `try!`, and `for try await`. It newly aligns `17,970` source-prevalence

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -131,6 +131,13 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   status, newly aligning `104` source-prevalence occurrences across `6` repos
   and leaving no Python closed-boundary rows in the scheduling lifecycle audit
   while exact admission remains closed.
+- [Ruby exception-channel reporting](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json) records the audit closeout for source-backed Ruby exception boundaries.
+  Unqualified `raise`/`fail` calls now lower to `Throw`, `rescue` remains on
+  `Try`, and the audit newly aligns `3,998` concrete Ruby exception-channel
+  occurrences while reclassifying the broad `4,010`-occurrence `raise/rescue`
+  row as superseded overlap. The Ruby-heavy query regression records
+  `2778.68ms -> 2670.37ms` (`-3.90%`) and intentional new exact families for
+  repeated Ruby `raise` guard clauses.
 - [Swift try-expression reporting alignment](../bench/recall_loss/swift-try-expression-reporting-2026-07-02.v1.json) records the source-backed `TryPropagation` audit closeout for `try`, `try?`,
   `try!`, and `for try await`. It newly aligns `17,970` source-prevalence
   occurrences across `18` repos while keeping exact admission closed and the

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -132,12 +132,13 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   and leaving no Python closed-boundary rows in the scheduling lifecycle audit
   while exact admission remains closed.
 - [Ruby exception-channel reporting](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json) records the audit closeout for source-backed Ruby exception boundaries.
-  Unqualified `raise`/`fail` calls now lower to `Throw`, `rescue` remains on
-  `Try`, and the audit newly aligns `3,998` concrete Ruby exception-channel
+  Unqualified `raise` calls now lower to `Throw`, `rescue` remains on `Try`,
+  and the audit newly aligns `3,998` concrete Ruby exception-channel
   occurrences while reclassifying the broad `4,010`-occurrence `raise/rescue`
-  row as superseded overlap. The Ruby-heavy query regression records
-  `2778.68ms -> 2670.37ms` (`-3.90%`) and intentional new exact families for
-  repeated Ruby `raise` guard clauses.
+  row as superseded overlap. The 12 broad-only occurrences are
+  receiver-qualified `.raise` overlaps. The Ruby-heavy query regression records
+  `3326.98ms -> 3354.09ms` (`+0.81%`) with stable family counts across all 6
+  repos and metadata/hash drift limited to `rubocop` and `rspec-core`.
 - [Swift try-expression reporting alignment](../bench/recall_loss/swift-try-expression-reporting-2026-07-02.v1.json) records the source-backed `TryPropagation` audit closeout for `try`, `try?`,
   `try!`, and `for try await`. It newly aligns `17,970` source-prevalence
   occurrences across `18` repos while keeping exact admission closed and the

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -97,9 +97,10 @@ occurrences across `6` repos to reporting-supported closed-boundary status and
 leaves no Python closed-boundary rows in the scheduling lifecycle audit.
 The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
 applies the existing `Throw`/`Try` runtime-boundary capability to Ruby exception
-flow. Unqualified `raise`/`fail` calls now report exception-channel obligations,
+flow. Unqualified `raise` calls now report exception-channel obligations,
 `rescue` remains a `Try` boundary, and the old broad `raise/rescue` lexical row
-is superseded by concrete reporting-supported rows.
+is superseded by concrete reporting-supported rows while receiver-qualified
+`.raise` overlaps remain outside the concrete rows.
 The follow-up [Swift structured-concurrency artifact](../bench/recall_loss/swift-structured-concurrency-obligation-reporting-2026-06-30.v1.json)
 keeps that same capability boundary and maps Swift `Task.sleep`, `Task.yield`,
 and task-group calls onto shared timer, task-yield, aggregate,

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -95,6 +95,11 @@ aligns the original direct `asyncio.sleep` timer row with the same
 runtime-boundary reporting capability. The 120-repo audit moves `104`
 occurrences across `6` repos to reporting-supported closed-boundary status and
 leaves no Python closed-boundary rows in the scheduling lifecycle audit.
+The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
+applies the existing `Throw`/`Try` runtime-boundary capability to Ruby exception
+flow. Unqualified `raise`/`fail` calls now report exception-channel obligations,
+`rescue` remains a `Try` boundary, and the old broad `raise/rescue` lexical row
+is superseded by concrete reporting-supported rows.
 The follow-up [Swift structured-concurrency artifact](../bench/recall_loss/swift-structured-concurrency-obligation-reporting-2026-06-30.v1.json)
 keeps that same capability boundary and maps Swift `Task.sleep`, `Task.yield`,
 and task-group calls onto shared timer, task-yield, aggregate,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2440,6 +2440,19 @@ closed-boundary rows in the scheduling lifecycle audit. Exact admission remains
 closed until timer suspension, cancellation, and event-loop timing semantics are
 proven.
 
+2026-07-02 Ruby exception-channel reporting note:
+The [ruby-exception-reporting-2026-07-02.v1.json](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
+artifact aligns Ruby exception flow with existing runtime-boundary capabilities.
+Unqualified `raise`/`fail` calls now lower to `NodeKind::Throw`, while `rescue`
+continues to lower to `NodeKind::Try`; both report `exception-channel-contract`
+without adding a Ruby-only kernel API. The 120-repo audit splits the old broad
+`raise/rescue` row into `2,065` `raise` and `1,933` `rescue`
+reporting-supported occurrences, reclassifies the `4,010` broad bucket as
+superseded overlap, and leaves Java Stream lifecycle as the largest non-JS
+actionable closed boundary. Exact admission remains closed until Ruby exception
+propagation, rescue matching, ensure ordering, and non-local control semantics
+are proven.
+
 2026-07-01 Go protocol reporting-support note:
 The [scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-protocol-reporting-support-2026-07-01.v1.json)
 artifact aligns the existing Go source protocol support with the shared

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2443,13 +2443,14 @@ proven.
 2026-07-02 Ruby exception-channel reporting note:
 The [ruby-exception-reporting-2026-07-02.v1.json](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
 artifact aligns Ruby exception flow with existing runtime-boundary capabilities.
-Unqualified `raise`/`fail` calls now lower to `NodeKind::Throw`, while `rescue`
+Unqualified `raise` calls now lower to `NodeKind::Throw`, while `rescue`
 continues to lower to `NodeKind::Try`; both report `exception-channel-contract`
-without adding a Ruby-only kernel API. The 120-repo audit splits the old broad
-`raise/rescue` row into `2,065` `raise` and `1,933` `rescue`
-reporting-supported occurrences, reclassifies the `4,010` broad bucket as
-superseded overlap, and leaves Java Stream lifecycle as the largest non-JS
-actionable closed boundary. Exact admission remains closed until Ruby exception
+without adding a Ruby-only kernel API. The 120-repo audit prices `2,065`
+`raise` and `1,933` `rescue` occurrences as reporting-supported, reclassifies
+the `4,010` broad `raise/rescue` bucket as superseded overlap, and leaves the
+12 receiver-qualified broad-only `.raise` overlaps outside the concrete rows.
+Java Stream lifecycle remains the largest non-JS actionable closed boundary.
+Exact admission remains closed until Ruby exception
 propagation, rescue matching, ensure ordering, and non-local control semantics
 are proven.
 

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -191,6 +191,13 @@ aligns the direct `asyncio.sleep` audit row with that existing timer
 runtime-boundary reporting. Direct calls add `104` reporting-supported
 closed-boundary occurrences across `6` repos, and the scheduling lifecycle
 audit now has no remaining Python closed-boundary rows.
+The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
+uses the same capability-first rule for Ruby exception flow: unqualified
+`raise`/`fail` calls lower to the existing `Throw` boundary, `rescue` remains on
+the existing `Try` boundary, and no Ruby-specific kernel API is added. The audit
+splits the broad `raise/rescue` row into `2,065` `raise` and `1,933` `rescue`
+reporting-supported closed-boundary occurrences while exact admission remains
+closed.
 The follow-up [Swift structured-concurrency artifact](../bench/recall_loss/swift-structured-concurrency-obligation-reporting-2026-06-30.v1.json)
 keeps exact admission closed while mapping `Task.sleep`, `Task.yield`, and
 task-group calls onto the existing timer, task-yield, aggregate,

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -193,11 +193,11 @@ closed-boundary occurrences across `6` repos, and the scheduling lifecycle
 audit now has no remaining Python closed-boundary rows.
 The follow-up [Ruby exception-channel reporting artifact](../bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json)
 uses the same capability-first rule for Ruby exception flow: unqualified
-`raise`/`fail` calls lower to the existing `Throw` boundary, `rescue` remains on
-the existing `Try` boundary, and no Ruby-specific kernel API is added. The audit
-splits the broad `raise/rescue` row into `2,065` `raise` and `1,933` `rescue`
-reporting-supported closed-boundary occurrences while exact admission remains
-closed.
+`raise` calls lower to the existing `Throw` boundary, `rescue` remains on the
+existing `Try` boundary, and no Ruby-specific kernel API is added. The audit
+prices `2,065` `raise` and `1,933` `rescue` occurrences as
+reporting-supported closed-boundaries while retaining the broad `4,010`
+`raise/rescue` row as superseded overlap; exact admission remains closed.
 The follow-up [Swift structured-concurrency artifact](../bench/recall_loss/swift-structured-concurrency-obligation-reporting-2026-06-30.v1.json)
 keeps exact admission closed while mapping `Task.sleep`, `Task.yield`, and
 task-group calls onto the existing timer, task-yield, aggregate,

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -81,6 +81,30 @@ class Pattern:
     status: str = "closed-boundary"
 
 
+RUBY_EXCEPTION_RAISE = Pattern(
+    "ruby",
+    "ruby.exception.raise",
+    "raise",
+    "exception-channel",
+    "ruby-exception-channel-contract-missing",
+    "raise exception channel",
+    "Ruby raise calls expose source-backed Throw exception-channel boundaries",
+    re.compile(r"(?<!\.)\braise\b"),
+    "reporting-supported-closed-boundary",
+)
+RUBY_EXCEPTION_RESCUE = Pattern(
+    "ruby",
+    "ruby.exception.rescue",
+    "rescue",
+    "exception-channel",
+    "ruby-exception-channel-contract-missing",
+    "rescue exception channel",
+    "Ruby rescue clauses lower to Try exception-channel boundaries",
+    re.compile(r"\brescue\b"),
+    "reporting-supported-closed-boundary",
+)
+
+
 PATTERNS: tuple[Pattern, ...] = (
     Pattern("javascript-typescript", "js-ts.async.await", "await", "scheduling-boundary", "async-await-scheduling-contract-missing", "await scheduling", "await is scheduling and thenable assimilation, not sync value equivalence", re.compile(r"\bawait\b")),
     Pattern("javascript-typescript", "js-ts.async.function", "async function", "scheduling-boundary", "async-function-scheduling-contract-missing", "async function scheduling", "async functions have scheduling and rejection boundaries even without explicit await", re.compile(r"\basync\s+(?:function\b|[A-Za-z_$]|\([^)]*\)\s*=>)")),
@@ -138,7 +162,9 @@ PATTERNS: tuple[Pattern, ...] = (
     Pattern("swift", "swift.continuation.checked", "withCheckedContinuation/withUnsafeContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift continuation bridge", "Swift continuation bridges suspend and resume through a callback-settled future-like result channel", re.compile(r"\bwith(?:Checked|Unsafe)Continuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("swift", "swift.continuation.throwing", "withCheckedThrowingContinuation/withUnsafeThrowingContinuation", "success-error-result-channel", "future-settled-value-channel-contract-missing", "Swift throwing continuation bridge", "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels", re.compile(r"\bwith(?:Checked|Unsafe)ThrowingContinuation\s*(?:\(|\{)"), "reporting-supported-closed-boundary"),
     Pattern("ruby", "ruby.thread.fiber", "Thread/Fiber", "scheduling-boundary", "task-spawn-scheduling-contract-missing", "thread/fiber scheduling", "Thread/Fiber APIs create scheduler and lifecycle boundaries", re.compile(r"\b(?:Thread\s*\.\s*(?:new|start|fork)|Fiber\s*\.\s*(?:new|schedule))\b"), "reporting-supported-closed-boundary"),
-    Pattern("ruby", "ruby.exception", "raise/rescue", "exception-channel", "ruby-exception-channel-contract-missing", "exception channel", "raise/rescue changes error channels and non-local control", re.compile(r"\b(?:raise|rescue)\b")),
+    RUBY_EXCEPTION_RAISE,
+    RUBY_EXCEPTION_RESCUE,
+    Pattern("ruby", "ruby.exception", "raise/rescue", "exception-channel", "ruby-exception-channel-contract-missing", "exception channel", "Historical lexical overlap bucket; use source-backed Ruby raise and rescue rows as actionable exception-channel surfaces", re.compile(r"\b(?:raise|rescue)\b"), "superseded-overlap-boundary"),
     Pattern("ruby", "ruby.block.yield", "yield", "callback-demand-effect", "ruby-yield-callback-demand-effect-contract-missing", "block callback", "Ruby yield invokes a block with demand/effect obligations", re.compile(r"\byield\b"), "reporting-supported-closed-boundary"),
     Pattern("c", "c.thread.pthread", "pthread_create", "scheduling-boundary", "c-pthread-scheduling-contract-missing", "thread scheduling", "pthread_create introduces thread scheduling and lifetime boundaries", re.compile(r"\bpthread_create\s*\(")),
     Pattern("c", "c.nonlocal_jump", "setjmp/longjmp", "exception-channel", "c-nonlocal-jump-contract-missing", "non-local jump", "setjmp/longjmp is non-local control flow, not ordinary return", re.compile(r"\b(?:setjmp|longjmp)\s*\(")),
@@ -893,6 +919,23 @@ def self_test() -> None:
     ruby_yield_pattern = next(item for item in PATTERNS if item.surface == "ruby.block.yield")
     assert ruby_yield.get(ruby_yield_pattern) == 1
     assert ruby_yield_pattern.status == "reporting-supported-closed-boundary"
+
+    ruby_exception = count_file(
+        "def f(error)\n"
+        "  raise error\n"
+        "rescue Error\n"
+        "  recover\n"
+        "end\n"
+        "raise_error(:not_a_raise)\n",
+        "ruby",
+    )
+    ruby_exception_overlap = next(item for item in PATTERNS if item.surface == "ruby.exception")
+    assert ruby_exception.get(RUBY_EXCEPTION_RAISE) == 1
+    assert ruby_exception.get(RUBY_EXCEPTION_RESCUE) == 1
+    assert ruby_exception.get(ruby_exception_overlap) == 2
+    assert RUBY_EXCEPTION_RAISE.status == "reporting-supported-closed-boundary"
+    assert RUBY_EXCEPTION_RESCUE.status == "reporting-supported-closed-boundary"
+    assert ruby_exception_overlap.status == "superseded-overlap-boundary"
 
     task_spawn_reporting_surfaces = {
         "python.asyncio.task",


### PR DESCRIPTION
## Summary
- lower unqualified Ruby `raise` calls to the existing `NodeKind::Throw` runtime boundary
- keep Ruby `rescue` on the existing `NodeKind::Try` boundary and add runtime-boundary coverage for Ruby raise
- keep Ruby `Try`/`Throw` closed in strict exact so Ruby exception flow does not become an ordinary exact clone surface, while preserving existing non-Ruby exact fragment contracts
- price Ruby exception-channel rows in the scheduling/lifecycle audit, retain the broad lexical row as superseded overlap, and update recall-loss/query-regression/docs evidence

## Quantified change
- `ruby.exception.raise`: 2,065 occurrences across 18 repos -> `reporting-supported-closed-boundary`
- `ruby.exception.rescue`: 1,933 occurrences across 18 repos -> `reporting-supported-closed-boundary`
- old broad `ruby.exception` row: 4,010 occurrences across 18 repos -> `superseded-overlap-boundary`
- 12 broad-only occurrences remain outside the concrete rows because they are receiver-qualified `.raise` overlaps
- reporting-supported total: 61 rows / 90,979 occurrences -> 63 rows / 94,977 occurrences
- largest actionable non-JS closed row after this slice: Java `stream/parallelStream`, 1,996 occurrences across 15 repos
- new exact admissions: 0; Ruby exception flow remains closed until propagation/rescue/ensure/non-local-control semantics are proven

## Query regression
- Ruby-heavy 6-repo alternating r15: `3295.78ms -> 3330.24ms` (`+1.05%`)
- family counts stay stable across all 6 repos
- output hashes unchanged on `fastlane`, `rack`, `sidekiq`, and `sinatra`
- output hash drift remains on `rubocop` and `rspec-core`, limited to metadata/representative changes: one Ruby helper family reports `value_nodes`/`mean_sem` 6 -> 7, and one HTML hidden family representative moves from `code` to `pre` with `static-attrs-only` origin evidence

## Validation
- `jq empty bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json bench/recall_loss/ruby-exception-reporting-2026-07-02.v1.json bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py scripts/query-regression-harness.py`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test`
- `python3 scripts/query-regression-harness.py --self-test`
- `cargo test -p nose-frontend ruby::tests -- --nocapture`
- `cargo test -p nose-detect strict_exact_closes_ruby_exception_boundaries -- --nocapture`
- `cargo test -p nose-cli --lib ruby_raise_reports_exception_channel_boundary -- --nocapture`
- `cargo test -p nose-cli --test cli exact_fragments -- --nocapture`
- `cargo llvm-cov --workspace --summary-only --fail-under-lines 83` (86.28% lines locally)
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json`
- `python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.ruby-exception-reporting.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-ruby-exception-reporting-2026-07-02.v1.json --generated-on 2026-07-02`
- `python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-ruby-exception-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref ruby-exception-reporting-alignment --current-source-sha 8bb0ed37d13d98bbb94f29fc23cc19163d8d52e3 --iterations 15 --repo rubocop --repo rspec-core --repo sidekiq --repo rack --repo fastlane --repo sinatra --output bench/recall_loss/ruby-exception-reporting-query-regression-2026-07-02.v1.json`
- `scripts/check-docs.sh`
- `cargo fmt --check`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `git diff --check`
- `./scripts/check-duplication.sh`