### PR TITLE
Report oracle exclusion classifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,14 @@ break.
   producer/continuation labels as missing-proof diagnostics rather than feature
   admissions; historical artifacts remain untouched and exact admission is
   unchanged.
+- Added the #658 oracle-exclusion classification layer to recall-loss reports.
+  `oracle_exclusions` now includes `by_classification`, so broad excluded units
+  are split into semantic-boundary attribution, missing oracle support, path
+  exploration budget, oracle cost budget, empty fingerprint, and core-span
+  failures. The current local `crates` report classifies all `6037` excluded
+  units, including `583`
+  semantic-boundary-attributed and `5447` residual missing-oracle-support rows,
+  while keeping exact admission unchanged and the hard gate at `0` false merges.
 - Added Swift structured-concurrency reporting for `Task.sleep`, `Task.yield`,
   and task-group calls. These now map to shared timer, task-yield, aggregate,
   cancellation/liveness, result-channel, and exception-channel obligations

--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -1172,6 +1172,13 @@ python3 scripts/interval-scheduler-lifecycle-slice-audit.py \
   `8` feature-shaped Promise diagnostics under their reusable capability
   blockers, documents `6` duplicate/grouping decisions, and keeps
   historical artifacts untouched with `semantic_admission_delta = 0`.
+- [issue-658-oracle-exclusion-classification-2026-07-02.v1.json](issue-658-oracle-exclusion-classification-2026-07-02.v1.json)
+  records the #658 report-shape refinement. `oracle_exclusions` now includes
+  `by_classification`, splitting the local `crates` excluded surface into
+  `5447` `missing-oracle-support`, `583`
+  `semantic-boundary-attributed`, `5` `path-exploration-budget`, `1`
+  `oracle-cost-budget`, and `1` `empty-value-fingerprint` unit while preserving
+  the legacy reason counts and exact admission behavior.
 - [scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json](scheduling-lifecycle-boundary-audit-non-js-async-runtime-scope-shadowing-2026-06-30.v1.json)
   records the Python/Rust async runtime scope-shadowing hardening. It keeps
   exact admission closed while making unrelated local shadows in other

