### PR TITLE
Report Java CompletableFuture receiver obligations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,8 @@ break.
   bleed-through across scopes, reclassifies the remaining `230` broad
   `CompletableFuture` type mentions as a superseded overlap row, and keeps
   exact admission closed. The Java-heavy query regression kept product output
-  hashes identical on all six measured repos and measured `8307.21ms ->
-  8331.21ms` (`+0.29%`).
+  hashes identical on all six measured repos and measured `8118.22ms ->
+  8151.13ms` (`+0.41%`).
 - Aligned already source-protocol-backed Python `await`/`async def`, Rust
   `.await`/`async fn`/`async block`, and Swift `async` function audit rows with
   runtime-boundary reporting. This moves `19,144` non-JS async source-protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ break.
   `276` to `230`; the Java-heavy query regression kept product output hashes
   identical on all six measured repos and measured `7023.49ms -> 6991.92ms`
   (`-0.45%`).
+- Added Java `CompletableFuture` receiver settlement and observation reporting
+  for import-backed `complete`/`completeExceptionally`,
+  `join`/`getNow`/`isCompletedExceptionally`, and timeout methods. The 120-repo
+  audit adds `45` settlement and `45` observation occurrences as
+  reporting-supported closed-boundaries after rejecting same-name receiver
+  bleed-through across scopes, reclassifies the remaining `230` broad
+  `CompletableFuture` type mentions as a superseded overlap row, and keeps
+  exact admission closed. The Java-heavy query regression kept product output
+  hashes identical on all six measured repos and measured `8307.21ms ->
+  8331.21ms` (`+0.29%`).
 - Aligned already source-protocol-backed Python `await`/`async def`, Rust
   `.await`/`async fn`/`async block`, and Swift `async` function audit rows with
   runtime-boundary reporting. This moves `19,144` non-JS async source-protocol

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -1131,7 +1131,7 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   [java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json](java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json)
   records the Java-heavy r9 product query regression. All six measured repos
   kept identical output hashes and family counts; aggregate median runtime was
-  `8307.21ms -> 8331.21ms` (`+0.29%`).
+  `8118.22ms -> 8151.13ms` (`+0.41%`).
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -1117,6 +1117,21 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   admission code changed; the artifact documents existing exact-supported
   iterator identity/static collection adapter capability and keeps untyped
   stream plus `parallelStream` lifecycle semantics closed for later proof.
+- [scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json](scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json)
+  records the Java `CompletableFuture` receiver split. It moves
+  scope-proven `complete`/`completeExceptionally` receiver settlement methods
+  (`45` across `2` repos) and `join`/`getNow`/`isCompletedExceptionally`
+  observation methods (`45` across `1` repo) to reporting-supported
+  closed-boundary rows, while the remaining `230` broad type/reference mentions
+  become a superseded overlap row instead of an actionable residual. Same-name
+  receivers in other scopes, custom imports, lambda parameters, and unsupported
+  arities remain closed.
+- [java-completablefuture-receiver-split-2026-07-02.v1.json](java-completablefuture-receiver-split-2026-07-02.v1.json)
+  records the compact closeout for the same slice, and
+  [java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json](java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json)
+  records the Java-heavy r9 product query regression. All six measured repos
+  kept identical output hashes and family counts; aggregate median runtime was
+  `8307.21ms -> 8331.21ms` (`+0.29%`).
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json
+++ b/bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json
@@ -93,9 +93,9 @@
       "h2database"
     ],
     "iterations": 9,
-    "aggregate_baseline_median_ms": 8307.208122918382,
-    "aggregate_current_median_ms": 8331.209500785917,
-    "aggregate_delta_pct": 0.2889223131573944,
+    "aggregate_baseline_median_ms": 8118.224832927808,
+    "aggregate_current_median_ms": 8151.13470912911,
+    "aggregate_delta_pct": 0.40538266528192457,
     "hashes_identical_all_repos": true,
     "families_identical_all_repos": true
   },
@@ -113,7 +113,8 @@
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
     "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json",
     "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json --generated-on 2026-07-02",
-    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-receiver-split --current-source-sha 234852d28ed109ba7b296137c26c553668932e66-dirty --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "cargo build --release -p nose-cli",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-residual-split --current-source-sha b9ec9151277a99ee634b8652e4518c74b3a92e4a --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
     "scripts/check-docs.sh",
     "python3 scripts/check-file-lengths.py --ratchet-base origin/main",
     "git diff --check",

--- a/bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json
+++ b/bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json
@@ -1,0 +1,123 @@
+{
+  "artifact_kind": "recall-loss-follow-up",
+  "branch": "java-completablefuture-receiver-split",
+  "generated_on": "2026-07-02",
+  "goal": "Move Java CompletableFuture receiver settlement and observation methods onto existing FutureLike reporting obligations, and split broad CompletableFuture type mentions out of actionable residual planning.",
+  "source_baseline": {
+    "ref": "origin/main",
+    "sha": "234852d28ed109ba7b296137c26c553668932e66"
+  },
+  "reporting_supported_rows_added": [
+    {
+      "language": "java",
+      "surface": "java.future.completable.receiver.settlement",
+      "operation": "CompletableFuture.complete/completeExceptionally",
+      "occurrences": 45,
+      "repos": 2,
+      "obligations": [
+        "future-settled-value-channel-contract",
+        "exception-channel-contract",
+        "task-handle-lifecycle-contract"
+      ]
+    },
+    {
+      "language": "java",
+      "surface": "java.future.completable.receiver.observe",
+      "operation": "CompletableFuture.join/getNow/isCompletedExceptionally",
+      "occurrences": 45,
+      "repos": 1,
+      "obligations": [
+        "future-settled-value-channel-contract",
+        "exception-channel-contract",
+        "task-handle-lifecycle-contract",
+        "task-cancellation-liveness-contract"
+      ]
+    }
+  ],
+  "reporting_supported_occurrences_added": 90,
+  "scope_safety_note": "The audit counts receiver rows only when the call-site scope's latest visible binding proves java.util.concurrent.CompletableFuture identity. Same-name receivers in other methods, custom imports, lambda parameters, and unsupported arities remain closed.",
+  "type_reference_overlap_rows": [
+    {
+      "language": "java",
+      "surface": "java.future.completable.type_reference",
+      "operation": "CompletableFuture type reference",
+      "occurrences": 230,
+      "repos": 7,
+      "status": "superseded-overlap-boundary",
+      "reason": "The previous broad java.future.completable row mixed imports, generic signatures, class literals, return types, fields, and subclass/type-shape mentions with concrete future operations. Concrete constructor, static, receiver, and unproven-constructor rows now drive actionable planning."
+    }
+  ],
+  "closed_boundary_delta": {
+    "before": {
+      "surface": "java.future.completable",
+      "operation": "CompletableFuture",
+      "occurrences": 230,
+      "repos": 7,
+      "status": "closed-boundary"
+    },
+    "after": {
+      "surface": "java.future.completable",
+      "operation": "CompletableFuture",
+      "occurrences": 0,
+      "status": "superseded_by_concrete_rows"
+    },
+    "recommended_order_delta": "Java CompletableFuture broad residual no longer appears in recommended_order; the remaining recommended candidates are JS/TS Promise and scheduler surfaces."
+  },
+  "exact_admission_policy": {
+    "semantic_admission_delta": 0,
+    "new_exact_admissions": 0,
+    "status": "reporting_only",
+    "summary": "The product change only adds missing-evidence labels for already rejected Java CompletableFuture receiver boundaries. Exact Future recovery remains closed until settled-value, exception, cancellation/liveness, timer, and callback/effect contracts are dependency-closed."
+  },
+  "current_recall_loss": {
+    "report": "target/recall-loss.java-completablefuture-receiver-split.crates.json",
+    "total_units": 6998,
+    "interpretable_units": 971,
+    "excluded_units": 6027,
+    "admission_rejections": 813,
+    "fingerprint_groups": 38,
+    "false_merges": 0,
+    "canon_checked": 100,
+    "canon_preservation_violations": 0,
+    "advisory_disagreements": 4,
+    "gate_passed": true
+  },
+  "query_regression": {
+    "artifact": "bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "repos": [
+      "netty",
+      "rxjava",
+      "retrofit",
+      "junit5",
+      "jedis",
+      "h2database"
+    ],
+    "iterations": 9,
+    "aggregate_baseline_median_ms": 8307.208122918382,
+    "aggregate_current_median_ms": 8331.209500785917,
+    "aggregate_delta_pct": 0.2889223131573944,
+    "hashes_identical_all_repos": true,
+    "families_identical_all_repos": true
+  },
+  "related_artifacts": [
+    "bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json",
+    "bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "bench/recall_loss/java-completablefuture-constructor-reporting-2026-07-02.v1.json",
+    "bench/recall_loss/java-future-residual-accounting-2026-07-02.v1.json"
+  ],
+  "validation": [
+    "cargo fmt --check",
+    "cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::java_completable_future_receiver -- --nocapture",
+    "cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::java::java_future_handle_methods_report_future_lifecycle_obligations -- --nocapture",
+    "python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json",
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json --generated-on 2026-07-02",
+    "python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-receiver-split --current-source-sha 234852d28ed109ba7b296137c26c553668932e66-dirty --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "scripts/check-docs.sh",
+    "python3 scripts/check-file-lengths.py --ratchet-base origin/main",
+    "git diff --check",
+    "./scripts/check-duplication.sh",
+    "jq empty bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json"
+  ]
+}

--- a/bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json
+++ b/bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json
@@ -6,12 +6,12 @@
     "baseline_source_ref": "origin/main",
     "baseline_source_sha": "234852d28ed109ba7b296137c26c553668932e66",
     "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
-    "current_binary_sha256": "99eee59922f9e203a1d6f2c82ef2c56c5509ce8317c76c9758e8a5f5af32b67f",
-    "current_source_ref": "java-completablefuture-receiver-split",
-    "current_source_sha": "234852d28ed109ba7b296137c26c553668932e66-dirty",
+    "current_binary_sha256": "2d4aec428f56e14e944a17fc738ba6d959909102b515adfe62b1c0855bd5d620",
+    "current_source_ref": "java-completablefuture-residual-split",
+    "current_source_sha": "b9ec9151277a99ee634b8652e4518c74b3a92e4a",
     "harness": "scripts/query-regression-harness.py",