--- a/bench/recall_loss/issue-658-oracle-exclusion-classification-2026-07-02.v1.json
+++ b/bench/recall_loss/issue-658-oracle-exclusion-classification-2026-07-02.v1.json
@@ -1,0 +1,270 @@
+{
+  "report_kind": "recall-loss-follow-up",
+  "schema_version": 1,
+  "generated_on": "2026-07-02",
+  "title": "Oracle exclusion classification for recall-loss reports",
+  "issues": {
+    "issue": 658,
+    "execution_tracker": 663,
+    "broader_epic": 653
+  },
+  "scope": {
+    "kind": "reporting-only",
+    "summary": "Add an action-oriented oracle_exclusions.by_classification rollup so excluded units can be split into semantic-boundary attribution, missing oracle support, path budget, oracle cost budget, empty fingerprint, and core-span failures without changing exact admission.",
+    "semantic_admission_delta": 0,
+    "exact_admission_opened": false,
+    "public_api_expansion": 0,
+    "legacy_reason_counts_preserved": true
+  },
+  "capability_alignment": {
+    "principle": "Capabilities over features",
+    "capability": "oracle-exclusion observability for strict semantic admission",
+    "added_report_fields": [
+      "oracle_exclusions.by_classification"
+    ],
+    "not_a_feature_list": [
+      "No language, API, or selector-specific exact admission path was opened.",
+      "No new semantic-pack API was added.",
+      "Top-level oracle_exclusions.counts and oracle_exclusions.by_obligation remain compatible."
+    ],
+    "reasoning": "The rollup separates missing oracle support from already-attributed semantic boundaries, so future stricter admission work can lower recall loss without hiding misses behind a broad uninterpretable bucket."
+  },
+  "baseline_report": {
+    "command": "/tmp/nose-target-origin-main-issue658/release/nose verify crates --max-violations 0 --recall-loss-report /tmp/recall-loss.issue658.origin.final3.json",
+    "report": "/tmp/recall-loss.issue658.origin.final3.json",
+    "has_by_classification": false,
+    "summary": {
+      "total_units": 7011,
+      "interpretable_units": 974,
+      "excluded_units": 6037,
+      "canon_checked": 102,
+      "canon_preservation_violations": 0,
+      "admission_rejections": 813
+    },
+    "oracle_exclusions": {
+      "core-missing": 0,
+      "battery-bail": 1,
+      "empty-fingerprint": 1,
+      "uninterpretable": 6030,
+      "path-bail": 5
+    },
+    "oracle_exclusions_by_obligation": [
+      {
+        "exclusion_reason": "uninterpretable",
+        "attribution_reason": "unsupported-runtime-boundary",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "count": 580,
+        "oracle_excluded": 580
+      },
+      {
+        "exclusion_reason": "uninterpretable",
+        "attribution_reason": "unsupported-runtime-boundary",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "count": 3,
+        "oracle_excluded": 3
+      }
+    ]
+  },
+  "current_report": {
+    "command": "/tmp/nose-target-current-issue658/release/nose verify crates --max-violations 0 --recall-loss-report /tmp/recall-loss.issue658.current.final3.json",
+    "report": "/tmp/recall-loss.issue658.current.final3.json",
+    "has_by_classification": true,
+    "summary": {
+      "total_units": 7011,
+      "interpretable_units": 974,
+      "excluded_units": 6037,
+      "canon_checked": 102,
+      "canon_preservation_violations": 0,
+      "admission_rejections": 813
+    },
+    "oracle_exclusions": {
+      "core-missing": 0,
+      "battery-bail": 1,
+      "empty-fingerprint": 1,
+      "uninterpretable": 6030,
+      "path-bail": 5
+    },
+    "oracle_exclusions_by_classification": [
+      {
+        "exclusion_reason": "uninterpretable",
+        "classification": "missing-oracle-support",
+        "count": 5447,
+        "oracle_excluded": 5447,
+        "attributed_units": 0,
+        "unattributed_units": 5447
+      },
+      {
+        "exclusion_reason": "uninterpretable",
+        "classification": "semantic-boundary-attributed",
+        "count": 583,
+        "oracle_excluded": 583,
+        "attributed_units": 583,
+        "unattributed_units": 0
+      },
+      {
+        "exclusion_reason": "path-bail",
+        "classification": "path-exploration-budget",
+        "count": 5,
+        "oracle_excluded": 5,
+        "attributed_units": 0,
+        "unattributed_units": 5
+      },
+      {
+        "exclusion_reason": "battery-bail",
+        "classification": "oracle-cost-budget",
+        "count": 1,
+        "oracle_excluded": 1,
+        "attributed_units": 0,
+        "unattributed_units": 1
+      },
+      {
+        "exclusion_reason": "empty-fingerprint",
+        "classification": "empty-value-fingerprint",
+        "count": 1,
+        "oracle_excluded": 1,
+        "attributed_units": 0,
+        "unattributed_units": 1
+      }
+    ],
+    "oracle_exclusions_by_obligation": [
+      {
+        "exclusion_reason": "uninterpretable",
+        "attribution_reason": "unsupported-runtime-boundary",
+        "obligation_family": "exception-channel",
+        "obligation_subreason": "exception-channel-contract-missing",
+        "count": 580,
+        "oracle_excluded": 580
+      },
+      {
+        "exclusion_reason": "uninterpretable",
+        "attribution_reason": "unsupported-runtime-boundary",
+        "obligation_family": "scheduling-boundary",
+        "obligation_subreason": "runtime-protocol-boundary-contract-missing",
+        "count": 3,
+        "oracle_excluded": 3
+      }
+    ]
+  },
+  "quantification": {
+    "newly_classified_exclusions": 6037,
+    "classification_coverage_percent": 100.0,
+    "new_classification_rows": 5,
+    "top_level_exclusion_count_delta": 0,
+    "broad_uninterpretable_reason_count_delta": 0,
+    "broad_uninterpretable_actionable_split": {
+      "coarse_reason_count": 6030,
+      "semantic_boundary_attributed": 583,
+      "missing_oracle_support": 5447,
+      "semantic_boundary_attributed_percent_of_uninterpretable": 9.67,
+      "residual_missing_oracle_support_percent_of_uninterpretable": 90.33
+    },
+    "hard_gate": {
+      "false_merges": 0,
+      "canon_preservation_violations": 0,
+      "gate_passed": true
+    },
+    "behavioral_deltas": {
+      "interpretable_units": 0,
+      "excluded_units": 0,
+      "admission_rejections": 0,
+      "under_merged_behavior_groups": 0,
+      "completeness_percent": 0.0,
+      "oracle_exclusion_obligation_rows": 0
+    }
+  },
+  "performance": {
+    "surface": "release verify crates with --recall-loss-report",
+    "baseline_binary": "/tmp/nose-target-origin-main-issue658/release/nose",
+    "current_binary": "/tmp/nose-target-current-issue658/release/nose",
+    "runs": 16,
+    "raw_real_seconds": {
+      "baseline": [
+        1.05,
+        1.27,
+        1.38,
+        1.39,
+        1.50,
+        1.46,
+        1.45,
+        1.45,
+        1.08,
+        1.46,
+        1.51,
+        1.43,
+        1.52,
+        1.49,
+        1.48,
+        1.59
+      ],
+      "current": [
+        1.17,
+        1.36,
+        1.63,
+        1.47,
+        1.50,
+        1.45,
+        1.42,
+        1.47,
+        1.03,
+        1.31,
+        1.51,
+        1.47,
+        1.43,
+        1.47,
+        1.52,
+        1.44
+      ]
+    },
+    "median_seconds": {
+      "baseline": 1.455,
+      "current": 1.46,
+      "delta_percent": 0.34
+    },
+    "mean_seconds": {
+      "baseline": 1.40687,
+      "current": 1.41563,
+      "delta_percent": 0.62
+    },
+    "file_size_bytes": {
+      "baseline": 2623808,
+      "current": 2624998,
+      "delta": 1190,
+      "delta_percent": 0.05
+    },
+    "optimization_note": "An earlier local draft repeated classification on every excluded unit, adding about 318 KB to the report and showing noisy mean regressions. The final shape keeps the classification as a compact rollup only, preserving actionability while avoiding repeated per-unit strings.",
+    "conclusion": "No material report-path degradation: the combined 16-run median delta is 0.34% and the mean delta is 0.62%. The final implementation avoids an extra exclusion-unit pass by deriving classification counts from existing exclusion counters and by_obligation rows."
+  },
+  "validation_commands": [
+    "cargo fmt --check",
+    "python3 scripts/recall-loss-diff.py --self-test",
+    "cargo test -q -p nose-cli recall_loss_report_classifies_oracle_exclusions_by_actionable_bucket --test cli",
+    "cargo test -q -p nose-cli verify_writes_local_recall_loss_report_without_source_snippets --test cli",
+    "cargo test -q -p nose-cli recall_loss_report_attributes_await_oracle_exclusions_to_shared_scheduling_obligation --test cli",
+    "cargo test -q -p nose-cli recall_loss_report_attributes_async_function_and_block_oracle_exclusions --test cli",
+    "cargo test -q -p nose-cli recall_loss_report_attributes_non_js_async_runtime_api_exclusions --test cli",
+    "cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-658.after.crates.json",
+    "CARGO_TARGET_DIR=/tmp/nose-target-origin-main-issue658 cargo build --release -p nose-cli",
+    "CARGO_TARGET_DIR=/tmp/nose-target-current-issue658 cargo build --release -p nose-cli",
+    "/usr/bin/time -p /tmp/nose-target-origin-main-issue658/release/nose verify crates --max-violations 0 --recall-loss-report /tmp/recall-loss.issue658.origin.final3.N.json",
+    "/usr/bin/time -p /tmp/nose-target-current-issue658/release/nose verify crates --max-violations 0 --recall-loss-report /tmp/recall-loss.issue658.current.final3.N.json"
+  ],
+  "next_work": [
+    {
+      "classification": "missing-oracle-support",
+      "count": 5447,
+      "recommendation": "Prioritize oracle interpreter coverage or finer source tags for the residual broad uninterpretable backlog."
+    },
+    {
+      "classification": "semantic-boundary-attributed",
+      "count": 583,
+      "recommendation": "Use oracle_exclusions.by_obligation first; these are already semantic-kernel capability gaps, not generic oracle-support misses."
+    },
+    {
+      "classification": "path-exploration-budget",
+      "count": 5,
+      "recommendation": "Keep separate from uninterpretable; future work can price symbolic branch exploration without weakening exact admission."
+    }
+  ]
+}

--- a/crates/nose-cli/src/recall_loss_report.rs
+++ b/crates/nose-cli/src/recall_loss_report.rs
@@ -347,6 +347,7 @@ fn top_opportunities(under_merges: &[UnderMerge]) -> Vec<TopOpportunity> {
 
 fn oracle_exclusions(exclusions: &VerifyExclusions) -> OracleExclusions {
     let by_obligation = oracle_exclusion_obligation_rollups(&exclusions.units);
+    let by_classification = oracle_exclusion_classification_rollups(exclusions, &by_obligation);
     let mut units: Vec<_> = exclusions
         .units
         .iter()
@@ -392,6 +393,7 @@ fn oracle_exclusions(exclusions: &VerifyExclusions) -> OracleExclusions {
                 count: exclusions.path_bail,
             },
         ],
+        by_classification,
         by_obligation,
         units,
     }
@@ -412,6 +414,107 @@ fn oracle_exclusion_attribution(
         obligation_subreason,
         oracle_status: "excluded",
     }
+}
+
+fn oracle_exclusion_classification_rollups(
+    exclusions: &VerifyExclusions,
+    by_obligation: &[OracleExclusionObligationRollup],
+) -> Vec<OracleExclusionClassificationRollup> {
+    let semantic_boundary_attributed = by_obligation
+        .iter()
+        .filter(|row| row.exclusion_reason == "uninterpretable")
+        .map(|row| row.oracle_excluded)
+        .sum::<usize>();
+    let missing_oracle_support = exclusions
+        .uninterpretable
+        .saturating_sub(semantic_boundary_attributed);
+
+    let mut rollups = Vec::new();
+    for (reason, classification, counter) in [
+        (
+            "core-missing",
+            "core-span-missing",
+            ClassificationCounter::unattributed(exclusions.core_missing),
+        ),
+        (
+            "battery-bail",
+            "oracle-cost-budget",
+            ClassificationCounter::unattributed(exclusions.battery_bail),
+        ),
+        (
+            "empty-fingerprint",
+            "empty-value-fingerprint",
+            ClassificationCounter::unattributed(exclusions.empty_fingerprint),
+        ),
+        (
+            "path-bail",
+            "path-exploration-budget",
+            ClassificationCounter::unattributed(exclusions.path_bail),
+        ),
+        (
+            "uninterpretable",
+            "semantic-boundary-attributed",
+            ClassificationCounter::attributed(semantic_boundary_attributed),
+        ),
+        (
+            "uninterpretable",
+            "missing-oracle-support",
+            ClassificationCounter::unattributed(missing_oracle_support),
+        ),
+    ] {
+        push_classification_rollup(&mut rollups, reason, classification, counter);
+    }
+
+    rollups.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then(a.exclusion_reason.cmp(b.exclusion_reason))
+            .then(a.classification.cmp(b.classification))
+    });
+    rollups
+}
+
+struct ClassificationCounter {
+    count: usize,
+    attributed_units: usize,
+    unattributed_units: usize,
+}
+
+impl ClassificationCounter {
+    fn attributed(count: usize) -> Self {
+        Self {
+            count,
+            attributed_units: count,
+            unattributed_units: 0,
+        }
+    }
+
+    fn unattributed(count: usize) -> Self {
+        Self {
+            count,
+            attributed_units: 0,
+            unattributed_units: count,
+        }
+    }
+}
+
+fn push_classification_rollup(
+    rollups: &mut Vec<OracleExclusionClassificationRollup>,
+    exclusion_reason: &'static str,
+    classification: &'static str,
+    counter: ClassificationCounter,
+) {
+    if counter.count == 0 {
+        return;
+    }
+    rollups.push(OracleExclusionClassificationRollup {
+        exclusion_reason,
+        classification,
+        count: counter.count,
+        oracle_excluded: counter.count,
+        attributed_units: counter.attributed_units,
+        unattributed_units: counter.unattributed_units,
+    });
 }
 
 fn oracle_exclusion_obligation_rollups(

--- a/crates/nose-cli/src/recall_loss_report/model.rs
+++ b/crates/nose-cli/src/recall_loss_report/model.rs
@@ -85,6 +85,7 @@ pub(super) struct UnderMerge {
 #[derive(Serialize)]
 pub(super) struct OracleExclusions {
     pub(super) counts: Vec<ReasonCount>,
+    pub(super) by_classification: Vec<OracleExclusionClassificationRollup>,
     pub(super) by_obligation: Vec<OracleExclusionObligationRollup>,
     pub(super) units: Vec<ExcludedUnit>,
 }
@@ -107,6 +108,16 @@ pub(super) struct OracleExclusionAttribution {
     pub(super) obligation_family: &'static str,
     pub(super) obligation_subreason: &'static str,
     pub(super) oracle_status: &'static str,
+}
+
+#[derive(Serialize)]
+pub(super) struct OracleExclusionClassificationRollup {
+    pub(super) exclusion_reason: &'static str,
+    pub(super) classification: &'static str,
+    pub(super) count: usize,
+    pub(super) oracle_excluded: usize,
+    pub(super) attributed_units: usize,
+    pub(super) unattributed_units: usize,
 }
 
 #[derive(Serialize)]

--- a/crates/nose-cli/tests/cli/commands.rs
+++ b/crates/nose-cli/tests/cli/commands.rs
@@ -16,6 +16,8 @@ mod query_reinvented;
 mod recall_loss_report;
 #[path = "commands/recall_loss_report/java_completable_future.rs"]
 mod recall_loss_report_java_completable_future;
+#[path = "commands/recall_loss_report/oracle_exclusions/classification.rs"]
+mod recall_loss_report_oracle_exclusion_classification;
 #[path = "commands/recall_loss_report/oracle_exclusions.rs"]
 mod recall_loss_report_oracle_exclusions;
 #[path = "commands/recall_loss_report/promise_continuations.rs"]

--- a/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
+++ b/crates/nose-cli/tests/cli/commands/recall_loss_report.rs
@@ -32,6 +32,12 @@ def custom_call(v):\n    return helper(v)\n",
     assert_eq!(report["soundness_gate"]["false_merges"], 0);
     assert_eq!(report["soundness_gate"]["canon_preservation_violations"], 0);
     assert_eq!(report["soundness_gate"]["gate_passed"], true);
+    assert!(
+        report["oracle_exclusions"]["by_classification"]
+            .as_array()
+            .is_some(),
+        "oracle exclusions should expose classification rollups: {report}"
+    );
 
     let reasons = report["by_reason"]
         .as_array()

--- a/crates/nose-cli/tests/cli/commands/recall_loss_report/oracle_exclusions/classification.rs
+++ b/crates/nose-cli/tests/cli/commands/recall_loss_report/oracle_exclusions/classification.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn recall_loss_report_classifies_oracle_exclusions_by_actionable_bucket() {
+    let project = TempProject::new("recall_loss_oracle_exclusion_classification");
+    project.write(
+        "await.js",
+        "async function idAsync(x) {\n  return await x + 1;\n}\n",
+    );
+    project.write(
+        "await.ts",
+        "async function idAsync(x: Promise<number>) {\n  return await x + 1;\n}\n",
+    );
+    project.write(
+        "await.py",
+        "async def id_async(x):\n    return await x + 1\n",
+    );
+    project.write(
+        "await.rs",
+        "async fn id_async(x: i32) -> i32 { async move { x + 1 }.await }\n",
+    );
+    project.write(
+        "await.swift",
+        "func idAsync(_ x: Int) async -> Int { return await x + 1 }\n",
+    );
+    let report_path = project.path().join("recall-loss.json");
+    let out = run_raw(&[
+        "verify",
+        project.path().to_str().unwrap(),
+        "--max-violations",
+        "0",
+        "--recall-loss-report",
+        report_path.to_str().unwrap(),
+    ]);
+    assert!(out.contains("GATE: 0"));
+
+    let report_text = fs::read_to_string(&report_path).expect("recall-loss report");
+    let report: serde_json::Value =
+        serde_json::from_str(&report_text).expect("recall-loss report JSON");
+    let classifications = report["oracle_exclusions"]["by_classification"]
+        .as_array()
+        .expect("oracle_exclusions.by_classification should be an array");
+    let units = report["oracle_exclusions"]["units"]
+        .as_array()
+        .expect("oracle_exclusions.units should be an array");
+    let classified: u64 = classifications
+        .iter()
+        .map(|item| item["count"].as_u64().unwrap_or(0))
+        .sum();
+    assert_eq!(
+        classified,
+        units.len() as u64,
+        "classification rollups should cover every excluded unit: {report}"
+    );
+    assert!(
+        classifications
+            .iter()
+            .any(|item| item["exclusion_reason"] == "uninterpretable"
+                && item["classification"] == "semantic-boundary-attributed"
+                && item["oracle_excluded"].as_u64().unwrap_or(0) >= 5
+                && item["attributed_units"].as_u64().unwrap_or(0) >= 5
+                && item["unattributed_units"].as_u64().unwrap_or(0) == 0),
+        "expected semantic-boundary-attributed oracle exclusions: {report}"
+    );
+}

--- a/docs/recall-loss-diagnostics.md
+++ b/docs/recall-loss-diagnostics.md
@@ -44,7 +44,7 @@ The current schema is `recall_loss_report.v1.json`:
 | `soundness_gate` | Fingerprint groups, false merges, advisory disagreements, canon-preservation violations, `--max-violations`, and gate result. |
 | `completeness` | Behavior groups, behavior-equal pairs, fingerprint-equal pairs, completeness percentage, and under-merged groups. |
 | `oracle_under_merges` | Behavior-equal but fingerprint-split pairs, sorted by value-Jaccard nearness. This is the structured form of the `--leads` signal. |
-| `oracle_exclusions` | Fail-closed oracle exclusions by reason, optional obligation attribution, and unit location. |
+| `oracle_exclusions` | Fail-closed oracle exclusions by reason, classification, optional obligation attribution, and unit location. |
 | `import_snapshot_census` | Corpus-level imported immutable snapshot diagnostics: successful snapshot record counts, unresolved binding-import miss counts by reason/language, and stable hash/location rows for follow-up fixtures. |
 | `admission_rejections` | Interpretable units whose exact semantic claim is closed, with structured reason, gate, capability, missing evidence, #594 obligation family/subreason, oracle status, and stable location. |
 | `by_reason` | Rollups for admission rejections by reason/gate/capability. |
@@ -63,6 +63,24 @@ boundary. Excluded-unit attribution reuses the same `reason`,
 `missing_evidence`, `obligation_family`, and `obligation_subreason` vocabulary
 as admission rejections, but carries `oracle_status: "excluded"` and does not
 open exact admission.
+
+`oracle_exclusions.by_classification` is the #658 reportability layer for all
+excluded units. It keeps the older coarse `counts` rows stable, but splits each
+unit into an action-oriented class:
+
+| classification | meaning |
+|---|---|
+| `semantic-boundary-attributed` | The oracle could not interpret the unit, but diagnostics found a reusable semantic boundary or missing-proof obligation. Work should start from `by_obligation`, not from broad oracle support. |
+| `missing-oracle-support` | The unit is `uninterpretable` and lacks a semantic-boundary attribution. This is the residual broad oracle-support backlog. |
+| `path-exploration-budget` | The unit exceeded the symbolic branch exploration cap and remains fail-closed. |
+| `oracle-cost-budget` | The unit exceeded the oracle battery cost budget and remains fail-closed. |
+| `empty-value-fingerprint` | The unit has no value fingerprint to compare on the exact semantic channel. |
+| `core-span-missing` | The normalized unit could not be span-matched back to core IL for oracle interpretation. |
+
+Use `by_classification` for aggregate planning, and use `units[].attribution`
+when a specific excluded location needs its missing-proof details. Per-unit
+rows deliberately avoid repeating the classification string to keep large local
+reports cheap to write.
 
 | reason | meaning |
 |---|---|

--- a/docs/recall-loss-recovery-loop.md
+++ b/docs/recall-loss-recovery-loop.md
@@ -162,6 +162,17 @@ Checked-in summaries live under [bench/recall_loss](../bench/recall_loss/):
   Promise/Future labels remain readable. Promise-shaped producer, receiver, and
   continuation diagnostics are documented as missing-proof blockers, not
   selector-only feature support. Exact admission remains unchanged.
+- The [#658 oracle-exclusion classification artifact](../bench/recall_loss/issue-658-oracle-exclusion-classification-2026-07-02.v1.json)
+  closes the selected #663 guardrail track by making excluded units actionable
+  without opening exact admission. Local `crates` recall-loss reports now split
+  `6037` oracle-excluded units into `5447` `missing-oracle-support`, `583`
+  `semantic-boundary-attributed`, `5` `path-exploration-budget`, `1`
+  `oracle-cost-budget`, and `1` `empty-value-fingerprint` row. The top-level
+  coarse exclusion counts remain stable for compatibility, while
+  `oracle_exclusions.by_classification` distinguishes fail-closed semantic
+  boundaries from residual oracle-support backlog without repeating that label
+  on every unit row. The hard gate stays at `false_merges = 0` and
+  `canon_preservation_violations = 0`.
 - [Non-JS source-protocol reporting alignment](../bench/recall_loss/non-js-source-protocol-reporting-alignment-2026-07-02.v1.json) records the audit closeout for already-backed async source-protocol rows.
   Python `await`/`async def`, Rust `.await`/`async fn`/`async block`, and Swift
   `async` function rows now move to reporting-supported closed-boundaries,

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2359,6 +2359,9 @@ The [#654 capability audit artifact](../bench/recall_loss/issue-654-semantic-ker
 2026-07-02 #656 obligation-label cleanup note:
 The [#656 cleanup artifact](../bench/recall_loss/issue-656-obligation-label-docs-cleanup-2026-07-02.v1.json) applies the #654 decisions as documentation, not behavior. It makes `async-await-scheduling-contract`, `async-function-scheduling-contract`, and `async-block-scheduling-contract` the canonical wording for shared protocol boundaries in new docs, preserves old Promise/Future labels for historical artifact readability, and groups Promise producer/receiver/continuation labels under their capability blockers. It records `semantic_admission_delta = 0`, `public_api_expansion = 0`, and `historical_artifacts_rewritten = 0`.
 
+2026-07-02 #658 oracle-exclusion classification note:
+The [#658 classification artifact](../bench/recall_loss/issue-658-oracle-exclusion-classification-2026-07-02.v1.json) adds an action-oriented report layer for fail-closed oracle exclusions. `oracle_exclusions.by_classification` splits coarse reason counts into reusable semantic-boundary attribution versus residual missing oracle support, path budget, oracle cost budget, empty fingerprint, and core-span failures. The current local `crates` report classifies all `6037` excluded units, with `583` semantic-boundary-attributed exclusions already tied to existing obligation vocabulary and `5447` residual missing-oracle-support units kept visible as the next oracle backlog. This is reporting-only: exact admission, public APIs, and the soundness gate remain unchanged.
+
 2026-06-30 Go channel protocol obligation note:
 The [scheduling-lifecycle-boundary-audit-go-channel-protocol-2026-06-30.v1.json](../bench/recall_loss/scheduling-lifecycle-boundary-audit-go-channel-protocol-2026-06-30.v1.json)
 artifact keeps exact admission closed while refining Go protocol-boundary

--- a/scripts/recall-loss-diff.py
+++ b/scripts/recall-loss-diff.py
@@ -11,6 +11,7 @@ from typing import Any
 
 
 Metric = tuple[str, str, str]
+OracleExclusionClassificationKey = tuple[str, str]
 OracleExclusionObligationKey = tuple[str, str, str, str]
 
 METRICS: list[Metric] = [
@@ -77,6 +78,20 @@ def oracle_exclusion_obligation_counts(
     return counts
 
 
+def oracle_exclusion_classification_counts(
+    report: dict[str, Any],
+) -> dict[OracleExclusionClassificationKey, int]:
+    counts: dict[OracleExclusionClassificationKey, int] = {}
+    for row in report.get("oracle_exclusions", {}).get("by_classification", []):
+        key = (
+            str(row.get("exclusion_reason", "unknown")),
+            str(row.get("classification", "unknown")),
+        )
+        count = row.get("count", row.get("oracle_excluded", 0))
+        counts[key] = counts.get(key, 0) + int(count)
+    return counts
+
+
 def delta_rows(before: dict[str, int], after: dict[str, int]) -> list[dict[str, Any]]:
     rows = [
         {
@@ -88,6 +103,30 @@ def delta_rows(before: dict[str, int], after: dict[str, int]) -> list[dict[str, 
         for key in sorted(set(before) | set(after))
     ]
     rows.sort(key=lambda row: (-abs(row["delta"]), row["key"]))
+    return rows
+
+
+def oracle_exclusion_classification_delta_rows(
+    before: dict[OracleExclusionClassificationKey, int],
+    after: dict[OracleExclusionClassificationKey, int],
+) -> list[dict[str, Any]]:
+    rows = [
+        {
+            "exclusion_reason": key[0],
+            "classification": key[1],
+            "before": before.get(key, 0),
+            "after": after.get(key, 0),
+            "delta": after.get(key, 0) - before.get(key, 0),
+        }
+        for key in sorted(set(before) | set(after))
+    ]
+    rows.sort(
+        key=lambda row: (
+            -abs(row["delta"]),
+            row["exclusion_reason"],
+            row["classification"],
+        )
+    )
     return rows
 
 
@@ -187,6 +226,10 @@ def build_diff(
         "oracle_exclusion_deltas": delta_rows(
             exclusion_counts(before), exclusion_counts(after)
         ),
+        "oracle_exclusion_classification_deltas": oracle_exclusion_classification_delta_rows(
+            oracle_exclusion_classification_counts(before),
+            oracle_exclusion_classification_counts(after),
+        ),
         "oracle_exclusion_obligation_deltas": oracle_exclusion_obligation_delta_rows(
             oracle_exclusion_obligation_counts(before),
             oracle_exclusion_obligation_counts(after),
@@ -228,6 +271,17 @@ def render_markdown(diff: dict[str, Any]) -> str:
     exclusion_rows = [
         [row["key"], str(row["before"]), str(row["after"]), str(row["delta"])]
         for row in diff["oracle_exclusion_deltas"]
+        if row["before"] or row["after"]
+    ]
+    exclusion_classification_rows = [
+        [
+            row["exclusion_reason"],
+            row["classification"],
+            str(row["before"]),
+            str(row["after"]),
+            str(row["delta"]),
+        ]
+        for row in diff["oracle_exclusion_classification_deltas"]
         if row["before"] or row["after"]
     ]
     exclusion_obligation_rows = [
@@ -272,6 +326,12 @@ def render_markdown(diff: dict[str, Any]) -> str:
         "",
         "### Oracle exclusions by reason",
         markdown_table(["reason", "before", "after", "delta"], exclusion_rows),
+        "",
+        "### Oracle exclusions by classification",
+        markdown_table(
+            ["exclusion_reason", "classification", "before", "after", "delta"],
+            exclusion_classification_rows,
+        ),
         "",
         "### Oracle exclusions by obligation",
         markdown_table(
@@ -318,6 +378,14 @@ def sample_report() -> dict[str, Any]:
                 {"reason": "uninterpretable", "count": 2},
                 {"reason": "path-bail", "count": 0},
             ],
+            "by_classification": [
+                {
+                    "exclusion_reason": "uninterpretable",
+                    "classification": "missing-oracle-support",
+                    "count": 2,
+                    "oracle_excluded": 2,
+                }
+            ],
             "by_obligation": [],
         },
         "by_reason": [
@@ -358,6 +426,20 @@ def self_test() -> None:
             "oracle_excluded": 1,
         }
     ]
+    after["oracle_exclusions"]["by_classification"] = [
+        {
+            "exclusion_reason": "uninterpretable",
+            "classification": "missing-oracle-support",
+            "count": 1,
+            "oracle_excluded": 1,
+        },
+        {
+            "exclusion_reason": "path-bail",
+            "classification": "path-exploration-budget",
+            "count": 1,
+            "oracle_excluded": 1,
+        },
+    ]
     after["top_opportunities"] = [
         {
             "reason": "b:receiver-domain-proof-missing",
@@ -376,6 +458,11 @@ def self_test() -> None:
     assert by_reason["receiver-domain-proof-missing"]["delta"] == 2
     by_exclusion = {row["key"]: row for row in diff["oracle_exclusion_deltas"]}
     assert by_exclusion["path-bail"]["delta"] == 1
+    by_exclusion_classification = {
+        row["classification"]: row
+        for row in diff["oracle_exclusion_classification_deltas"]
+    }
+    assert by_exclusion_classification["path-exploration-budget"]["delta"] == 1
     by_exclusion_obligation = {
         row["obligation_subreason"]: row
         for row in diff["oracle_exclusion_obligation_deltas"]
@@ -387,6 +474,7 @@ def self_test() -> None:
     assert diff["top_opportunity_changes"]["added"][0]["a"] == "c.py:5:6"
     markdown = render_markdown(diff)
     assert "strict-exact-unsafe" in markdown
+    assert "path-exploration-budget" in markdown
     assert "async-await-scheduling-contract-missing" in markdown
     assert "| completeness_percent | 50.00 | 75.00 | 25.00 |" in markdown
 


### PR DESCRIPTION
## Summary

Closes #658.

Adds an additive `oracle_exclusions.by_classification` rollup to local recall-loss reports. The existing coarse `oracle_exclusions.counts`, `oracle_exclusions.by_obligation`, and per-unit attribution rows remain compatible; the new rollup makes excluded units actionable without repeating classification strings on every unit row.

Classification buckets:

- `semantic-boundary-attributed`
- `missing-oracle-support`
- `path-exploration-budget`
- `oracle-cost-budget`
- `empty-value-fingerprint`
- `core-span-missing`

This is reporting-only: no exact admission path, semantic-pack API, or public kernel API is opened.

## Quantification

Final local `crates` recall-loss report:

- total units: `7011`
- interpretable units: `974`
- excluded units: `6037`
- broad `uninterpretable`: `6030`
- newly classified exclusions: `6037 / 6037` (`100%`)
- `semantic-boundary-attributed`: `583`
- residual `missing-oracle-support`: `5447`
- `path-exploration-budget`: `5`
- `oracle-cost-budget`: `1`
- `empty-value-fingerprint`: `1`
- `false_merges = 0`
- `canon_preservation_violations = 0`

Behavioral deltas against `origin/main` are zero for interpretable units, excluded units, admission rejections, oracle exclusion reason counts, oracle-exclusion obligation rows, under-merged behavior groups, and completeness percent.

## Performance

Measured release `nose verify crates --max-violations 0 --recall-loss-report ...` with both execution orders to reduce order bias:

- 16-run median: `1.455s -> 1.460s` (`+0.34%`)
- 16-run mean: `1.40687s -> 1.41563s` (`+0.62%`)
- report size: `2,623,808 -> 2,624,998` bytes (`+0.05%`)

The implementation derives classification from existing exclusion counters and `by_obligation`, avoiding an additional exclusion-unit pass.

## Validation

- `cargo fmt --check`
- `python3 scripts/recall-loss-diff.py --self-test`
- `cargo test -q -p nose-cli recall_loss_report --test cli`
- `cargo test -q -p nose-cli recall_loss_report_classifies_oracle_exclusions_by_actionable_bucket --test cli`
- `cargo run -q -p nose-cli -- verify crates --max-violations 0 --recall-loss-report target/recall-loss.issue-658.after.crates.json`
- `scripts/check-docs.sh`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `scripts/check-duplication.sh`
- `git diff --check`
- checked artifact invariant via `jq -e`

## Reviews

Pre-commit reviews:

- Laplace the 2nd: no findings
- Nietzsche the 2nd: no findings