-    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-receiver-split --current-source-sha 234852d28ed109ba7b296137c26c553668932e66-dirty --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
-    "working_tree_status_before_measurement": "M crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs\n M crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java/receiver_provenance.rs\n M crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs\n M scripts/scheduling-lifecycle-boundary-audit.py\n?? bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json"
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-residual-split --current-source-sha b9ec9151277a99ee634b8652e4518c74b3a92e4a --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "working_tree_status_before_measurement": ""
   },
   "repos": [
     "netty",
@@ -24,7 +24,7 @@
   "runs": [
     {
       "bytes": 1321539,
-      "elapsed_ms": 2344.547792105004,
+      "elapsed_ms": 2278.3260841388255,
       "families": 879,
       "iteration": 1,
       "label": "baseline",
@@ -33,7 +33,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1597.0091668423265,
+      "elapsed_ms": 1493.341916007921,
       "families": 618,
       "iteration": 1,
       "label": "baseline",
@@ -42,7 +42,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 163.38104102760553,
+      "elapsed_ms": 153.78283290192485,
       "families": 81,
       "iteration": 1,
       "label": "baseline",
@@ -51,7 +51,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 868.1968331802636,
+      "elapsed_ms": 874.9294171575457,
       "families": 327,
       "iteration": 1,
       "label": "baseline",
@@ -60,7 +60,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1339.4911671057343,
+      "elapsed_ms": 1387.336584040895,
       "families": 267,
       "iteration": 1,
       "label": "baseline",
@@ -69,7 +69,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2054.749625036493,
+      "elapsed_ms": 1964.0081250108778,
       "families": 515,
       "iteration": 1,
       "label": "baseline",
@@ -78,7 +78,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2420.312583912164,
+      "elapsed_ms": 2259.148374898359,
       "families": 879,
       "iteration": 1,
       "label": "current",
@@ -87,7 +87,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1499.1909579839557,
+      "elapsed_ms": 1542.8983750753105,
       "families": 618,
       "iteration": 1,
       "label": "current",
@@ -96,7 +96,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 203.01258307881653,
+      "elapsed_ms": 167.58208279497921,
       "families": 81,
       "iteration": 1,
       "label": "current",
@@ -105,7 +105,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 881.2955419998616,
+      "elapsed_ms": 816.7062089778483,
       "families": 327,
       "iteration": 1,
       "label": "current",
@@ -114,7 +114,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1462.24887506105,
+      "elapsed_ms": 1389.9780409410596,
       "families": 267,
       "iteration": 1,
       "label": "current",
@@ -123,7 +123,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2023.0819168500602,
+      "elapsed_ms": 1922.2254999913275,
       "families": 515,
       "iteration": 1,
       "label": "current",
@@ -132,7 +132,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2377.080208156258,
+      "elapsed_ms": 2256.0650839004666,
       "families": 879,
       "iteration": 2,
       "label": "current",
@@ -141,7 +141,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1576.5132089145482,
+      "elapsed_ms": 1511.1039171461016,
       "families": 618,
       "iteration": 2,
       "label": "current",
@@ -150,7 +150,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 177.12054192088544,
+      "elapsed_ms": 150.60266596265137,
       "families": 81,
       "iteration": 2,
       "label": "current",
@@ -159,7 +159,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 892.4802090041339,
+      "elapsed_ms": 778.6929588764906,
       "families": 327,
       "iteration": 2,
       "label": "current",
@@ -168,7 +168,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1446.5781250037253,
+      "elapsed_ms": 1491.0699999891222,
       "families": 267,
       "iteration": 2,
       "label": "current",
@@ -177,7 +177,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2038.9361248817295,
+      "elapsed_ms": 2003.778083017096,
       "families": 515,
       "iteration": 2,
       "label": "current",
@@ -186,7 +186,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2289.321458199993,
+      "elapsed_ms": 2427.684749942273,
       "families": 879,
       "iteration": 2,
       "label": "baseline",
@@ -195,7 +195,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1521.3979999534786,
+      "elapsed_ms": 1531.1439998913556,
       "families": 618,
       "iteration": 2,
       "label": "baseline",
@@ -204,7 +204,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 175.57254200801253,
+      "elapsed_ms": 142.42387493140996,
       "families": 81,
       "iteration": 2,
       "label": "baseline",
@@ -213,7 +213,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 850.9347918443382,
+      "elapsed_ms": 845.4835410229862,
       "families": 327,
       "iteration": 2,
       "label": "baseline",
@@ -222,7 +222,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1423.7429169006646,
+      "elapsed_ms": 1343.7402909621596,
       "families": 267,
       "iteration": 2,
       "label": "baseline",
@@ -231,7 +231,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2058.398582972586,
+      "elapsed_ms": 1981.1720829457045,
       "families": 515,
       "iteration": 2,
       "label": "baseline",
@@ -240,7 +240,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2350.402291165665,
+      "elapsed_ms": 2309.272457845509,
       "families": 879,
       "iteration": 3,
       "label": "baseline",
@@ -249,7 +249,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1564.0610000118613,
+      "elapsed_ms": 1480.011499952525,
       "families": 618,
       "iteration": 3,
       "label": "baseline",
@@ -258,7 +258,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 150.6904170382768,
+      "elapsed_ms": 138.52216699160635,
       "families": 81,
       "iteration": 3,
       "label": "baseline",
@@ -267,7 +267,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 899.9700418207794,
+      "elapsed_ms": 847.8430828545243,
       "families": 327,
       "iteration": 3,
       "label": "baseline",
@@ -276,7 +276,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1418.575583025813,
+      "elapsed_ms": 1389.9546249303967,
       "families": 267,
       "iteration": 3,
       "label": "baseline",
@@ -285,7 +285,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2082.076500169933,
+      "elapsed_ms": 1971.803749911487,
       "families": 515,
       "iteration": 3,
       "label": "baseline",
@@ -294,7 +294,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2349.66995799914,
+      "elapsed_ms": 2280.4920410271734,
       "families": 879,
       "iteration": 3,
       "label": "current",
@@ -303,7 +303,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1493.6913340352476,
+      "elapsed_ms": 1524.859916884452,
       "families": 618,
       "iteration": 3,
       "label": "current",
@@ -312,7 +312,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 172.87204111926258,
+      "elapsed_ms": 148.77395797520876,
       "families": 81,
       "iteration": 3,
       "label": "current",
@@ -321,7 +321,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 877.2130829747766,
+      "elapsed_ms": 903.2107919920236,
       "families": 327,
       "iteration": 3,
       "label": "current",
@@ -330,7 +330,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1564.213499892503,
+      "elapsed_ms": 1364.4137079827487,
       "families": 267,
       "iteration": 3,
       "label": "current",
@@ -339,7 +339,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2028.7145420443267,
+      "elapsed_ms": 1996.916624950245,
       "families": 515,
       "iteration": 3,
       "label": "current",
@@ -348,7 +348,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2303.2184168696404,
+      "elapsed_ms": 2222.048708004877,
       "families": 879,
       "iteration": 4,
       "label": "current",
@@ -357,7 +357,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1612.8436659928411,
+      "elapsed_ms": 1495.1344998553395,
       "families": 618,
       "iteration": 4,
       "label": "current",
@@ -366,7 +366,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 160.9630840830505,
+      "elapsed_ms": 164.54520798288286,
       "families": 81,
       "iteration": 4,
       "label": "current",
@@ -375,7 +375,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 905.173874925822,
+      "elapsed_ms": 838.6170000303537,
       "families": 327,
       "iteration": 4,
       "label": "current",
@@ -384,7 +384,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1422.9627919849008,
+      "elapsed_ms": 1393.9899168908596,
       "families": 267,
       "iteration": 4,
       "label": "current",
@@ -393,7 +393,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2027.0849158987403,
+      "elapsed_ms": 1973.495792131871,
       "families": 515,
       "iteration": 4,
       "label": "current",
@@ -402,7 +402,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2357.5020839925855,
+      "elapsed_ms": 2220.7113329786807,
       "families": 879,
       "iteration": 4,
       "label": "baseline",
@@ -411,7 +411,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1498.5191668383777,
+      "elapsed_ms": 1484.5966659486294,
       "families": 618,
       "iteration": 4,
       "label": "baseline",
@@ -420,7 +420,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 148.4851250424981,
+      "elapsed_ms": 177.3745841346681,
       "families": 81,
       "iteration": 4,
       "label": "baseline",
@@ -429,7 +429,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 851.6910830512643,
+      "elapsed_ms": 847.845584154129,
       "families": 327,
       "iteration": 4,
       "label": "baseline",
@@ -438,7 +438,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1401.4621248934418,
+      "elapsed_ms": 1444.765083026141,
       "families": 267,
       "iteration": 4,
       "label": "baseline",
@@ -447,7 +447,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 1990.0022081565112,
+      "elapsed_ms": 1954.5423749368638,
       "families": 515,
       "iteration": 4,
       "label": "baseline",
@@ -456,7 +456,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2387.0932089630514,
+      "elapsed_ms": 2275.4641249775887,
       "families": 879,
       "iteration": 5,
       "label": "baseline",
@@ -465,7 +465,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1555.6746248621494,
+      "elapsed_ms": 1555.239416891709,
       "families": 618,
       "iteration": 5,
       "label": "baseline",
@@ -474,7 +474,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 148.3174590393901,
+      "elapsed_ms": 159.09983403980732,
       "families": 81,
       "iteration": 5,
       "label": "baseline",
@@ -483,7 +483,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 924.6527499053627,
+      "elapsed_ms": 834.2054169625044,
       "families": 327,
       "iteration": 5,
       "label": "baseline",
@@ -492,7 +492,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1433.0890418495983,
+      "elapsed_ms": 1368.348625022918,
       "families": 267,
       "iteration": 5,
       "label": "baseline",
@@ -501,7 +501,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2026.799499988556,
+      "elapsed_ms": 1983.4323751274496,
       "families": 515,
       "iteration": 5,
       "label": "baseline",
@@ -510,7 +510,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2351.0039581451565,
+      "elapsed_ms": 2368.095374898985,
       "families": 879,
       "iteration": 5,
       "label": "current",
@@ -519,7 +519,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1549.1109581198543,
+      "elapsed_ms": 1477.7442920021713,
       "families": 618,
       "iteration": 5,
       "label": "current",
@@ -528,7 +528,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 157.27741597220302,
+      "elapsed_ms": 147.83329190686345,
       "families": 81,
       "iteration": 5,
       "label": "current",
@@ -537,7 +537,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 845.956499921158,
+      "elapsed_ms": 862.5794998370111,
       "families": 327,
       "iteration": 5,
       "label": "current",
@@ -546,7 +546,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1379.0567079558969,
+      "elapsed_ms": 1350.7532910443842,
       "families": 267,
       "iteration": 5,
       "label": "current",
@@ -555,7 +555,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2060.873207869008,
+      "elapsed_ms": 1988.1018330343068,
       "families": 515,
       "iteration": 5,
       "label": "current",
@@ -564,7 +564,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2340.811417205259,
+      "elapsed_ms": 2255.8560410980135,
       "families": 879,
       "iteration": 6,
       "label": "current",
@@ -573,7 +573,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1514.7639999631792,
+      "elapsed_ms": 1537.9022909328341,
       "families": 618,
       "iteration": 6,
       "label": "current",
@@ -582,7 +582,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 188.0193748511374,
+      "elapsed_ms": 147.78400002978742,
       "families": 81,
       "iteration": 6,
       "label": "current",
@@ -591,7 +591,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 846.2024999316782,
+      "elapsed_ms": 868.0255000945181,
       "families": 327,
       "iteration": 6,
       "label": "current",
@@ -600,7 +600,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1412.0265829842538,
+      "elapsed_ms": 1485.6097500305623,
       "families": 267,
       "iteration": 6,
       "label": "current",
@@ -609,7 +609,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2032.5897501315922,
+      "elapsed_ms": 1927.0374581683427,
       "families": 515,
       "iteration": 6,
       "label": "current",
@@ -618,7 +618,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2278.88200012967,
+      "elapsed_ms": 2260.87454194203,
       "families": 879,
       "iteration": 6,
       "label": "baseline",
@@ -627,7 +627,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1496.2942500133067,
+      "elapsed_ms": 1478.4273749683052,
       "families": 618,
       "iteration": 6,
       "label": "baseline",
@@ -636,7 +636,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 166.09420790337026,
+      "elapsed_ms": 200.11224993504584,
       "families": 81,
       "iteration": 6,
       "label": "baseline",
@@ -645,7 +645,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 817.9246250074357,
+      "elapsed_ms": 835.7877500820905,
       "families": 327,
       "iteration": 6,
       "label": "baseline",
@@ -654,7 +654,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1427.1764578297734,
+      "elapsed_ms": 1442.290582926944,
       "families": 267,
       "iteration": 6,
       "label": "baseline",
@@ -663,7 +663,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2003.5297910217196,
+      "elapsed_ms": 1946.8403328210115,
       "families": 515,
       "iteration": 6,
       "label": "baseline",
@@ -672,7 +672,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2337.1414998546243,
+      "elapsed_ms": 2261.4961250219494,
       "families": 879,
       "iteration": 7,
       "label": "baseline",
@@ -681,7 +681,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1528.2315409276634,
+      "elapsed_ms": 1525.2887499518692,
       "families": 618,
       "iteration": 7,
       "label": "baseline",
@@ -690,7 +690,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 167.04783402383327,
+      "elapsed_ms": 141.88591693527997,
       "families": 81,
       "iteration": 7,
       "label": "baseline",
@@ -699,7 +699,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 849.2975828703493,
+      "elapsed_ms": 870.112624950707,
       "families": 327,
       "iteration": 7,
       "label": "baseline",
@@ -708,7 +708,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1398.5590829979628,
+      "elapsed_ms": 1441.5664169937372,
       "families": 267,
       "iteration": 7,
       "label": "baseline",
@@ -717,7 +717,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 1988.1168331485242,
+      "elapsed_ms": 2011.7405420169234,
       "families": 515,
       "iteration": 7,
       "label": "baseline",
@@ -726,7 +726,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2325.4168338607997,
+      "elapsed_ms": 2269.9357920791954,
       "families": 879,
       "iteration": 7,
       "label": "current",
@@ -735,7 +735,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1498.6884579993784,
+      "elapsed_ms": 1510.0175000261515,
       "families": 618,
       "iteration": 7,
       "label": "current",
@@ -744,7 +744,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 163.48341689445078,
+      "elapsed_ms": 159.83737516216934,
       "families": 81,
       "iteration": 7,
       "label": "current",
@@ -753,7 +753,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 826.1875840835273,
+      "elapsed_ms": 832.7276250347495,
       "families": 327,
       "iteration": 7,
       "label": "current",
@@ -762,7 +762,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1467.8165828809142,
+      "elapsed_ms": 1399.1047921590507,
       "families": 267,
       "iteration": 7,
       "label": "current",
@@ -771,7 +771,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2002.1242499351501,
+      "elapsed_ms": 1985.1527919527143,
       "families": 515,
       "iteration": 7,
       "label": "current",
@@ -780,7 +780,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2243.5327500570565,
+      "elapsed_ms": 2288.5211249813437,
       "families": 879,
       "iteration": 8,
       "label": "current",
@@ -789,7 +789,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1494.0359161701053,
+      "elapsed_ms": 1543.2169588748366,
       "families": 618,
       "iteration": 8,
       "label": "current",
@@ -798,7 +798,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 162.89729089476168,
+      "elapsed_ms": 152.3352910298854,
       "families": 81,
       "iteration": 8,
       "label": "current",
@@ -807,7 +807,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 847.3808339331299,
+      "elapsed_ms": 846.3255839888006,
       "families": 327,
       "iteration": 8,
       "label": "current",
@@ -816,7 +816,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1395.4749160911888,
+      "elapsed_ms": 1361.101625021547,
       "families": 267,
       "iteration": 8,
       "label": "current",
@@ -825,7 +825,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 1999.6157079003751,
+      "elapsed_ms": 2006.0817908961326,
       "families": 515,
       "iteration": 8,
       "label": "current",
@@ -834,7 +834,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2219.8769999668,
+      "elapsed_ms": 2235.4523329995573,
       "families": 879,
       "iteration": 8,
       "label": "baseline",
@@ -843,7 +843,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1513.934874907136,
+      "elapsed_ms": 1520.513666793704,
       "families": 618,
       "iteration": 8,
       "label": "baseline",
@@ -852,7 +852,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 180.73087488301098,
+      "elapsed_ms": 143.2397081516683,
       "families": 81,
       "iteration": 8,
       "label": "baseline",
@@ -861,7 +861,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 906.0157500207424,
+      "elapsed_ms": 855.4024170152843,
       "families": 327,
       "iteration": 8,
       "label": "baseline",
@@ -870,7 +870,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1381.2653340864927,
+      "elapsed_ms": 1377.5014579296112,
       "families": 267,
       "iteration": 8,
       "label": "baseline",
@@ -879,7 +879,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 1939.2098330426961,
+      "elapsed_ms": 2008.920333115384,
       "families": 515,
       "iteration": 8,
       "label": "baseline",
@@ -888,7 +888,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2330.0983749795705,
+      "elapsed_ms": 2202.812499832362,
       "families": 879,
       "iteration": 9,
       "label": "baseline",
@@ -897,7 +897,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1569.9717078823596,
+      "elapsed_ms": 1492.535667028278,
       "families": 618,
       "iteration": 9,
       "label": "baseline",
@@ -906,7 +906,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 162.62416704557836,
+      "elapsed_ms": 175.0167498830706,
       "families": 81,
       "iteration": 9,
       "label": "baseline",
@@ -915,7 +915,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 856.3486670609564,
+      "elapsed_ms": 852.7997091878206,
       "families": 327,
       "iteration": 9,
       "label": "baseline",
@@ -924,7 +924,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1455.0177499186248,
+      "elapsed_ms": 1391.8671249412,
       "families": 267,
       "iteration": 9,
       "label": "baseline",
@@ -933,7 +933,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 1982.4045831337571,
+      "elapsed_ms": 1961.840417003259,
       "families": 515,
       "iteration": 9,
       "label": "baseline",
@@ -942,7 +942,7 @@
     },
     {
       "bytes": 1321539,
-      "elapsed_ms": 2375.0234579201788,
+      "elapsed_ms": 2274.8680831864476,
       "families": 879,
       "iteration": 9,
       "label": "current",
@@ -951,7 +951,7 @@
     },
     {
       "bytes": 1169728,
-      "elapsed_ms": 1521.4770419988781,
+      "elapsed_ms": 1450.1115421298891,
       "families": 618,
       "iteration": 9,
       "label": "current",
@@ -960,7 +960,7 @@
     },
     {
       "bytes": 124169,
-      "elapsed_ms": 147.3399589303881,
+      "elapsed_ms": 175.13716709800065,
       "families": 81,
       "iteration": 9,
       "label": "current",
@@ -969,7 +969,7 @@
     },
     {
       "bytes": 514636,
-      "elapsed_ms": 851.6147918999195,
+      "elapsed_ms": 764.5895411260426,
       "families": 327,
       "iteration": 9,
       "label": "current",
@@ -978,7 +978,7 @@
     },
     {
       "bytes": 329711,
-      "elapsed_ms": 1402.4951250758022,
+      "elapsed_ms": 1417.7749999798834,
       "families": 267,
       "iteration": 9,
       "label": "current",
@@ -987,7 +987,7 @@
     },
     {
       "bytes": 650060,
-      "elapsed_ms": 2036.8892920669168,
+      "elapsed_ms": 1921.8596669379622,
       "families": 515,
       "iteration": 9,
       "label": "current",
@@ -996,9 +996,9 @@
     }
   ],
   "summary": {
-    "aggregate_baseline_median_ms": 8307.208122918382,
-    "aggregate_current_median_ms": 8331.209500785917,
-    "aggregate_delta_pct": 0.2889223131573944,
+    "aggregate_baseline_median_ms": 8118.224832927808,
+    "aggregate_current_median_ms": 8151.13470912911,
+    "aggregate_delta_pct": 0.40538266528192457,
     "by_repo": {
       "h2database": {
         "baseline": {
@@ -1011,7 +1011,7 @@
           "hashes": [
             "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
           ],
-          "median_ms": 2003.5297910217196
+          "median_ms": 1971.803749911487
         },
         "current": {
           "bytes": [
@@ -1023,7 +1023,7 @@
           "hashes": [
             "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
           ],
-          "median_ms": 2028.7145420443267
+          "median_ms": 1985.1527919527143
         }
       },
       "jedis": {
@@ -1037,7 +1037,7 @@
           "hashes": [
             "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
           ],
-          "median_ms": 1418.575583025813
+          "median_ms": 1389.9546249303967
         },
         "current": {
           "bytes": [
@@ -1049,7 +1049,7 @@
           "hashes": [
             "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
           ],
-          "median_ms": 1422.9627919849008
+          "median_ms": 1393.9899168908596
         }
       },
       "junit5": {
@@ -1063,7 +1063,7 @@
           "hashes": [
             "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
           ],
-          "median_ms": 856.3486670609564
+          "median_ms": 847.845584154129
         },
         "current": {
           "bytes": [
@@ -1075,7 +1075,7 @@
           "hashes": [
             "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
           ],
-          "median_ms": 851.6147918999195
+          "median_ms": 838.6170000303537
         }
       },
       "netty": {
@@ -1089,7 +1089,7 @@
           "hashes": [
             "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
           ],
-          "median_ms": 2337.1414998546243
+          "median_ms": 2261.4961250219494
         },
         "current": {
           "bytes": [
@@ -1101,7 +1101,7 @@
           "hashes": [
             "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
           ],
-          "median_ms": 2349.66995799914
+          "median_ms": 2269.9357920791954
         }
       },
       "retrofit": {
@@ -1115,7 +1115,7 @@
           "hashes": [
             "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
           ],
-          "median_ms": 163.38104102760553
+          "median_ms": 153.78283290192485
         },
         "current": {
           "bytes": [
@@ -1127,7 +1127,7 @@
           "hashes": [
             "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
           ],
-          "median_ms": 163.48341689445078
+          "median_ms": 152.3352910298854
         }
       },
       "rxjava": {
@@ -1141,7 +1141,7 @@
           "hashes": [
             "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
           ],
-          "median_ms": 1528.2315409276634
+          "median_ms": 1493.341916007921
         },
         "current": {
           "bytes": [
@@ -1153,7 +1153,7 @@
           "hashes": [
             "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
           ],
-          "median_ms": 1514.7639999631792
+          "median_ms": 1511.1039171461016
         }
       }
     },

--- a/bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json
+++ b/bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json
@@ -1,0 +1,1169 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-java-cf-receiver-main/target/release/nose",
+    "baseline_binary_sha256": "4cb79fbb01b1f38a835c887a873951bd86487c9021ba70a1135c7cf2edbdddfa",
+    "baseline_source_ref": "origin/main",
+    "baseline_source_sha": "234852d28ed109ba7b296137c26c553668932e66",
+    "current_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
+    "current_binary_sha256": "99eee59922f9e203a1d6f2c82ef2c56c5509ce8317c76c9758e8a5f5af32b67f",
+    "current_source_ref": "java-completablefuture-receiver-split",
+    "current_source_sha": "234852d28ed109ba7b296137c26c553668932e66-dirty",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-receiver-split --current-source-sha 234852d28ed109ba7b296137c26c553668932e66-dirty --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json",
+    "working_tree_status_before_measurement": "M crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs\n M crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java/receiver_provenance.rs\n M crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs\n M scripts/scheduling-lifecycle-boundary-audit.py\n?? bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json"
+  },
+  "repos": [
+    "netty",
+    "rxjava",
+    "retrofit",
+    "junit5",
+    "jedis",
+    "h2database"
+  ],
+  "runs": [
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2344.547792105004,
+      "families": 879,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1597.0091668423265,
+      "families": 618,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 163.38104102760553,
+      "families": 81,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 868.1968331802636,
+      "families": 327,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1339.4911671057343,
+      "families": 267,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2054.749625036493,
+      "families": 515,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2420.312583912164,
+      "families": 879,
+      "iteration": 1,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1499.1909579839557,
+      "families": 618,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 203.01258307881653,
+      "families": 81,
+      "iteration": 1,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 881.2955419998616,
+      "families": 327,
+      "iteration": 1,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1462.24887506105,
+      "families": 267,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2023.0819168500602,
+      "families": 515,
+      "iteration": 1,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2377.080208156258,
+      "families": 879,
+      "iteration": 2,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1576.5132089145482,
+      "families": 618,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 177.12054192088544,
+      "families": 81,
+      "iteration": 2,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 892.4802090041339,
+      "families": 327,
+      "iteration": 2,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1446.5781250037253,
+      "families": 267,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2038.9361248817295,
+      "families": 515,
+      "iteration": 2,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2289.321458199993,
+      "families": 879,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1521.3979999534786,
+      "families": 618,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 175.57254200801253,
+      "families": 81,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 850.9347918443382,
+      "families": 327,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1423.7429169006646,
+      "families": 267,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2058.398582972586,
+      "families": 515,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2350.402291165665,
+      "families": 879,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1564.0610000118613,
+      "families": 618,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 150.6904170382768,
+      "families": 81,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 899.9700418207794,
+      "families": 327,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1418.575583025813,
+      "families": 267,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2082.076500169933,
+      "families": 515,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2349.66995799914,
+      "families": 879,
+      "iteration": 3,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1493.6913340352476,
+      "families": 618,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 172.87204111926258,
+      "families": 81,
+      "iteration": 3,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 877.2130829747766,
+      "families": 327,
+      "iteration": 3,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1564.213499892503,
+      "families": 267,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2028.7145420443267,
+      "families": 515,
+      "iteration": 3,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2303.2184168696404,
+      "families": 879,
+      "iteration": 4,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1612.8436659928411,
+      "families": 618,
+      "iteration": 4,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 160.9630840830505,
+      "families": 81,
+      "iteration": 4,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 905.173874925822,
+      "families": 327,
+      "iteration": 4,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1422.9627919849008,
+      "families": 267,
+      "iteration": 4,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2027.0849158987403,
+      "families": 515,
+      "iteration": 4,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2357.5020839925855,
+      "families": 879,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1498.5191668383777,
+      "families": 618,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 148.4851250424981,
+      "families": 81,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 851.6910830512643,
+      "families": 327,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1401.4621248934418,
+      "families": 267,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1990.0022081565112,
+      "families": 515,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2387.0932089630514,
+      "families": 879,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1555.6746248621494,
+      "families": 618,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 148.3174590393901,
+      "families": 81,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 924.6527499053627,
+      "families": 327,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1433.0890418495983,
+      "families": 267,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2026.799499988556,
+      "families": 515,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2351.0039581451565,
+      "families": 879,
+      "iteration": 5,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1549.1109581198543,
+      "families": 618,
+      "iteration": 5,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 157.27741597220302,
+      "families": 81,
+      "iteration": 5,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 845.956499921158,
+      "families": 327,
+      "iteration": 5,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1379.0567079558969,
+      "families": 267,
+      "iteration": 5,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2060.873207869008,
+      "families": 515,
+      "iteration": 5,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2340.811417205259,
+      "families": 879,
+      "iteration": 6,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1514.7639999631792,
+      "families": 618,
+      "iteration": 6,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 188.0193748511374,
+      "families": 81,
+      "iteration": 6,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 846.2024999316782,
+      "families": 327,
+      "iteration": 6,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1412.0265829842538,
+      "families": 267,
+      "iteration": 6,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2032.5897501315922,
+      "families": 515,
+      "iteration": 6,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2278.88200012967,
+      "families": 879,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1496.2942500133067,
+      "families": 618,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 166.09420790337026,
+      "families": 81,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 817.9246250074357,
+      "families": 327,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1427.1764578297734,
+      "families": 267,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2003.5297910217196,
+      "families": 515,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2337.1414998546243,
+      "families": 879,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1528.2315409276634,
+      "families": 618,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 167.04783402383327,
+      "families": 81,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 849.2975828703493,
+      "families": 327,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1398.5590829979628,
+      "families": 267,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1988.1168331485242,
+      "families": 515,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2325.4168338607997,
+      "families": 879,
+      "iteration": 7,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1498.6884579993784,
+      "families": 618,
+      "iteration": 7,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 163.48341689445078,
+      "families": 81,
+      "iteration": 7,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 826.1875840835273,
+      "families": 327,
+      "iteration": 7,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1467.8165828809142,
+      "families": 267,
+      "iteration": 7,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2002.1242499351501,
+      "families": 515,
+      "iteration": 7,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2243.5327500570565,
+      "families": 879,
+      "iteration": 8,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1494.0359161701053,
+      "families": 618,
+      "iteration": 8,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 162.89729089476168,
+      "families": 81,
+      "iteration": 8,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 847.3808339331299,
+      "families": 327,
+      "iteration": 8,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1395.4749160911888,
+      "families": 267,
+      "iteration": 8,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1999.6157079003751,
+      "families": 515,
+      "iteration": 8,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2219.8769999668,
+      "families": 879,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1513.934874907136,
+      "families": 618,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 180.73087488301098,
+      "families": 81,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 906.0157500207424,
+      "families": 327,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1381.2653340864927,
+      "families": 267,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1939.2098330426961,
+      "families": 515,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2330.0983749795705,
+      "families": 879,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1569.9717078823596,
+      "families": 618,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 162.62416704557836,
+      "families": 81,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 856.3486670609564,
+      "families": 327,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1455.0177499186248,
+      "families": 267,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1982.4045831337571,
+      "families": 515,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2375.0234579201788,
+      "families": 879,
+      "iteration": 9,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1521.4770419988781,
+      "families": 618,
+      "iteration": 9,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 147.3399589303881,
+      "families": 81,
+      "iteration": 9,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 851.6147918999195,
+      "families": 327,
+      "iteration": 9,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1402.4951250758022,
+      "families": 267,
+      "iteration": 9,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 2036.8892920669168,
+      "families": 515,
+      "iteration": 9,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 8307.208122918382,
+    "aggregate_current_median_ms": 8331.209500785917,
+    "aggregate_delta_pct": 0.2889223131573944,
+    "by_repo": {
+      "h2database": {
+        "baseline": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+          ],
+          "median_ms": 2003.5297910217196
+        },
+        "current": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "2c4611c2bc4065f41c80cb3787177174e55366eed1ef7d3c6701a2509ac24365"
+          ],
+          "median_ms": 2028.7145420443267
+        }
+      },
+      "jedis": {
+        "baseline": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+          ],
+          "median_ms": 1418.575583025813
+        },
+        "current": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "606ecaf372e28109fec434aa821fd55d30b9507f7eebfee6090233a600159024"
+          ],
+          "median_ms": 1422.9627919849008
+        }
+      },
+      "junit5": {
+        "baseline": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+          ],
+          "median_ms": 856.3486670609564
+        },
+        "current": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "f14acbc7f5f2d62ae82fc76db8774f47911381f6acdd40a8f933987784fa2c5e"
+          ],
+          "median_ms": 851.6147918999195
+        }
+      },
+      "netty": {
+        "baseline": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+          ],
+          "median_ms": 2337.1414998546243
+        },
+        "current": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "ff967cc0cd517ba9cdde85d2f79e98a3ba7c2f0fc5c627aa4d41cc41e983f83f"
+          ],
+          "median_ms": 2349.66995799914
+        }
+      },
+      "retrofit": {
+        "baseline": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+          ],
+          "median_ms": 163.38104102760553
+        },
+        "current": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "9e59d42b1282cb828c4e641fef8c3898d73a8e9a7c897380dc58cda43db2cb14"
+          ],
+          "median_ms": 163.48341689445078
+        }
+      },
+      "rxjava": {
+        "baseline": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+          ],
+          "median_ms": 1528.2315409276634
+        },
+        "current": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "69fceb883e475097cd9dbda7569f66422357d05bee804f50611fc32bfa8d19e2"
+          ],
+          "median_ms": 1514.7639999631792
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "h2database": true,
+      "jedis": true,
+      "junit5": true,
+      "netty": true,
+      "retrofit": true,
+      "rxjava": true
+    }
+  }
+}

--- a/bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json
+++ b/bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json
@@ -1,0 +1,5932 @@
+{
+  "current_recall_loss": {
+    "relevant_obligations": [
+      {
+        "count": 17,
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_interpretable": 17
+      },
+      {
+        "count": 10,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-rust-macro-call-effect-proof-missing",
+        "oracle_interpretable": 10
+      },
+      {
+        "count": 9,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-member-call-effect-proof-missing",
+        "oracle_interpretable": 9
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-assignment-effect-proof-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 5,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-direct-function-call-effect-contract-missing",
+        "oracle_interpretable": 5
+      },
+      {
+        "count": 2,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-identity-or-shape-proof-missing",
+        "oracle_interpretable": 2
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "callback-imported-function-call-effect-contract-missing",
+        "oracle_interpretable": 1
+      },
+      {
+        "count": 1,
+        "obligation_family": "callback-demand-effect",
+        "obligation_subreason": "predicate-callback-demand-effect-profile-missing",
+        "oracle_interpretable": 1
+      }
+    ],
+    "relevant_oracle_exclusion_obligations": [
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 580,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "oracle_excluded": 580
+      },
+      {
+        "attribution_reason": "unsupported-runtime-boundary",
+        "count": 3,
+        "exclusion_reason": "uninterpretable",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "oracle_excluded": 3
+      }
+    ],
+    "report": "target/recall-loss.java-completablefuture-receiver-split.crates.json",
+    "soundness_gate": {
+      "advisory_disagreements": 4,
+      "canon_preservation_violations": 0,
+      "false_merges": 0,
+      "fingerprint_groups": 38,
+      "gate_passed": true,
+      "lossy_fingerprint_collisions": 0,
+      "max_violations": 0
+    },
+    "summary": {
+      "admission_rejections": 813,
+      "canon_checked": 100,
+      "canon_preservation_violations": 0,
+      "excluded_units": 6027,
+      "interpretable_units": 971,
+      "total_units": 6998
+    }
+  },
+  "generated_on": "2026-07-02",
+  "hard_negative_inventory": [
+    {
+      "class": "thenable assimilation and custom Promise-like receivers",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "first-settled versus all-settled aggregate semantics",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_js_promise_protocol_convergence",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "executor callback timing and thrown executor errors",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::promise_constructor_missing_evidence_splits_executor_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "scheduler/microtask ordering versus synchronous evaluation",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary.rs::scheduler_and_interval_calls_report_timing_and_lifecycle_obligations",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "interval stream liveness/cardinality",
+      "evidence": "crates/nose-cli/tests/cli/commands/recall_loss_report.rs::recall_loss_report_splits_promise_protocol_boundaries",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "cross-language lifecycle one-shot/reusable/materialized distinctions",
+      "evidence": "docs/scheduling-channel-callback-obligations-594.md",
+      "status": "mapped-doc-policy"
+    },
+    {
+      "class": "Go direct call versus goroutine/defer scheduling and callback effects",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_select_defer_and_goroutine_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Go channel receive value/status, channel send, and select/default readiness boundaries",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_go_concurrency_protocol_convergence and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::go_channel_protocol_boundaries_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Python imported asyncio bindings shadowed by parameters, assignments, nested imports, or project-local asyncio modules",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_local_shadows and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Python async iterator and async context-manager protocol boundaries versus synchronous loops, comprehensions, and with-blocks",
+      "evidence": "crates/nose-cli/tests/cli/semantic_boundaries/python_async_protocol.rs::query_mode_semantic_rejects_unproven_python_async_protocol_lifecycle_convergence, ::query_mode_semantic_rejects_unproven_python_async_comprehension_convergence, crates/nose-frontend/src/python/tests.rs::async_for_preserves_source_backed_iteration_boundary, ::async_comprehension_preserves_source_backed_iteration_boundary, ::multi_clause_async_comprehension_preserves_source_backed_iteration_boundary, ::async_with_preserves_source_backed_context_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::python_async_lifecycle_protocols_report_specific_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Ruby block yield callback demand/effect versus ordinary value return or direct call",
+      "evidence": "crates/nose-frontend/src/ruby/tests.rs::yield_preserves_source_backed_protocol_boundary, crates/nose-cli/src/verify_admission/runtime_boundary/tests.rs::yield_protocol_missing_evidence_is_language_specific, and crates/nose-cli/tests/cli/semantic_boundaries/ruby_yield_protocol.rs::query_mode_semantic_rejects_unproven_ruby_yield_callback_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Rust brace/direct-imported runtime bindings shadowed by parameters, lets, local macros, block scopes, other modules, or project-local runtime roots",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/imported_bindings.rs::non_js_async_runtime_imported_bindings_reject_rust_shadows_and_scopes and ::non_js_async_runtime_context_rejects_project_local_imported_bindings",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Rust async closures versus synchronous closures and async blocks",
+      "evidence": "crates/nose-frontend/src/rust/tests/async_protocols.rs::async_closure_preserves_source_backed_protocol_boundary, ::sync_closure_does_not_create_async_protocol_boundary, and crates/nose-cli/tests/cli/semantic_boundaries.rs::query_mode_semantic_rejects_unproven_rust_async_closure_sync_convergence",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Swift structured-concurrency runtime names shadowed by local Task bindings, Task extensions, same-file task-group functions, or project-visible task-group functions",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_structured_concurrency_rejects_local_runtime_shadows",
+      "status": "mapped-existing"
+    },
+    {
+      "class": "Swift throwing functions and closures versus non-throwing callables, plus async throwing callables that must retain both scheduling and exception-channel obligations",
+      "evidence": "crates/nose-frontend/src/swift/tests/async_protocols.rs::async_throwing_function_preserves_scheduling_and_exception_boundaries, ::async_throwing_closure_keeps_exception_boundary_inside_async_boundary, and crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/swift.rs::swift_throwing_callables_report_exception_obligations",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletableFuture static calls without exact stdlib type identity, or with local/conflicting type names",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_static_wildcard.rs::java_completable_future_static_attribution_requires_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java CompletionStage-style receiver continuations without import-backed java.util.concurrent type-domain evidence",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_completion_stage_receiver_methods_require_import_backed_type_domain",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future local receivers with reassignment, local shadows, or conflicting imports, plus conflicting Executor local receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java Future field receivers that are implicit, non-this, member-shadowed, duplicate, or conflicting, plus conflicting Executor field receivers",
+      "evidence": "crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java.rs::java_local_and_this_field_receivers_require_exact_type_identity",
+      "status": "expanded-this-slice"
+    },
+    {
+      "class": "Java stream source adapters split into proof-backed receiver.stream/Arrays.stream rows versus residual untyped stream and parallelStream lifecycle boundaries",
+      "evidence": "crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/iterator_adapter.rs::admitted_java_stream_identity_adapter_uses_same_protocol_pack and crates/nose-semantics/src/tests/library_api_evidence/admission_resolvers/pack_resolvers_5.rs::admitted_static_collection_adapter_resolver_requires_import_backed_api_occurrence_evidence",
+      "status": "expanded-this-slice"
+    }
+  ],
+  "policy": {
+    "go_channel_operation_pricing": "Directional channel type arrows such as <-chan and chan<- are excluded from send/receive operation counts.",
+    "note": "Counts price boundary surfaces; they do not prove exact semantics.",
+    "raw_source_snippets_included": false,
+    "semantic_admission_delta": 0,
+    "source_prevalence_only": true
+  },
+  "recommended_order": [
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "rank": 1,
+      "repos": 17,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "rank": 2,
+      "repos": 8,
+      "why": "Promise aggregate semantics are already corpus-priced and have adjacent first/all-settled hard negatives."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "rank": 3,
+      "repos": 18,
+      "why": "new Promise is high-risk because timing, resolve/reject callback, and throw-to-rejection behavior interact."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "rank": 4,
+      "repos": 7,
+      "why": "Cancellation appears across JS/TS scheduling APIs and must stay separate from fulfillment/rejection recovery."
+    },
+    {
+      "language": "javascript-typescript",
+      "next_action": "reporting-only split and hard-negative expansion before exact admission",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "rank": 5,
+      "repos": 11,
+      "why": "Repeated emission/liveness needs lifecycle proof before interval streams can be compared exactly."
+    }
+  ],
+  "regenerate": [
+    "python3 scripts/scheduling-lifecycle-boundary-audit.py --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json --output bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json --generated-on 2026-07-02"
+  ],
+  "report_kind": "scheduling-lifecycle-boundary-audit",
+  "schema_version": 1,
+  "summary": {
+    "languages": {
+      "c": 81,
+      "go": 31500,
+      "java": 6792,
+      "javascript-typescript": 45382,
+      "python": 6439,
+      "ruby": 8883,
+      "rust": 13228,
+      "swift": 64366
+    },
+    "obligation_families": {
+      "callback-demand-effect": 801,
+      "cancellation-liveness-boundary": 547,
+      "channel-boundary": 12030,
+      "exception-channel": 59776,
+      "executor-callback": 795,
+      "lifecycle-materialization-boundary": 23041,
+      "scheduling-boundary": 78509,
+      "success-error-result-channel": 1172
+    },
+    "repos_in_manifest": 120,
+    "total_source_prevalence": 176671
+  },
+  "surfaces": [
+    {
+      "boundary": "await scheduling",
+      "language": "javascript-typescript",
+      "note": "await is scheduling and thenable assimilation, not sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 29305,
+      "operation": "await",
+      "repos": 21,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.await",
+      "top_files": [
+        {
+          "occurrences": 1058,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 689,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 673,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 635,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 615,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 615,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 487,
+          "path": "drizzle-orm/integration-tests/tests/sqlite/sqlite-common.ts"
+        },
+        {
+          "occurrences": 484,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12136,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3321,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 2666,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2413,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1604,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 1592,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 1171,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 1164,
+          "repo": "swr"
+        }
+      ]
+    },
+    {
+      "boundary": "throws channel",
+      "language": "swift",
+      "note": "Historical lexical overlap bucket; use source-backed Swift try and throwing-callable rows as actionable exception-channel surfaces",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "swift-throws-exception-channel-contract-missing",
+      "occurrences": 26608,
+      "operation": "throws/try",
+      "repos": 18,
+      "status": "superseded-overlap-boundary",
+      "surface": "swift.error.throws",
+      "top_files": [
+        {
+          "occurrences": 664,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 489,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 450,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 406,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 396,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 364,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 344,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 304,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14760,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2508,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1466,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 1356,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 1107,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 914,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 805,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "try propagation error channel",
+      "language": "swift",
+      "note": "Swift try expressions and for-try-await loops expose source-backed TryPropagation boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 17970,
+      "operation": "try/try?/try!",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.try_expression",
+      "top_files": [
+        {
+          "occurrences": 529,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 411,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 391,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelPipelineTest.swift"
+        },
+        {
+          "occurrences": 357,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 337,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 282,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 273,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 259,
+          "path": "swift-nio/Tests/NIOHTTP1Tests/HTTPServerUpgradeTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10831,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 1460,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 760,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 758,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 722,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 635,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 610,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 562,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "defer lifecycle",
+      "language": "go",
+      "note": "defer has scope-exit ordering and panic interaction semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "defer-lifecycle-ordering-contract-missing",
+      "occurrences": 17521,
+      "operation": "defer statement",
+      "repos": 16,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.defer",
+      "top_files": [
+        {
+          "occurrences": 1001,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 560,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 494,
+          "path": "nats-server/server/jetstream_consumer_test.go"
+        },
+        {
+          "occurrences": 461,
+          "path": "nats-server/server/filestore_test.go"
+        },
+        {
+          "occurrences": 420,
+          "path": "nats-server/server/mqtt_test.go"
+        },
+        {
+          "occurrences": 396,
+          "path": "nats-server/server/jetstream_cluster_3_test.go"
+        },
+        {
+          "occurrences": 394,
+          "path": "nats-server/server/jetstream_cluster_1_test.go"
+        },
+        {
+          "occurrences": 379,
+          "path": "nats-server/server/gateway_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 10073,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 2461,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 1797,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 1151,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 581,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 449,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 422,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 161,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "javascript-typescript",
+      "note": "async functions have scheduling and rejection boundaries even without explicit await",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 14491,
+      "operation": "async function",
+      "repos": 22,
+      "status": "closed-boundary",
+      "surface": "js-ts.async.function",
+      "top_files": [
+        {
+          "occurrences": 352,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 314,
+          "path": "ky/test/hooks.ts"
+        },
+        {
+          "occurrences": 278,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 278,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 210,
+          "path": "drizzle-orm/integration-tests/tests/mysql/mysql-common.ts"
+        },
+        {
+          "occurrences": 207,
+          "path": "drizzle-orm/integration-tests/tests/pg/pg-common.ts"
+        },
+        {
+          "occurrences": 198,
+          "path": "drizzle-orm/integration-tests/tests/bun/bun-sql.test.ts"
+        },
+        {
+          "occurrences": 192,
+          "path": "drizzle-orm/integration-tests/tests/gel/gel.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4595,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 1621,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 1607,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1193,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 1079,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 883,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 814,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 688,
+          "repo": "axios"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "swift",
+      "note": "Swift await has task scheduling and actor/lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8689,
+      "operation": "await",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.await",
+      "top_files": [
+        {
+          "occurrences": 612,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 556,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 263,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 257,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 251,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 221,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 153,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 150,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3169,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 2261,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 969,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 944,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 724,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 155,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 139,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 96,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "future await",
+      "language": "rust",
+      "note": "Rust .await polls a Future and must keep wake/scheduling effects explicit",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 8647,
+      "operation": ".await",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.await",
+      "top_files": [
+        {
+          "occurrences": 545,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/proxy.rs"
+        },
+        {
+          "occurrences": 255,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 227,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 221,
+          "path": "meilisearch/crates/meilisearch/tests/dumps/mod.rs"
+        },
+        {
+          "occurrences": 193,
+          "path": "meilisearch/crates/meilisearch/tests/search/mod.rs"
+        },
+        {
+          "occurrences": 147,
+          "path": "meilisearch/crates/meilisearch/tests/tasks/mod.rs"
+        },
+        {
+          "occurrences": 141,
+          "path": "meilisearch/crates/meilisearch/tests/batches/mod.rs"
+        },
+        {
+          "occurrences": 138,
+          "path": "meilisearch/crates/meilisearch/tests/documents/get_documents.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5632,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 2942,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 39,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 34,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing callable error channel",
+      "language": "swift",
+      "note": "Swift body-bearing throwing functions expose an error channel even when the body has no explicit try expression",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 7008,
+      "operation": "func/init/subscript throws/rethrows",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_function",
+      "top_files": [
+        {
+          "occurrences": 135,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 133,
+          "path": "swift-nio/Tests/NIOCoreTests/ByteBufferTest.swift"
+        },
+        {
+          "occurrences": 82,
+          "path": "swift-nio/Tests/NIOPosixTests/DatagramChannelTests.swift"
+        },
+        {
+          "occurrences": 76,
+          "path": "swift-nio/Tests/NIOPosixTests/ChannelTests.swift"
+        },
+        {
+          "occurrences": 74,
+          "path": "swift-nio/Tests/NIOPosixTests/CodecTest.swift"
+        },
+        {
+          "occurrences": 69,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 64,
+          "path": "swift-collections/Tests/_CollectionsTestSupport/MinimalTypes/MinimalDecoder.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3459,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 864,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 518,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 445,
+          "repo": "swift-argument-parser"
+        },
+        {
+          "occurrences": 387,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 284,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 219,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 165,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive value",
+      "language": "go",
+      "note": "Go channel receives have blocking, synchronization, and close/zero-value channel semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-value-channel-contract-missing",
+      "occurrences": 4294,
+      "operation": "channel receive",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive",
+      "top_files": [
+        {
+          "occurrences": 126,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 102,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 98,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "delve/service/test/integration2_test.go"
+        },
+        {
+          "occurrences": 82,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 73,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 68,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 65,
+          "path": "nats-server/server/norace_2_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1476,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1354,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 541,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 537,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 175,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 85,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 17,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "exception channel",
+      "language": "ruby",
+      "note": "Historical lexical overlap bucket; use source-backed Ruby raise and rescue rows as actionable exception-channel surfaces",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 4010,
+      "operation": "raise/rescue",
+      "repos": 18,
+      "status": "superseded-overlap-boundary",
+      "surface": "ruby.exception",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 71,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 67,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 53,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 50,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1334,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 699,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 343,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 264,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 226,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 203,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 155,
+          "repo": "sinatra"
+        }
+      ]
+    },
+    {
+      "boundary": "select case selection",
+      "language": "go",
+      "note": "Go select cases require readiness, case-selection, and send/receive side-effect proof",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-case-selection-contract-missing",
+      "occurrences": 3590,
+      "operation": "select case",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.case",
+      "top_files": [
+        {
+          "occurrences": 110,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 106,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 86,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 71,
+          "path": "nats-server/server/jetstream_cluster.go"
+        },
+        {
+          "occurrences": 67,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 63,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 62,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 61,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1342,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1086,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 533,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 430,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 82,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 53,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 29,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 15,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "executor scheduling",
+      "language": "java",
+      "note": "Historical lexical type-name bucket; use proof-backed Java Future, CompletionStage, Executor, and ScheduledExecutor receiver-method rows as actionable surfaces",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "java-executor-scheduling-contract-missing",
+      "occurrences": 3297,
+      "operation": "Executor/Future",
+      "repos": 16,
+      "status": "superseded-overlap-boundary",
+      "surface": "java.future.executor",
+      "top_files": [
+        {
+          "occurrences": 59,
+          "path": "netty/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 39,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 38,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 33,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1338,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 1173,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 343,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 107,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 86,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 84,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 57,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 44,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "swift",
+      "note": "Swift async surfaces create task/future-like protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2964,
+      "operation": "async",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.function",
+      "top_files": [
+        {
+          "occurrences": 134,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileSystemTests.swift"
+        },
+        {
+          "occurrences": 67,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 54,
+          "path": "vapor/Tests/VaporMacroTests/HTTPMethodMacroTests.swift"
+        },
+        {
+          "occurrences": 45,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 45,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 44,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 42,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 41,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1119,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 605,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 507,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 265,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 99,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 97,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 79,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 76,
+          "repo": "swiftlint"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "rust",
+      "note": "async fn creates a suspended async function boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 2806,
+      "operation": "async fn",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 67,
+          "path": "meilisearch/crates/meilisearch/tests/common/index.rs"
+        },
+        {
+          "occurrences": 60,
+          "path": "meilisearch/crates/meilisearch/tests/search/multi/mod.rs"
+        },
+        {
+          "occurrences": 56,
+          "path": "meilisearch/crates/meilisearch/tests/common/server.rs"
+        },
+        {
+          "occurrences": 49,
+          "path": "meilisearch/crates/meilisearch/tests/search/errors.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "meilisearch/crates/meilisearch/tests/documents/add_documents.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 37,
+          "path": "meilisearch/crates/meilisearch/tests/auth/api_keys.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1405,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 1352,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 28,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 21,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "generator lifecycle",
+      "language": "python",
+      "note": "Python yield expressions expose source-backed generator lifecycle and protocol boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "generator-yield-lifecycle-contract-missing",
+      "occurrences": 2404,
+      "operation": "yield",
+      "repos": 21,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.generator.yield",
+      "top_files": [
+        {
+          "occurrences": 86,
+          "path": "sympy/sympy/utilities/iterables.py"
+        },
+        {
+          "occurrences": 83,
+          "path": "black/src/black/linegen.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "scrapy/tests/test_crawl.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sympy/sympy/core/facts.py"
+        },
+        {
+          "occurrences": 39,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 37,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 31,
+          "path": "packaging/src/packaging/tags.py"
+        },
+        {
+          "occurrences": 29,
+          "path": "rich/rich/segment.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 540,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 446,
+          "repo": "sympy"
+        },
+        {
+          "occurrences": 367,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 339,
+          "repo": "rich"
+        },
+        {
+          "occurrences": 172,
+          "repo": "black"
+        },
+        {
+          "occurrences": 139,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 76,
+          "repo": "poetry"
+        },
+        {
+          "occurrences": 64,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "raise exception channel",
+      "language": "ruby",
+      "note": "Ruby raise calls expose source-backed Throw exception-channel boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 2065,
+      "operation": "raise",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.exception.raise",
+      "top_files": [
+        {
+          "occurrences": 92,
+          "path": "rack/lib/rack/lint.rb"
+        },
+        {
+          "occurrences": 49,
+          "path": "fastlane/spaceship/lib/spaceship/tunes/tunes_client.rb"
+        },
+        {
+          "occurrences": 45,
+          "path": "rubocop/spec/rubocop/cop/style/raise_args_spec.rb"
+        },
+        {
+          "occurrences": 38,
+          "path": "fastlane/spaceship/lib/spaceship/client.rb"
+        },
+        {
+          "occurrences": 30,
+          "path": "sidekiq/test/retry_test.rb"
+        },
+        {
+          "occurrences": 29,
+          "path": "puma/lib/puma/client.rb"
+        },
+        {
+          "occurrences": 27,
+          "path": "asciidoctor/lib/asciidoctor/extensions.rb"
+        },
+        {
+          "occurrences": 27,
+          "path": "rubocop/spec/rubocop/cop/style/guard_clause_spec.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 425,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 373,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 182,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 174,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 155,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 138,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 126,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 112,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "goroutine scheduling",
+      "language": "go",
+      "note": "go statements spawn concurrent execution",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "goroutine-scheduling-contract-missing",
+      "occurrences": 1949,
+      "operation": "go statement",
+      "repos": 14,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.concurrent.goroutine",
+      "top_files": [
+        {
+          "occurrences": 52,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "prometheus/discovery/kubernetes/kubernetes.go"
+        },
+        {
+          "occurrences": 23,
+          "path": "prometheus/scrape/scrape_test.go"
+        },
+        {
+          "occurrences": 22,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 20,
+          "path": "nats-server/server/jwt_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 501,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 439,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 364,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 253,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 126,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 91,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 60,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 36,
+          "repo": "hugo"
+        }
+      ]
+    },
+    {
+      "boundary": "rescue exception channel",
+      "language": "ruby",
+      "note": "Ruby rescue clauses lower to Try exception-channel boundaries",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "ruby-exception-channel-contract-missing",
+      "occurrences": 1933,
+      "operation": "rescue",
+      "repos": 18,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.exception.rescue",
+      "top_files": [
+        {
+          "occurrences": 91,
+          "path": "rubocop/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/lint/shadowed_exception_spec.rb"
+        },
+        {
+          "occurrences": 65,
+          "path": "rubocop/spec/rubocop/cop/naming/rescued_exceptions_variable_name_spec.rb"
+        },
+        {
+          "occurrences": 55,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_standard_error_spec.rb"
+        },
+        {
+          "occurrences": 40,
+          "path": "rubocop/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb"
+        },
+        {
+          "occurrences": 39,
+          "path": "rubocop/spec/rubocop/cop/style/rescue_modifier_spec.rb"
+        },
+        {
+          "occurrences": 37,
+          "path": "rubocop/spec/rubocop/cop/style/signal_exception_spec.rb"
+        },
+        {
+          "occurrences": 31,
+          "path": "rubocop/spec/rubocop/cop/layout/else_alignment_spec.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 901,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 326,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 186,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 99,
+          "repo": "pry"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 63,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 44,
+          "repo": "jekyll"
+        }
+      ]
+    },
+    {
+      "boundary": "channel select",
+      "language": "go",
+      "note": "select has readiness, default, and scheduling semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-readiness-contract-missing",
+      "occurrences": 1920,
+      "operation": "select",
+      "repos": 13,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select",
+      "top_files": [
+        {
+          "occurrences": 62,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 58,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 45,
+          "path": "nats-server/server/jetstream_test.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jetstream_cluster_2_test.go"
+        },
+        {
+          "occurrences": 33,
+          "path": "nats-server/server/norace_2_test.go"
+        },
+        {
+          "occurrences": 31,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "nats-server/server/routes_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "prometheus/scrape/scrape_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 706,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 574,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 279,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 250,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 47,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 25,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 21,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "await scheduling",
+      "language": "python",
+      "note": "Python await has coroutine scheduling and exception channel semantics",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-await-scheduling-contract-missing",
+      "occurrences": 1789,
+      "operation": "await",
+      "repos": 8,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.await",
+      "top_files": [
+        {
+          "occurrences": 145,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 122,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 78,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 72,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 62,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 54,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 50,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 716,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 661,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 200,
+          "repo": "black"
+        },
+        {
+          "occurrences": 196,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 5,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "async function scheduling",
+      "language": "python",
+      "note": "async def creates coroutine protocol boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 1596,
+      "operation": "async def",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.function",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 75,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 57,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/result.py"
+        },
+        {
+          "occurrences": 53,
+          "path": "scrapy/tests/test_feedexport.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 47,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 43,
+          "path": "scrapy/tests/test_spidermiddleware.py"
+        },
+        {
+          "occurrences": 40,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 790,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 424,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 209,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 144,
+          "repo": "black"
+        },
+        {
+          "occurrences": 19,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 3,
+          "repo": "packaging"
+        },
+        {
+          "occurrences": 2,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "channel send synchronization",
+      "language": "go",
+      "note": "Go channel sends have blocking and synchronization semantics",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-send-synchronization-contract-missing",
+      "occurrences": 1525,
+      "operation": "channel send",
+      "repos": 12,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.send",
+      "top_files": [
+        {
+          "occurrences": 43,
+          "path": "nats-server/server/filestore.go"
+        },
+        {
+          "occurrences": 35,
+          "path": "nats-server/server/jwt_test.go"
+        },
+        {
+          "occurrences": 30,
+          "path": "minio/cmd/metrics.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 29,
+          "path": "prometheus/tsdb/head_wal.go"
+        },
+        {
+          "occurrences": 27,
+          "path": "nats-server/server/reload_test.go"
+        },
+        {
+          "occurrences": 25,
+          "path": "etcd/server/etcdserver/server_test.go"
+        },
+        {
+          "occurrences": 21,
+          "path": "nats-server/server/leafnode_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 474,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 436,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 275,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 189,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 39,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 33,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 28,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 18,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Java streams need lazy/eager lifecycle and terminal materialization proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 1496,
+      "operation": "stream/parallelStream",
+      "repos": 14,
+      "status": "closed-boundary",
+      "surface": "java.stream.lifecycle",
+      "top_files": [
+        {
+          "occurrences": 137,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/GeoPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 124,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java"
+        },
+        {
+          "occurrences": 75,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java"
+        },
+        {
+          "occurrences": 60,
+          "path": "netty/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java"
+        },
+        {
+          "occurrences": 26,
+          "path": "netty/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java"
+        },
+        {
+          "occurrences": 23,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java"
+        },
+        {
+          "occurrences": 21,
+          "path": "graphhopper/reader-gtfs/src/test/java/com/graphhopper/gtfs/fare/FareTest.java"
+        },
+        {
+          "occurrences": 19,
+          "path": "jedis/src/main/java/redis/clients/jedis/BuilderFactory.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 377,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 375,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 329,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 202,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 92,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 58,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 27,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 8,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "async block construction",
+      "language": "rust",
+      "note": "async blocks create suspended async boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-block-scheduling-contract-missing",
+      "occurrences": 1342,
+      "operation": "async block",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.block",
+      "top_files": [
+        {
+          "occurrences": 109,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        },
+        {
+          "occurrences": 86,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 57,
+          "path": "tokio/tokio/tests/task_local_set.rs"
+        },
+        {
+          "occurrences": 43,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 42,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 39,
+          "path": "tokio/tokio-util/tests/task_join_map.rs"
+        },
+        {
+          "occurrences": 33,
+          "path": "tokio/tokio/tests/rt_basic.rs"
+        },
+        {
+          "occurrences": 31,
+          "path": "tokio/tokio/tests/task_join_set.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1273,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 5,
+          "repo": "rustls"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "block callback",
+      "language": "ruby",
+      "note": "Ruby yield invokes a block with demand/effect obligations",
+      "obligation_family": "callback-demand-effect",
+      "obligation_subreason": "ruby-yield-callback-demand-effect-contract-missing",
+      "occurrences": 801,
+      "operation": "yield",
+      "repos": 17,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.block.yield",
+      "top_files": [
+        {
+          "occurrences": 26,
+          "path": "rubocop/spec/rubocop/cop/style/explicit_block_argument_spec.rb"
+        },
+        {
+          "occurrences": 22,
+          "path": "rspec-core/benchmarks/capture_block_vs_yield.rb"
+        },
+        {
+          "occurrences": 18,
+          "path": "rack/test/spec_deflater.rb"
+        },
+        {
+          "occurrences": 16,
+          "path": "sinatra/lib/sinatra/base.rb"
+        },
+        {
+          "occurrences": 12,
+          "path": "rubocop/spec/rubocop/cop/layout/hash_alignment_spec.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "faraday/lib/faraday/connection.rb"
+        },
+        {
+          "occurrences": 9,
+          "path": "rack/test/spec_lint.rb"
+        },
+        {
+          "occurrences": 8,
+          "path": "rspec-core/lib/rspec/core/configuration.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 228,
+          "repo": "rubocop"
+        },
+        {
+          "occurrences": 98,
+          "repo": "rspec-core"
+        },
+        {
+          "occurrences": 81,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 55,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 38,
+          "repo": "sinatra"
+        },
+        {
+          "occurrences": 36,
+          "repo": "devise"
+        },
+        {
+          "occurrences": 34,
+          "repo": "liquid"
+        }
+      ]
+    },
+    {
+      "boundary": "executor timing",
+      "language": "javascript-typescript",
+      "note": "new Promise needs executor timing, resolve/reject callback, and throw-to-rejection contracts",
+      "obligation_family": "executor-callback",
+      "obligation_subreason": "promise-executor-timing-contract-missing",
+      "occurrences": 795,
+      "operation": "new Promise",
+      "repos": 18,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.executor",
+      "top_files": [
+        {
+          "occurrences": 46,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 28,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 20,
+          "path": "axios/tests/unit/prototypePollution.test.js"
+        },
+        {
+          "occurrences": 20,
+          "path": "trpc/packages/tests/server/websockets.test.ts"
+        },
+        {
+          "occurrences": 12,
+          "path": "esbuild/scripts/plugin-tests.js"
+        },
+        {
+          "occurrences": 12,
+          "path": "prettier/tests/format/flow/flow-repo/promises/promise.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 151,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 135,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 96,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 89,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 80,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 61,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 55,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 50,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "select default liveness",
+      "language": "go",
+      "note": "Go select defaults change blocking and liveness behavior",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-select-default-liveness-contract-missing",
+      "occurrences": 546,
+      "operation": "select default",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.select.default",
+      "top_files": [
+        {
+          "occurrences": 14,
+          "path": "nats-server/server/norace_1_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/gateway_test.go"
+        },
+        {
+          "occurrences": 13,
+          "path": "nats-server/server/leafnode_test.go"
+        },
+        {
+          "occurrences": 11,
+          "path": "prometheus/storage/remote/queue_manager.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "etcd/pkg/proxy/server.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "nats-server/server/jetstream_cluster_4_test.go"
+        },
+        {
+          "occurrences": 10,
+          "path": "prometheus/tsdb/db.go"
+        },
+        {
+          "occurrences": 9,
+          "path": "nats-server/server/jetstream_cluster_long_test.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 195,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 144,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 94,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 71,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 13,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 7,
+          "repo": "hugo"
+        },
+        {
+          "occurrences": 2,
+          "repo": "chi"
+        }
+      ]
+    },
+    {
+      "boundary": "all-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.all needs ordered all-fulfilled value and first rejection semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-fulfilled-contract-missing",
+      "occurrences": 397,
+      "operation": "Promise.all",
+      "repos": 17,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "execa/test/convert/concurrent.js"
+        },
+        {
+          "occurrences": 21,
+          "path": "jest/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 21,
+          "path": "prettier/.yarn/releases/yarn-4.15.0.cjs"
+        },
+        {
+          "occurrences": 12,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 11,
+          "path": "zod/packages/zod/src/v4/core/schemas.ts"
+        },
+        {
+          "occurrences": 9,
+          "path": "esbuild/scripts/js-api-tests.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "date-fns/pkgs/docs/src/bin.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "execa/test/pipe/streaming.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 79,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 62,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 60,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 56,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 29,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 17,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 17,
+          "repo": "zod"
+        },
+        {
+          "occurrences": 16,
+          "repo": "date-fns"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Typed collection/set receiver.stream() calls are already admitted through iterator identity adapter occurrence proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 372,
+      "operation": "receiver.stream",
+      "repos": 10,
+      "status": "exact-supported-boundary",
+      "surface": "java.stream.receiver_adapter",
+      "top_files": [
+        {
+          "occurrences": 80,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGeospatialCommandsTest.java"
+        },
+        {
+          "occurrences": 14,
+          "path": "jedis/src/main/java/redis/clients/jedis/ClusterCommandObjects.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "jedis/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "graphhopper/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java"
+        },
+        {
+          "occurrences": 8,
+          "path": "guava/guava-tests/test/com/google/common/collect/StreamsTest.java"
+        },
+        {
+          "occurrences": 7,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "graphhopper/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "graphhopper/core/src/main/java/com/graphhopper/GraphHopper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 161,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 88,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 71,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 14,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 11,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 10,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 6,
+          "repo": "gson"
+        },
+        {
+          "occurrences": 6,
+          "repo": "netty"
+        }
+      ]
+    },
+    {
+      "boundary": "async context lifecycle",
+      "language": "python",
+      "note": "async with needs async enter/exit cleanup, exception-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-context-lifecycle-contract-missing",
+      "occurrences": 361,
+      "operation": "async with",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.context",
+      "top_files": [
+        {
+          "occurrences": 66,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 59,
+          "path": "scrapy/tests/test_downloader_handlers_http_base.py"
+        },
+        {
+          "occurrences": 33,
+          "path": "sqlalchemy/test/ext/asyncio/test_session.py"
+        },
+        {
+          "occurrences": 27,
+          "path": "httpx/tests/client/test_auth.py"
+        },
+        {
+          "occurrences": 26,
+          "path": "httpx/tests/client/test_async_client.py"
+        },
+        {
+          "occurrences": 14,
+          "path": "scrapy/tests/test_scheduler.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "scrapy/tests/test_downloadermiddleware.py"
+        },
+        {
+          "occurrences": 13,
+          "path": "sqlalchemy/test/dialect/postgresql/test_async_pg.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 169,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 95,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 77,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 19,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "task spawn",
+      "language": "rust",
+      "note": "async spawn APIs introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 349,
+      "operation": "tokio/async-std spawn",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn",
+      "top_files": [
+        {
+          "occurrences": 32,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 18,
+          "path": "tokio/tokio/tests/rt_unstable_metrics.rs"
+        },
+        {
+          "occurrences": 16,
+          "path": "tokio/tokio/tests/rt_threaded.rs"
+        },
+        {
+          "occurrences": 12,
+          "path": "tokio/tokio/tests/task_abort.rs"
+        },
+        {
+          "occurrences": 11,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "meilisearch/crates/meilisearch/src/routes/indexes/documents.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/sync_mpsc.rs"
+        },
+        {
+          "occurrences": 9,
+          "path": "tokio/tokio/tests/net_named_pipe.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 284,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 62,
+          "repo": "meilisearch"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nushell"
+        }
+      ]
+    },
+    {
+      "boundary": "cancellation signal",
+      "language": "javascript-typescript",
+      "note": "AbortSignal/AbortController can change scheduling and rejection outcomes",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "abort-signal-cancellation-contract-missing",
+      "occurrences": 260,
+      "operation": "AbortController/AbortSignal",
+      "repos": 7,
+      "status": "closed-boundary",
+      "surface": "js-ts.cancellation.abort",
+      "top_files": [
+        {
+          "occurrences": 18,
+          "path": "execa/test/terminate/cancel.js"
+        },
+        {
+          "occurrences": 18,
+          "path": "execa/test/ipc/graceful.js"
+        },
+        {
+          "occurrences": 14,
+          "path": "execa/test/terminate/graceful.js"
+        },
+        {
+          "occurrences": 13,
+          "path": "trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test-d/arguments/options.test-d.ts"
+        },
+        {
+          "occurrences": 8,
+          "path": "execa/test/pipe/abort.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 7,
+          "path": "trpc/packages/client/src/internals/signals.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 108,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 87,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 30,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 17,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 8,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 4,
+          "repo": "pixijs"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle get",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose blocking settled-value and exception channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 249,
+      "operation": "Future.get",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.get",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/ConcurrentUtilsTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/CompletableFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 83,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 65,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 28,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 23,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 13,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 11,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 8,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle cancellation",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose cancellation and task-handle liveness boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 239,
+      "operation": "Future.cancel/isCancelled",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.cancel",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 15,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 104,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 101,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 14,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 11,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 3,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "future type/reference shape",
+      "language": "java",
+      "note": "CompletableFuture type references are evidence or wrapper/type-shape mentions; concrete constructor/static/receiver operation rows drive actionable future work",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "task-handle-lifecycle-contract-missing",
+      "occurrences": 230,
+      "operation": "CompletableFuture type reference",
+      "repos": 7,
+      "status": "superseded-overlap-boundary",
+      "surface": "java.future.completable.type_reference",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "retrofit/retrofit/src/main/java/retrofit2/CompletableFutureCallAdapterFactory.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 13,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 12,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit-adapters/java8/src/test/java/retrofit2/adapter/java8/Java8CallAdapterFactoryTest.java"
+        },
+        {
+          "occurrences": 10,
+          "path": "retrofit/retrofit/java-test/src/test/java/retrofit2/CompletableFutureCallAdapterFactoryTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 94,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 62,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 35,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 24,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 7,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 6,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service future scheduling",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService receivers schedule callbacks and return Future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 222,
+      "operation": "ExecutorService.submit",
+      "repos": 15,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.submit",
+      "top_files": [
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java"
+        },
+        {
+          "occurrences": 28,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/collect/QueuesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 90,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 72,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 27,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 6,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 5,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 4,
+          "repo": "antlr4"
+        },
+        {
+          "occurrences": 4,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task scheduling",
+      "language": "swift",
+      "note": "Task APIs introduce scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 215,
+      "operation": "Task/Task.detached",
+      "repos": 12,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.spawn",
+      "top_files": [
+        {
+          "occurrences": 21,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncWriterTests.swift"
+        },
+        {
+          "occurrences": 21,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-nio/Tests/NIOEmbeddedTests/AsyncTestingChannelTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 10,
+          "path": "rxswift/Sources/AllTestz/PrimitiveSequence+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 63,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 35,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 31,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 23,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 23,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 16,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 6,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "swift",
+      "note": "Swift async sequence loops need async iterator lifecycle, value-channel, scheduling, and throwing-channel proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 193,
+      "operation": "for await/for try await",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-nio/Tests/NIOFSIntegrationTests/FileHandleTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/Reducers/PresentationReducerTests.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Sources/ServiceLifecycle/ServiceGroup.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxswift/Sources/AllTestz/Observable+ConcurrencyTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 72,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 67,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 13,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "executor runnable scheduling",
+      "language": "java",
+      "note": "Import-backed Java Executor receivers schedule callback execution without returning a task handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 180,
+      "operation": "Executor.execute",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor.execute",
+      "top_files": [
+        {
+          "occurrences": 13,
+          "path": "netty/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "mockito/mockito-core/src/test/java/org/mockitousage/bugs/ShouldNotDeadlockAnswerExecutionTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 114,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 38,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 14,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 2,
+          "repo": "gson"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "throwing closure error channel",
+      "language": "swift",
+      "note": "Swift throwing closures expose the same error-channel obligation as throwing functions and async throwing closures",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "exception-channel-contract-missing",
+      "occurrences": 169,
+      "operation": "closure throws/rethrows",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.error.throwing_closure",
+      "top_files": [
+        {
+          "occurrences": 16,
+          "path": "swift-collections/Tests/DequeTests/RigidDequeTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "vapor/Tests/VaporTests/QueryTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "vapor/Tests/VaporTests/ContentTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Sources/AllTestz/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "rxswift/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Tests/VaporMacroTests/AuthMiddlewareMacroTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 58,
+          "repo": "swift-collections"
+        },
+        {
+          "occurrences": 52,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 38,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 10,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 3,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "task sleep timer",
+      "language": "swift",
+      "note": "Swift Task.sleep creates a timer-backed scheduling boundary and cancellation/liveness boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 161,
+      "operation": "Task.sleep",
+      "repos": 10,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.sleep",
+      "top_files": [
+        {
+          "occurrences": 15,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 11,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-nio/Tests/NIOPosixTests/EventLoopTest.swift"
+        },
+        {
+          "occurrences": 7,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Tests/KingfisherTests/KingfisherManagerTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "nimble/Tests/NimbleTests/AsyncAwaitTest.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 71,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 32,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 17,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 10,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 8,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "channel receive status",
+      "language": "go",
+      "note": "Go comma-ok receives expose the channel close status as an additional protocol result",
+      "obligation_family": "channel-boundary",
+      "obligation_subreason": "channel-receive-status-contract-missing",
+      "occurrences": 155,
+      "operation": "comma-ok channel receive",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "go.channel.receive_status",
+      "top_files": [
+        {
+          "occurrences": 22,
+          "path": "etcd/tests/integration/clientv3/watch/watch_test.go"
+        },
+        {
+          "occurrences": 12,
+          "path": "etcd/tests/integration/clientv3/lease/lease_test.go"
+        },
+        {
+          "occurrences": 6,
+          "path": "etcd/tests/integration/cache_test.go"
+        },
+        {
+          "occurrences": 5,
+          "path": "etcd/tests/integration/v3_election_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "etcd/cache/cache_test.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/admin-handlers.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/cmd/bucket-replication.go"
+        },
+        {
+          "occurrences": 4,
+          "path": "minio/internal/grid/muxclient.go"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 84,
+          "repo": "etcd"
+        },
+        {
+          "occurrences": 48,
+          "repo": "minio"
+        },
+        {
+          "occurrences": 11,
+          "repo": "prometheus"
+        },
+        {
+          "occurrences": 5,
+          "repo": "badger"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "nats-server"
+        },
+        {
+          "occurrences": 1,
+          "repo": "delve"
+        },
+        {
+          "occurrences": 1,
+          "repo": "esbuild"
+        }
+      ]
+    },
+    {
+      "boundary": "task-group aggregate",
+      "language": "swift",
+      "note": "Swift task groups need all-completion, result-channel, cancellation/liveness, and throwing error-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 153,
+      "operation": "withTaskGroup/withThrowingTaskGroup/withDiscardingTaskGroup/withThrowingDiscardingTaskGroup",
+      "repos": 9,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.group",
+      "top_files": [
+        {
+          "occurrences": 31,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupTests.swift"
+        },
+        {
+          "occurrences": 18,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/Concurrency Primitives/BufferedStreamTests.swift"
+        },
+        {
+          "occurrences": 15,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 14,
+          "path": "swift-nio/Tests/NIOPosixTests/AsyncChannelBootstrapTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOThrowingAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 9,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/ServiceGroupAddServiceTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOFSTests/Internal/CancellationTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 68,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 61,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 4,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 3,
+          "repo": "quick"
+        },
+        {
+          "occurrences": 2,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 1,
+          "repo": "fastlane"
+        }
+      ]
+    },
+    {
+      "boundary": "stream lifecycle",
+      "language": "java",
+      "note": "Exact-import or fully qualified Arrays.stream(xs) calls are already admitted through static collection adapter occurrence proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "java-stream-lifecycle-contract-missing",
+      "occurrences": 128,
+      "operation": "Arrays.stream",
+      "repos": 12,
+      "status": "exact-supported-boundary",
+      "surface": "java.stream.arrays_adapter",
+      "top_files": [
+        {
+          "occurrences": 14,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/stream/LangCollectorsTest.java"
+        },
+        {
+          "occurrences": 8,
+          "path": "junit5/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "junit5/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "junit5/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TestExecutionResultConditions.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "jedis/src/main/java/redis/clients/jedis/search/querybuilder/QueryBuilders.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "junit5/documentation/src/tools/java/org/junit/api/tools/ApiReportGenerator.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "graphhopper/core/src/test/java/com/graphhopper/util/ArrayUtilTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 72,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 18,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 16,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 7,
+          "repo": "graphhopper"
+        },
+        {
+          "occurrences": 5,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jackson-core"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jsoup"
+        },
+        {
+          "occurrences": 2,
+          "repo": "netty"
+        }
+      ]
+    },
+    {
+      "boundary": "future handle lifecycle",
+      "language": "java",
+      "note": "Import-backed Java Future receivers expose task-handle lifecycle status",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "task-handle-lifecycle-contract-missing",
+      "occurrences": 127,
+      "operation": "Future.isDone",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.handle.status",
+      "top_files": [
+        {
+          "occurrences": 11,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 11,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 5,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 61,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 49,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 10,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 4,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "mockito"
+        },
+        {
+          "occurrences": 1,
+          "repo": "libgdx"
+        }
+      ]
+    },
+    {
+      "boundary": "async iteration lifecycle",
+      "language": "python",
+      "note": "async for statements and comprehensions need async iterator lifecycle, value-channel, and scheduling proof",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "async-iteration-lifecycle-contract-missing",
+      "occurrences": 114,
+      "operation": "async for",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.async.iteration",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "httpx/tests/test_content.py"
+        },
+        {
+          "occurrences": 16,
+          "path": "httpx/tests/models/test_responses.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "black/tests/data/cases/python37.py"
+        },
+        {
+          "occurrences": 6,
+          "path": "httpx/httpx/_models.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_spidermiddleware_referer.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/starred_for_target.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 48,
+          "repo": "httpx"
+        },
+        {
+          "occurrences": 30,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 20,
+          "repo": "black"
+        },
+        {
+          "occurrences": 15,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timer",
+      "language": "python",
+      "note": "asyncio sleep creates a timer-backed scheduling boundary",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 104,
+      "operation": "asyncio.sleep",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.sleep",
+      "top_files": [
+        {
+          "occurrences": 48,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 9,
+          "path": "scrapy/tests/spiders.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "flask/tests/test_async.py"
+        },
+        {
+          "occurrences": 5,
+          "path": "scrapy/tests/test_command_parse.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "scrapy/tests/test_utils_defer.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 3,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 59,
+          "repo": "black"
+        },
+        {
+          "occurrences": 32,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "flask"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "async closure scheduling",
+      "language": "swift",
+      "note": "Swift async closures create async callable protocol boundaries even when the surrounding function is synchronous",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "async-function-scheduling-contract-missing",
+      "occurrences": 100,
+      "operation": "async closure",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.closure",
+      "top_files": [
+        {
+          "occurrences": 29,
+          "path": "vapor/Tests/VaporTests/FileTests.swift"
+        },
+        {
+          "occurrences": 13,
+          "path": "vapor/Tests/VaporTests/AuthenticationTests.swift"
+        },
+        {
+          "occurrences": 12,
+          "path": "vapor/Tests/VaporMacroTests/ControllerMacroTests.swift"
+        },
+        {
+          "occurrences": 8,
+          "path": "swift-composable-architecture/Benchmarks/Benchmarks/swift-composable-architecture-benchmark/Benchmarks.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "vapor/Tests/VaporTests/MiddlewareTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "vapor/Tests/VaporTests/RouteTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "nimble/Tests/NimbleTests/Matchers/EqualTest.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "vapor/Sources/Development/routes.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 86,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 8,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 5,
+          "repo": "nimble"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-nio"
+        }
+      ]
+    },
+    {
+      "boundary": "thread/fiber scheduling",
+      "language": "ruby",
+      "note": "Thread/Fiber APIs create scheduler and lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 74,
+      "operation": "Thread/Fiber",
+      "repos": 11,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "ruby.thread.fiber",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "puma/test/test_cli.rb"
+        },
+        {
+          "occurrences": 6,
+          "path": "rack/test/spec_multipart.rb"
+        },
+        {
+          "occurrences": 4,
+          "path": "puma/test/test_pumactl.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/test/test_thread_pool.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/lib/puma/cluster/worker.rb"
+        },
+        {
+          "occurrences": 3,
+          "path": "puma/benchmarks/local/response_time_wrk.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "fastlane/fastlane/lib/fastlane/swift_lane_manager.rb"
+        },
+        {
+          "occurrences": 2,
+          "path": "puma/test/test_puma_server_ssl.rb"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 36,
+          "repo": "puma"
+        },
+        {
+          "occurrences": 10,
+          "repo": "fastlane"
+        },
+        {
+          "occurrences": 10,
+          "repo": "sidekiq"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rack"
+        },
+        {
+          "occurrences": 3,
+          "repo": "jekyll"
+        },
+        {
+          "occurrences": 2,
+          "repo": "asciidoctor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "fzf"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rspec-core"
+        }
+      ]
+    },
+    {
+      "boundary": "interval lifecycle",
+      "language": "javascript-typescript",
+      "note": "setInterval and timers interval streams have repeated emission, cancellation, and liveness semantics",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 73,
+      "operation": "setInterval",
+      "repos": 11,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.interval",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "jest/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjs/packages/rxjs/spec/Observable-spec.ts"
+        },
+        {
+          "occurrences": 4,
+          "path": "swr/test/use-swr-subscription.test.tsx"
+        },
+        {
+          "occurrences": 3,
+          "path": "drizzle-orm/drizzle-kit/src/cli/views.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/example/src/main/resources/io/netty/example/stomp/websocket/stomp.js"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/src/internal/scheduler/intervalProvider.ts"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjs/packages/rxjs/spec/schedulers/TestScheduler-spec.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 16,
+          "repo": "rxjs"
+        },
+        {
+          "occurrences": 7,
+          "repo": "prettier"
+        },
+        {
+          "occurrences": 7,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 6,
+          "repo": "swr"
+        },
+        {
+          "occurrences": 3,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 3,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "thread scheduling",
+      "language": "c",
+      "note": "pthread_create introduces thread scheduling and lifetime boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "c-pthread-scheduling-contract-missing",
+      "occurrences": 68,
+      "operation": "pthread_create",
+      "repos": 10,
+      "status": "closed-boundary",
+      "surface": "c.thread.pthread",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "redis/tests/modules/blockedclient.c"
+        },
+        {
+          "occurrences": 3,
+          "path": "redis/tests/modules/blockonbackground.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/name-hash.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/transport-helper.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/read-cache.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/fsmonitor--daemon.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/builtin/pack-objects.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/helper/test-trace2.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 24,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 23,
+          "repo": "git"
+        },
+        {
+          "occurrences": 7,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 5,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 3,
+          "repo": "libuv"
+        },
+        {
+          "occurrences": 2,
+          "repo": "raylib"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jq"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nginx"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime join style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 68,
+      "operation": "tokio/futures/futures_util join/try_join",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join",
+      "top_files": [
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_try_join.rs"
+        },
+        {
+          "occurrences": 20,
+          "path": "tokio/tokio/tests/macros_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_try_join.rs"
+        },
+        {
+          "occurrences": 6,
+          "path": "tokio/tests-build/tests/fail/macros_join.rs"
+        },
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_common.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/task_id.rs"
+        },
+        {
+          "occurrences": 2,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "meilisearch/crates/index-scheduler/src/scheduler/enterprise_edition/s3.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 67,
+          "repo": "tokio"
+        },
+        {
+          "occurrences": 1,
+          "repo": "meilisearch"
+        }
+      ]
+    },
+    {
+      "boundary": "structured task binding",
+      "language": "swift",
+      "note": "Swift async let creates a child task with scheduling, handle lifecycle, cancellation/liveness, and awaited result boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 51,
+      "operation": "async let",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.async.let",
+      "top_files": [
+        {
+          "occurrences": 17,
+          "path": "alamofire/Tests/ConcurrencyTests.swift"
+        },
+        {
+          "occurrences": 16,
+          "path": "alamofire/Tests/OfflineRetrierTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swiftlint/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "swift-nio/Tests/NIOCoreTests/AsyncSequences/NIOAsyncSequenceTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NonBlockingFileIOTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "vapor/Tests/VaporTests/EndpointCacheTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/TestStoreNonExhaustiveTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 33,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 5,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swiftlint"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 1,
+          "repo": "rxswift"
+        }
+      ]
+    },
+    {
+      "boundary": "future constructor channel",
+      "language": "java",
+      "note": "Import- or qualified-name-backed Java CompletableFuture constructors create manual settlement future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 46,
+      "operation": "new CompletableFuture",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.constructor",
+      "top_files": [
+        {
+          "occurrences": 10,
+          "path": "netty/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "retrofit/retrofit-adapters/java8/src/main/java/retrofit2/adapter/java8/Java8CallAdapterFactory.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 20,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 18,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 2,
+          "repo": "retrofit"
+        },
+        {
+          "occurrences": 1,
+          "repo": "jedis"
+        }
+      ]
+    },
+    {
+      "boundary": "future receiver settlement",
+      "language": "java",
+      "note": "Import-backed CompletableFuture receivers expose manual fulfilled or exceptional settlement channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 45,
+      "operation": "CompletableFuture.complete/completeExceptionally",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.receiver.settlement",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 6,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "netty/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 41,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "netty"
+        }
+      ]
+    },
+    {
+      "boundary": "future receiver observation",
+      "language": "java",
+      "note": "Import-backed CompletableFuture receivers expose settled-value, exceptional, lifecycle, and cancellation observation boundaries",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 45,
+      "operation": "CompletableFuture.join/getNow/isCompletedExceptionally",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.receiver.observe",
+      "top_files": [
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java"
+        },
+        {
+          "occurrences": 9,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeToCompletionStageTest.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableToCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 45,
+          "repo": "rxjava"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift throwing continuation bridge",
+      "language": "swift",
+      "note": "Swift throwing continuation bridges add exception-channel behavior to callback-settled future-like result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 43,
+      "operation": "withCheckedThrowingContinuation/withUnsafeThrowingContinuation",
+      "repos": 7,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.throwing",
+      "top_files": [
+        {
+          "occurrences": 8,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 6,
+          "path": "swift-nio/Sources/NIOCore/AsyncAwaitSupport.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/Sources/RxSwift/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxswift/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOPosix/NIOThreadPool.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingChannel.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/BufferedStream.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOFS/Internal/BufferedStream.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 18,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 13,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxswift"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vapor"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 1,
+          "repo": "alamofire"
+        }
+      ]
+    },
+    {
+      "boundary": "first-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.race needs first-settled ordering and liveness proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "promise-aggregate-first-settled-contract-missing",
+      "occurrences": 32,
+      "operation": "Promise.race",
+      "repos": 8,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "execa/test/convert/iterable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/setup/server.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "axios/tests/unit/adapters/http.test.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/convert/readable.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "ky/source/core/Ky.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/client/src/links/localLink.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/mysql2/session.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "drizzle-orm/drizzle-orm/src/singlestore/session.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 15,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 4,
+          "repo": "axios"
+        },
+        {
+          "occurrences": 3,
+          "repo": "esbuild"
+        },
+        {
+          "occurrences": 3,
+          "repo": "ky"
+        },
+        {
+          "occurrences": 2,
+          "repo": "drizzle-orm"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 1,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "Swift continuation bridge",
+      "language": "swift",
+      "note": "Swift continuation bridges suspend and resume through a callback-settled future-like result channel",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 30,
+      "operation": "withCheckedContinuation/withUnsafeContinuation",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.continuation.checked",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "alamofire/Tests/RequestInterceptorTests.swift"
+        },
+        {
+          "occurrences": 5,
+          "path": "kingfisher/Sources/Cache/ImageCache.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Sources/NIOEmbedded/AsyncTestingEventLoop.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-nio/Tests/NIOPosixTests/NIOThreadPoolTest.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 2,
+          "path": "alamofire/Source/Features/Concurrency.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/_NIOFileSystem/Internal/Concurrency Primitives/TokenBucket.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-nio/Sources/NIOFS/Internal/Concurrency Primitives/TokenBucket.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "alamofire"
+        },
+        {
+          "occurrences": 8,
+          "repo": "kingfisher"
+        },
+        {
+          "occurrences": 7,
+          "repo": "swift-nio"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-service-lifecycle"
+        },
+        {
+          "occurrences": 2,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 1,
+          "repo": "nimble"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor timer",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService schedule calls add timer-backed task scheduling and Future result channels",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 27,
+      "operation": "ScheduledExecutorService.schedule",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.schedule",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadWorker.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "netty/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 6,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio future drive",
+      "language": "python",
+      "note": "asyncio.run drives a coroutine to completion with scheduling, result-channel, and exception boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "future-drive-scheduling-contract-missing",
+      "occurrences": 23,
+      "operation": "asyncio.run",
+      "repos": 6,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/_concurrency_fixtures.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/base/test_concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/tests/test_concurrency_manager_shutdown.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "boltons/tests/test_funcutils_fb_py3.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "curl/tests/http/testenv/ws_echo_server.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/AsyncCrawlerRunner/reactorless_simple.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 14,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 5,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "boltons"
+        },
+        {
+          "occurrences": 1,
+          "repo": "curl"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduled executor interval lifecycle",
+      "language": "java",
+      "note": "Import-backed Java ScheduledExecutorService repeating schedules expose interval lifecycle and cancellation boundaries",
+      "obligation_family": "lifecycle-materialization-boundary",
+      "obligation_subreason": "interval-async-iteration-lifecycle-contract-missing",
+      "occurrences": 22,
+      "operation": "ScheduledExecutorService.scheduleAtFixedRate/scheduleWithFixedDelay",
+      "repos": 5,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.scheduled_executor.interval",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/MoreExecutors.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingScheduledExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "jedis/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 12,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 5,
+          "repo": "jedis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "netty"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "commons-lang"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service all-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAll waits for all submitted tasks and returns Future result channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 21,
+      "operation": "ExecutorService.invokeAll",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_all",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 4,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/MoreExecutorsTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava-tests/test/com/google/common/util/concurrent/WrappingExecutorServiceTest.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "commons-lang/src/test/java/org/apache/commons/lang3/builder/ReflectionToStringBuilderConcurrencyTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 16,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "commons-lang"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "h2database"
+        }
+      ]
+    },
+    {
+      "boundary": "all-settled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.allSettled needs settled-record channel and shape proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-all-settled-contract-missing",
+      "occurrences": 17,
+      "operation": "Promise.allSettled",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/lib/resolve/wait-subprocess.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "jest/packages/jest-haste-map/src/watchers/index.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/streaming.test.ts"
+        },
+        {
+          "occurrences": 2,
+          "path": "trpc/packages/tests/server/adapters/standalone.test.ts"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/pipe/setup.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/resolve/exit-async.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/buffer-messages.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/convert/concurrent.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "execa"
+        },
+        {
+          "occurrences": 5,
+          "repo": "trpc"
+        },
+        {
+          "occurrences": 2,
+          "repo": "jest"
+        },
+        {
+          "occurrences": 2,
+          "repo": "pixijs"
+        },
+        {
+          "occurrences": 2,
+          "repo": "prettier"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio all-completion aggregate",
+      "language": "python",
+      "note": "asyncio gather needs all-completion, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 17,
+      "operation": "asyncio.gather",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.gather",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "black/tests/data/cases/remove_await_parens.py"
+        },
+        {
+          "occurrences": 4,
+          "path": "sqlalchemy/test/ext/asyncio/test_engine.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/examples/asyncio/gather_orm_statements.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "packaging/tasks/check_frozen_revs.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_downloadermiddleware_robotstxt.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/pipelines/media.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 6,
+          "repo": "black"
+        },
+        {
+          "occurrences": 6,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "packaging"
+        }
+      ]
+    },
+    {
+      "boundary": "future settled value",
+      "language": "java",
+      "note": "CompletableFuture settled factories create fulfilled or exceptional future channels",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settled-value-channel-contract-missing",
+      "occurrences": 14,
+      "operation": "CompletableFuture.completedFuture/failedFuture",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.factory",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/defaultanswers/ReturnsEmptyValues.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStageTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStageTest.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 13,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio task spawn",
+      "language": "python",
+      "note": "asyncio task APIs create scheduler, cancellation, and handle lifecycle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 14,
+      "operation": "asyncio.create_task/ensure_future",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.task",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "black/tests/test_blackd.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/tests/test_crawler.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/core/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/defer.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 4,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 3,
+          "repo": "black"
+        }
+      ]
+    },
+    {
+      "boundary": "non-local jump",
+      "language": "c",
+      "note": "setjmp/longjmp is non-local control flow, not ordinary return",
+      "obligation_family": "exception-channel",
+      "obligation_subreason": "c-nonlocal-jump-contract-missing",
+      "occurrences": 13,
+      "operation": "setjmp/longjmp",
+      "repos": 5,
+      "status": "closed-boundary",
+      "surface": "c.nonlocal_jump",
+      "top_files": [
+        {
+          "occurrences": 5,
+          "path": "sqlite/autosetup/jimsh0.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "git/t/unit-tests/clar/clar.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "lua/ltests.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "redis/modules/vector-sets/fastjson_test.c"
+        },
+        {
+          "occurrences": 2,
+          "path": "vim/src/if_python3.c"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlite"
+        },
+        {
+          "occurrences": 2,
+          "repo": "git"
+        },
+        {
+          "occurrences": 2,
+          "repo": "lua"
+        },
+        {
+          "occurrences": 2,
+          "repo": "redis"
+        },
+        {
+          "occurrences": 2,
+          "repo": "vim"
+        }
+      ]
+    },
+    {
+      "boundary": "future task spawn",
+      "language": "java",
+      "note": "CompletableFuture async factories schedule executor callbacks and return future handles",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "CompletableFuture.supplyAsync/runAsync",
+      "repos": 4,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.spawn",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 3,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/TypeCachingMockBytecodeGeneratorTest.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 4,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        },
+        {
+          "occurrences": 1,
+          "repo": "mockito"
+        }
+      ]
+    },
+    {
+      "boundary": "task yield",
+      "language": "swift",
+      "note": "Swift Task.yield yields to the task scheduler and must not collapse into sync value equivalence",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-yield-scheduling-contract-missing",
+      "occurrences": 12,
+      "operation": "Task.yield",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "swift.task.yield",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "swift-metrics/Tests/MetricsTests/TaskLocalMetricsFactoryTests.swift"
+        },
+        {
+          "occurrences": 4,
+          "path": "swift-composable-architecture/Sources/ComposableArchitecture/TestStore.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-service-lifecycle/Tests/ServiceLifecycleTests/GracefulShutdownTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/DebugTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/EffectCancellationTests.swift"
+        },
+        {
+          "occurrences": 1,
+          "path": "swift-composable-architecture/Tests/ComposableArchitectureTests/StoreTests.swift"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 7,
+          "repo": "swift-composable-architecture"
+        },
+        {
+          "occurrences": 4,
+          "repo": "swift-metrics"
+        },
+        {
+          "occurrences": 1,
+          "repo": "swift-service-lifecycle"
+        }
+      ]
+    },
+    {
+      "boundary": "scheduler yield",
+      "language": "javascript-typescript",
+      "note": "scheduler.yield needs microtask/order proof",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "scheduler-yield-microtask-order-contract-missing",
+      "occurrences": 11,
+      "operation": "scheduler.yield",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.scheduler",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/generator.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/web-transform.js"
+        },
+        {
+          "occurrences": 2,
+          "path": "execa/test/helpers/duplex.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/graceful.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/lib/ipc/incoming.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/ipc/get-each.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/transform/generator-main.js"
+        },
+        {
+          "occurrences": 1,
+          "path": "execa/test/convert/writable.js"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 11,
+          "repo": "execa"
+        }
+      ]
+    },
+    {
+      "boundary": "future settlement continuation",
+      "language": "java",
+      "note": "Future-like receivers need settlement continuation and callback demand/effect proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "future-settlement-continuation-contract-missing",
+      "occurrences": 10,
+      "operation": "FutureLike.handle/whenComplete",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completion_stage.settlement",
+      "top_files": [
+        {
+          "occurrences": 4,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "rxjava/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 9,
+          "repo": "rxjava"
+        },
+        {
+          "occurrences": 1,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "imported future all-completion aggregate",
+      "language": "rust",
+      "note": "import-backed tokio/futures/futures_util join-style macros need all-completion result-channel proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 8,
+      "operation": "use runtime::join; join!",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.join.imported",
+      "top_files": [
+        {
+          "occurrences": 6,
+          "path": "tokio/tokio/tests/tcp_connect.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tests-integration/tests/process_stdio.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/tcp_stream.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 8,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "executor service first-completion aggregate",
+      "language": "java",
+      "note": "Import-backed Java ExecutorService invokeAny exposes first-success completion, cancellation, and exception boundaries",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 6,
+      "operation": "ExecutorService.invokeAny",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.executor_service.invoke_any",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "guava/android/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "guava/guava/src/com/google/common/util/concurrent/WrappingExecutorService.java"
+        },
+        {
+          "occurrences": 2,
+          "path": "rxjava/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 4,
+          "repo": "guava"
+        },
+        {
+          "occurrences": 2,
+          "repo": "rxjava"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio cancellation shield",
+      "language": "python",
+      "note": "asyncio.shield changes cancellation propagation while preserving an awaitable result channel",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "task-cancellation-liveness-contract-missing",
+      "occurrences": 5,
+      "operation": "asyncio.shield",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.shield",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/session.py"
+        },
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/ext/asyncio/engine.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "sqlalchemy/lib/sqlalchemy/connectors/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "sqlalchemy"
+        }
+      ]
+    },
+    {
+      "boundary": "future first-completion aggregate",
+      "language": "rust",
+      "note": "qualified runtime select style macros need first-completion, cancellation, and result-channel proof",
+      "obligation_family": "cancellation-liveness-boundary",
+      "obligation_subreason": "async-aggregate-first-completion-contract-missing",
+      "occurrences": 5,
+      "operation": "tokio/futures/futures_util select",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.select",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/examples/dump.rs"
+        },
+        {
+          "occurrences": 1,
+          "path": "tokio/tokio/tests/macros_select.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 5,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "future all-completion aggregate",
+      "language": "java",
+      "note": "CompletableFuture.allOf needs all-completion and exceptional completion proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-all-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "CompletableFuture.allOf",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "java.future.completable.all",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/tools/DirectRecover.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "h2database/h2/src/main/org/h2/mvstore/MVStore.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java"
+        },
+        {
+          "occurrences": 1,
+          "path": "junit5/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "h2database"
+        },
+        {
+          "occurrences": 2,
+          "repo": "junit5"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio completion aggregate",
+      "language": "python",
+      "note": "asyncio wait needs completion-selection, result-channel, cancellation, and exception semantics",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "async-aggregate-completion-contract-missing",
+      "occurrences": 4,
+      "operation": "asyncio.wait",
+      "repos": 3,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "black/src/black/concurrency.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/extensions/feedexport.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "black"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio timeout wait",
+      "language": "python",
+      "note": "asyncio.wait_for adds timer and cancellation/liveness boundaries around an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "asyncio.wait_for",
+      "repos": 2,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.wait_for",
+      "top_files": [
+        {
+          "occurrences": 2,
+          "path": "sqlalchemy/lib/sqlalchemy/util/queue.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "httpx/tests/conftest.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "sqlalchemy"
+        },
+        {
+          "occurrences": 1,
+          "repo": "httpx"
+        }
+      ]
+    },
+    {
+      "boundary": "imported task spawn",
+      "language": "rust",
+      "note": "import-backed tokio/async-std spawn bindings introduce scheduler, cancellation, and join-handle boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 3,
+      "operation": "use runtime::spawn; spawn",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "rust.async.spawn.imported",
+      "top_files": [
+        {
+          "occurrences": 3,
+          "path": "tokio/tokio/tests/rt_handle_block_on.rs"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 3,
+          "repo": "tokio"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread-safe task submission",
+      "language": "python",
+      "note": "asyncio.run_coroutine_threadsafe schedules a coroutine onto another loop and returns a future handle",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "asyncio.run_coroutine_threadsafe",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.run_coroutine_threadsafe",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/shell.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/commands/shell.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "imported asyncio timer",
+      "language": "python",
+      "note": "import-backed asyncio sleep bindings create timer-backed scheduling boundaries",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "timer-scheduling-contract-missing",
+      "occurrences": 2,
+      "operation": "from asyncio import sleep; binding",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.imported.sleep",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spidermiddleware_process_start.py"
+        },
+        {
+          "occurrences": 1,
+          "path": "scrapy/tests/test_spider_start.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 2,
+          "repo": "scrapy"
+        }
+      ]
+    },
+    {
+      "boundary": "first-fulfilled aggregate",
+      "language": "javascript-typescript",
+      "note": "Promise.any needs first-fulfilled and AggregateError rejection proof",
+      "obligation_family": "success-error-result-channel",
+      "obligation_subreason": "promise-aggregate-first-fulfilled-contract-missing",
+      "occurrences": 1,
+      "operation": "Promise.any",
+      "repos": 1,
+      "status": "closed-boundary",
+      "surface": "js-ts.promise.aggregate",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "jest/packages/expect/src/__tests__/toThrowMatchers.test.ts"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "jest"
+        }
+      ]
+    },
+    {
+      "boundary": "asyncio thread offload",
+      "language": "python",
+      "note": "asyncio.to_thread schedules a callback on a worker thread and returns an awaitable result channel",
+      "obligation_family": "scheduling-boundary",
+      "obligation_subreason": "task-spawn-scheduling-contract-missing",
+      "occurrences": 1,
+      "operation": "asyncio.to_thread",
+      "repos": 1,
+      "status": "reporting-supported-closed-boundary",
+      "surface": "python.asyncio.to_thread",
+      "top_files": [
+        {
+          "occurrences": 1,
+          "path": "scrapy/scrapy/utils/asyncio.py"
+        }
+      ],
+      "top_repos": [
+        {
+          "occurrences": 1,
+          "repo": "scrapy"
+        }
+      ]
+    }
+  ],
+  "tracking_issue": {
+    "number": 602,
+    "url": "https://github.com/corca-ai/nose/issues/602"
+  }
+}

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs
@@ -404,8 +404,10 @@ fn push_completable_future_receiver_method_missing_evidence(
             true
         }
         "isCompletedExceptionally" => {
+            super::push_future_settled_value_missing_evidence(labels);
             super::super::push_unique(labels, "exception-channel-contract");
             super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            super::super::push_unique(labels, "task-cancellation-liveness-contract");
             true
         }
         "orTimeout" => {

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java.rs
@@ -51,6 +51,11 @@ pub(super) fn push_java_future_runtime_call_missing_evidence(
     {
         return true;
     }
+    if receiver_provenance::completable_future_receiver_proven(il, interner, callee, context)
+        && push_completable_future_receiver_method_missing_evidence(method, labels)
+    {
+        return true;
+    }
     if receiver_provenance::future_handle_receiver_proven(il, interner, callee, context)
         && push_future_handle_method_missing_evidence(method, labels)
     {
@@ -369,6 +374,53 @@ fn push_completion_stage_continuation_missing_evidence(
         "handle" | "handleAsync" | "whenComplete" | "whenCompleteAsync" => {
             super::super::push_unique(labels, "future-settlement-continuation-contract");
             push_future_result_callback_exception_missing_evidence(labels);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn push_completable_future_receiver_method_missing_evidence(
+    method: &str,
+    labels: &mut Vec<&'static str>,
+) -> bool {
+    match method {
+        "complete" => {
+            super::push_future_settled_value_missing_evidence(labels);
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            true
+        }
+        "completeExceptionally" => {
+            super::push_future_settled_value_missing_evidence(labels);
+            super::super::push_unique(labels, "exception-channel-contract");
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            true
+        }
+        "join" | "getNow" => {
+            super::push_future_settled_value_missing_evidence(labels);
+            super::super::push_unique(labels, "exception-channel-contract");
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            super::super::push_unique(labels, "task-cancellation-liveness-contract");
+            true
+        }
+        "isCompletedExceptionally" => {
+            super::super::push_unique(labels, "exception-channel-contract");
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            true
+        }
+        "orTimeout" => {
+            super::super::push_unique(labels, "timer-scheduling-contract");
+            super::push_future_settled_value_missing_evidence(labels);
+            super::super::push_unique(labels, "exception-channel-contract");
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            super::super::push_unique(labels, "task-cancellation-liveness-contract");
+            true
+        }
+        "completeOnTimeout" => {
+            super::super::push_unique(labels, "timer-scheduling-contract");
+            super::push_future_settled_value_missing_evidence(labels);
+            super::super::push_unique(labels, "task-handle-lifecycle-contract");
+            super::super::push_unique(labels, "task-cancellation-liveness-contract");
             true
         }
         _ => false,

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java/receiver_provenance.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/async_runtime/java/receiver_provenance.rs
@@ -41,6 +41,22 @@ pub(super) fn future_handle_receiver_proven(
     )
 }
 
+pub(super) fn completable_future_receiver_proven(
+    il: &nose_il::Il,
+    interner: &Interner,
+    callee: NodeId,
+    context: &crate::verify_admission::AdmissionContext,
+) -> bool {
+    receiver_type_proven(
+        il,
+        interner,
+        callee,
+        context,
+        |domain| domain == DomainEvidence::FutureLike,
+        java_completable_future_type_import_dependency,
+    )
+}
+
 pub(super) fn executor_receiver_kind_proven(
     il: &nose_il::Il,
     interner: &Interner,
@@ -300,6 +316,13 @@ fn java_future_handle_type_import_dependency(
         dependency,
         &[COMPLETABLE_FUTURE_TYPE, FUTURE_TYPE, SCHEDULED_FUTURE_TYPE],
     )
+}
+
+fn java_completable_future_type_import_dependency(
+    il: &nose_il::Il,
+    dependency: EvidenceId,
+) -> Option<&'static str> {
+    java_concurrent_type_import_dependency(il, dependency, &[COMPLETABLE_FUTURE_TYPE])
 }
 
 fn java_executor_type_import_dependency(

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime.rs
@@ -9,6 +9,7 @@ use super::super::runtime_boundary_missing_evidence_with_context;
 
 mod imported_bindings;
 mod java;
+mod java_completable_future_receiver;
 mod java_constructor;
 mod java_static_wildcard;
 mod python;

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_completable_future_receiver.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_completable_future_receiver.rs
@@ -58,8 +58,10 @@ fn java_completable_future_receiver_methods_report_settlement_and_timeout_obliga
     assert!(join.contains(&"task-cancellation-liveness-contract"));
     assert!(get_now.contains(&"future-settled-value-channel-contract"));
     assert!(get_now.contains(&"exception-channel-contract"));
+    assert!(status.contains(&"future-settled-value-channel-contract"));
     assert!(status.contains(&"exception-channel-contract"));
     assert!(status.contains(&"task-handle-lifecycle-contract"));
+    assert!(status.contains(&"task-cancellation-liveness-contract"));
     assert!(or_timeout.contains(&"timer-scheduling-contract"));
     assert!(or_timeout.contains(&"future-settled-value-channel-contract"));
     assert!(or_timeout.contains(&"exception-channel-contract"));

--- a/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_completable_future_receiver.rs
+++ b/crates/nose-cli/src/verify_admission/runtime_boundary/tests/async_runtime/java_completable_future_receiver.rs
@@ -1,0 +1,105 @@
+use super::{
+    assert_missing_evidence_not_contains, missing_evidence_for_lang_call,
+    runtime_boundary_evidence_for_lang_call,
+};
+use nose_il::Lang;
+
+#[test]
+fn java_completable_future_receiver_methods_report_settlement_and_timeout_obligations() {
+    let complete = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { boolean run(CompletableFuture<String> future, String value) { return future.complete(value); } }\n",
+        Lang::Java,
+        "future.complete",
+    );
+    let complete_exceptionally = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { boolean run(CompletableFuture<String> future, Throwable error) { return future.completeExceptionally(error); } }\n",
+        Lang::Java,
+        "future.completeExceptionally",
+    );
+    let join = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { Object run(CompletableFuture<String> future) { return future.join(); } }\n",
+        Lang::Java,
+        "future.join",
+    );
+    let get_now = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { Object run(CompletableFuture<String> future) { return future.getNow(\"fallback\"); } }\n",
+        Lang::Java,
+        "future.getNow",
+    );
+    let status = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { boolean run(CompletableFuture<String> future) { return future.isCompletedExceptionally(); } }\n",
+        Lang::Java,
+        "future.isCompletedExceptionally",
+    );
+    let or_timeout = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nimport java.util.concurrent.TimeUnit;\nclass Runtime { Object run(CompletableFuture<String> future) { return future.orTimeout(1, TimeUnit.SECONDS); } }\n",
+        Lang::Java,
+        "future.orTimeout",
+    );
+    let complete_on_timeout = missing_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nimport java.util.concurrent.TimeUnit;\nclass Runtime { Object run(CompletableFuture<String> future) { return future.completeOnTimeout(\"fallback\", 1, TimeUnit.SECONDS); } }\n",
+        Lang::Java,
+        "future.completeOnTimeout",
+    );
+
+    assert!(complete.contains(&"future-settled-value-channel-contract"));
+    assert!(complete.contains(&"task-handle-lifecycle-contract"));
+    assert!(complete_exceptionally.contains(&"future-settled-value-channel-contract"));
+    assert!(complete_exceptionally.contains(&"exception-channel-contract"));
+    assert!(join.contains(&"future-settled-value-channel-contract"));
+    assert!(join.contains(&"exception-channel-contract"));
+    assert!(join.contains(&"task-cancellation-liveness-contract"));
+    assert!(get_now.contains(&"future-settled-value-channel-contract"));
+    assert!(get_now.contains(&"exception-channel-contract"));
+    assert!(status.contains(&"exception-channel-contract"));
+    assert!(status.contains(&"task-handle-lifecycle-contract"));
+    assert!(or_timeout.contains(&"timer-scheduling-contract"));
+    assert!(or_timeout.contains(&"future-settled-value-channel-contract"));
+    assert!(or_timeout.contains(&"exception-channel-contract"));
+    assert!(complete_on_timeout.contains(&"timer-scheduling-contract"));
+    assert!(complete_on_timeout.contains(&"future-settled-value-channel-contract"));
+}
+
+#[test]
+fn java_completable_future_receiver_methods_require_completable_future_import_identity() {
+    let custom_completable = runtime_boundary_evidence_for_lang_call(
+        "Runtime.java",
+        "import example.CompletableFuture;\nclass Runtime { Object run(CompletableFuture<String> future) { return future.join(); } }\n",
+        Lang::Java,
+        "future.join",
+    );
+    let completion_stage_timeout = runtime_boundary_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletionStage;\nimport java.util.concurrent.TimeUnit;\nclass Runtime { Object run(CompletionStage<String> stage) { return stage.orTimeout(1, TimeUnit.SECONDS); } }\n",
+        Lang::Java,
+        "stage.orTimeout",
+    );
+    let local_completable = runtime_boundary_evidence_for_lang_call(
+        "Runtime.java",
+        "import java.util.concurrent.CompletableFuture;\nclass Runtime { static class CompletableFuture<T> { Object join() { return null; } }\nObject run(CompletableFuture<String> future) { return future.join(); } }\n",
+        Lang::Java,
+        "future.join",
+    );
+
+    for (labels, surface) in [
+        (custom_completable, "custom CompletableFuture receiver"),
+        (
+            completion_stage_timeout,
+            "CompletionStage-only timeout receiver",
+        ),
+        (local_completable, "local CompletableFuture receiver"),
+    ] {
+        assert_missing_evidence_not_contains(
+            labels,
+            "future-settled-value-channel-contract",
+            surface,
+        );
+    }
+}

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -216,6 +216,15 @@ aligns existing receiver-domain reporting with the audit by marking
 `Executor/Future` type-name bucket as a superseded overlap row at `3,297`
 occurrences, so Java residual work is ranked from concrete operation rows
 rather than broad type mentions. The
+follow-up [Java CompletableFuture receiver split artifact](../bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json)
+extends the same FutureLike receiver-domain reporting to
+`complete`/`completeExceptionally`, `join`/`getNow`/`isCompletedExceptionally`,
+and timeout methods. The 120-repo audit moves `45` scope-proven receiver
+settlement and `45` receiver observation occurrences to reporting-supported
+rows, reclassifies the remaining `230` broad `CompletableFuture` type/reference
+mentions as a superseded overlap bucket, and keeps exact admission closed.
+Same-name receivers outside the proven scope, custom imports, lambda parameters,
+and unsupported arities remain closed. The
 follow-up [Java stream lifecycle split artifact](../bench/recall_loss/java-stream-lifecycle-split-2026-07-02.v1.json)
 accounts for existing proof-backed stream adapter capability in the same audit:
 typed `receiver.stream()` contributes `372` exact-supported occurrences and

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -109,7 +109,7 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
 - [Java stream lifecycle split](../bench/recall_loss/java-stream-lifecycle-split-2026-07-02.v1.json) records the follow-up audit alignment for existing stream adapter capability. The audit now separates `372` typed `receiver.stream()` and `128` exact-import/qualified `Arrays.stream(xs)` occurrences as exact-supported rows, reducing the broad `stream/parallelStream` residual from `1,996` to `1,496` while leaving untyped, shadowed, arity/range overload, and parallel stream lifecycle semantics closed.
 - [Non-JS task-spawn reporting alignment](../bench/recall_loss/non-js-task-spawn-reporting-alignment-2026-07-01.v1.json) records the cross-language closeout for already-backed task-spawn rows. Rust `tokio`/`async-std` spawn, Swift `Task`/`Task.detached`, Python `asyncio.create_task`/`ensure_future`, and Java `CompletableFuture.supplyAsync`/`runAsync` move from closed/candidate audit rows to reporting-supported closed-boundaries, newly aligning `590` occurrences while keeping exact admission closed and the checked `crates` gate at `0` false merges.
 - [Non-JS async aggregate reporting alignment](../bench/recall_loss/non-js-async-aggregate-reporting-alignment-2026-07-01.v1.json) records the companion closeout for already-backed aggregate rows. Rust `tokio`/`futures`/`futures_util` `join!`/`try_join!`/`select!`, Python `asyncio.gather`/`wait`, and Java `CompletableFuture.allOf`/`anyOf` move to reporting-supported closed-boundaries, newly aligning `98` occurrences while keeping exact admission closed and the checked `crates` gate at `0` false merges.
-- [Swift await and Java settled-factory reporting alignment](../bench/recall_loss/swift-await-java-factory-reporting-alignment-2026-07-02.v1.json) records the next closeout for already-backed protocol/static-runtime rows. Swift `await` and Java `CompletableFuture.completedFuture`/`failedFuture` move to reporting-supported closed-boundaries, newly aligning `8,703` occurrences while keeping exact admission closed and the checked `crates` gate at `0` false merges. Broad Java `CompletableFuture` mentions and looser FutureLike settlement receiver counts remain closed/deferred.
+- [Swift await and Java settled-factory reporting alignment](../bench/recall_loss/swift-await-java-factory-reporting-alignment-2026-07-02.v1.json) records the next closeout for already-backed protocol/static-runtime rows. Swift `await` and Java `CompletableFuture.completedFuture`/`failedFuture` move to reporting-supported closed-boundaries, newly aligning `8,703` occurrences while keeping exact admission closed and the checked `crates` gate at `0` false merges. At that checkpoint, broad Java `CompletableFuture` mentions and looser FutureLike settlement receiver counts remained closed/deferred.
 - The [Java CompletableFuture constructor reporting](../bench/recall_loss/java-completablefuture-constructor-reporting-2026-07-02.v1.json)
   artifact records the proof-backed constructor split from the broad Java Future
   bucket. Fully qualified or exact-/wildcard-import-backed constructor calls now
@@ -118,6 +118,16 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   admission remains closed. The residual broad Java `CompletableFuture` bucket
   falls from `276` to `230`; the Java-heavy query regression kept all product
   output hashes identical and measured `7023.49ms -> 6991.92ms` (`-0.45%`).
+- The [Java CompletableFuture receiver split](../bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json)
+  records the receiver-method follow-up. Import-backed `CompletableFuture`
+  receivers now report settlement, observation, timeout, exception, lifecycle,
+  and cancellation/liveness obligations without opening exact admission. The
+  scope-aware audit moves `45` settlement and `45` observation occurrences to
+  reporting-supported rows, keeps same-name receivers outside the proven scope
+  closed, reclassifies the remaining `230` broad `CompletableFuture`
+  type/reference mentions as superseded overlap, and the Java-heavy query
+  regression measured `8307.21ms -> 8331.21ms` (`+0.29%`) with identical product
+  hashes on all six measured repos.
 - [Non-JS source-protocol reporting alignment](../bench/recall_loss/non-js-source-protocol-reporting-alignment-2026-07-02.v1.json) records the audit closeout for already-backed async source-protocol rows.
   Python `await`/`async def`, Rust `.await`/`async fn`/`async block`, and Swift
   `async` function rows now move to reporting-supported closed-boundaries,

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -126,7 +126,7 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   reporting-supported rows, keeps same-name receivers outside the proven scope
   closed, reclassifies the remaining `230` broad `CompletableFuture`
   type/reference mentions as superseded overlap, and the Java-heavy query
-  regression measured `8307.21ms -> 8331.21ms` (`+0.29%`) with identical product
+  regression measured `8118.22ms -> 8151.13ms` (`+0.41%`) with identical product
   hashes on all six measured repos.
 - [Non-JS source-protocol reporting alignment](../bench/recall_loss/non-js-source-protocol-reporting-alignment-2026-07-02.v1.json) records the audit closeout for already-backed async source-protocol rows.
   Python `await`/`async def`, Rust `.await`/`async fn`/`async block`, and Swift

--- a/docs/scheduling-channel-callback-obligations-594.md
+++ b/docs/scheduling-channel-callback-obligations-594.md
@@ -212,6 +212,16 @@ settlement-continuation occurrences across `2` repos. The broad
 is now a superseded overlap row rather than an actionable implementation target;
 concrete static call, constructor, and receiver-method rows drive the Java
 Future/Executor residual queue.
+The follow-up [Java CompletableFuture receiver split artifact](../bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json)
+keeps using those shared FutureLike obligations for receiver-specific
+`CompletableFuture` methods. `complete`/`completeExceptionally` now report
+manual settlement and exception/lifecycle obligations; `join`, `getNow`, and
+`isCompletedExceptionally` report settled-value, exception, lifecycle, and
+cancellation/liveness observation; timeout methods add timer-backed settlement
+obligations. The scope-aware audit prices `45` settlement and `45` observation
+occurrences, keeps same-name receivers outside the proven scope closed, and
+moves the old `230` broad type/reference mentions out of the actionable
+closed-boundary queue as a superseded overlap row.
 The follow-up [Java stream lifecycle split artifact](../bench/recall_loss/java-stream-lifecycle-split-2026-07-02.v1.json)
 applies the same accounting discipline to stream-shaped domains. Existing
 iterator identity/static collection adapter proof already supports `372`

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2150,7 +2150,13 @@ different APIs.
   product-backed `FutureLike.handle/whenComplete` settlement continuations
   reporting-supported at `10` occurrences, so concrete static call,
   constructor, and receiver-method rows drive Java Future/Executor residual
-  planning.
+  planning. The `CompletableFuture` receiver-method follow-up extends the same
+  FutureLike evidence path to `complete`/`completeExceptionally`,
+  `join`/`getNow`/`isCompletedExceptionally`, and timeout methods without adding
+  a Java-only kernel API. The scope-aware 120-repo audit moves `45` settlement
+  and `45` observation occurrences to reporting-supported rows, keeps same-name
+  receivers outside the proven scope closed, and reclassifies the remaining
+  `230` broad `CompletableFuture` type/reference mentions as superseded overlap.
 - The Go channel/goroutine/defer follow-up applies the same capability
   vocabulary to source-backed Go protocol boundaries. It does not add a Go-only
   admission feature: sends, receives, comma-ok receives, select
@@ -2455,6 +2461,19 @@ the `4,010` broad `raise/rescue` bucket as superseded overlap, and leaves the
 Exact admission remains closed until Ruby exception
 propagation, rescue matching, ensure ordering, and non-local control semantics
 are proven.
+
+2026-07-02 Java CompletableFuture receiver split note:
+The [java-completablefuture-receiver-split-2026-07-02.v1.json](../bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json)
+artifact records the next Java Future accounting and reporting slice. Existing
+import-backed FutureLike receiver proof now reports
+`complete`/`completeExceptionally`, `join`/`getNow`/`isCompletedExceptionally`,
+and timeout receiver methods under the shared settled-value, exception,
+lifecycle, cancellation/liveness, and timer obligations. The 120-repo audit
+adds `45` settlement and `45` observation reporting-supported occurrences after
+rejecting same-name receiver bleed-through across scopes, while the old
+`230`-occurrence broad `CompletableFuture` type/reference row becomes superseded
+overlap. The Java-heavy query regression kept all six product output hashes
+identical and measured `8307.21ms -> 8331.21ms` (`+0.29%`).
 
 2026-07-02 Java stream lifecycle audit split note:
 The [java-stream-lifecycle-split-2026-07-02.v1.json](../bench/recall_loss/java-stream-lifecycle-split-2026-07-02.v1.json)

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2473,7 +2473,7 @@ adds `45` settlement and `45` observation reporting-supported occurrences after
 rejecting same-name receiver bleed-through across scopes, while the old
 `230`-occurrence broad `CompletableFuture` type/reference row becomes superseded
 overlap. The Java-heavy query regression kept all six product output hashes
-identical and measured `8307.21ms -> 8331.21ms` (`+0.29%`).
+identical and measured `8118.22ms -> 8151.13ms` (`+0.41%`).
 
 2026-07-02 Java stream lifecycle audit split note:
 The [java-stream-lifecycle-split-2026-07-02.v1.json](../bench/recall_loss/java-stream-lifecycle-split-2026-07-02.v1.json)

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -63,8 +63,13 @@ Java `new CompletableFuture<...>()` constructors now preserve a construct-call
 callee only when the stdlib type identity is fully qualified or exact-/
 wildcard-import-backed and unshadowed. Those constructors report future-settled,
 exception-channel, task-handle lifecycle, and cancellation/liveness obligations
-without opening exact admission; residual broad `CompletableFuture` mentions
-remain closed until split into product-backed surfaces.
+without opening exact admission. Scope-proven import-backed
+`CompletableFuture` receivers now also report manual settlement
+(`complete`/`completeExceptionally`), observation
+(`join`/`getNow`/`isCompletedExceptionally`), and timeout obligations through
+the same FutureLike evidence path. The old broad `CompletableFuture` type-name
+bucket is now a superseded overlap row, so actionable Java Future tracking uses
+concrete constructor, static, and receiver-operation rows.
 Java Future/Executor audit accounting now treats proof-backed
 `CompletionStage.handle`/`whenComplete` settlement continuations as
 reporting-supported receiver-domain surfaces. The older broad `Executor/Future`
@@ -1619,9 +1624,12 @@ this worktree because the required evidence is not yet modeled:
   and explicit `this.<field>` receivers now reuse the same capability
   vocabulary for handle lifecycle, cancellation/liveness, executor scheduling,
   timer/interval lifecycle, aggregate, callback/effect, settled-value, and
-  exception obligations. Exact Future/CompletionStage/Executor recovery remains
-  closed: implicit fields, non-`this` fields, wrapper aliases,
-  project-specific executors, callback
+  exception obligations. Import-backed `CompletableFuture` receivers additionally
+  report manual settlement, observation, and timeout-specific obligations; the
+  broad `CompletableFuture` type-reference row is superseded by concrete
+  constructor/static/receiver operation rows. Exact Future/CompletionStage/
+  Executor recovery remains closed: implicit fields, non-`this` fields, wrapper
+  aliases, project-specific executors, callback
   identity/effects, cancellation/liveness, exceptional completion, result
   channels, and constructor semantics still need dependency-closed contracts
   before Java future calls can converge with synchronous values or each other.

--- a/scripts/scheduling-lifecycle-boundary-audit.py
+++ b/scripts/scheduling-lifecycle-boundary-audit.py
@@ -468,6 +468,60 @@ JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR = Pattern(
     re.compile(r"(?!x)x"),
     "reporting-supported-closed-boundary",
 )
+JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN = Pattern(
+    "java",
+    "java.future.completable.constructor_unproven",
+    "new CompletableFuture without stdlib proof",
+    "success-error-result-channel",
+    "future-settled-value-channel-contract-missing",
+    "future constructor channel",
+    "Unqualified or shadowed CompletableFuture constructors remain closed until stdlib type identity is proven",
+    re.compile(r"(?!x)x"),
+)
+JAVA_COMPLETABLE_FUTURE_TYPE_REFERENCE = Pattern(
+    "java",
+    "java.future.completable.type_reference",
+    "CompletableFuture type reference",
+    "lifecycle-materialization-boundary",
+    "task-handle-lifecycle-contract-missing",
+    "future type/reference shape",
+    "CompletableFuture type references are evidence or wrapper/type-shape mentions; concrete constructor/static/receiver operation rows drive actionable future work",
+    re.compile(r"(?!x)x"),
+    "superseded-overlap-boundary",
+)
+JAVA_COMPLETABLE_FUTURE_RECEIVER_SETTLEMENT = Pattern(
+    "java",
+    "java.future.completable.receiver.settlement",
+    "CompletableFuture.complete/completeExceptionally",
+    "success-error-result-channel",
+    "future-settled-value-channel-contract-missing",
+    "future receiver settlement",
+    "Import-backed CompletableFuture receivers expose manual fulfilled or exceptional settlement channels",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
+JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE = Pattern(
+    "java",
+    "java.future.completable.receiver.observe",
+    "CompletableFuture.join/getNow/isCompletedExceptionally",
+    "success-error-result-channel",
+    "future-settled-value-channel-contract-missing",
+    "future receiver observation",
+    "Import-backed CompletableFuture receivers expose settled-value, exceptional, lifecycle, and cancellation observation boundaries",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
+JAVA_COMPLETABLE_FUTURE_RECEIVER_TIMEOUT = Pattern(
+    "java",
+    "java.future.completable.receiver.timeout",
+    "CompletableFuture.orTimeout/completeOnTimeout",
+    "scheduling-boundary",
+    "timer-scheduling-contract-missing",
+    "future timeout settlement",
+    "Import-backed CompletableFuture timeout receivers add timer-backed settlement and liveness boundaries",
+    re.compile(r"(?!x)x"),
+    "reporting-supported-closed-boundary",
+)
 JAVA_FUTURE_HANDLE_GET = Pattern(
     "java",
     "java.future.handle.get",
@@ -708,6 +762,11 @@ def all_known_patterns() -> tuple[Pattern, ...]:
         JAVA_FUTURE_ALL_COMPLETION_CONTINUATION,
         JAVA_FUTURE_FIRST_COMPLETION_CONTINUATION,
         JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR,
+        JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN,
+        JAVA_COMPLETABLE_FUTURE_TYPE_REFERENCE,
+        JAVA_COMPLETABLE_FUTURE_RECEIVER_SETTLEMENT,
+        JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE,
+        JAVA_COMPLETABLE_FUTURE_RECEIVER_TIMEOUT,
         JAVA_FUTURE_HANDLE_GET,
         JAVA_FUTURE_HANDLE_CANCEL,
         JAVA_FUTURE_HANDLE_STATUS,
@@ -808,7 +867,8 @@ def self_test() -> None:
         "java",
     )
     assert exact_completable_constructor.get(JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR) == 1
-    assert exact_completable_constructor.get(java_completable_broad) == 1
+    assert exact_completable_constructor.get(JAVA_COMPLETABLE_FUTURE_TYPE_REFERENCE) == 1
+    assert java_completable_broad not in exact_completable_constructor
 
     wildcard_completable_constructor = count_file(
         "import java.util.concurrent.*;\n"
@@ -827,7 +887,13 @@ def self_test() -> None:
         JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR
         not in wildcard_package_shadow_completable_constructor
     )
-    assert wildcard_package_shadow_completable_constructor.get(java_completable_broad) == 1
+    assert (
+        wildcard_package_shadow_completable_constructor.get(
+            JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN
+        )
+        == 1
+    )
+    assert java_completable_broad not in wildcard_package_shadow_completable_constructor
 
     qualified_completable_constructor = count_file(
         "class T { Object run() { return new java.util.concurrent.CompletableFuture<String>(); } }\n",
@@ -840,7 +906,76 @@ def self_test() -> None:
         "java",
     )
     assert JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR not in unimported_completable_constructor
-    assert unimported_completable_constructor.get(java_completable_broad) == 1
+    assert (
+        unimported_completable_constructor.get(JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN) == 1
+    )
+    assert java_completable_broad not in unimported_completable_constructor
+
+    imported_completable_type_reference = count_file(
+        "import java.util.concurrent.CompletableFuture;\n"
+        "class T { Object run(CompletableFuture<String> future) { return CompletableFuture.class; } }\n",
+        "java",
+    )
+    assert imported_completable_type_reference.get(JAVA_COMPLETABLE_FUTURE_TYPE_REFERENCE) == 3
+    assert java_completable_broad not in imported_completable_type_reference
+
+    completable_receiver_methods = count_file(
+        "import java.util.concurrent.CompletableFuture;\n"
+        "import java.util.concurrent.TimeUnit;\n"
+        "class T { Object run(CompletableFuture<String> future, Throwable error) {\n"
+        "  future.complete(\"ok\");\n"
+        "  future.completeExceptionally(error);\n"
+        "  future.join();\n"
+        "  future.getNow(\"fallback\");\n"
+        "  future.isCompletedExceptionally();\n"
+        "  future.orTimeout(1, TimeUnit.SECONDS);\n"
+        "  return future.completeOnTimeout(\"fallback\", 1, TimeUnit.SECONDS);\n"
+        "} }\n",
+        "java",
+    )
+    assert completable_receiver_methods.get(JAVA_COMPLETABLE_FUTURE_RECEIVER_SETTLEMENT) == 2
+    assert completable_receiver_methods.get(JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE) == 3
+    assert completable_receiver_methods.get(JAVA_COMPLETABLE_FUTURE_RECEIVER_TIMEOUT) == 2
+
+    custom_completable_receiver_method = count_file(
+        "import example.CompletableFuture;\n"
+        "class T { Object run(CompletableFuture<String> future) { return future.join(); } }\n",
+        "java",
+    )
+    assert JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE not in custom_completable_receiver_method
+
+    same_name_other_scope_completable_receiver = count_file(
+        "import java.util.concurrent.CompletableFuture;\n"
+        "class CustomFuture { Object join() { return null; } }\n"
+        "class T {\n"
+        "  Object first(CompletableFuture<String> future) { return future; }\n"
+        "  Object second(CustomFuture future) { return future.join(); }\n"
+        "}\n",
+        "java",
+    )
+    assert (
+        JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE
+        not in same_name_other_scope_completable_receiver
+    )
+
+    wrong_arity_completable_receiver_method = count_file(
+        "import java.util.concurrent.CompletableFuture;\n"
+        "class T { Object run(CompletableFuture<String> future) { return future.join(\"bad\"); } }\n",
+        "java",
+    )
+    assert (
+        JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE
+        not in wrong_arity_completable_receiver_method
+    )
+
+    lambda_shadowed_completable_receiver = count_file(
+        "import java.util.concurrent.CompletableFuture;\n"
+        "class T { Object run(CompletableFuture<String> future, java.util.List<Object> values) {\n"
+        "  return values.stream().map(future -> future.join());\n"
+        "} }\n",
+        "java",
+    )
+    assert JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE not in lambda_shadowed_completable_receiver
 
     java_stream_broad = next(
         item for item in PATTERNS if item.surface == "java.stream.lifecycle"
@@ -934,6 +1069,7 @@ def self_test() -> None:
         "java",
     )
     assert JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR not in conflict_completable_constructor
+    assert conflict_completable_constructor.get(JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN) == 1
 
     shadow_completable_constructor = count_file(
         "import java.util.concurrent.CompletableFuture;\n"
@@ -942,6 +1078,7 @@ def self_test() -> None:
         "java",
     )
     assert JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR not in shadow_completable_constructor
+    assert shadow_completable_constructor.get(JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN) == 1
 
     wildcard_package_shadow_future_receiver = count_file(
         "import java.util.concurrent.*;\n"
@@ -1247,13 +1384,15 @@ def count_file(
 
 def java_completable_future_counts(
     text: str,
-    broad_pattern: Pattern,
+    _broad_pattern: Pattern,
     package_local_types: set[str] | None = None,
 ) -> dict[Pattern, int]:
+    constructor_candidate_starts = java_completable_future_constructor_candidate_name_starts(text)
     accepted_constructor_starts = java_completable_future_constructor_name_starts(
         text, package_local_types
     )
-    broad_count = 0
+    unproven_constructor_starts = constructor_candidate_starts - accepted_constructor_starts
+    type_reference_count = 0
     for match in re.finditer(
         r"\bCompletableFuture\b"
         r"(?!\s*\.\s*(?:supplyAsync|runAsync|completedFuture|completedStage|failedFuture|failedStage|allOf|anyOf)\s*\()",
@@ -1261,14 +1400,32 @@ def java_completable_future_counts(
     ):
         if match.start() in accepted_constructor_starts:
             continue
-        broad_count += 1
+        if match.start() in unproven_constructor_starts:
+            continue
+        type_reference_count += 1
 
     counts: dict[Pattern, int] = {}
-    if broad_count:
-        counts[broad_pattern] = broad_count
     if accepted_constructor_starts:
         counts[JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR] = len(accepted_constructor_starts)
+    if unproven_constructor_starts:
+        counts[JAVA_COMPLETABLE_FUTURE_CONSTRUCTOR_UNPROVEN] = len(
+            unproven_constructor_starts
+        )
+    if type_reference_count:
+        counts[JAVA_COMPLETABLE_FUTURE_TYPE_REFERENCE] = type_reference_count
     return counts
+
+
+def java_completable_future_constructor_candidate_name_starts(text: str) -> set[int]:
+    starts: set[int] = set()
+    qualified = re.compile(
+        r"\bnew\s+java\s*\.\s*util\s*\.\s*concurrent\s*\.\s*"
+        r"(CompletableFuture)\b(?:\s*<[^;(){}]*>)?\s*\("
+    )
+    starts.update(match.start(1) for match in qualified.finditer(text))
+    simple = re.compile(r"\bnew\s+(CompletableFuture)\b(?:\s*<[^;(){}]*>)?\s*\(")
+    starts.update(match.start(1) for match in simple.finditer(text))
+    return starts
 
 
 def java_completable_future_constructor_name_starts(
@@ -2443,9 +2600,147 @@ def java_future_receiver_counts(
             ),
             ".",
         )
+    java_completable_future_receiver_method_counts(counts, text, package_local_types)
     java_future_handle_counts(counts, text, package_local_types)
     java_executor_receiver_counts(counts, text, package_local_types)
     return counts
+
+
+JAVA_COMPLETABLE_FUTURE_RECEIVER_METHODS = {
+    "complete": (JAVA_COMPLETABLE_FUTURE_RECEIVER_SETTLEMENT, {1}),
+    "completeExceptionally": (JAVA_COMPLETABLE_FUTURE_RECEIVER_SETTLEMENT, {1}),
+    "join": (JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE, {0}),
+    "getNow": (JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE, {1}),
+    "isCompletedExceptionally": (JAVA_COMPLETABLE_FUTURE_RECEIVER_OBSERVE, {0}),
+    "orTimeout": (JAVA_COMPLETABLE_FUTURE_RECEIVER_TIMEOUT, {2}),
+    "completeOnTimeout": (JAVA_COMPLETABLE_FUTURE_RECEIVER_TIMEOUT, {3}),
+}
+
+
+def java_completable_future_receiver_method_counts(
+    counts: dict[Pattern, int],
+    text: str,
+    package_local_types: set[str] | None = None,
+) -> None:
+    methods = "|".join(
+        re.escape(method)
+        for method in sorted(JAVA_COMPLETABLE_FUTURE_RECEIVER_METHODS, key=len, reverse=True)
+    )
+    pattern = re.compile(
+        rf"\b(?P<receiver>{JAVA_IDENTIFIER_RE})\s*(?P<dot>\.)\s*"
+        rf"(?P<method>{methods})\s*\("
+    )
+    for match in pattern.finditer(text):
+        row, arities = JAVA_COMPLETABLE_FUTURE_RECEIVER_METHODS[match.group("method")]
+        if not java_call_arity_matches_masked_literals(text, match.end() - 1, arities):
+            continue
+        receiver = match.group("receiver")
+        if (
+            java_latest_value_binding_import_backed_concurrent_type(
+                text,
+                match.start("dot"),
+                receiver,
+                {"CompletableFuture"},
+                package_local_types,
+            )
+            is True
+        ):
+            counts[row] = counts.get(row, 0) + 1
+
+
+def java_call_arity_matches_masked_literals(
+    text: str,
+    open_paren: int,
+    allowed: set[int],
+) -> bool:
+    arity = java_call_arity(text, open_paren)
+    if arity is None:
+        return False
+    width = java_call_argument_span_width(text, open_paren)
+    if arity == 0 and width is not None and width > 0:
+        return 1 in allowed
+    return arity in allowed
+
+
+def java_call_argument_span_width(text: str, open_paren: int) -> int | None:
+    if open_paren >= len(text) or text[open_paren] != "(":
+        return None
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    idx = open_paren + 1
+    while idx < len(text):
+        current = text[idx]
+        if current == "(":
+            paren_depth += 1
+        elif current == ")":
+            if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0:
+                return idx - open_paren - 1
+            if paren_depth > 0:
+                paren_depth -= 1
+        elif current == "[":
+            bracket_depth += 1
+        elif current == "]":
+            bracket_depth = max(0, bracket_depth - 1)
+        elif current == "{":
+            brace_depth += 1
+        elif current == "}":
+            brace_depth = max(0, brace_depth - 1)
+        idx += 1
+    return None
+
+
+def java_latest_value_binding_import_backed_concurrent_type(
+    text: str,
+    before: int,
+    name: str,
+    type_names: set[str],
+    package_local_types: set[str] | None = None,
+) -> bool | None:
+    region = java_enclosing_method_like_region(text, before)
+    if region is None:
+        return None
+    if java_lambda_parameter_visible_before(text, before, name):
+        return False
+    latest: tuple[int, bool] | None = None
+    for match in JAVA_VALUE_BINDING_PATTERN.finditer(text, region[0], before):
+        if match.group("name") != name:
+            continue
+        if match.group("name") in {"class", "interface", "enum", "record"}:
+            continue
+        if java_binding_type_is_keyword(match.group("type")):
+            continue
+        if java_binding_is_callable_declaration(text, match.end("name")):
+            continue
+        latest = (
+            match.start("name"),
+            java_concurrent_type_binding_supported(
+                text,
+                match.group("type"),
+                type_names,
+                package_local_types,
+            ),
+        )
+    return latest[1] if latest is not None else None
+
+
+def java_concurrent_type_binding_supported(
+    text: str,
+    type_text: str,
+    type_names: set[str],
+    package_local_types: set[str] | None = None,
+) -> bool:
+    normalized = re.sub(r"\s+", "", type_text)
+    concurrent_prefix = "java.util.concurrent."
+    if normalized.startswith(concurrent_prefix):
+        return normalized[len(concurrent_prefix) :] in type_names
+    if "." in normalized:
+        return False
+    return normalized in java_imported_concurrent_types(
+        text,
+        type_names,
+        package_local_types,
+    )
 
 
 def java_future_like_receiver_names(text: str) -> set[str]:


### PR DESCRIPTION
## Summary
- Report Java `CompletableFuture` receiver settlement, observation, and timeout methods through existing FutureLike missing-evidence obligations.
- Split the broad Java `CompletableFuture` audit bucket into constructor-unproven, type-reference overlap, and scope-proven receiver rows.
- Add recall-loss/query-regression artifacts and update docs/changelog.

## Measurements
- Audit moves `45` settlement and `45` observation receiver occurrences to reporting-supported rows.
- Remaining `230` broad `CompletableFuture` type/reference mentions are superseded overlap, not actionable residuals.
- Query regression r9 over netty/rxjava/retrofit/junit5/jedis/h2database, measured against clean source commit `b9ec9151277a99ee634b8652e4518c74b3a92e4a`: `8118.22ms -> 8151.13ms` (`+0.41%`), identical hashes and family counts on all six repos.

## Validation
- `cargo fmt --check`
- `cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::java_completable_future_receiver -- --nocapture`
- `cargo test -p nose-cli verify_admission::runtime_boundary::tests::async_runtime::java::java_future_handle_methods_report_future_lifecycle_obligations -- --nocapture`
- `python3 -m py_compile scripts/scheduling-lifecycle-boundary-audit.py && python3 scripts/scheduling-lifecycle-boundary-audit.py --self-test`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.java-completablefuture-receiver-split.crates.json`
- `cargo build --release -p nose-cli`
- `python3 scripts/query-regression-harness.py --baseline-binary /tmp/nose-java-cf-receiver-main/target/release/nose --current-binary target/release/nose --baseline-source-ref origin/main --current-source-ref java-completablefuture-residual-split --current-source-sha b9ec9151277a99ee634b8652e4518c74b3a92e4a --iterations 9 --repo netty --repo rxjava --repo retrofit --repo junit5 --repo jedis --repo h2database --output bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json`
- `scripts/check-docs.sh`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `git diff --check`
- `./scripts/check-duplication.sh`
- `jq empty bench/recall_loss/java-completablefuture-receiver-split-2026-07-02.v1.json bench/recall_loss/java-completablefuture-receiver-split-query-regression-2026-07-02.v1.json bench/recall_loss/scheduling-lifecycle-boundary-audit-java-completablefuture-receiver-split-2026-07-02.v1.json`