### PR TITLE
Add final divergent replay artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ break.
   page now record the current builtin lane state, row-level coverage refs,
   promotion-candidate decision, rollback requirements, and external
   metadata-only policy.
+- Added checked divergent-edit v2 final closeout artifacts for the clean
+  `a38ecb8b` replay summary and policy reproduction, and extended
+  `eval/divergence_fire/replay.py check-artifacts` to validate that final
+  replay evidence instead of relying only on `/tmp` scratch summaries.
 - Added the #677 Rust `block_on` residual closeout: the async scheduling
   hard-negative suite now covers nested runtime drive, wrapper-returned
   `Runtime` values, and constructor-assigned runtime fields, with a checked

--- a/eval/divergence_fire/RESULTS.md
+++ b/eval/divergence_fire/RESULTS.md
@@ -113,8 +113,13 @@ the replay checks the no-runtime-regression constraint.
 
 The #675 closeout replay reran the same 28-repo, 560-record replay after the
 v2 strict gate, bounded `new-copy` lane, SARIF/output polish, and docs updates.
-It completed with 0 errors. Scratch raw records are intentionally not checked in
-because they contain source excerpts; the closeout summary and policy commands were:
+It completed with 0 errors. The durable closeout summary is
+[`replay_summary_final_head_a38ecb8b_2026_07_06.json`](replay_summary_final_head_a38ecb8b_2026_07_06.json),
+and the final policy reproduction is
+[`policy_eval_final_head_a38ecb8b_2026_07_06.json`](policy_eval_final_head_a38ecb8b_2026_07_06.json).
+Scratch raw records are intentionally not checked in because they contain source
+excerpts; the closeout summary records the raw path and sha. The closeout
+commands were:
 
 ```sh
 cargo build --release -p nose-cli

--- a/eval/divergence_fire/policy_eval_final_head_a38ecb8b_2026_07_06.json
+++ b/eval/divergence_fire/policy_eval_final_head_a38ecb8b_2026_07_06.json
@@ -1,0 +1,3107 @@
+{
+  "schema_version": 2,
+  "method": "policy simulation from sampled findings joined to verdict labels by stable finding identity, with sid fallback for legacy verdict drafts",
+  "labeled": 179,
+  "positives": 49,
+  "finding_level": [
+    {
+      "policy": "any sampled finding",
+      "fires": 179,
+      "tp": 49,
+      "fp": 130,
+      "precision": 0.274
+    },
+    {
+      "policy": "touches-shared (line)",
+      "fires": 115,
+      "tp": 46,
+      "fp": 69,
+      "precision": 0.4
+    },
+    {
+      "policy": "exact-witness only",
+      "fires": 3,
+      "tp": 2,
+      "fp": 1,
+      "precision": 0.667
+    },
+    {
+      "policy": "line OR exact-witness",
+      "fires": 115,
+      "tp": 46,
+      "fp": 69,
+      "precision": 0.4
+    },
+    {
+      "policy": "V1 conservative: (line OR exact-witness) AND scope!=test",
+      "fires": 94,
+      "tp": 45,
+      "fp": 49,
+      "precision": 0.479
+    },
+    {
+      "policy": "serialized fire_eligible",
+      "fires": 94,
+      "tp": 45,
+      "fp": 49,
+      "precision": 0.479
+    },
+    {
+      "policy": "V2 strict: tier=strict",
+      "fires": 80,
+      "tp": 45,
+      "fp": 35,
+      "precision": 0.562
+    }
+  ],
+  "rows": [
+    {
+      "sid": "rv2-161",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "default",
+        1,
+        "3af19e8c03a61614"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-175",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "guava",
+        "2993b8f7e5b7e10e15e732aba4e3a3f12f5db555",
+        "near",
+        1,
+        "4c67f4fe9a76d1af"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-186",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "scrapy",
+        "180ca39b230590a2a2862c8d18c574661b1d16ad",
+        "near",
+        1,
+        "81fbe4bda0d48513"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-193",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 1,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        1,
+        "b3ae65fc72ba3fbe"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-199",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "default",
+        2,
+        "e8c9fdc458f16229"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-202",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "scrapy",
+        "180ca39b230590a2a2862c8d18c574661b1d16ad",
+        "default",
+        2,
+        "81fbe4bda0d48513"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-207",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 1,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        1,
+        "b3ae65fc72ba3fbe"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-218",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        1,
+        "3af19e8c03a61614"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-225",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "default",
+        2,
+        "2b76f1567078cd34"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-228",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "date-fns",
+        "99bd2e773962f5c574684e9685abaef102b7409b",
+        "default",
+        1,
+        "9909bf6de30ed915"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-231",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "prometheus",
+        "551b5b1c565215536b46a648300d53acf968ea61",
+        "default",
+        2,
+        "0f0187d5838e086a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-233",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "default",
+        3,
+        "1537a49a7ba64705"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-241",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "date-fns",
+        "99bd2e773962f5c574684e9685abaef102b7409b",
+        "near",
+        1,
+        "9909bf6de30ed915"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-242",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "mixed",
+      "rank": 1,
+      "identity": [
+        "execa",
+        "507b09c841e3a55569681023d74d46ff7580668b",
+        "near",
+        1,
+        "8023b2c5a20b31fc"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-247",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "mixed",
+      "rank": 1,
+      "identity": [
+        "netty",
+        "9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d",
+        "near",
+        1,
+        "94a3b3c35babbd08"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-249",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "redis",
+        "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+        "near",
+        1,
+        "51193811c8f4c18e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-250",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        2,
+        "e8c9fdc458f16229"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-255",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "default",
+        3,
+        "35cc025093a95365"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-262",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 4,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "default",
+        4,
+        "6399b89bb6c8d4e1"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-265",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        3,
+        "2b76f1567078cd34"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-266",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "clap",
+        "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+        "near",
+        1,
+        "6d3463a8de185758"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-273",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "netty",
+        "9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d",
+        "near",
+        2,
+        "55494f8814975a1e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-274",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 1,
+      "identity": [
+        "prometheus",
+        "129ee0d31786ae020bcadc5535f2889a6fd6924d",
+        "near",
+        1,
+        "0444fc9cfda8811d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-276",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        3,
+        "1537a49a7ba64705"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-280",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "tokio",
+        "ad8c59add6a1988d8c327fb3358beeeae3bbb5cd",
+        "near",
+        3,
+        "764464c902d6b50c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-283",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 2,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        2,
+        "63af31f2d21a125c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-289",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 4,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        4,
+        "35cc025093a95365"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-292",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 2,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        2,
+        "63af31f2d21a125c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-298",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 4,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        4,
+        "6399b89bb6c8d4e1"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-303",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 5,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "default",
+        5,
+        "646f5dd927c55426"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-310",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 5,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        5,
+        "351d82017160c1af"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-312",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "date-fns",
+        "99bd2e773962f5c574684e9685abaef102b7409b",
+        "near",
+        2,
+        "f4d52786fb21aa6b"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-316",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "prometheus",
+        "551b5b1c565215536b46a648300d53acf968ea61",
+        "near",
+        2,
+        "0f0187d5838e086a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-318",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 5,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        5,
+        "d9f01ddbce44379a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-321",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 3,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        3,
+        "fa2baaf41db30f36"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-328",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "date-fns",
+        "219d02ebff00a53dc332dcdb73407f0b81ad7e5d",
+        "near",
+        3,
+        "ebd2a82f4dce10bc"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-332",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 6,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        6,
+        "7dc93c7618d585d9"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-335",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 4,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        4,
+        "d1f500db47a3b62c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-340",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 7,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        7,
+        "646f5dd927c55426"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-341",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 3,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        3,
+        "fa2baaf41db30f36"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-345",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 7,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        7,
+        "83f914705c219bfc"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-348",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 5,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        5,
+        "385b993f8dfe1446"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-353",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 8,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        8,
+        "5da9e6aab2696a17"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-358",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 8,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        8,
+        "38522f3ac2e01d1c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-362",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "gson",
+        "9471163df1f972975878784d9fd3c646c8d0b840",
+        "default",
+        2,
+        "fef570c239a70b07"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-366",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 4,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        4,
+        "d1f500db47a3b62c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-374",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 5,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        5,
+        "385b993f8dfe1446"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-375",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "gson",
+        "9471163df1f972975878784d9fd3c646c8d0b840",
+        "near",
+        2,
+        "fef570c239a70b07"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-399",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "rxjava",
+        "939b5ce0bb17dfd1660a5750abe46b9be473d8eb",
+        "near",
+        2,
+        "76e7cb0c4da9a25d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-406",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 2,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "near",
+        2,
+        "26414e2521981e40"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-409",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "rxjava",
+        "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+        "default",
+        3,
+        "4e6164edcf389091"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-414",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "default",
+        3,
+        "26414e2521981e40"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-426",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 3,
+      "identity": [
+        "rxjava",
+        "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+        "near",
+        3,
+        "4e6164edcf389091"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-438",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 4,
+      "identity": [
+        "rxjava",
+        "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+        "near",
+        4,
+        "f1ed7fabaae184de"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-444",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 8,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "default",
+        8,
+        "9fbd1134afd80126"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-448",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 9,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "default",
+        9,
+        "d98080227c3e13f7"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-465",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 7,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "near",
+        7,
+        "9fbd1134afd80126"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-471",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 8,
+      "identity": [
+        "rxjava",
+        "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+        "near",
+        8,
+        "d98080227c3e13f7"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2-477",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 10,
+      "identity": [
+        "rxjava",
+        "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+        "near",
+        10,
+        "b1cd5c8e4b59707a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-000",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "38ba1b3d2b0aa5ada0463a37a548feb83a84dfa1",
+        "default",
+        0,
+        "6d55b9d43d50c9d8"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-001",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 0,
+      "identity": [
+        "black",
+        "f705197f57149b79ed83cccf22e4fed19b48a7bf",
+        "default",
+        0,
+        "e2aa061e88d579ec"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-002",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "clap",
+        "6671d9350027a9fb5cfca44304603d0d32f5e30a",
+        "default",
+        0,
+        "f77cd3a808fa30b0"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-003",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "cobra",
+        "02a0d2fbc9e61d26f8e5979749f6030964a55a3e",
+        "default",
+        0,
+        "f95dc2639b8ed55e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-004",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "curl",
+        "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+        "default",
+        0,
+        "0881a9f140b6c5ae"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-005",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "date-fns",
+        "219d02ebff00a53dc332dcdb73407f0b81ad7e5d",
+        "default",
+        0,
+        "e1055d67519b267d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-006",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "devise",
+        "7d1dc56fdba2402c452c4224567077b23184637e",
+        "default",
+        0,
+        "444d4d05e9d72412"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-007",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "execa",
+        "507b09c841e3a55569681023d74d46ff7580668b",
+        "default",
+        0,
+        "5923505cb090dc39"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-008",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "git",
+        "341be27dfef8aba66f10be58aec1395075081e85",
+        "default",
+        0,
+        "8f665eb5ed8fed5d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-009",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "gson",
+        "19f54ee6ed33b7517c729c801bc57c8c0478be7d",
+        "default",
+        0,
+        "7acf774a8f6f17b1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-010",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 0,
+      "identity": [
+        "guava",
+        "2b6b902d4ebefa14e18521a6b9ac772c9ab1e136",
+        "default",
+        0,
+        "f54c34ae2d4cc45a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-011",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "hugo",
+        "3c823408ee51bbfbad847d4b9f926ba813097185",
+        "default",
+        0,
+        "7cfde85affab5b30"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-012",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "jest",
+        "7a1588e41bfaff92742865c716776cead0d62e86",
+        "default",
+        0,
+        "a2dfd7316219374a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-013",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "minio",
+        "2c7fe094d11b023623f18b2a04cb1675587c3de6",
+        "default",
+        0,
+        "4c411ea8a84677e4"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-014",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 0,
+      "identity": [
+        "netty",
+        "66568d1ab8bcd34d4b2d48636e69bf6c0d773034",
+        "default",
+        0,
+        "cfb62e54f8c090be"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-015",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "prettier",
+        "8d63dddaaa63f000c5c26d125ef84157f7c7bf18",
+        "default",
+        0,
+        "ab730258cbd4f24a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-016",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prometheus",
+        "129ee0d31786ae020bcadc5535f2889a6fd6924d",
+        "default",
+        0,
+        "7b4a35232f868c45"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-017",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "redis",
+        "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+        "default",
+        0,
+        "9fea3c9dfa97af89"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-018",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "regex",
+        "930770bb8b4811b80a9cfbd0237d1f225e7c7c20",
+        "default",
+        0,
+        "bafb63371b1ac831"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-019",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "exact-value-graph",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "requests",
+        "e976ea839b55e07f01a962c5bb38bedb543a2df7",
+        "default",
+        0,
+        "90204190d02da592"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-020",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rubocop",
+        "810c790a68123a8c4aae6607bfa792e9d9275585",
+        "default",
+        0,
+        "7826a084cf5b0114"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-021",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjava",
+        "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+        "default",
+        0,
+        "176e35e3b383d94a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-022",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjs",
+        "414a692db7744d9ec2e3d8ac14536fd48d65dc14",
+        "default",
+        0,
+        "c00c1b2224f30ec5"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-023",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "scrapy",
+        "09bd8f42318bbd413e16d43900f4f27bdfa50962",
+        "default",
+        0,
+        "02fc231661f34cd2"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-024",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "sidekiq",
+        "54ad22363358c47b3cfc5eef56ce632914360832",
+        "default",
+        0,
+        "967e344a57dadfeb"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-025",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "sympy",
+        "1fdc9112629e0da6945e2dca6c62c7c299901561",
+        "default",
+        0,
+        "00426d1c6220ef19"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-026",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "tokio",
+        "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+        "default",
+        0,
+        "a934c7e8e07e1ed4"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-027",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "38ba1b3d2b0aa5ada0463a37a548feb83a84dfa1",
+        "near",
+        0,
+        "6d55b9d43d50c9d8"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-028",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 0,
+      "identity": [
+        "black",
+        "f705197f57149b79ed83cccf22e4fed19b48a7bf",
+        "near",
+        0,
+        "e2aa061e88d579ec"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-029",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "clap",
+        "6671d9350027a9fb5cfca44304603d0d32f5e30a",
+        "near",
+        0,
+        "f77cd3a808fa30b0"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-030",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "cobra",
+        "02a0d2fbc9e61d26f8e5979749f6030964a55a3e",
+        "near",
+        0,
+        "f95dc2639b8ed55e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-031",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "curl",
+        "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+        "near",
+        0,
+        "0881a9f140b6c5ae"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-032",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "date-fns",
+        "219d02ebff00a53dc332dcdb73407f0b81ad7e5d",
+        "near",
+        0,
+        "e1055d67519b267d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-033",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "devise",
+        "7d1dc56fdba2402c452c4224567077b23184637e",
+        "near",
+        0,
+        "fd02b483fd96d3d7"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-034",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "execa",
+        "507b09c841e3a55569681023d74d46ff7580668b",
+        "near",
+        0,
+        "5923505cb090dc39"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-035",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "git",
+        "0d5b240d73ffe8b66fe22dbe166329f1b27b5fe7",
+        "near",
+        0,
+        "78c036fc8eafb21c"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-036",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "gson",
+        "19f54ee6ed33b7517c729c801bc57c8c0478be7d",
+        "near",
+        0,
+        "7acf774a8f6f17b1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-037",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "guava",
+        "2993b8f7e5b7e10e15e732aba4e3a3f12f5db555",
+        "near",
+        0,
+        "8bde2cb6be45e98c"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-038",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "hugo",
+        "3c823408ee51bbfbad847d4b9f926ba813097185",
+        "near",
+        0,
+        "7cfde85affab5b30"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-039",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "jest",
+        "357edffef532d383da10e30d001ff0105361e6d8",
+        "near",
+        0,
+        "74c4e5df47326ae9"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-040",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "minio",
+        "02ba581ecf8414788804009ea554478f97657f55",
+        "near",
+        0,
+        "b2eb2875c88b8945"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-041",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "netty",
+        "596be74de29fa87ba4c5a94c18e9bc8684ad4fee",
+        "near",
+        0,
+        "8dc8e481ce2c5c25"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-042",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prettier",
+        "599bad14158a7815430662f96ecdd6d2e1f0fe54",
+        "near",
+        0,
+        "7e11d92206724dca"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-043",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prometheus",
+        "129ee0d31786ae020bcadc5535f2889a6fd6924d",
+        "near",
+        0,
+        "57a797104d814ef9"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-044",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "redis",
+        "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+        "near",
+        0,
+        "9fea3c9dfa97af89"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-045",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "regex",
+        "930770bb8b4811b80a9cfbd0237d1f225e7c7c20",
+        "near",
+        0,
+        "bafb63371b1ac831"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-046",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "exact-value-graph",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "requests",
+        "e976ea839b55e07f01a962c5bb38bedb543a2df7",
+        "near",
+        0,
+        "90204190d02da592"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-047",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rubocop",
+        "0db1c8ccf936f1df726a530c9084035504d990d5",
+        "near",
+        0,
+        "9c267e7df2ff7cd9"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-048",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjava",
+        "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+        "near",
+        0,
+        "176e35e3b383d94a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-049",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjs",
+        "414a692db7744d9ec2e3d8ac14536fd48d65dc14",
+        "near",
+        0,
+        "c00c1b2224f30ec5"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-050",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "scrapy",
+        "09bd8f42318bbd413e16d43900f4f27bdfa50962",
+        "near",
+        0,
+        "02fc231661f34cd2"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-051",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "sidekiq",
+        "54ad22363358c47b3cfc5eef56ce632914360832",
+        "near",
+        0,
+        "967e344a57dadfeb"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-052",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "sympy",
+        "0bb3c7521ac3482f334d6053bfc5bf85d6cbb1d9",
+        "near",
+        0,
+        "c60b70d2f2d57c8c"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-053",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "tokio",
+        "25a24de0e661d86fa059779e87e0605909465f4a",
+        "near",
+        0,
+        "e436520bac1048d6"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-054",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "63e12ecb4f27c55b4cd0ca4a1fef9e85b03ebe15",
+        "default",
+        0,
+        "8b3aac7554b962b8"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-055",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "clap",
+        "93e050b0b787e102bc1a6defdc32331d13940699",
+        "default",
+        0,
+        "394dddbdb4df8fa1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-056",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "cobra",
+        "3fed3ef5adf9fa1cfff46b6860850828d6c60154",
+        "default",
+        0,
+        "29f8477180e87aff"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-057",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "curl",
+        "c2ca16f3ff2ad8300e67ea5a3cc4060738473e45",
+        "default",
+        0,
+        "10d0f21c246ed350"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-058",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "default",
+        0,
+        "e702046b12e9e62f"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-059",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "execa",
+        "5abc429233bd8ed71a2dd992a60fa11a74653554",
+        "default",
+        0,
+        "114a0205a92a136a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-060",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "git",
+        "7b7d67104e315437c46e62986e163c97c5a51dd3",
+        "default",
+        0,
+        "047fa46bc1125932"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-061",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "gson",
+        "335ff0f9ae2ed71714a937513d4e6aba1d4318a4",
+        "default",
+        0,
+        "0bf7e955b03667a4"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-062",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "guava",
+        "b2975e90b6552943a8d31cf965b52a4c73c5b69c",
+        "default",
+        0,
+        "72fe9586b829e2b3"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-063",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "hugo",
+        "991d2f9aba69a5b79bb46c40faf57c7b6d7adcc9",
+        "default",
+        0,
+        "9de9f9878bb31eb0"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-064",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "jest",
+        "a2218e4f794f914884c403ecceb274ada595f2b9",
+        "default",
+        0,
+        "2ced35c726e98309"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-065",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "minio",
+        "398ffb1136a46639eb220a1cd33707fb3420cb65",
+        "default",
+        0,
+        "df41b0bc4624cd19"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-066",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "netty",
+        "9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d",
+        "default",
+        0,
+        "55494f8814975a1e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-067",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prometheus",
+        "551b5b1c565215536b46a648300d53acf968ea61",
+        "default",
+        0,
+        "ed30e15aedd79c0e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-068",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "redis",
+        "5ee05d8de489fadb30a75f46c8e931888d6c5401",
+        "default",
+        0,
+        "2c70801cd6494a7b"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-069",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "default",
+        0,
+        "3ac5bcfe7df738a8"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-070",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjava",
+        "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+        "default",
+        0,
+        "7f52f8c386f9e1b1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-071",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjs",
+        "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+        "default",
+        0,
+        "e2b0ee1f8eb91c42"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-072",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "exact-value-graph",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "scrapy",
+        "180ca39b230590a2a2862c8d18c574661b1d16ad",
+        "default",
+        0,
+        "23233f89a12b1f24"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-073",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "sidekiq",
+        "6545e2a3a615d3cfe0ff7fa5dd2c3ecc4ef8275e",
+        "default",
+        0,
+        "cd0f5df5ccbb10bc"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-074",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "sympy",
+        "39e29cd3ec2358e6c97b1ea275ba6df3460c0bf1",
+        "default",
+        0,
+        "48cda45e1998896d"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-075",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "tokio",
+        "ad8c59add6a1988d8c327fb3358beeeae3bbb5cd",
+        "default",
+        0,
+        "d39cd9c2b993ab26"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-076",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "63e12ecb4f27c55b4cd0ca4a1fef9e85b03ebe15",
+        "near",
+        0,
+        "8b3aac7554b962b8"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-077",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "clap",
+        "93e050b0b787e102bc1a6defdc32331d13940699",
+        "near",
+        0,
+        "394dddbdb4df8fa1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-078",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "cobra",
+        "3fed3ef5adf9fa1cfff46b6860850828d6c60154",
+        "near",
+        0,
+        "29f8477180e87aff"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-079",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "shared-sub-dag",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "curl",
+        "c2ca16f3ff2ad8300e67ea5a3cc4060738473e45",
+        "near",
+        0,
+        "74fa4c94cf13dca6"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-080",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "date-fns",
+        "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+        "near",
+        0,
+        "e702046b12e9e62f"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-081",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "execa",
+        "5abc429233bd8ed71a2dd992a60fa11a74653554",
+        "near",
+        0,
+        "b3d89f92967a8151"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-082",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "git",
+        "341be27dfef8aba66f10be58aec1395075081e85",
+        "near",
+        0,
+        "8f665eb5ed8fed5d"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-083",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "gson",
+        "335ff0f9ae2ed71714a937513d4e6aba1d4318a4",
+        "near",
+        0,
+        "0bf7e955b03667a4"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-084",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "guava",
+        "2b6b902d4ebefa14e18521a6b9ac772c9ab1e136",
+        "near",
+        0,
+        "0244410cb771fb3c"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-085",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "hugo",
+        "991d2f9aba69a5b79bb46c40faf57c7b6d7adcc9",
+        "near",
+        0,
+        "9de9f9878bb31eb0"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-086",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "jest",
+        "7a1588e41bfaff92742865c716776cead0d62e86",
+        "near",
+        0,
+        "a2dfd7316219374a"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-087",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "minio",
+        "2c7fe094d11b023623f18b2a04cb1675587c3de6",
+        "near",
+        0,
+        "4c411ea8a84677e4"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-088",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "mixed",
+      "rank": 0,
+      "identity": [
+        "netty",
+        "66568d1ab8bcd34d4b2d48636e69bf6c0d773034",
+        "near",
+        0,
+        "cfb62e54f8c090be"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-089",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "prettier",
+        "8d63dddaaa63f000c5c26d125ef84157f7c7bf18",
+        "near",
+        0,
+        "ab730258cbd4f24a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-090",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prometheus",
+        "551b5b1c565215536b46a648300d53acf968ea61",
+        "near",
+        0,
+        "ed30e15aedd79c0e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-091",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "redis",
+        "5ee05d8de489fadb30a75f46c8e931888d6c5401",
+        "near",
+        0,
+        "2c70801cd6494a7b"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-092",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "regex",
+        "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+        "near",
+        0,
+        "3ac5bcfe7df738a8"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-093",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "structural-similarity",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "rubocop",
+        "2544a9e28309436db5c708931ebb39e6f0fa4dea",
+        "near",
+        0,
+        "03251b05f55b70bd"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-094",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjava",
+        "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+        "near",
+        0,
+        "7f52f8c386f9e1b1"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-095",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjs",
+        "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+        "near",
+        0,
+        "e2b0ee1f8eb91c42"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-096",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "scrapy",
+        "180ca39b230590a2a2862c8d18c574661b1d16ad",
+        "near",
+        0,
+        "bd070a6a94ac9986"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-097",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "structural-similarity",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "sidekiq",
+        "589a409b74b1ae2f4194a95613962de1b706d9a0",
+        "near",
+        0,
+        "9942caad471e7961"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-098",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "sympy",
+        "1fdc9112629e0da6945e2dca6c62c7c299901561",
+        "near",
+        0,
+        "00426d1c6220ef19"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-099",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "tokio",
+        "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+        "near",
+        0,
+        "a934c7e8e07e1ed4"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-100",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "default",
+        0,
+        "f4d34596275dc2a1"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-101",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "clap",
+        "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+        "default",
+        0,
+        "6d3463a8de185758"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-102",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "cobra",
+        "5b11656e45a6a6579298a3b28c71f456ff196ad6",
+        "default",
+        0,
+        "bf4ba04fb58e73c9"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-103",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "date-fns",
+        "99bd2e773962f5c574684e9685abaef102b7409b",
+        "default",
+        0,
+        "91b3cabcb9f7d9b9"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-104",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "execa",
+        "663136bff6d10ec3a815bd9164b637bf8b84aac4",
+        "default",
+        0,
+        "43167911032f4202"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-105",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "git",
+        "c563b12ce7aa6bf8130385c80c001b2340026ff5",
+        "default",
+        0,
+        "e68b6b2c8b7fd55a"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-106",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "gson",
+        "3d241ca0a6435cbf1fa1cdaed2af8480b99fecde",
+        "default",
+        0,
+        "054831e18eacc760"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-107",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "hugo",
+        "dc9b51d2e2fa1bfc2b7c68c01417bb7ae2c9c6a2",
+        "default",
+        0,
+        "b3b67ea6a571f471"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-108",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "jest",
+        "b36d6edf1343059a1cab13920cfbcb7afe2b075e",
+        "default",
+        0,
+        "af6d9e104d44f5c5"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-109",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "minio",
+        "402b798f1b794741663aad8061b9f74832379f9d",
+        "default",
+        0,
+        "3a6965e1a2de44d3"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-110",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "netty",
+        "fb4cd81d13a0d0e3003110d3bca5628297fdde81",
+        "default",
+        0,
+        "9ddbb33cf25d20d3"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-111",
+      "pos": false,
+      "verdict": "no_propagation_needed",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "prometheus",
+        "b2e63376da7487c32ae4e2ec45434b0f4d8adb12",
+        "default",
+        0,
+        "6cf51cc5fe89fc58"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-112",
+      "pos": false,
+      "verdict": "not_a_clone",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "redis",
+        "8da9c04bb8dae11a2ccea5b5017f529f2f809b9e",
+        "default",
+        0,
+        "b79cd1255dc83337"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-113",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "regex",
+        "f5b8cb4d52ca0fa01a9c4e8e70bcd3e4b6673368",
+        "default",
+        0,
+        "073d581029d5429e"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-114",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "rxjava",
+        "338f2a11350480cef409f64eff4a2d307be7e05a",
+        "default",
+        0,
+        "fa3436db13a37201"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-115",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "rxjs",
+        "c408acda16d654682596822c118c31a814dae5c9",
+        "default",
+        0,
+        "c7b700bc437bd80d"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-116",
+      "pos": false,
+      "verdict": "intentional_divergence",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "scrapy",
+        "2b174e348d88d19dd32135e8e483c4eb784aeca8",
+        "default",
+        0,
+        "f257ddbbffdb009c"
+      ],
+      "fire_eligible": true
+    },
+    {
+      "sid": "rv2t1-117",
+      "pos": false,
+      "verdict": "test_scaffolding",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "test",
+      "rank": 0,
+      "identity": [
+        "sidekiq",
+        "b7e116c5fa8e5e302512e387baecde2795a43512",
+        "default",
+        0,
+        "2e675af38ed1ddaf"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-118",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": false,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "sympy",
+        "c3326587bc11b115d3d9ecd0b1a0ba911d73ddeb",
+        "default",
+        0,
+        "e8466308aaa66399"
+      ],
+      "fire_eligible": false
+    },
+    {
+      "sid": "rv2t1-119",
+      "pos": true,
+      "verdict": "should_propagate",
+      "line": true,
+      "witness": "copy-paste-run",
+      "scope": "prod",
+      "rank": 0,
+      "identity": [
+        "axios",
+        "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+        "near",
+        0,
+        "f4d34596275dc2a1"
+      ],
+      "fire_eligible": true
+    }
+  ],
+  "inputs": {
+    "samples": "eval/divergence_fire/sampled_findings_2026_07_06.jsonl",
+    "verdicts": "eval/divergence_fire/verdicts_2026_07_06.jsonl"
+  },
+  "command": "eval/divergence_fire/replay.py policy-eval --samples eval/divergence_fire/sampled_findings_2026_07_06.jsonl --verdicts eval/divergence_fire/verdicts_2026_07_06.jsonl --out /tmp/nose-675/policy_eval_final_head_a38ecb8b_2026_07_06.json"
+}

--- a/eval/divergence_fire/replay.py
+++ b/eval/divergence_fire/replay.py
@@ -87,6 +87,13 @@ REFRESH_ARTIFACTS = {
     "policy": ROOT / "eval" / "divergence_fire" / "policy_eval_2026_07_06.json",
 }
 
+FINAL_ARTIFACTS = {
+    "summary": ROOT / "eval" / "divergence_fire"
+    / "replay_summary_final_head_a38ecb8b_2026_07_06.json",
+    "policy": ROOT / "eval" / "divergence_fire"
+    / "policy_eval_final_head_a38ecb8b_2026_07_06.json",
+}
+
 
 def sh(args, cwd=None, timeout=None):
     return subprocess.run(
@@ -785,6 +792,35 @@ def cmd_check_artifacts(_args):
     require({tuple(r.get("identity") or []) for r in refresh_policy.get("rows", [])}
             == {identity_key(v) for v in refresh_verdicts},
             "refresh policy rows do not cover verdict identities")
+
+    missing_final = [str(p) for p in FINAL_ARTIFACTS.values() if not p.exists()]
+    require(not missing_final, f"missing final artifacts: {missing_final}")
+    final_summary = json.loads(FINAL_ARTIFACTS["summary"].read_text())
+    require(final_summary.get("schema_version") == 2, "final summary schema")
+    final_meta = final_summary.get("metadata", {})
+    require(final_meta.get("source_commit") == "a38ecb8bec6164c091e10b7b970e7c6ff47d3746",
+            "final summary source commit")
+    require(final_meta.get("source_dirty") is False, "final summary must be clean")
+    require(final_meta.get("raw_records", {}).get("sha256"),
+            "final summary raw sha")
+    for arm in ("default", "near"):
+        row = final_summary.get("per_arm", {}).get(arm, {})
+        require(row.get("replays") == 280, f"final {arm} replay count")
+        require(row.get("errors") == 0, f"final {arm} replay errors")
+        require(row.get("tier_counts", {}).get("strict") is not None,
+                f"final {arm} strict tier count")
+        require(row.get("tier_counts", {}).get("report-only") is not None,
+                f"final {arm} report-only tier count")
+    final_policy = json.loads(FINAL_ARTIFACTS["policy"].read_text())
+    require(final_policy.get("schema_version") == 2, "final policy schema")
+    require(final_policy.get("labeled") == len(refresh_verdicts),
+            "final policy labeled count")
+    require(final_policy.get("positives") == refresh_policy.get("positives"),
+            "final policy positives")
+    require(final_policy.get("finding_level") == expected_policy["finding_level"],
+            "final policy finding_level is stale")
+    require(final_policy.get("rows") == expected_policy["rows"],
+            "final policy rows are stale")
     print("artifact check OK")
 
 

--- a/eval/divergence_fire/replay_summary_final_head_a38ecb8b_2026_07_06.json
+++ b/eval/divergence_fire/replay_summary_final_head_a38ecb8b_2026_07_06.json
@@ -1,0 +1,6196 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "schema_version": 2,
+    "arms": {
+      "default": [],
+      "near": [
+        "--mode",
+        "syntax,semantic,near"
+      ]
+    },
+    "repos": [
+      "git",
+      "redis",
+      "curl",
+      "hugo",
+      "minio",
+      "cobra",
+      "prometheus",
+      "netty",
+      "rxjava",
+      "guava",
+      "gson",
+      "scrapy",
+      "sympy",
+      "black",
+      "requests",
+      "rubocop",
+      "sidekiq",
+      "devise",
+      "clap",
+      "tokio",
+      "regex",
+      "fd",
+      "jest",
+      "rxjs",
+      "prettier",
+      "axios",
+      "date-fns",
+      "execa"
+    ],
+    "per_repo": 10,
+    "timeout_s": 240,
+    "jobs": 6,
+    "query_depth": 800,
+    "eligible_pool_cap": 200,
+    "min_changed_src_lines": 3,
+    "max_changed_src_lines": 600,
+    "supported_exts": [
+      ".c",
+      ".cjs",
+      ".go",
+      ".h",
+      ".html",
+      ".java",
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".py",
+      ".rb",
+      ".rs",
+      ".svelte",
+      ".ts",
+      ".tsx",
+      ".vue"
+    ],
+    "query_template": "nose query . base=<parent> top=0 --format json [arm args]",
+    "timing_fields": [
+      "duration_s"
+    ],
+    "selection": "even sample over newest eligible first-parent commits",
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "78b5eedeaaced187f2566e860561c36b77fdf3d3164b10daeb602fda0a2c109f",
+    "nose_version": "nose 0.17.0",
+    "source_commit": "a38ecb8bec6164c091e10b7b970e7c6ff47d3746",
+    "source_dirty": false,
+    "commands": {
+      "replay": "eval/divergence_fire/replay.py replay --repos git redis curl hugo minio cobra prometheus netty rxjava guava gson scrapy sympy black requests rubocop sidekiq devise clap tokio regex fd jest rxjs prettier axios date-fns execa --per-repo 10 --jobs 6 --timeout 240 --out /tmp/nose-675/divfire-final-head-a38ecb8b-2026-07-06.raw.jsonl",
+      "summarize": "eval/divergence_fire/replay.py summarize --records /tmp/nose-675/divfire-final-head-a38ecb8b-2026-07-06.raw.jsonl --out /tmp/nose-675/replay_summary_final_head_a38ecb8b_2026_07_06.json"
+    },
+    "raw_records": {
+      "path": "/tmp/nose-675/divfire-final-head-a38ecb8b-2026-07-06.raw.jsonl",
+      "sha256": "4c8d459b0fca9a3f7547082902522766fcf11bcae4228f517105422c9ea56942"
+    },
+    "checked_artifacts": {
+      "summary": "eval/divergence_fire/replay_summary_final_head_a38ecb8b_2026_07_06.json",
+      "policy": "eval/divergence_fire/policy_eval_final_head_a38ecb8b_2026_07_06.json",
+      "samples": "eval/divergence_fire/sampled_findings_2026_07_06.jsonl",
+      "verdicts": "eval/divergence_fire/verdicts_2026_07_06.jsonl"
+    }
+  },
+  "per_arm": {
+    "default": {
+      "replays": 280,
+      "errors": 0,
+      "fired": 89,
+      "fire_rate": 0.3179,
+      "strict_fired": 32,
+      "new_copy_fired": 0,
+      "findings_total": 209,
+      "lane_counts": {
+        "base-divergence": 209
+      },
+      "tier_counts": {
+        "report-only": 105,
+        "review": 62,
+        "strict": 42
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 1,
+      "findings_per_fire_p50": 1,
+      "findings_per_fire_p90": 5,
+      "findings_per_fire_max": 35,
+      "divergence_s_p50": 2.21,
+      "divergence_s_p90": 8.97,
+      "divergence_s_max": 11.59
+    },
+    "near": {
+      "replays": 280,
+      "errors": 0,
+      "fired": 111,
+      "fire_rate": 0.3964,
+      "strict_fired": 43,
+      "new_copy_fired": 0,
+      "findings_total": 274,
+      "lane_counts": {
+        "base-divergence": 274
+      },
+      "tier_counts": {
+        "report-only": 118,
+        "review": 90,
+        "strict": 66
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 3,
+      "findings_per_fire_p50": 1,
+      "findings_per_fire_p90": 6,
+      "findings_per_fire_max": 35,
+      "divergence_s_p50": 2.4,
+      "divergence_s_p90": 11.0,
+      "divergence_s_max": 15.17
+    }
+  },
+  "per_repo": {
+    "axios": {
+      "default": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 9,
+        "divergence_s_p50": 0.72,
+        "divergence_s_p90": 0.95
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 12,
+        "divergence_s_p50": 0.71,
+        "divergence_s_p90": 3.66
+      }
+    },
+    "black": {
+      "default": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.77,
+        "divergence_s_p90": 3.06
+      },
+      "near": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.83,
+        "divergence_s_p90": 2.53
+      }
+    },
+    "clap": {
+      "default": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 8,
+        "divergence_s_p50": 1.03,
+        "divergence_s_p90": 1.34
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 9,
+        "divergence_s_p50": 1.14,
+        "divergence_s_p90": 1.82
+      }
+    },
+    "cobra": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 0.3,
+        "divergence_s_p90": 0.4
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 4,
+        "divergence_s_p50": 0.25,
+        "divergence_s_p90": 0.43
+      }
+    },
+    "curl": {
+      "default": {
+        "replays": 10,
+        "fired": 2,
+        "findings": 7,
+        "divergence_s_p50": 3.9,
+        "divergence_s_p90": 4.48
+      },
+      "near": {
+        "replays": 10,
+        "fired": 2,
+        "findings": 8,
+        "divergence_s_p50": 4.16,
+        "divergence_s_p90": 4.57
+      }
+    },
+    "date-fns": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 13,
+        "divergence_s_p50": 1.41,
+        "divergence_s_p90": 2.54
+      },
+      "near": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 15,
+        "divergence_s_p50": 1.47,
+        "divergence_s_p90": 2.89
+      }
+    },
+    "devise": {
+      "default": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 5,
+        "divergence_s_p50": 0.45,
+        "divergence_s_p90": 0.62
+      },
+      "near": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 5,
+        "divergence_s_p50": 0.48,
+        "divergence_s_p90": 0.8
+      }
+    },
+    "execa": {
+      "default": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 4,
+        "divergence_s_p50": 0.62,
+        "divergence_s_p90": 0.79
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 7,
+        "divergence_s_p50": 0.63,
+        "divergence_s_p90": 1.0
+      }
+    },
+    "fd": {
+      "default": {
+        "replays": 10,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 0.29,
+        "divergence_s_p90": 0.3
+      },
+      "near": {
+        "replays": 10,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 0.27,
+        "divergence_s_p90": 0.34
+      }
+    },
+    "git": {
+      "default": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 4,
+        "divergence_s_p50": 5.19,
+        "divergence_s_p90": 5.73
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 5,
+        "divergence_s_p50": 5.82,
+        "divergence_s_p90": 6.57
+      }
+    },
+    "gson": {
+      "default": {
+        "replays": 10,
+        "fired": 7,
+        "findings": 19,
+        "divergence_s_p50": 0.68,
+        "divergence_s_p90": 0.88
+      },
+      "near": {
+        "replays": 10,
+        "fired": 8,
+        "findings": 21,
+        "divergence_s_p50": 0.74,
+        "divergence_s_p90": 0.98
+      }
+    },
+    "guava": {
+      "default": {
+        "replays": 10,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 10.1,
+        "divergence_s_p90": 11.59
+      },
+      "near": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 9,
+        "divergence_s_p50": 12.02,
+        "divergence_s_p90": 13.75
+      }
+    },
+    "hugo": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 4.25,
+        "divergence_s_p90": 4.52
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 6,
+        "divergence_s_p50": 4.37,
+        "divergence_s_p90": 4.84
+      }
+    },
+    "jest": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 2.96,
+        "divergence_s_p90": 5.71
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 4,
+        "divergence_s_p50": 2.95,
+        "divergence_s_p90": 5.79
+      }
+    },
+    "minio": {
+      "default": {
+        "replays": 10,
+        "fired": 6,
+        "findings": 10,
+        "divergence_s_p50": 3.98,
+        "divergence_s_p90": 4.36
+      },
+      "near": {
+        "replays": 10,
+        "fired": 7,
+        "findings": 12,
+        "divergence_s_p50": 4.61,
+        "divergence_s_p90": 4.77
+      }
+    },
+    "netty": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 4,
+        "divergence_s_p50": 10.28,
+        "divergence_s_p90": 10.85
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 7,
+        "divergence_s_p50": 11.47,
+        "divergence_s_p90": 12.39
+      }
+    },
+    "prettier": {
+      "default": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 2.44,
+        "divergence_s_p90": 7.75
+      },
+      "near": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 2.65,
+        "divergence_s_p90": 9.38
+      }
+    },
+    "prometheus": {
+      "default": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 6,
+        "divergence_s_p50": 3.88,
+        "divergence_s_p90": 4.17
+      },
+      "near": {
+        "replays": 10,
+        "fired": 6,
+        "findings": 9,
+        "divergence_s_p50": 4.29,
+        "divergence_s_p90": 4.84
+      }
+    },
+    "redis": {
+      "default": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 13,
+        "divergence_s_p50": 3.27,
+        "divergence_s_p90": 4.66
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 18,
+        "divergence_s_p50": 3.44,
+        "divergence_s_p90": 5.43
+      }
+    },
+    "regex": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 7,
+        "divergence_s_p50": 1.71,
+        "divergence_s_p90": 2.07
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 12,
+        "divergence_s_p50": 1.97,
+        "divergence_s_p90": 2.52
+      }
+    },
+    "requests": {
+      "default": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 0.34,
+        "divergence_s_p90": 0.41
+      },
+      "near": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 0.44,
+        "divergence_s_p90": 0.58
+      }
+    },
+    "rubocop": {
+      "default": {
+        "replays": 10,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 3.02,
+        "divergence_s_p90": 6.22
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 5,
+        "divergence_s_p50": 3.67,
+        "divergence_s_p90": 4.16
+      }
+    },
+    "rxjava": {
+      "default": {
+        "replays": 10,
+        "fired": 8,
+        "findings": 28,
+        "divergence_s_p50": 7.57,
+        "divergence_s_p90": 11.51
+      },
+      "near": {
+        "replays": 10,
+        "fired": 8,
+        "findings": 37,
+        "divergence_s_p50": 8.74,
+        "divergence_s_p90": 15.17
+      }
+    },
+    "rxjs": {
+      "default": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 39,
+        "divergence_s_p50": 1.52,
+        "divergence_s_p90": 1.86
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 39,
+        "divergence_s_p50": 1.42,
+        "divergence_s_p90": 1.6
+      }
+    },
+    "scrapy": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 6,
+        "divergence_s_p50": 1.05,
+        "divergence_s_p90": 1.44
+      },
+      "near": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 8,
+        "divergence_s_p50": 1.25,
+        "divergence_s_p90": 1.81
+      }
+    },
+    "sidekiq": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 5.25,
+        "divergence_s_p90": 10.7
+      },
+      "near": {
+        "replays": 10,
+        "fired": 4,
+        "findings": 4,
+        "divergence_s_p50": 5.8,
+        "divergence_s_p90": 10.42
+      }
+    },
+    "sympy": {
+      "default": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 3,
+        "divergence_s_p50": 10.18,
+        "divergence_s_p90": 10.63
+      },
+      "near": {
+        "replays": 10,
+        "fired": 5,
+        "findings": 5,
+        "divergence_s_p50": 11.25,
+        "divergence_s_p90": 12.12
+      }
+    },
+    "tokio": {
+      "default": {
+        "replays": 10,
+        "fired": 2,
+        "findings": 6,
+        "divergence_s_p50": 1.75,
+        "divergence_s_p90": 1.95
+      },
+      "near": {
+        "replays": 10,
+        "fired": 3,
+        "findings": 8,
+        "divergence_s_p50": 1.95,
+        "divergence_s_p90": 2.58
+      }
+    }
+  },
+  "selected_replays": [
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "25387ae1cedb93b385029e759cac9a22b71ec498",
+      "parent": "caa3497913b731fbae957e6e88edd82da7930111",
+      "subject": "chore: added clarifying docs for the type change (#10804)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.91
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "25387ae1cedb93b385029e759cac9a22b71ec498",
+      "parent": "caa3497913b731fbae957e6e88edd82da7930111",
+      "subject": "chore: added clarifying docs for the type change (#10804)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.67
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "38ba1b3d2b0aa5ada0463a37a548feb83a84dfa1",
+      "parent": "32e2515f1e09b649723e4acd89d920df13eee77e",
+      "subject": "fix(fetch): support basic auth from URL (#10896)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.93
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "38ba1b3d2b0aa5ada0463a37a548feb83a84dfa1",
+      "parent": "32e2515f1e09b649723e4acd89d920df13eee77e",
+      "subject": "fix(fetch): support basic auth from URL (#10896)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.18
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "63e12ecb4f27c55b4cd0ca4a1fef9e85b03ebe15",
+      "parent": "7e1a65c3a90a6f0b18ddc4dd7c5cd835b81d9bf7",
+      "subject": "refactor: migrate express test harness (#7506)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.71
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "63e12ecb4f27c55b4cd0ca4a1fef9e85b03ebe15",
+      "parent": "7e1a65c3a90a6f0b18ddc4dd7c5cd835b81d9bf7",
+      "subject": "refactor: migrate express test harness (#7506)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.75
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "8b68491d04838aaab5d1a4d30e23d1f534beceeb",
+      "parent": "62f62816608823e1b152b27d3209092adc77b454",
+      "subject": "fix(http): handle socket-only request errors without leaking keep-alive listeners (#10576)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.77
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "8b68491d04838aaab5d1a4d30e23d1f534beceeb",
+      "parent": "62f62816608823e1b152b27d3209092adc77b454",
+      "subject": "fix(http): handle socket-only request errors without leaking keep-alive listeners (#10576)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.66
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "bcd5581d208cd372055afdcb2fd10b68ca40613c",
+      "parent": "c9b33712aac00ca6da7e9767426ff2e0a36c7eed",
+      "subject": "fix(http): fixed a regression that caused the data stream to be interrupted for responses with non-OK HTTP statuses; (#7",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.46
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "bcd5581d208cd372055afdcb2fd10b68ca40613c",
+      "parent": "c9b33712aac00ca6da7e9767426ff2e0a36c7eed",
+      "subject": "fix(http): fixed a regression that caused the data stream to be interrupted for responses with non-OK HTTP statuses; (#7",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.64
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "c4453bab70f53575175903aee60810c821f72129",
+      "parent": "caa00a90b524bb67ed033474abcf4d8645ced793",
+      "subject": "fix: add the ability to add additional sponsors to the process sponsors script (#10859)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.95
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "c4453bab70f53575175903aee60810c821f72129",
+      "parent": "caa00a90b524bb67ed033474abcf4d8645ced793",
+      "subject": "fix: add the ability to add additional sponsors to the process sponsors script (#10859)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.85
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+      "parent": "a9f47afbf3224d2ca987dbd8188789c7ea853c5d",
+      "subject": "feat(fetch): add fetch, Request, Response env config variables for the adapter; (#7003)",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 0.65
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "c959ff29013a3bc90cde3ac7ea2d9a3f9c08974b",
+      "parent": "a9f47afbf3224d2ca987dbd8188789c7ea853c5d",
+      "subject": "feat(fetch): add fetch, Request, Response env config variables for the adapter; (#7003)",
+      "ok": true,
+      "findings": 9,
+      "duration_s": 3.66
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "d1178cad4c4fe21be3d36a5a89c1590f474b4d89",
+      "parent": "5a9134e0995b08cc0817548ed44e79c420c620b7",
+      "subject": "chore(types): move AxiosStatic#create to AxiosInstance#create (#5096)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.72
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "d1178cad4c4fe21be3d36a5a89c1590f474b4d89",
+      "parent": "5a9134e0995b08cc0817548ed44e79c420c620b7",
+      "subject": "chore(types): move AxiosStatic#create to AxiosInstance#create (#5096)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.71
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "f0b98673b32677643a3b608431270d36e997473c",
+      "parent": "e033f243a08e3514c03e510f76658da1e0fac3bd",
+      "subject": "chore: added additional testing for this issue (#10760)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.68
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "f0b98673b32677643a3b608431270d36e997473c",
+      "parent": "e033f243a08e3514c03e510f76658da1e0fac3bd",
+      "subject": "chore: added additional testing for this issue (#10760)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.67
+    },
+    {
+      "repo": "axios",
+      "arm": "default",
+      "commit": "f8694341deaabd2e81059543fe03f9c791656903",
+      "parent": "46db3316ac1579633d82f468181c51186ab3af50",
+      "subject": "docs: refresh CDN URLs and example JSON headers (#7236)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.49
+    },
+    {
+      "repo": "axios",
+      "arm": "near",
+      "commit": "f8694341deaabd2e81059543fe03f9c791656903",
+      "parent": "46db3316ac1579633d82f468181c51186ab3af50",
+      "subject": "docs: refresh CDN URLs and example JSON headers (#7236)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.61
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "058da5f81af3efc7115cc41de8f29fb76bb0d429",
+      "parent": "98a580bbdc217a8b1a47b772d2140ed29cdc587a",
+      "subject": "Report Black version on internal error (#4457)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.99
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "058da5f81af3efc7115cc41de8f29fb76bb0d429",
+      "parent": "98a580bbdc217a8b1a47b772d2140ed29cdc587a",
+      "subject": "Report Black version on internal error (#4457)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.95
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "23dfc5b2c3b0694a8c27e58e28439591976aaf94",
+      "parent": "a20100395cf6179a81289452efad1d8e72b19682",
+      "subject": "Fix ignoring input files for symlink reasons (#4222)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.62
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "23dfc5b2c3b0694a8c27e58e28439591976aaf94",
+      "parent": "a20100395cf6179a81289452efad1d8e72b19682",
+      "subject": "Fix ignoring input files for symlink reasons (#4222)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.83
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "24e4cb20ab03c20af390fec7303207af2a4a09e8",
+      "parent": "e7bf7b4619928da69d486f36fcb456fb201ff53e",
+      "subject": "Fix backslash cr nl bug (#4673)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.26
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "24e4cb20ab03c20af390fec7303207af2a4a09e8",
+      "parent": "e7bf7b4619928da69d486f36fcb456fb201ff53e",
+      "subject": "Fix backslash cr nl bug (#4673)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.05
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "2f88085da588d34286bc9a24e288de204f141243",
+      "parent": "12ce3db077780ab01cc5ad1f92d5c85fcca3f54c",
+      "subject": "Github Action: Directly install from repo if `export-subst` is skipped (#4313)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.77
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "2f88085da588d34286bc9a24e288de204f141243",
+      "parent": "12ce3db077780ab01cc5ad1f92d5c85fcca3f54c",
+      "subject": "Github Action: Directly install from repo if `export-subst` is skipped (#4313)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.56
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "4f6ad7cf8c3092e0fb4d82f54fe77ccde134468a",
+      "parent": "24f516961720c5578069dee30415b776359b7be5",
+      "subject": "Wrap the `in` clause of comprehensions across lines if necessary (#4699)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "4f6ad7cf8c3092e0fb4d82f54fe77ccde134468a",
+      "parent": "24f516961720c5578069dee30415b776359b7be5",
+      "subject": "Wrap the `in` clause of comprehensions across lines if necessary (#4699)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "6e84c2b6d39698debf3b9002bd8644bab5e4d345",
+      "parent": "e8a08ac0e211ec17c6bf042288940e392caf5d46",
+      "subject": "Use \"Version X.Y.Z\" headings in changelog for stable permalink anchors (#5063)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.89
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "6e84c2b6d39698debf3b9002bd8644bab5e4d345",
+      "parent": "e8a08ac0e211ec17c6bf042288940e392caf5d46",
+      "subject": "Use \"Version X.Y.Z\" headings in changelog for stable permalink anchors (#5063)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.26
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "6e9654065ca5e4b7c7a9491431a6cd7bc4016da3",
+      "parent": "8dc912774e322a2cd46f691f19fb91d2237d06e2",
+      "subject": "Fix CI (#4551)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.77
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "6e9654065ca5e4b7c7a9491431a6cd7bc4016da3",
+      "parent": "8dc912774e322a2cd46f691f19fb91d2237d06e2",
+      "subject": "Fix CI (#4551)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.29
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "d246367ab471cd56298407858661d475c33b3e36",
+      "parent": "c77093e228ff21a93638b42356aa0a4d2713aa17",
+      "subject": "fix: resolve CWD before lru_cache key in find_project_root (#5152)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.58
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "d246367ab471cd56298407858661d475c33b3e36",
+      "parent": "c77093e228ff21a93638b42356aa0a4d2713aa17",
+      "subject": "fix: resolve CWD before lru_cache key in find_project_root (#5152)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.83
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "f4b006f61d4009135b744941f02df384f7604bc8",
+      "parent": "115dbcf3f2593b88909faee31404b83d6dcc5ff7",
+      "subject": "Fix: Preserve parentheses when merging # type: ignore with other comments to prevent AST errors  (#4888)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.06
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "f4b006f61d4009135b744941f02df384f7604bc8",
+      "parent": "115dbcf3f2593b88909faee31404b83d6dcc5ff7",
+      "subject": "Fix: Preserve parentheses when merging # type: ignore with other comments to prevent AST errors  (#4888)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.53
+    },
+    {
+      "repo": "black",
+      "arm": "default",
+      "commit": "f705197f57149b79ed83cccf22e4fed19b48a7bf",
+      "parent": "994e184dbc1f1cbca00093885c732892f9948d1c",
+      "subject": "t-string support (#4805)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.47
+    },
+    {
+      "repo": "black",
+      "arm": "near",
+      "commit": "f705197f57149b79ed83cccf22e4fed19b48a7bf",
+      "parent": "994e184dbc1f1cbca00093885c732892f9948d1c",
+      "subject": "t-string support (#4805)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.32
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "5504a134684fc1148e08d8e6919ca16e13ed83a4",
+      "parent": "c3f05a80ee7c3d18f85a97cb1077cf7de4c4c6b6",
+      "subject": "Merge pull request #6047 from clap-rs/revert-6045-cleanup-docsrs",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.85
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "5504a134684fc1148e08d8e6919ca16e13ed83a4",
+      "parent": "c3f05a80ee7c3d18f85a97cb1077cf7de4c4c6b6",
+      "subject": "Merge pull request #6047 from clap-rs/revert-6045-cleanup-docsrs",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.88
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "6671d9350027a9fb5cfca44304603d0d32f5e30a",
+      "parent": "e1bdfcc6adc99ec99bb23745fd38c500e0edd09c",
+      "subject": "Merge pull request #5613 from epage/flatten",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.03
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "6671d9350027a9fb5cfca44304603d0d32f5e30a",
+      "parent": "e1bdfcc6adc99ec99bb23745fd38c500e0edd09c",
+      "subject": "Merge pull request #5613 from epage/flatten",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.07
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "8e75826e91fa92741b3b1bac0e7b92ad87463d0d",
+      "parent": "eabbc6b9dbe155aed3165ad60f8e80b6430a2b97",
+      "subject": "Merge pull request #6221 from sffc/lex-lifetime",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.26
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "8e75826e91fa92741b3b1bac0e7b92ad87463d0d",
+      "parent": "eabbc6b9dbe155aed3165ad60f8e80b6430a2b97",
+      "subject": "Merge pull request #6221 from sffc/lex-lifetime",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "93e050b0b787e102bc1a6defdc32331d13940699",
+      "parent": "ce567854274d6a1c9eac1976b2c6b5e13499c473",
+      "subject": "Merge pull request #5662 from epage/register",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 0.97
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "93e050b0b787e102bc1a6defdc32331d13940699",
+      "parent": "ce567854274d6a1c9eac1976b2c6b5e13499c473",
+      "subject": "Merge pull request #5662 from epage/register",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 1.13
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "a2860be85a5fe0ad2b48592a0cbd75fa928341df",
+      "parent": "8e3d03639756241aa2b7dd624a7f5852bef76f31",
+      "subject": "Merge pull request #6138 from epage/concepts",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.03
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "a2860be85a5fe0ad2b48592a0cbd75fa928341df",
+      "parent": "8e3d03639756241aa2b7dd624a7f5852bef76f31",
+      "subject": "Merge pull request #6138 from epage/concepts",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.14
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "a7f6acfbece63ec1eb880bcc36a685c48256b231",
+      "parent": "26f23e4feae2373328802a51cc8c15e794e56951",
+      "subject": "Merge pull request #5879 from therealprof/features/suggestions-use-insertion-sort",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.83
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "a7f6acfbece63ec1eb880bcc36a685c48256b231",
+      "parent": "26f23e4feae2373328802a51cc8c15e794e56951",
+      "subject": "Merge pull request #5879 from therealprof/features/suggestions-use-insertion-sort",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.67
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.88
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.82
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "d94b5afd52633086fe59c227fd8ba53de71c8e20",
+      "parent": "7adce9627829278f9aa842e4e8c0753861b6c6d1",
+      "subject": "Merge pull request #5967 from eric-seppanen/args_raw_doc_fix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.04
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "d94b5afd52633086fe59c227fd8ba53de71c8e20",
+      "parent": "7adce9627829278f9aa842e4e8c0753861b6c6d1",
+      "subject": "Merge pull request #5967 from eric-seppanen/args_raw_doc_fix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.99
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "f9721f1435353630827e10a891bb864938717487",
+      "parent": "0e28259e55d46154f7c126020800b6a66f474a22",
+      "subject": "Merge pull request #5695 from epage/value",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.34
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "f9721f1435353630827e10a891bb864938717487",
+      "parent": "0e28259e55d46154f7c126020800b6a66f474a22",
+      "subject": "Merge pull request #5695 from epage/value",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.02
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "fca8f73c2c01bd88e171f2f5d9adb7a08039c124",
+      "parent": "d2874a50cf594ace49a9dfa644e734f83491a403",
+      "subject": "Merge pull request #5706 from shannmu/external_subcommand",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.16
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "fca8f73c2c01bd88e171f2f5d9adb7a08039c124",
+      "parent": "d2874a50cf594ace49a9dfa644e734f83491a403",
+      "subject": "Merge pull request #5706 from shannmu/external_subcommand",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.42
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "00b68a1c260eaf2b9bcb10a3178d36cec81548ca",
+      "parent": "b711e8760b73c6aa1b4aa1bef3a26da5926f175d",
+      "subject": "Add tests for flag completion registration (#2053)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.25
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "00b68a1c260eaf2b9bcb10a3178d36cec81548ca",
+      "parent": "b711e8760b73c6aa1b4aa1bef3a26da5926f175d",
+      "subject": "Add tests for flag completion registration (#2053)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "02a0d2fbc9e61d26f8e5979749f6030964a55a3e",
+      "parent": "9ed1d713d619c428c8a8adcd13667d6b3f54b247",
+      "subject": "doc: GenMarkdown skip Synopsis on empty long cmd (#1207)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.38
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "02a0d2fbc9e61d26f8e5979749f6030964a55a3e",
+      "parent": "9ed1d713d619c428c8a8adcd13667d6b3f54b247",
+      "subject": "doc: GenMarkdown skip Synopsis on empty long cmd (#1207)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.23
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "3741457400aa1a40bac77971975dc4d99360764e",
+      "parent": "50665e99933b63952bde8df17bfe2113ab6dbe44",
+      "subject": "add CommandTemplate",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "3741457400aa1a40bac77971975dc4d99360764e",
+      "parent": "50665e99933b63952bde8df17bfe2113ab6dbe44",
+      "subject": "add CommandTemplate",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "3fed3ef5adf9fa1cfff46b6860850828d6c60154",
+      "parent": "507caf5ac8d1c81229af3d3df4e43e497bcdc233",
+      "subject": "Support different bash completion options (#1509)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.24
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "3fed3ef5adf9fa1cfff46b6860850828d6c60154",
+      "parent": "507caf5ac8d1c81229af3d3df4e43e497bcdc233",
+      "subject": "Support different bash completion options (#1509)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.21
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "5b11656e45a6a6579298a3b28c71f456ff196ad6",
+      "parent": "ffa8860dbe017851bc4e8ff4fb2b6249cfc1e4d8",
+      "subject": "perf(bash-v2): read directly to COMPREPLY on descriptionless short circuit (#1700)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.34
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "5b11656e45a6a6579298a3b28c71f456ff196ad6",
+      "parent": "ffa8860dbe017851bc4e8ff4fb2b6249cfc1e4d8",
+      "subject": "perf(bash-v2): read directly to COMPREPLY on descriptionless short circuit (#1700)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.18
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "6b0bd3076cfafd1c108264ed1e4aa0c0fe3f8537",
+      "parent": "cc7e235fc26cfd0b5ae36c960f399eea4badaa3e",
+      "subject": "fix: don't remove flag value that matches subcommand name (#1781)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.31
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "6b0bd3076cfafd1c108264ed1e4aa0c0fe3f8537",
+      "parent": "cc7e235fc26cfd0b5ae36c960f399eea4badaa3e",
+      "subject": "fix: don't remove flag value that matches subcommand name (#1781)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "8eaca5f0f49ad747a0722d39dca7a75c34abd21a",
+      "parent": "ace6b14345897f1b757058291a84945a41f59f30",
+      "subject": "drop mitchellh/go-homedir (#853)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.23
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "8eaca5f0f49ad747a0722d39dca7a75c34abd21a",
+      "parent": "ace6b14345897f1b757058291a84945a41f59f30",
+      "subject": "drop mitchellh/go-homedir (#853)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.17
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "993cc5372a05240dfd59e3ba952748b36b2cd117",
+      "parent": "d85196337cc9d017cd24c1b0416eb1494e2aef26",
+      "subject": "Adjustments per PR review feedback from @bogem",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.2
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "993cc5372a05240dfd59e3ba952748b36b2cd117",
+      "parent": "d85196337cc9d017cd24c1b0416eb1494e2aef26",
+      "subject": "Adjustments per PR review feedback from @bogem",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.36
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "ad460ea8f249db69c943a365fb84f3a59042d54e",
+      "parent": "746ef07158728502482cea9f880a6f4b21ef29a9",
+      "subject": "Add cobra unique args validator (#2397)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.16
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "ad460ea8f249db69c943a365fb84f3a59042d54e",
+      "parent": "746ef07158728502482cea9f880a6f4b21ef29a9",
+      "subject": "Add cobra unique args validator (#2397)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.24
+    },
+    {
+      "repo": "cobra",
+      "arm": "default",
+      "commit": "d1e9d85fcf592461f3bc2f4b6d5e140c4c0aabf8",
+      "parent": "9f9056765ccb3bfb1c72a560b4c6edbff71c0f32",
+      "subject": "Make detection for test-binary more universal (#2173)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.4
+    },
+    {
+      "repo": "cobra",
+      "arm": "near",
+      "commit": "d1e9d85fcf592461f3bc2f4b6d5e140c4c0aabf8",
+      "parent": "9f9056765ccb3bfb1c72a560b4c6edbff71c0f32",
+      "subject": "Make detection for test-binary more universal (#2173)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.25
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "049ec8a3631b72e834a4a87dcd04759885138f7c",
+      "parent": "a8e6f90a6980a70839823b7fe5f6e0faeeec4833",
+      "subject": "content_encoding: fix limit failure message",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.89
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "049ec8a3631b72e834a4a87dcd04759885138f7c",
+      "parent": "a8e6f90a6980a70839823b7fe5f6e0faeeec4833",
+      "subject": "content_encoding: fix limit failure message",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.56
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "06839bda7662b9f24a3c26223f0767e9e094926e",
+      "parent": "21687202d957453dd147e835c357598c02a52b29",
+      "subject": "RELEASE-NOTES: synced",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.02
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "06839bda7662b9f24a3c26223f0767e9e094926e",
+      "parent": "21687202d957453dd147e835c357598c02a52b29",
+      "subject": "RELEASE-NOTES: synced",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.12
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "47f411c6d840dcee63a2ac9cbc0bfbea522ac5cd",
+      "parent": "a15483c4caa746a265749071c0532fdf7f53e252",
+      "subject": "GHA: enable `-Wunused-macros` in clang-tidy jobs",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.34
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "47f411c6d840dcee63a2ac9cbc0bfbea522ac5cd",
+      "parent": "a15483c4caa746a265749071c0532fdf7f53e252",
+      "subject": "GHA: enable `-Wunused-macros` in clang-tidy jobs",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.62
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "69f3a36bcb94b6e69f0248ac749833483326edf9",
+      "parent": "00cac453c7955d8a3894772e02029bb8b65a2c12",
+      "subject": "doh: remove conn->bits.doh",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.81
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "69f3a36bcb94b6e69f0248ac749833483326edf9",
+      "parent": "00cac453c7955d8a3894772e02029bb8b65a2c12",
+      "subject": "doh: remove conn->bits.doh",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.29
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "77e4e5b86de025e3f87761282f0fdac286fa2750",
+      "parent": "b158d1c9f7456a8f976c74c08d2dc5a555e9cc77",
+      "subject": "websockets: auto-tunnel through http proxy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.21
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "77e4e5b86de025e3f87761282f0fdac286fa2750",
+      "parent": "b158d1c9f7456a8f976c74c08d2dc5a555e9cc77",
+      "subject": "websockets: auto-tunnel through http proxy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.68
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "a36c571984b1c4966e11a7b196b79a3b272cc31b",
+      "parent": "e25e497c5ef5a15450ae239eb3d019090c8298c9",
+      "subject": "pythonlint.sh: make it fail on error, fix ruff warnings in pytest",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.9
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "a36c571984b1c4966e11a7b196b79a3b272cc31b",
+      "parent": "e25e497c5ef5a15450ae239eb3d019090c8298c9",
+      "subject": "pythonlint.sh: make it fail on error, fix ruff warnings in pytest",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.19
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+      "parent": "28341c303d6fdaabb5a9c97abc3ae04614e70693",
+      "subject": "http: prefer chunked encoding over Content-Length: 0",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.56
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+      "parent": "28341c303d6fdaabb5a9c97abc3ae04614e70693",
+      "subject": "http: prefer chunked encoding over Content-Length: 0",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.88
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "c2ca16f3ff2ad8300e67ea5a3cc4060738473e45",
+      "parent": "e4139a73c82d2035142f5ae36196adb4e9831dae",
+      "subject": "h3: sync printf masks with types, drop two casts",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 3.63
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "c2ca16f3ff2ad8300e67ea5a3cc4060738473e45",
+      "parent": "e4139a73c82d2035142f5ae36196adb4e9831dae",
+      "subject": "h3: sync printf masks with types, drop two casts",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 3.96
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "e0e56e9ae434552bd6ac5570ed91483188d75788",
+      "parent": "daf6f541cc1fc4f5d17989d317464764d1bd7cd7",
+      "subject": "hostip: remove unused MAX_HOSTCACHE_LEN and MAX_DNS_CACHE_SIZE",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.3
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "e0e56e9ae434552bd6ac5570ed91483188d75788",
+      "parent": "daf6f541cc1fc4f5d17989d317464764d1bd7cd7",
+      "subject": "hostip: remove unused MAX_HOSTCACHE_LEN and MAX_DNS_CACHE_SIZE",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.57
+    },
+    {
+      "repo": "curl",
+      "arm": "default",
+      "commit": "ea392e6b36d875056cf9e28f841bdc8cdc2efbb6",
+      "parent": "c29278cc83f31a3e5113eb5c68604fc48ce22fcb",
+      "subject": "RELEASE-NOTES: synced",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.48
+    },
+    {
+      "repo": "curl",
+      "arm": "near",
+      "commit": "ea392e6b36d875056cf9e28f841bdc8cdc2efbb6",
+      "parent": "c29278cc83f31a3e5113eb5c68604fc48ce22fcb",
+      "subject": "RELEASE-NOTES: synced",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.16
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "0356eccfa906c9aa5c3b135f333c50ee320b489d",
+      "parent": "d22be9f1aa2615349f4f19775cde287db4e2c6b0",
+      "subject": "Add CDN versions of modules (#3737)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.6
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "0356eccfa906c9aa5c3b135f333c50ee320b489d",
+      "parent": "d22be9f1aa2615349f4f19775cde287db4e2c6b0",
+      "subject": "Add CDN versions of modules (#3737)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.08
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "219d02ebff00a53dc332dcdb73407f0b81ad7e5d",
+      "parent": "db3d57cf7a9dcc8f14f35deefdedf12a04edddd3",
+      "subject": "Add tz normalization to differenceInCalendarDays, differenceInCalendarMonths, differenceInCalendarYears, differenceInDay",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 1.12
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "219d02ebff00a53dc332dcdb73407f0b81ad7e5d",
+      "parent": "db3d57cf7a9dcc8f14f35deefdedf12a04edddd3",
+      "subject": "Add tz normalization to differenceInCalendarDays, differenceInCalendarMonths, differenceInCalendarYears, differenceInDay",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 1.34
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "29394724f78d2c0ff23b3c6a9c93965eb5b0ac66",
+      "parent": "ff60d482987214ac9171adc3ea42a66ebb04da05",
+      "subject": "Fix incorrect rounding introduced in v3.3.0",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.33
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "29394724f78d2c0ff23b3c6a9c93965eb5b0ac66",
+      "parent": "ff60d482987214ac9171adc3ea42a66ebb04da05",
+      "subject": "Fix incorrect rounding introduced in v3.3.0",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.31
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "34c049b97f8e69d9695fc05038e622274253430c",
+      "parent": "57a9b735d8d69a8d8529fbe0b91d7b8384bbf514",
+      "subject": "Update wikipedia location (#3629)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.18
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "34c049b97f8e69d9695fc05038e622274253430c",
+      "parent": "57a9b735d8d69a8d8529fbe0b91d7b8384bbf514",
+      "subject": "Update wikipedia location (#3629)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.47
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "6c70ac6d073ebe869e42795f5e71dfecf5abbea0",
+      "parent": "5a27a8a76be25bccf8c43a80a0a32a1a943561c5",
+      "subject": "Add simple parse tz tests",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.74
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "6c70ac6d073ebe869e42795f5e71dfecf5abbea0",
+      "parent": "5a27a8a76be25bccf8c43a80a0a32a1a943561c5",
+      "subject": "Add simple parse tz tests",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.74
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+      "parent": "3612b2cb0bd1de83a1ff66c3899da1b75632355c",
+      "subject": "Make tests work across all packages, fix core package build",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 2.54
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "86be6e08bc7b4d01637991d7f5c43e3dab29b7f5",
+      "parent": "3612b2cb0bd1de83a1ff66c3899da1b75632355c",
+      "subject": "Make tests work across all packages, fix core package build",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 2.65
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "99bd2e773962f5c574684e9685abaef102b7409b",
+      "parent": "db4804f94731abd42228f0a1a25e97d013147216",
+      "subject": "Add tz support to startOfSecond, startOfToday and startOfTomorrow",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 1.19
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "99bd2e773962f5c574684e9685abaef102b7409b",
+      "parent": "db4804f94731abd42228f0a1a25e97d013147216",
+      "subject": "Add tz support to startOfSecond, startOfToday and startOfTomorrow",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 1.2
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "bffe4bd8d8c45d28b89c5fd6cd90171a4a508ae4",
+      "parent": "a32176e508c48af7cf9b30b3f27c8877df933a89",
+      "subject": "Enforce using import type where possible",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.41
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "bffe4bd8d8c45d28b89c5fd6cd90171a4a508ae4",
+      "parent": "a32176e508c48af7cf9b30b3f27c8877df933a89",
+      "subject": "Enforce using import type where possible",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.22
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "c77ac2e18f1eb3caefb727989b506b9ddea6e4bd",
+      "parent": "86c6f018d7b963a7bac910a0b6e047b05674d9c7",
+      "subject": "Remove throw from roundToNearestMinutes",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.33
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "c77ac2e18f1eb3caefb727989b506b9ddea6e4bd",
+      "parent": "86c6f018d7b963a7bac910a0b6e047b05674d9c7",
+      "subject": "Remove throw from roundToNearestMinutes",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.16
+    },
+    {
+      "repo": "date-fns",
+      "arm": "default",
+      "commit": "d948ec151d395096de8a45fbcd9b1e79c26fda25",
+      "parent": "ee65753cfc5d73cc9acd43aaa8012b3b233ddf32",
+      "subject": "Preserve but deprecate CDN versions for v4, set up v5 with polyfills",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.21
+    },
+    {
+      "repo": "date-fns",
+      "arm": "near",
+      "commit": "d948ec151d395096de8a45fbcd9b1e79c26fda25",
+      "parent": "ee65753cfc5d73cc9acd43aaa8012b3b233ddf32",
+      "subject": "Preserve but deprecate CDN versions for v4, set up v5 with polyfills",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.89
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "025fe2124f9928766fc46520e999633b598d0360",
+      "parent": "7ca7ed9c174525a4d36167441b35af4a0991b6af",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.33
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "025fe2124f9928766fc46520e999633b598d0360",
+      "parent": "7ca7ed9c174525a4d36167441b35af4a0991b6af",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "13d4fd40884315b8059b6bfd7738050da0ac2357",
+      "parent": "bbd614a7250ed364bf7b962b723fd3e4497716c3",
+      "subject": "Merge pull request #4193 from 3wille/master",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.62
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "13d4fd40884315b8059b6bfd7738050da0ac2357",
+      "parent": "bbd614a7250ed364bf7b962b723fd3e4497716c3",
+      "subject": "Merge pull request #4193 from 3wille/master",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.8
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "15135f7dc61e3b109e62f1e9be826cb31dfd12d9",
+      "parent": "e39b9b91340cc63d28897c10c83cf0af5820e4e9",
+      "subject": "User `assert_includes`/`refute_includes` minitest helpers",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.32
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "15135f7dc61e3b109e62f1e9be826cb31dfd12d9",
+      "parent": "e39b9b91340cc63d28897c10c83cf0af5820e4e9",
+      "subject": "User `assert_includes`/`refute_includes` minitest helpers",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "31801fc9a0774657b30b08208ca54f9572609fbd",
+      "parent": "ce0414271a03b3ee9594dd76a5a4e766f1896981",
+      "subject": "Fix missing validations on Signup (#4674)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.45
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "31801fc9a0774657b30b08208ca54f9572609fbd",
+      "parent": "ce0414271a03b3ee9594dd76a5a4e766f1896981",
+      "subject": "Fix missing validations on Signup (#4674)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.63
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "48251f236f53369b8f3a8a4b3ba036de3ad90fdc",
+      "parent": "8e6e70eaa7302418586db2d330bb966295951b56",
+      "subject": "Use single quotes consistently through the integration test example.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "48251f236f53369b8f3a8a4b3ba036de3ad90fdc",
+      "parent": "8e6e70eaa7302418586db2d330bb966295951b56",
+      "subject": "Use single quotes consistently through the integration test example.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.38
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "7d1dc56fdba2402c452c4224567077b23184637e",
+      "parent": "400eaf7fbe05f50b48c08dc7dbf23259cbdb8bdb",
+      "subject": "Merge branch 'ca-replace-refute-assert-not'",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 0.36
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "7d1dc56fdba2402c452c4224567077b23184637e",
+      "parent": "400eaf7fbe05f50b48c08dc7dbf23259cbdb8bdb",
+      "subject": "Merge branch 'ca-replace-refute-assert-not'",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 0.55
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "b02bb5b75af73753affa1a0a1f79a79cc28a358d",
+      "parent": "23058dcc62ed5bc3a79043ee5f375bc31d65bd73",
+      "subject": "Merge pull request #5746 from c960657/config-warden",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.35
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "b02bb5b75af73753affa1a0a1f79a79cc28a358d",
+      "parent": "23058dcc62ed5bc3a79043ee5f375bc31d65bd73",
+      "subject": "Merge pull request #5746 from c960657/config-warden",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.41
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "d1571627b78399b55b76c400a78c4a3f367dad2c",
+      "parent": "52b24e41de5093fe60a89019b2462608874d5745",
+      "subject": "Add deprication waring if use options argument at DatabaseAuthenticatable#update_with_password,#update_without_password ",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.47
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "d1571627b78399b55b76c400a78c4a3f367dad2c",
+      "parent": "52b24e41de5093fe60a89019b2462608874d5745",
+      "subject": "Add deprication waring if use options argument at DatabaseAuthenticatable#update_with_password,#update_without_password ",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.48
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "f220b992c338122226f6fd396056d5a1adf28df8",
+      "parent": "2bb8e1c236c068f7726ff3aaef7e9106e9a9a9c5",
+      "subject": "add test for lazy loading hook",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.45
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "f220b992c338122226f6fd396056d5a1adf28df8",
+      "parent": "2bb8e1c236c068f7726ff3aaef7e9106e9a9a9c5",
+      "subject": "add test for lazy loading hook",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.48
+    },
+    {
+      "repo": "devise",
+      "arm": "default",
+      "commit": "ffeb942699494170e943a9a61667948e8f6f5d01",
+      "parent": "f148c90fc7d8c4b841cf6e83924077aa04ff8c0b",
+      "subject": "Merge pull request #5148 from gurgelrenan/flash_message",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.55
+    },
+    {
+      "repo": "devise",
+      "arm": "near",
+      "commit": "ffeb942699494170e943a9a61667948e8f6f5d01",
+      "parent": "f148c90fc7d8c4b841cf6e83924077aa04ff8c0b",
+      "subject": "Merge pull request #5148 from gurgelrenan/flash_message",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.62
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "316f562a49ec3a06611cd58c4211fbef8dd4a287",
+      "parent": "86949e0ba9430f9ff27a7b8bdcdf66ae0b601393",
+      "subject": "`.pipe()` shortcut for `$` (#840)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.33
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "316f562a49ec3a06611cd58c4211fbef8dd4a287",
+      "parent": "86949e0ba9430f9ff27a7b8bdcdf66ae0b601393",
+      "subject": "`.pipe()` shortcut for `$` (#840)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.28
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "3bdab60fd1986f9600653e97d81ac5240777cf12",
+      "parent": "8fbb643438839e5eb1c4d702909649c8a142cf51",
+      "subject": "Add `.js` to imports in types (#1033)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.66
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "3bdab60fd1986f9600653e97d81ac5240777cf12",
+      "parent": "8fbb643438839e5eb1c4d702909649c8a142cf51",
+      "subject": "Add `.js` to imports in types (#1033)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.5
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "477bbc4ed9d0a18933d3dd4b0aeecdb0e312c1ad",
+      "parent": "c9cdd2d27a1cb4a11bcfee2586defea0104bed12",
+      "subject": "Stricter values for the `encoding` option (#928)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "477bbc4ed9d0a18933d3dd4b0aeecdb0e312c1ad",
+      "parent": "c9cdd2d27a1cb4a11bcfee2586defea0104bed12",
+      "subject": "Stricter values for the `encoding` option (#928)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.4
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "507b09c841e3a55569681023d74d46ff7580668b",
+      "parent": "15ab4e6ef8a511d94e920db9c904b4ed72dfd7ca",
+      "subject": "Improve `encoding` option (#958)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.79
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "507b09c841e3a55569681023d74d46ff7580668b",
+      "parent": "15ab4e6ef8a511d94e920db9c904b4ed72dfd7ca",
+      "subject": "Improve `encoding` option (#958)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.0
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "5abc429233bd8ed71a2dd992a60fa11a74653554",
+      "parent": "6fda30fe18573a5a6611dc5921e262916bd6b022",
+      "subject": "Improve streams pipe logic (#885)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.26
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "5abc429233bd8ed71a2dd992a60fa11a74653554",
+      "parent": "6fda30fe18573a5a6611dc5921e262916bd6b022",
+      "subject": "Improve streams pipe logic (#885)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "663136bff6d10ec3a815bd9164b637bf8b84aac4",
+      "parent": "2fd9351c8b78f79f363ff75424b4b534d1402f02",
+      "subject": "Add `node` option (#804)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.32
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "663136bff6d10ec3a815bd9164b637bf8b84aac4",
+      "parent": "2fd9351c8b78f79f363ff75424b4b534d1402f02",
+      "subject": "Add `node` option (#804)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.32
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "71434929a7efc37cf4569e662e721f6a1675ed2f",
+      "parent": "7bf6ac26592e1c69d12f7378af6584438b53f4cb",
+      "subject": "Fix `break` statement with `subprocess.getEachMessage()` (#1082)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.62
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "71434929a7efc37cf4569e662e721f6a1675ed2f",
+      "parent": "7bf6ac26592e1c69d12f7378af6584438b53f4cb",
+      "subject": "Fix `break` statement with `subprocess.getEachMessage()` (#1082)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.63
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "a2e4dbea9420720c06144832e905c0ee88680b0b",
+      "parent": "8572eb11475fadd5666ce2dc577d248403253e94",
+      "subject": "Export TypeScript types for the `execa` method (#1066)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.67
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "a2e4dbea9420720c06144832e905c0ee88680b0b",
+      "parent": "8572eb11475fadd5666ce2dc577d248403253e94",
+      "subject": "Export TypeScript types for the `execa` method (#1066)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.71
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "bd3b478a9536ac85d88f2645bd875cb785445f3d",
+      "parent": "08eb743d6da56425922ff4f58847a7bc419800aa",
+      "subject": "Refactor logic and rename some variables (#983)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.53
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "bd3b478a9536ac85d88f2645bd875cb785445f3d",
+      "parent": "08eb743d6da56425922ff4f58847a7bc419800aa",
+      "subject": "Refactor logic and rename some variables (#983)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.65
+    },
+    {
+      "repo": "execa",
+      "arm": "default",
+      "commit": "f3a2e8481a1e9138de3895827895c834078b9456",
+      "parent": "6ad1a6eeba451ca9a1bcf625b267226e00b06d0d",
+      "subject": "Harden against prototype pollution (#1223)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.68
+    },
+    {
+      "repo": "execa",
+      "arm": "near",
+      "commit": "f3a2e8481a1e9138de3895827895c834078b9456",
+      "parent": "6ad1a6eeba451ca9a1bcf625b267226e00b06d0d",
+      "subject": "Harden against prototype pollution (#1223)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.95
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "42b2ab8a84ddedf80eeed9079128c60161f64658",
+      "parent": "febc1b692f5521c4a5e0ddaf926700954ce4d035",
+      "subject": "Merge pull request #1983 from DeflateAwning/feat-exact-i1963",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "42b2ab8a84ddedf80eeed9079128c60161f64658",
+      "parent": "febc1b692f5521c4a5e0ddaf926700954ce4d035",
+      "subject": "Merge pull request #1983 from DeflateAwning/feat-exact-i1963",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.32
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "5b4869a940ecba3afef71894b019507d9d271474",
+      "parent": "049232439ab1bc19b08739eb29852ab967eb7d6c",
+      "subject": "fix spelling",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.23
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "5b4869a940ecba3afef71894b019507d9d271474",
+      "parent": "049232439ab1bc19b08739eb29852ab967eb7d6c",
+      "subject": "fix spelling",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.27
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "5bb7a52704175ad0d1a545646c96bd72cd1f4c58",
+      "parent": "93e54884202723255395664ac2f0926f42f09ecd",
+      "subject": "walk: Switch back to crossbeam-channel",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "5bb7a52704175ad0d1a545646c96bd72cd1f4c58",
+      "parent": "93e54884202723255395664ac2f0926f42f09ecd",
+      "subject": "walk: Switch back to crossbeam-channel",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.26
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "8b5532d8dd89d932d304f9adbcac8d723682973a",
+      "parent": "c6fcdbe000d2ac0161eaba524f020d6ccdbc50d5",
+      "subject": "Merge pull request #1409 from marcospb19/fix-docs-typo",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.28
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "8b5532d8dd89d932d304f9adbcac8d723682973a",
+      "parent": "c6fcdbe000d2ac0161eaba524f020d6ccdbc50d5",
+      "subject": "Merge pull request #1409 from marcospb19/fix-docs-typo",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.24
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "a81fef99921287501480d76ed5236625489502eb",
+      "parent": "53c338d71fbe46375937921bd9acde49524cbc71",
+      "subject": "Windows: Check for xterm-256color environment variable as a proxy for color support",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.26
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "a81fef99921287501480d76ed5236625489502eb",
+      "parent": "53c338d71fbe46375937921bd9acde49524cbc71",
+      "subject": "Windows: Check for xterm-256color environment variable as a proxy for color support",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "cb385a4822dfa4df452da2b4aa9d6c5d3e87ca91",
+      "parent": "efc71bc00b66afdbd570ad0ada21569e2a81cdae",
+      "subject": "Issue 624 newer older help text (#733)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "cb385a4822dfa4df452da2b4aa9d6c5d3e87ca91",
+      "parent": "efc71bc00b66afdbd570ad0ada21569e2a81cdae",
+      "subject": "Issue 624 newer older help text (#733)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.27
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "de611c8835be33fa33ce602cd7e57149e48cb52a",
+      "parent": "7c86c7d58544021ae4ec50a171cde8585f8c65b0",
+      "subject": "Merge pull request #1217 from tmccombs/skip-executable-test-if-root",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.2
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "de611c8835be33fa33ce602cd7e57149e48cb52a",
+      "parent": "7c86c7d58544021ae4ec50a171cde8585f8c65b0",
+      "subject": "Merge pull request #1217 from tmccombs/skip-executable-test-if-root",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.34
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "e990a13405883581e174d484a9f55c7451023bd1",
+      "parent": "7b7876e7012665b558a9873d505b8d7e2e6c8e5e",
+      "subject": "squash! Add buffering to stdout when it's not a terminal",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.26
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "e990a13405883581e174d484a9f55c7451023bd1",
+      "parent": "7b7876e7012665b558a9873d505b8d7e2e6c8e5e",
+      "subject": "squash! Add buffering to stdout when it's not a terminal",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.21
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "e9fe337921de8acdb5e9939b30537280adf24ded",
+      "parent": "8958a7bd747b0ac6c2898f977d18d26e3c6c5b6a",
+      "subject": "Merge pull request #1596 from RossSmyth/WinLints",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "e9fe337921de8acdb5e9939b30537280adf24ded",
+      "parent": "8958a7bd747b0ac6c2898f977d18d26e3c6c5b6a",
+      "subject": "Merge pull request #1596 from RossSmyth/WinLints",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.26
+    },
+    {
+      "repo": "fd",
+      "arm": "default",
+      "commit": "f57206a3a13c76ad0d5eae22c2f53b42ca600040",
+      "parent": "f823eac67285013dcf58d3e1cada278f20fac058",
+      "subject": "Update help text and man page",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.3
+    },
+    {
+      "repo": "fd",
+      "arm": "near",
+      "commit": "f57206a3a13c76ad0d5eae22c2f53b42ca600040",
+      "parent": "f823eac67285013dcf58d3e1cada278f20fac058",
+      "subject": "Update help text and man page",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "06cef761b1067c6debb7dc946f2c4f202fd60083",
+      "parent": "ea03b35bb59b73f00180c88d9875ffeb72f41adc",
+      "subject": "Merge branch 'rs/blame-ignore-colors-fix'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.73
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "06cef761b1067c6debb7dc946f2c4f202fd60083",
+      "parent": "ea03b35bb59b73f00180c88d9875ffeb72f41adc",
+      "subject": "Merge branch 'rs/blame-ignore-colors-fix'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.57
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "0d5b240d73ffe8b66fe22dbe166329f1b27b5fe7",
+      "parent": "6a4418c36d6bad69a599044b3cf49dcbd049cb45",
+      "subject": "Merge branch 'kk/paint-down-to-common-optim'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.82
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "0d5b240d73ffe8b66fe22dbe166329f1b27b5fe7",
+      "parent": "6a4418c36d6bad69a599044b3cf49dcbd049cb45",
+      "subject": "Merge branch 'kk/paint-down-to-common-optim'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.28
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "341be27dfef8aba66f10be58aec1395075081e85",
+      "parent": "7b2bccb0d58d4f24705bf985de1f4612e4cf06e5",
+      "subject": "Merge branch 'lo/repo-info-keys'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.42
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "341be27dfef8aba66f10be58aec1395075081e85",
+      "parent": "7b2bccb0d58d4f24705bf985de1f4612e4cf06e5",
+      "subject": "Merge branch 'lo/repo-info-keys'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.97
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "4fee6ff3b23321b55073ca2d13c4e2aa6adaea65",
+      "parent": "0c0cbd8ab7c8e1884d6f0bdf1f36f5f9d4732553",
+      "subject": "Merge branch 'ps/reftable-portability'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.94
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "4fee6ff3b23321b55073ca2d13c4e2aa6adaea65",
+      "parent": "0c0cbd8ab7c8e1884d6f0bdf1f36f5f9d4732553",
+      "subject": "Merge branch 'ps/reftable-portability'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.99
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "6d7492cf85448df3da67e0e0a1430270d516e6ec",
+      "parent": "d17a7b8191d59e387e728ff60c2e226fa6c940bc",
+      "subject": "Merge branch 'rs/grep-column-only-match-fix'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.46
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "6d7492cf85448df3da67e0e0a1430270d516e6ec",
+      "parent": "d17a7b8191d59e387e728ff60c2e226fa6c940bc",
+      "subject": "Merge branch 'rs/grep-column-only-match-fix'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.73
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "7b7d67104e315437c46e62986e163c97c5a51dd3",
+      "parent": "2d843a2d3d6c2d5e7861e6aa99743d15d36746b9",
+      "subject": "Merge branch 'pw/no-more-NULL-means-current-worktree'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.66
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "7b7d67104e315437c46e62986e163c97c5a51dd3",
+      "parent": "2d843a2d3d6c2d5e7861e6aa99743d15d36746b9",
+      "subject": "Merge branch 'pw/no-more-NULL-means-current-worktree'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.51
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "968e62c18794535f9b010d3075806f0950aa16bb",
+      "parent": "d1f07dd50087bef18246feffb963d73b23e2cdd6",
+      "subject": "Merge branch 'rs/prio-queue-to-commit-stack'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.19
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "968e62c18794535f9b010d3075806f0950aa16bb",
+      "parent": "d1f07dd50087bef18246feffb963d73b23e2cdd6",
+      "subject": "Merge branch 'rs/prio-queue-to-commit-stack'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.33
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "c563b12ce7aa6bf8130385c80c001b2340026ff5",
+      "parent": "d4b2a7908de36697d56e79eecc50d1d92a091041",
+      "subject": "Merge branch 'ty/setup-error-tightening'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.12
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "c563b12ce7aa6bf8130385c80c001b2340026ff5",
+      "parent": "d4b2a7908de36697d56e79eecc50d1d92a091041",
+      "subject": "Merge branch 'ty/setup-error-tightening'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.29
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "e0613d24f9902a581b6a1cf0aa39b517db1e3f2f",
+      "parent": "05ddb9ee8a4c619fbb0e7309fe291bff5cd7c987",
+      "subject": "Merge branch 'sa/replay-revert'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.33
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "e0613d24f9902a581b6a1cf0aa39b517db1e3f2f",
+      "parent": "05ddb9ee8a4c619fbb0e7309fe291bff5cd7c987",
+      "subject": "Merge branch 'sa/replay-revert'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.82
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.62
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.13
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "19f54ee6ed33b7517c729c801bc57c8c0478be7d",
+      "parent": "af2179843601c73aa96062208d8f324a45243e47",
+      "subject": "Fixes #776: Add settings for the kind of newline to use (#2231)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.74
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "19f54ee6ed33b7517c729c801bc57c8c0478be7d",
+      "parent": "af2179843601c73aa96062208d8f324a45243e47",
+      "subject": "Fixes #776: Add settings for the kind of newline to use (#2231)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.7
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "335ff0f9ae2ed71714a937513d4e6aba1d4318a4",
+      "parent": "bf572581b9156002ee98866620279d92ba8dc509",
+      "subject": "validating the date format, add test case, since NumberFormatExceptio… (#2538)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 0.59
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "335ff0f9ae2ed71714a937513d4e6aba1d4318a4",
+      "parent": "bf572581b9156002ee98866620279d92ba8dc509",
+      "subject": "validating the date format, add test case, since NumberFormatExceptio… (#2538)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 0.67
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "3d241ca0a6435cbf1fa1cdaed2af8480b99fecde",
+      "parent": "5055b6246314e04f54f7d7e2c46b7d22786a9089",
+      "subject": "Modification in test cases (#2454)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.88
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "3d241ca0a6435cbf1fa1cdaed2af8480b99fecde",
+      "parent": "5055b6246314e04f54f7d7e2c46b7d22786a9089",
+      "subject": "Modification in test cases (#2454)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.98
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "3e3266cf48f132928225e1561a6ae4cb5503d08f",
+      "parent": "796193d0326a2f44bc314bf24262732ea3e64014",
+      "subject": "Perform numeric conversion for primitive numeric type adapters (#2158)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.59
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "3e3266cf48f132928225e1561a6ae4cb5503d08f",
+      "parent": "796193d0326a2f44bc314bf24262732ea3e64014",
+      "subject": "Perform numeric conversion for primitive numeric type adapters (#2158)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.74
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "5e1005ea27cdaeb2c328983521f99e6c1e177524",
+      "parent": "53234aa3518223dc13ec356cb0bd7a92211642d8",
+      "subject": "Disallow `JsonObject` `Entry.setValue(null)` (#2167)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 0.68
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "5e1005ea27cdaeb2c328983521f99e6c1e177524",
+      "parent": "53234aa3518223dc13ec356cb0bd7a92211642d8",
+      "subject": "Disallow `JsonObject` `Entry.setValue(null)` (#2167)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 0.64
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "72537db9a6095720aca3a67abe77ec5a16200081",
+      "parent": "569279fada1f623732ca4836404954d8cf8ca89c",
+      "subject": "Make AppendableWriter do flush and close if delegation object supports (#2925)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.59
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "72537db9a6095720aca3a67abe77ec5a16200081",
+      "parent": "569279fada1f623732ca4836404954d8cf8ca89c",
+      "subject": "Make AppendableWriter do flush and close if delegation object supports (#2925)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.71
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "87d30c0686822426ad2711a85bced1b5bc582572",
+      "parent": "528fd3195bad9c6c816e77c96750b3188a514365",
+      "subject": "Remove redundant generic type arguments from method calls (#2810)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.52
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "87d30c0686822426ad2711a85bced1b5bc582572",
+      "parent": "528fd3195bad9c6c816e77c96750b3188a514365",
+      "subject": "Remove redundant generic type arguments from method calls (#2810)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.62
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "8bfdbb4e14172b013c3d1f56c3a36812075e2886",
+      "parent": "9008b093ac40f226643df17c767357aa1947984a",
+      "subject": "Guarantee that `JsonElement.toString()` produces JSON (#2659)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.66
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "8bfdbb4e14172b013c3d1f56c3a36812075e2886",
+      "parent": "9008b093ac40f226643df17c767357aa1947984a",
+      "subject": "Guarantee that `JsonElement.toString()` produces JSON (#2659)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.98
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "9471163df1f972975878784d9fd3c646c8d0b840",
+      "parent": "afed86beaddf0812f4cdd038d99f461295e67a8a",
+      "subject": "Fix some new Error Prone warnings. (#2753)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 0.72
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "9471163df1f972975878784d9fd3c646c8d0b840",
+      "parent": "afed86beaddf0812f4cdd038d99f461295e67a8a",
+      "subject": "Fix some new Error Prone warnings. (#2753)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 0.95
+    },
+    {
+      "repo": "gson",
+      "arm": "default",
+      "commit": "9eb61b30acdfd1c8497eee7de9bec3a7448ff41e",
+      "parent": "681c01f1e2e5064ced8cdeb6b5c2c88bbd980d4e",
+      "subject": "Bump Error Prone to 2.49.0 and fix new warnings (#3030)",
+      "ok": true,
+      "findings": 8,
+      "duration_s": 0.84
+    },
+    {
+      "repo": "gson",
+      "arm": "near",
+      "commit": "9eb61b30acdfd1c8497eee7de9bec3a7448ff41e",
+      "parent": "681c01f1e2e5064ced8cdeb6b5c2c88bbd980d4e",
+      "subject": "Bump Error Prone to 2.49.0 and fix new warnings (#3030)",
+      "ok": true,
+      "findings": 9,
+      "duration_s": 0.96
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "1d45ec804609b91743c88200b536ead1981e2a01",
+      "parent": "a8e9533b499a446cccf7eff54e7775327fb119ec",
+      "subject": "fix tiny javadoc typo in `Strings.isNullOrEmpty()`.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.15
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "1d45ec804609b91743c88200b536ead1981e2a01",
+      "parent": "a8e9533b499a446cccf7eff54e7775327fb119ec",
+      "subject": "fix tiny javadoc typo in `Strings.isNullOrEmpty()`.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 12.23
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "2993b8f7e5b7e10e15e732aba4e3a3f12f5db555",
+      "parent": "4a21b074c12bfb7fdbbe0bffc0b9e09ad4c7baeb",
+      "subject": "Reduce visibility of members of `AbstractIndexedListIterator`.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.43
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "2993b8f7e5b7e10e15e732aba4e3a3f12f5db555",
+      "parent": "4a21b074c12bfb7fdbbe0bffc0b9e09ad4c7baeb",
+      "subject": "Reduce visibility of members of `AbstractIndexedListIterator`.",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 12.76
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "2b6b902d4ebefa14e18521a6b9ac772c9ab1e136",
+      "parent": "1eb270d2a30638b3b8ac62bc3eef852ddd86e1a2",
+      "subject": "Address a subset of warnings from the likely forthcoming https://errorprone.info/bugpattern/ExposedPrivateType.",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 10.1
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "2b6b902d4ebefa14e18521a6b9ac772c9ab1e136",
+      "parent": "1eb270d2a30638b3b8ac62bc3eef852ddd86e1a2",
+      "subject": "Address a subset of warnings from the likely forthcoming https://errorprone.info/bugpattern/ExposedPrivateType.",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 13.75
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "2f1ebdd49d945ff2c9e7b80818390cccc32cc034",
+      "parent": "56ee117de0debbc7bf7f9530ff775bc81aff7740",
+      "subject": "Suppress some tests under J2KT to address failures from cl/864303970 + cl/863485621.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.17
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "2f1ebdd49d945ff2c9e7b80818390cccc32cc034",
+      "parent": "56ee117de0debbc7bf7f9530ff775bc81aff7740",
+      "subject": "Suppress some tests under J2KT to address failures from cl/864303970 + cl/863485621.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.35
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "41673f4992f03708bd3b5c529eaed27b0441eaa2",
+      "parent": "5267fc45d12f1111915bf3d389eb918b6e44ac3e",
+      "subject": "Test that `AbstractFuture` does not declare a static initializer.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.0
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "41673f4992f03708bd3b5c529eaed27b0441eaa2",
+      "parent": "5267fc45d12f1111915bf3d389eb918b6e44ac3e",
+      "subject": "Test that `AbstractFuture` does not declare a static initializer.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 12.23
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "4802ac3c1be4ac806b8ca4477e5e875bb5f84e16",
+      "parent": "2e27929f97bdb81e8115188343ebfb6666ea1b3f",
+      "subject": "Speed up AbstractNonStreamingHashFunction for non-bytes types",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.59
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "4802ac3c1be4ac806b8ca4477e5e875bb5f84e16",
+      "parent": "2e27929f97bdb81e8115188343ebfb6666ea1b3f",
+      "subject": "Speed up AbstractNonStreamingHashFunction for non-bytes types",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.89
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "576e8b28d35a6f5d858f1eb1178c84e68baf317d",
+      "parent": "3550b988de50fcab6745399ea7318d56449d7d80",
+      "subject": "Change `Combiner.inputs` to be `private`.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.4
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "576e8b28d35a6f5d858f1eb1178c84e68baf317d",
+      "parent": "3550b988de50fcab6745399ea7318d56449d7d80",
+      "subject": "Change `Combiner.inputs` to be `private`.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.0
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "b2975e90b6552943a8d31cf965b52a4c73c5b69c",
+      "parent": "21a7198063bf2b3d5fdc71fac4aaafb0667f6f0d",
+      "subject": "Use Truth in place of `assertEquals` assertions for `Boolean` instances.",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 10.58
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "b2975e90b6552943a8d31cf965b52a4c73c5b69c",
+      "parent": "21a7198063bf2b3d5fdc71fac4aaafb0667f6f0d",
+      "subject": "Use Truth in place of `assertEquals` assertions for `Boolean` instances.",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.77
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "b4db46493f604aabca8ab352e14beb896a94ad95",
+      "parent": "263049692413ddc43ef348e5064da429504b71c7",
+      "subject": "Update Public Suffix List data.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.24
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "b4db46493f604aabca8ab352e14beb896a94ad95",
+      "parent": "263049692413ddc43ef348e5064da429504b71c7",
+      "subject": "Update Public Suffix List data.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.39
+    },
+    {
+      "repo": "guava",
+      "arm": "default",
+      "commit": "d6bdc7be7e8003c1d9bdd7a76c449471d42e02f2",
+      "parent": "779296787cd3bdaca92340d2dd63c0a01c871cd0",
+      "subject": "Fix or suppress some https://errorprone.info/bugpattern/ClassCanBeStatic warnings.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.65
+    },
+    {
+      "repo": "guava",
+      "arm": "near",
+      "commit": "d6bdc7be7e8003c1d9bdd7a76c449471d42e02f2",
+      "parent": "779296787cd3bdaca92340d2dd63c0a01c871cd0",
+      "subject": "Fix or suppress some https://errorprone.info/bugpattern/ClassCanBeStatic warnings.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 12.02
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "00c4228f61c839431957a6750f1fe1f0016aefec",
+      "parent": "5f5b2f378f51fe1c3a7e50f29f55b8e592b23e8a",
+      "subject": "testscripts: Move server tests to own folder",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.02
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "00c4228f61c839431957a6750f1fe1f0016aefec",
+      "parent": "5f5b2f378f51fe1c3a7e50f29f55b8e592b23e8a",
+      "subject": "testscripts: Move server tests to own folder",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.37
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "3c823408ee51bbfbad847d4b9f926ba813097185",
+      "parent": "3f9d0ad2b6045849cbafe133cb9fb82ed5f5ee06",
+      "subject": "Move common/hugo/HugoInfo to resources/page",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.28
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "3c823408ee51bbfbad847d4b9f926ba813097185",
+      "parent": "3f9d0ad2b6045849cbafe133cb9fb82ed5f5ee06",
+      "subject": "Move common/hugo/HugoInfo to resources/page",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 4.41
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "5d51b82a7e096abaf3e34f5bd89aaca9e0d939c9",
+      "parent": "d81e3c29c0ec6832c28498a3bcbc4b1ff2c3879d",
+      "subject": "resources: Fix the :counter placeholder",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.83
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "5d51b82a7e096abaf3e34f5bd89aaca9e0d939c9",
+      "parent": "d81e3c29c0ec6832c28498a3bcbc4b1ff2c3879d",
+      "subject": "resources: Fix the :counter placeholder",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.9
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "991d2f9aba69a5b79bb46c40faf57c7b6d7adcc9",
+      "parent": "b29c2f7adee341353bf9f39570482bfa32790f01",
+      "subject": "Replace Exif with Meta in tests",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.52
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "991d2f9aba69a5b79bb46c40faf57c7b6d7adcc9",
+      "parent": "b29c2f7adee341353bf9f39570482bfa32790f01",
+      "subject": "Replace Exif with Meta in tests",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.53
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.96
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.34
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "d27b9c06bddbf2482e351aba0ce99fec2c5dafa8",
+      "parent": "62cef3678b219d0daf15dad040bd3df9384e5162",
+      "subject": "tpl/tplimpl: Extend page image lookup to include global resources",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.3
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "d27b9c06bddbf2482e351aba0ce99fec2c5dafa8",
+      "parent": "62cef3678b219d0daf15dad040bd3df9384e5162",
+      "subject": "tpl/tplimpl: Extend page image lookup to include global resources",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.21
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "dc9b51d2e2fa1bfc2b7c68c01417bb7ae2c9c6a2",
+      "parent": "481baa08968e29e2a2771e9d6022c9f995b2fc11",
+      "subject": "markup/goldmark: Fix double-escaping of ampersands in link URLs",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.25
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "dc9b51d2e2fa1bfc2b7c68c01417bb7ae2c9c6a2",
+      "parent": "481baa08968e29e2a2771e9d6022c9f995b2fc11",
+      "subject": "markup/goldmark: Fix double-escaping of ampersands in link URLs",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.36
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "eaf4c7515a63224b75279575d7ffc8c0ec40776b",
+      "parent": "3315a86d67dafda106eb8e422f8aebff67bff92d",
+      "subject": "tpl/tplimpl: Fix Vimeo shortcode test",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.06
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "eaf4c7515a63224b75279575d7ffc8c0ec40776b",
+      "parent": "3315a86d67dafda106eb8e422f8aebff67bff92d",
+      "subject": "tpl/tplimpl: Fix Vimeo shortcode test",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.84
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "ee91280412078dd0c12e701891c68a1e6f550ff1",
+      "parent": "8a858213b73907e823e2be2b5640a0ce4c04d295",
+      "subject": "releaser: Prepare repository for 0.156.0-DEV",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.91
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "ee91280412078dd0c12e701891c68a1e6f550ff1",
+      "parent": "8a858213b73907e823e2be2b5640a0ce4c04d295",
+      "subject": "releaser: Prepare repository for 0.156.0-DEV",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.3
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "f5fce935e768f4c301fb5c825e512a17f8a13e2e",
+      "parent": "52123ae23f38ed474e3414ba386cbb47c4539f0c",
+      "subject": "tpl/collections: Honor the Eqer interface in where comparisons",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.31
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "f5fce935e768f4c301fb5c825e512a17f8a13e2e",
+      "parent": "52123ae23f38ed474e3414ba386cbb47c4539f0c",
+      "subject": "tpl/collections: Honor the Eqer interface in where comparisons",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.61
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "357edffef532d383da10e30d001ff0105361e6d8",
+      "parent": "94830794dc5dfca1b49bc435b7b031b27838a798",
+      "subject": "Update the website. (#15940)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.21
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "357edffef532d383da10e30d001ff0105361e6d8",
+      "parent": "94830794dc5dfca1b49bc435b7b031b27838a798",
+      "subject": "Update the website. (#15940)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.07
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "37b16862e6116e572f25479fb5459b8a0da73a4c",
+      "parent": "c2b2faa1e1ae945561cce025bc27b9b8360b2965",
+      "subject": "fix: prevent double teardown on test environment error (#15731)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.42
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "37b16862e6116e572f25479fb5459b8a0da73a4c",
+      "parent": "c2b2faa1e1ae945561cce025bc27b9b8360b2965",
+      "subject": "fix: prevent double teardown on test environment error (#15731)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.0
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "404ea042037b8a0929e9bf418c5d21c6c4a096b7",
+      "parent": "4f964516152633333c12a1e0239a358344dccc75",
+      "subject": "fix(jest-runtime): apply moduleNameMapper to require.resolve paths (#16135)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.7
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "404ea042037b8a0929e9bf418c5d21c6c4a096b7",
+      "parent": "4f964516152633333c12a1e0239a358344dccc75",
+      "subject": "fix(jest-runtime): apply moduleNameMapper to require.resolve paths (#16135)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.86
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "7a1588e41bfaff92742865c716776cead0d62e86",
+      "parent": "572dbae747d8b2c0cc8ddca6e2739b3764401069",
+      "subject": "feat: add `isError` helper (#16076)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.96
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "7a1588e41bfaff92742865c716776cead0d62e86",
+      "parent": "572dbae747d8b2c0cc8ddca6e2739b3764401069",
+      "subject": "feat: add `isError` helper (#16076)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.95
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "a2218e4f794f914884c403ecceb274ada595f2b9",
+      "parent": "8fcefef1780c13e17c79ac1b07d7ea0c9f7f7c34",
+      "subject": "Stop using `import X = require('…')`. (#15659)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.26
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "a2218e4f794f914884c403ecceb274ada595f2b9",
+      "parent": "8fcefef1780c13e17c79ac1b07d7ea0c9f7f7c34",
+      "subject": "Stop using `import X = require('…')`. (#15659)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.28
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "ab15575283ebdff53f0266ab08bce2758681035a",
+      "parent": "6c568953f50b68d626adee2f005adf50a0861b45",
+      "subject": "feat: allow passing TS config loader options (#15234)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.12
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "ab15575283ebdff53f0266ab08bce2758681035a",
+      "parent": "6c568953f50b68d626adee2f005adf50a0861b45",
+      "subject": "feat: allow passing TS config loader options (#15234)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.34
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "b36d6edf1343059a1cab13920cfbcb7afe2b075e",
+      "parent": "4d5f41d0885c1d9630c81b4fd47f74ab0615e18f",
+      "subject": "fix(snapshot-utils): Handle Windows line endings (#15800)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.42
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "b36d6edf1343059a1cab13920cfbcb7afe2b075e",
+      "parent": "4d5f41d0885c1d9630c81b4fd47f74ab0615e18f",
+      "subject": "fix(snapshot-utils): Handle Windows line endings (#15800)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.52
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.71
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.79
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "cfd6e34b0d44cc8d176eb7343251f3f4e55b0aa9",
+      "parent": "4556297436a21c17a1c24aea4a85a6bd239413b8",
+      "subject": "chore: migrate `eslint-plugin-markdown` to `@eslint/markdown` (#15618)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.23
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "cfd6e34b0d44cc8d176eb7343251f3f4e55b0aa9",
+      "parent": "4556297436a21c17a1c24aea4a85a6bd239413b8",
+      "subject": "chore: migrate `eslint-plugin-markdown` to `@eslint/markdown` (#15618)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.39
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "e6d71a25b08f016b2d5ac5723b6b22f71be5b969",
+      "parent": "f4246f31395d209d102aa51ee6d5e53b96e69812",
+      "subject": "[jest-get-type] minor simplification (#15514)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.12
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "e6d71a25b08f016b2d5ac5723b6b22f71be5b969",
+      "parent": "f4246f31395d209d102aa51ee6d5e53b96e69812",
+      "subject": "[jest-get-type] minor simplification (#15514)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.29
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "02ba581ecf8414788804009ea554478f97657f55",
+      "parent": "b44b2a090cf62519b1e5bf61927808dbe44e87ff",
+      "subject": "custom user-agent transport wrapper (#21483)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.8
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "02ba581ecf8414788804009ea554478f97657f55",
+      "parent": "b44b2a090cf62519b1e5bf61927808dbe44e87ff",
+      "subject": "custom user-agent transport wrapper (#21483)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.61
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.77
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.33
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "2712f7576279598993376968c18aa09dc2772534",
+      "parent": "4c46668da886e2f12030ad0f5d7176d092c231ea",
+      "subject": "prevent IAM cleanup errors (#20691)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.31
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "2712f7576279598993376968c18aa09dc2772534",
+      "parent": "4c46668da886e2f12030ad0f5d7176d092c231ea",
+      "subject": "prevent IAM cleanup errors (#20691)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.71
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "2c7fe094d11b023623f18b2a04cb1675587c3de6",
+      "parent": "9ebe168782a9d3d12b58d5be276f0f2d6aea4d3d",
+      "subject": "s3: Fix early listing stopping when ILM is enabled (#472) (#21246)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.96
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "2c7fe094d11b023623f18b2a04cb1675587c3de6",
+      "parent": "9ebe168782a9d3d12b58d5be276f0f2d6aea4d3d",
+      "subject": "s3: Fix early listing stopping when ILM is enabled (#472) (#21246)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.2
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "398ffb1136a46639eb220a1cd33707fb3420cb65",
+      "parent": "5862582cd7d0067793698d1fcd9a7c3ed331aa27",
+      "subject": " Enable compression with encryption in CopyObject API  (#20411)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 3.82
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "398ffb1136a46639eb220a1cd33707fb3420cb65",
+      "parent": "5862582cd7d0067793698d1fcd9a7c3ed331aa27",
+      "subject": " Enable compression with encryption in CopyObject API  (#20411)",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 4.49
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "402b798f1b794741663aad8061b9f74832379f9d",
+      "parent": "4759532e90346bcb43d8430c2d60da1a7b54226f",
+      "subject": "fix: allow all console actions with custom authZ (#20489)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.11
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "402b798f1b794741663aad8061b9f74832379f9d",
+      "parent": "4759532e90346bcb43d8430c2d60da1a7b54226f",
+      "subject": "fix: allow all console actions with custom authZ (#20489)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.6
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "6640be3bedac19eb41dd86cf1ac33ea049b7b7e4",
+      "parent": "eafeb27e90934e08aa11f9139ad0f6efb604d56f",
+      "subject": "fix: listParts crash when partNumberMarker is expected (#620)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.36
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "6640be3bedac19eb41dd86cf1ac33ea049b7b7e4",
+      "parent": "eafeb27e90934e08aa11f9139ad0f6efb604d56f",
+      "subject": "fix: listParts crash when partNumberMarker is expected (#620)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.63
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "6f47414b23dc1e6be8800daea81633887d61ba4e",
+      "parent": "224a27992a0d0f24f0eada31a49859c88993ff98",
+      "subject": "Correct bucket metrics name (#20823)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.98
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "6f47414b23dc1e6be8800daea81633887d61ba4e",
+      "parent": "224a27992a0d0f24f0eada31a49859c88993ff98",
+      "subject": "Correct bucket metrics name (#20823)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.67
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "b312f134736a573ab2c3a5440e86a141d85ec436",
+      "parent": "727a803bc01f3e7cac5908968262604790ec40d5",
+      "subject": "Extract all files from encrypted stream with inspect (#20937)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.21
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "b312f134736a573ab2c3a5440e86a141d85ec436",
+      "parent": "727a803bc01f3e7cac5908968262604790ec40d5",
+      "subject": "Extract all files from encrypted stream with inspect (#20937)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.6
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "f85c28e960013df229392e4a16908b4cd54f7bad",
+      "parent": "f7e176d4ca6075c56ca9525d6d5f10aa57fef3f5",
+      "subject": "heal: large objects fix and avoid .healing.bin corner case premature exit (#20577)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.92
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "f85c28e960013df229392e4a16908b4cd54f7bad",
+      "parent": "f7e176d4ca6075c56ca9525d6d5f10aa57fef3f5",
+      "subject": "heal: large objects fix and avoid .healing.bin corner case premature exit (#20577)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.77
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "211accf32d19133170541ec334200cb2d6db9a32",
+      "parent": "4a6b87558af6f1338c75d7ed3a65091dd4bcb0e7",
+      "subject": "Native DNS resolver: Guard against malloc failures (#16559)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.14
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "211accf32d19133170541ec334200cb2d6db9a32",
+      "parent": "4a6b87558af6f1338c75d7ed3a65091dd4bcb0e7",
+      "subject": "Native DNS resolver: Guard against malloc failures (#16559)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 12.39
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.15
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.71
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "2d7c55e94b08f1a731f70869545df06ca54e492e",
+      "parent": "0399e4a4b2893c9dfdaf0286c785347276ce6c72",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.8
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "2d7c55e94b08f1a731f70869545df06ca54e492e",
+      "parent": "0399e4a4b2893c9dfdaf0286c785347276ce6c72",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.27
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "596be74de29fa87ba4c5a94c18e9bc8684ad4fee",
+      "parent": "b9eaceaf6a3024e1822dd760df76db27991bfa8a",
+      "subject": "Remove dead native declarations (#16783)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.76
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "596be74de29fa87ba4c5a94c18e9bc8684ad4fee",
+      "parent": "b9eaceaf6a3024e1822dd760df76db27991bfa8a",
+      "subject": "Remove dead native declarations (#16783)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.22
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "66568d1ab8bcd34d4b2d48636e69bf6c0d773034",
+      "parent": "dfe0972b53c79367245259bb63138167bd79251f",
+      "subject": "Fix IllegalReferenceCountException in AdaptiveByteBuf.deallocate() (#16654)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 10.56
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "66568d1ab8bcd34d4b2d48636e69bf6c0d773034",
+      "parent": "dfe0972b53c79367245259bb63138167bd79251f",
+      "subject": "Fix IllegalReferenceCountException in AdaptiveByteBuf.deallocate() (#16654)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 11.48
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "95cc055f6f564af1561be4f52d5a24b99bb73e2a",
+      "parent": "a40fb71bc09e94efb42830bd5dbf1b529c61c8e9",
+      "subject": "Fix high-order bit aliasing in HttpUtil.validateToken (#16279)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.85
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "95cc055f6f564af1561be4f52d5a24b99bb73e2a",
+      "parent": "a40fb71bc09e94efb42830bd5dbf1b529c61c8e9",
+      "subject": "Fix high-order bit aliasing in HttpUtil.validateToken (#16279)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.47
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d",
+      "parent": "e216d307ef2c0018c3b833249a12ef8485ceefa9",
+      "subject": "Fix UnsupportedOperationException in readTrailingHeaders (#16412)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 8.97
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d",
+      "parent": "e216d307ef2c0018c3b833249a12ef8485ceefa9",
+      "subject": "Fix UnsupportedOperationException in readTrailingHeaders (#16412)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 11.87
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "cdba011dfb91d586340b7a6d3ed41063e06b8e59",
+      "parent": "48162ced7e381200658e645f6be79e3d30846f7e",
+      "subject": "IoUring: Use more correct bitmask check (#16507)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.28
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "cdba011dfb91d586340b7a6d3ed41063e06b8e59",
+      "parent": "48162ced7e381200658e645f6be79e3d30846f7e",
+      "subject": "IoUring: Use more correct bitmask check (#16507)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.42
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "e62d403f9eeb80f2fbb0f60871f5d876deff66b4",
+      "parent": "afec03ab02bc1640630a23c33f3a1153d0c9db95",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.69
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "e62d403f9eeb80f2fbb0f60871f5d876deff66b4",
+      "parent": "afec03ab02bc1640630a23c33f3a1153d0c9db95",
+      "subject": "Merge commit from fork",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.91
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "fb4cd81d13a0d0e3003110d3bca5628297fdde81",
+      "parent": "b7ec449fe6b83e2603e92b5fc0d9be7c85141533",
+      "subject": "Fix leak in SniHandlerTest (#16367)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 8.88
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "fb4cd81d13a0d0e3003110d3bca5628297fdde81",
+      "parent": "b7ec449fe6b83e2603e92b5fc0d9be7c85141533",
+      "subject": "Fix leak in SniHandlerTest (#16367)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.36
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "2322275644b51d4942b55a05f866a7766da6d830",
+      "parent": "e4804b143962254067997bb44be47d4b70f7fe16",
+      "subject": "Refactor `printKey` (#18708)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.42
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "2322275644b51d4942b55a05f866a7766da6d830",
+      "parent": "e4804b143962254067997bb44be47d4b70f7fe16",
+      "subject": "Refactor `printKey` (#18708)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.37
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "599bad14158a7815430662f96ecdd6d2e1f0fe54",
+      "parent": "cc90434c80cf60e8f6a5b64066325d3d6113df5a",
+      "subject": "Fix parenthesis for optional function as return type (#11004)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.44
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "599bad14158a7815430662f96ecdd6d2e1f0fe54",
+      "parent": "cc90434c80cf60e8f6a5b64066325d3d6113df5a",
+      "subject": "Fix parenthesis for optional function as return type (#11004)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.45
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "5adf56767677972faef02b147a95c8cc32a97618",
+      "parent": "afb9c080bdcc183623be40b618ee569644fcccce",
+      "subject": "Support directives on directive definitions in GraphQL (#19171)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.75
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "5adf56767677972faef02b147a95c8cc32a97618",
+      "parent": "afb9c080bdcc183623be40b618ee569644fcccce",
+      "subject": "Support directives on directive definitions in GraphQL (#19171)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.08
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "5d0e890a5022b5957db3cc68215c33255d8de40c",
+      "parent": "11c31c6b61c919d889dcefc1e58443f6f75ed598",
+      "subject": "Exclude semicolon from `DoWhileStatement` (#18851)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.89
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "5d0e890a5022b5957db3cc68215c33255d8de40c",
+      "parent": "11c31c6b61c919d889dcefc1e58443f6f75ed598",
+      "subject": "Exclude semicolon from `DoWhileStatement` (#18851)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.65
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "719373fb7566b009fb4f209ce36767a6bdfc93a8",
+      "parent": "f5e3980c3085f6fb2b166c8e3f91e8db317d6eb2",
+      "subject": "Move `BreakStatement` `ContinueStatement` location override to `locEnd` (#18675)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.43
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "719373fb7566b009fb4f209ce36767a6bdfc93a8",
+      "parent": "f5e3980c3085f6fb2b166c8e3f91e8db317d6eb2",
+      "subject": "Move `BreakStatement` `ContinueStatement` location override to `locEnd` (#18675)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.39
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "8bb1341ff4be1e5849e569676204784b2470dbe1",
+      "parent": "5d5094e084decf2fde61e7be1bde2cf3236ba1aa",
+      "subject": "Update flow parse options (#18641)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.42
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "8bb1341ff4be1e5849e569676204784b2470dbe1",
+      "parent": "5d5094e084decf2fde61e7be1bde2cf3236ba1aa",
+      "subject": "Update flow parse options (#18641)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.4
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "8d63dddaaa63f000c5c26d125ef84157f7c7bf18",
+      "parent": "e79c012e3bd122cb76637a11c4b28c98de55abe1",
+      "subject": "Update to yaml@2 (#18419)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 7.46
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "8d63dddaaa63f000c5c26d125ef84157f7c7bf18",
+      "parent": "e79c012e3bd122cb76637a11c4b28c98de55abe1",
+      "subject": "Update to yaml@2 (#18419)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 9.38
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "b4489dc05fa6d8a443410e59223ba807f884a0af",
+      "parent": "5638eb6966468ea82316678f95675999fbfcfcc8",
+      "subject": "Update flow parser to v0.307.0 (#19038)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.38
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "b4489dc05fa6d8a443410e59223ba807f884a0af",
+      "parent": "5638eb6966468ea82316678f95675999fbfcfcc8",
+      "subject": "Update flow parser to v0.307.0 (#19038)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.32
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "d4f80427db73cc9495be2badf597f96db32178f0",
+      "parent": "df65ef94eab7932557618dba48a99a531b665df5",
+      "subject": "Improve `handleIfStatementComments` (#18809)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.37
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "d4f80427db73cc9495be2badf597f96db32178f0",
+      "parent": "df65ef94eab7932557618dba48a99a531b665df5",
+      "subject": "Improve `handleIfStatementComments` (#18809)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.57
+    },
+    {
+      "repo": "prettier",
+      "arm": "default",
+      "commit": "e8413ba558ca7c309ac7d15328599fa77f2cde71",
+      "parent": "0fb018ccd5c2a91910fccebdcabcd9c69e2a4f4f",
+      "subject": "Add parentheses to conditional types in type parameter constraint (#18760)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.31
+    },
+    {
+      "repo": "prettier",
+      "arm": "near",
+      "commit": "e8413ba558ca7c309ac7d15328599fa77f2cde71",
+      "parent": "0fb018ccd5c2a91910fccebdcabcd9c69e2a4f4f",
+      "subject": "Add parentheses to conditional types in type parameter constraint (#18760)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.65
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "0dd834e924156a82fd8c7f45089a0b6a18ec85f5",
+      "parent": "320901614eee8122cf6bb4ff6183e17bdd9b1ee1",
+      "subject": "Merge pull request #18406 from machine424/depll",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.97
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "0dd834e924156a82fd8c7f45089a0b6a18ec85f5",
+      "parent": "320901614eee8122cf6bb4ff6183e17bdd9b1ee1",
+      "subject": "Merge pull request #18406 from machine424/depll",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.37
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "0f5727f420f890d9bb5679325a2d606a9da7ac23",
+      "parent": "ea787c89cbe7fbc4e4cf1cbe4785d2de4c83a042",
+      "subject": "tsdb: count EncXOR2 chunks as float samples; fix snapshot encoding (#18739)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.33
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "0f5727f420f890d9bb5679325a2d606a9da7ac23",
+      "parent": "ea787c89cbe7fbc4e4cf1cbe4785d2de4c83a042",
+      "subject": "tsdb: count EncXOR2 chunks as float samples; fix snapshot encoding (#18739)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.24
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "129ee0d31786ae020bcadc5535f2889a6fd6924d",
+      "parent": "c591287db3ff5a19597219e932f55aa5d559b027",
+      "subject": "PromQL: `resets()` function considers start timestamp resets (#18627)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.95
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "129ee0d31786ae020bcadc5535f2889a6fd6924d",
+      "parent": "c591287db3ff5a19597219e932f55aa5d559b027",
+      "subject": "PromQL: `resets()` function considers start timestamp resets (#18627)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 4.66
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "551b5b1c565215536b46a648300d53acf968ea61",
+      "parent": "9c89645d8714add0e0660695be060d340a4f03df",
+      "subject": "Merge pull request #17171 from bboreham/aws-external-id",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 3.46
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "551b5b1c565215536b46a648300d53acf968ea61",
+      "parent": "9c89645d8714add0e0660695be060d340a4f03df",
+      "subject": "Merge pull request #17171 from bboreham/aws-external-id",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.29
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "971e64756eecb6bcae93f321a1a1cb2c2c2cd705",
+      "parent": "07c6232d159bfb474a077788be184d87adcfac3c",
+      "subject": "Merge pull request #18498 from ldufr/revive-emit-warning-when-sort-is-used-range",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.0
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "971e64756eecb6bcae93f321a1a1cb2c2c2cd705",
+      "parent": "07c6232d159bfb474a077788be184d87adcfac3c",
+      "subject": "Merge pull request #18498 from ldufr/revive-emit-warning-when-sort-is-used-range",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.84
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "b2e63376da7487c32ae4e2ec45434b0f4d8adb12",
+      "parent": "5bd0d00f8ca1ec808015b30f30b3cf1dba656518",
+      "subject": "Merge pull request #18105 from mmorel-35/staticcheck",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.78
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "b2e63376da7487c32ae4e2ec45434b0f4d8adb12",
+      "parent": "5bd0d00f8ca1ec808015b30f30b3cf1dba656518",
+      "subject": "Merge pull request #18105 from mmorel-35/staticcheck",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.55
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "c532b658e4b537245b2b4178937b333b8833a13e",
+      "parent": "bdfb3fc2327b49392abb948334b38e35113dda84",
+      "subject": "histograms: BenchmarkFloatHistogramAdd (#18248)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.72
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "c532b658e4b537245b2b4178937b333b8833a13e",
+      "parent": "bdfb3fc2327b49392abb948334b38e35113dda84",
+      "subject": "histograms: BenchmarkFloatHistogramAdd (#18248)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.6
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "cb3382314d63ed457279c9582cd6db63d0a06631",
+      "parent": "3f40ca38e6c371b9cb83fd8b552bb5532263e2a4",
+      "subject": "Merge pull request #18374 from roidelapluie/roidelapluie/retention-percentage-float",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.17
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "cb3382314d63ed457279c9582cd6db63d0a06631",
+      "parent": "3f40ca38e6c371b9cb83fd8b552bb5532263e2a4",
+      "subject": "Merge pull request #18374 from roidelapluie/roidelapluie/retention-percentage-float",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.35
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "f3d653fb5cee5e503356eef531b5da7e578cf22f",
+      "parent": "91fa0fd5b77d20c458fd0107b2e3ba5992ad71b3",
+      "subject": "chore: fix typos in comments (#18834)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.75
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "f3d653fb5cee5e503356eef531b5da7e578cf22f",
+      "parent": "91fa0fd5b77d20c458fd0107b2e3ba5992ad71b3",
+      "subject": "chore: fix typos in comments (#18834)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.06
+    },
+    {
+      "repo": "prometheus",
+      "arm": "default",
+      "commit": "f5fe1573bac68e1a43cb9289517fffca6c38eeb2",
+      "parent": "318980a5c284ef577c074ca18bd23112e81abb40",
+      "subject": "Merge pull request #18219 from machine424/ttyyy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.88
+    },
+    {
+      "repo": "prometheus",
+      "arm": "near",
+      "commit": "f5fe1573bac68e1a43cb9289517fffca6c38eeb2",
+      "parent": "318980a5c284ef577c074ca18bd23112e81abb40",
+      "subject": "Merge pull request #18219 from machine424/ttyyy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.94
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "07c5e5640be7fb0c0ff08a9e919755bfd3feb410",
+      "parent": "7842df622ffb4243edbed865c3dd72569c86e95c",
+      "subject": "redis-cli: Add word-jump navigation (Alt/Option + ←/→, Ctrl + ←/→) (#14331)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.77
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "07c5e5640be7fb0c0ff08a9e919755bfd3feb410",
+      "parent": "7842df622ffb4243edbed865c3dd72569c86e95c",
+      "subject": "redis-cli: Add word-jump navigation (Alt/Option + ←/→, Ctrl + ←/→) (#14331)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.25
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "0fa78fd8fddaa1576070ac430d4d796d7396835e",
+      "parent": "58dc4f3c854a5abd18a826f97f39048dd1a6abd2",
+      "subject": "perf: widen fast_float_strtod fast path to 17-19 digit mantissas (#15061)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.55
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "0fa78fd8fddaa1576070ac430d4d796d7396835e",
+      "parent": "58dc4f3c854a5abd18a826f97f39048dd1a6abd2",
+      "subject": "perf: widen fast_float_strtod fast path to 17-19 digit mantissas (#15061)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.18
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.27
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.64
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "31a4356ac0aaabcd8f4ace568e14e18eb462b3e6",
+      "parent": "44157ee35e62f7670d67c84f8739af7d2f283045",
+      "subject": "GCRA Rate Limiter (#14826)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.66
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "31a4356ac0aaabcd8f4ace568e14e18eb462b3e6",
+      "parent": "44157ee35e62f7670d67c84f8739af7d2f283045",
+      "subject": "GCRA Rate Limiter (#14826)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.43
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "5e155593d9df688274fd82b63def60c82bc0df33",
+      "parent": "a38493a70e63086fc148c91785c45e8480b52071",
+      "subject": "Reject corrupt stream payloads with mismatched entry counts (#15124)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.28
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "5e155593d9df688274fd82b63def60c82bc0df33",
+      "parent": "a38493a70e63086fc148c91785c45e8480b52071",
+      "subject": "Reject corrupt stream payloads with mismatched entry counts (#15124)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.95
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "5ee05d8de489fadb30a75f46c8e931888d6c5401",
+      "parent": "bb6389e8237723b2c88325a4c4b7853a48db2da2",
+      "subject": "Broadcast config change immediately to the other nodes in cluster (#14504)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.99
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "5ee05d8de489fadb30a75f46c8e931888d6c5401",
+      "parent": "bb6389e8237723b2c88325a4c4b7853a48db2da2",
+      "subject": "Broadcast config change immediately to the other nodes in cluster (#14504)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.9
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "8da9c04bb8dae11a2ccea5b5017f529f2f809b9e",
+      "parent": "7e7c7b0558124c53bf5c4b48a0f07b45914da818",
+      "subject": "Eliminate zslGetRank calls from ZCOUNT/ZLEXCOUNT + simplify zslGetRankByNode() (#14684)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 2.24
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "8da9c04bb8dae11a2ccea5b5017f529f2f809b9e",
+      "parent": "7e7c7b0558124c53bf5c4b48a0f07b45914da818",
+      "subject": "Eliminate zslGetRank calls from ZCOUNT/ZLEXCOUNT + simplify zslGetRankByNode() (#14684)",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 4.24
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "b22ce4abb50360bda0e7a7ae9bfa95e1af38853c",
+      "parent": "a6a27f56f2df1a9da3d46aea1fca6e33a89e3f61",
+      "subject": "Fix sds unit test and improve unittest output formatting (#14927)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.16
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "b22ce4abb50360bda0e7a7ae9bfa95e1af38853c",
+      "parent": "a6a27f56f2df1a9da3d46aea1fca6e33a89e3f61",
+      "subject": "Fix sds unit test and improve unittest output formatting (#14927)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.06
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "cecdc998736d81108711982cc0fb7b90bdf1c624",
+      "parent": "37f685908eb3fac84bb1f57a4ed577be6bce6802",
+      "subject": "Optimize Redis XREADGROUP CLAIM (#14726)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 3.65
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "cecdc998736d81108711982cc0fb7b90bdf1c624",
+      "parent": "37f685908eb3fac84bb1f57a4ed577be6bce6802",
+      "subject": "Optimize Redis XREADGROUP CLAIM (#14726)",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 3.85
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "fde3576f8898b0d851f4d20620810e3a5ef489c1",
+      "parent": "c5f3d3e11ce1bbcf9713003d5e94c211de5ab8d1",
+      "subject": "Fix adjacent slot range behavior in ASM operations (#14637)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.4
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "fde3576f8898b0d851f4d20620810e3a5ef489c1",
+      "parent": "c5f3d3e11ce1bbcf9713003d5e94c211de5ab8d1",
+      "subject": "Fix adjacent slot range behavior in ASM operations (#14637)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.44
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "1873e96a7bc36595ddcfae1968ee84ed9af4ae04",
+      "parent": "89ff15310b72d73f64acaf77c37d350f14455164",
+      "subject": "automata: add `DFA::set_prefilter` method to the DFA types",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.36
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "1873e96a7bc36595ddcfae1968ee84ed9af4ae04",
+      "parent": "89ff15310b72d73f64acaf77c37d350f14455164",
+      "subject": "automata: add `DFA::set_prefilter` method to the DFA types",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.86
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "308f9e949f4e4515eb56e65a6445ff03c83e225c",
+      "parent": "c2888da95e6f8f28a2782b8a58e83abee4ea0e5c",
+      "subject": "doc: add example that uses an alternation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.62
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "308f9e949f4e4515eb56e65a6445ff03c83e225c",
+      "parent": "c2888da95e6f8f28a2782b8a58e83abee4ea0e5c",
+      "subject": "doc: add example that uses an alternation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.94
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "536cf701ade853afd2a7a541684485f24491be91",
+      "parent": "17d9c1c6c4368fb0a18f88d0698482063931a361",
+      "subject": "syntax: remove guarantees in the HIR related to 'u' flag",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.76
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "536cf701ade853afd2a7a541684485f24491be91",
+      "parent": "17d9c1c6c4368fb0a18f88d0698482063931a361",
+      "subject": "syntax: remove guarantees in the HIR related to 'u' flag",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.97
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "5fed4167240b3370fde354b8c8de803527b4e283",
+      "parent": "784c271d0b404f60d175444345dae01f7f29b819",
+      "subject": "syntax: rejigger Hir::{dot,any}",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.9
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "5fed4167240b3370fde354b8c8de803527b4e283",
+      "parent": "784c271d0b404f60d175444345dae01f7f29b819",
+      "subject": "syntax: rejigger Hir::{dot,any}",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.88
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "930770bb8b4811b80a9cfbd0237d1f225e7c7c20",
+      "parent": "e29b915c3878fadfe63041f29ddb5f4a5bfc4f8d",
+      "subject": "regex: switch RegexSet to use WhichCaptures::None",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.39
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "930770bb8b4811b80a9cfbd0237d1f225e7c7c20",
+      "parent": "e29b915c3878fadfe63041f29ddb5f4a5bfc4f8d",
+      "subject": "regex: switch RegexSet to use WhichCaptures::None",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.46
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+      "parent": "8773579baf55bc801c32d5e4c20293baf75d325e",
+      "subject": "regex-automata: fix bug in DFA quit behavior",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 1.71
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "95a745ecb619c2cb5e83fddb9445cf3bb2db2408",
+      "parent": "8773579baf55bc801c32d5e4c20293baf75d325e",
+      "subject": "regex-automata: fix bug in DFA quit behavior",
+      "ok": true,
+      "findings": 9,
+      "duration_s": 2.05
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "c4865a0c8446a701e10b0fd987f19068f5dcc365",
+      "parent": "d8761c00ed25c5899e3dcfb0f17e827b8e41530a",
+      "subject": "syntax: fix negation handling in HIR translation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.77
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "c4865a0c8446a701e10b0fd987f19068f5dcc365",
+      "parent": "d8761c00ed25c5899e3dcfb0f17e827b8e41530a",
+      "subject": "syntax: fix negation handling in HIR translation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.52
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "f5b8cb4d52ca0fa01a9c4e8e70bcd3e4b6673368",
+      "parent": "dd04a57e1db3099fdcee337b8219eddc58ce4eb4",
+      "subject": "lite: fix doctests on 32-bit",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.07
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "f5b8cb4d52ca0fa01a9c4e8e70bcd3e4b6673368",
+      "parent": "dd04a57e1db3099fdcee337b8219eddc58ce4eb4",
+      "subject": "lite: fix doctests on 32-bit",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.2
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "f5d0b69b750369d535c3f200222132403b0d9bff",
+      "parent": "aa2d8bd8be283471b17b4ab6faeae5b751553572",
+      "subject": "syntax: accept `{,n}` as an equivalent to `{0,n}`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.87
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "f5d0b69b750369d535c3f200222132403b0d9bff",
+      "parent": "aa2d8bd8be283471b17b4ab6faeae5b751553572",
+      "subject": "syntax: accept `{,n}` as an equivalent to `{0,n}`",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.44
+    },
+    {
+      "repo": "regex",
+      "arm": "default",
+      "commit": "fbe2e164e9b8a4ccce37db7640905d5255228697",
+      "parent": "6e5e537b65710fb262eee8610e2424058fdb15a3",
+      "subject": "syntax: factor out common prefixes of alternations",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.99
+    },
+    {
+      "repo": "regex",
+      "arm": "near",
+      "commit": "fbe2e164e9b8a4ccce37db7640905d5255228697",
+      "parent": "6e5e537b65710fb262eee8610e2424058fdb15a3",
+      "subject": "syntax: factor out common prefixes of alternations",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.0
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "05a1a21593c9c8e79393d35fae12c9c27a6f7605",
+      "parent": "c45a4dfe6bfc6017d4ea7e9f051d6cc30972b310",
+      "subject": "Throw value error when serializing JSON object with NaN value (#5810)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.34
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "05a1a21593c9c8e79393d35fae12c9c27a6f7605",
+      "parent": "c45a4dfe6bfc6017d4ea7e9f051d6cc30972b310",
+      "subject": "Throw value error when serializing JSON object with NaN value (#5810)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.35
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "111d2b77790bf49943c0dfa09b365371c24aec7e",
+      "parent": "f0198e6dfc431a2293dc16e1b1e8fcddc910a7f3",
+      "subject": "v2.33.1",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.41
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "111d2b77790bf49943c0dfa09b365371c24aec7e",
+      "parent": "f0198e6dfc431a2293dc16e1b1e8fcddc910a7f3",
+      "subject": "v2.33.1",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.45
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "1b7c37ef4e3db003cc52f09da9ab6b947054e245",
+      "parent": "f761e74a4d50d2e88d9e30e660494b36c9d630f8",
+      "subject": "Merge pull request #6529 from anupam-arista/patch-1",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.34
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "1b7c37ef4e3db003cc52f09da9ab6b947054e245",
+      "parent": "f761e74a4d50d2e88d9e30e660494b36c9d630f8",
+      "subject": "Merge pull request #6529 from anupam-arista/patch-1",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.44
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "28d537dde33b35c3b7071afd99122eff3538b42c",
+      "parent": "d09659997cd1e3eca49a07c59ece5557071c0ab9",
+      "subject": "Merge pull request #5917 from nateprewitt/proxy_scheme_unknown_fix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.34
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "28d537dde33b35c3b7071afd99122eff3538b42c",
+      "parent": "d09659997cd1e3eca49a07c59ece5557071c0ab9",
+      "subject": "Merge pull request #5917 from nateprewitt/proxy_scheme_unknown_fix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.44
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "382fc2c0c6c0ef0874bc65bc1175f97c073e5086",
+      "parent": "7a13c041dbef42f9f3feb14110f02626f6892e9a",
+      "subject": "Merge pull request #6629 from Tarty/fix-6628-jsondecode-error-not-deserializable",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.37
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "382fc2c0c6c0ef0874bc65bc1175f97c073e5086",
+      "parent": "7a13c041dbef42f9f3feb14110f02626f6892e9a",
+      "subject": "Merge pull request #6629 from Tarty/fix-6628-jsondecode-error-not-deserializable",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.58
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "42c5a4f62268dd6e0499aac02a2ef481286e5798",
+      "parent": "11ed88bcb2748f4ce7924e95ae47a9c0b87d6af4",
+      "subject": "Merge pull request #5128 from lmvlmv/urllibfix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.35
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "42c5a4f62268dd6e0499aac02a2ef481286e5798",
+      "parent": "11ed88bcb2748f4ce7924e95ae47a9c0b87d6af4",
+      "subject": "Merge pull request #5128 from lmvlmv/urllibfix",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.43
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "6e83187b8feb273ed4c6cdab5efd8d54901dfab3",
+      "parent": "84d10f0be83e8f6aeca8a05230c52216431c4d0b",
+      "subject": "v2.34.2",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.31
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "6e83187b8feb273ed4c6cdab5efd8d54901dfab3",
+      "parent": "84d10f0be83e8f6aeca8a05230c52216431c4d0b",
+      "subject": "v2.34.2",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.32
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "b7c6aba848b10933f327fcce41970c29dc59051b",
+      "parent": "fd13816d015c4c90ee65297fa996caea6a094ed1",
+      "subject": "v2.23.0",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.33
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "b7c6aba848b10933f327fcce41970c29dc59051b",
+      "parent": "fd13816d015c4c90ee65297fa996caea6a094ed1",
+      "subject": "v2.23.0",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.37
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "c57f1f0ca10e61771b459c857182c23626607312",
+      "parent": "7104ad4b135daab0ed19d8e41bd469874702342b",
+      "subject": "Allow charset normalizer >=2 and <4 (#6261)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.31
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "c57f1f0ca10e61771b459c857182c23626607312",
+      "parent": "7104ad4b135daab0ed19d8e41bd469874702342b",
+      "subject": "Allow charset normalizer >=2 and <4 (#6261)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.45
+    },
+    {
+      "repo": "requests",
+      "arm": "default",
+      "commit": "e976ea839b55e07f01a962c5bb38bedb543a2df7",
+      "parent": "a559d62f17c0c3129029870146b74da50a81d433",
+      "subject": "no more stickers :-/",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.37
+    },
+    {
+      "repo": "requests",
+      "arm": "near",
+      "commit": "e976ea839b55e07f01a962c5bb38bedb543a2df7",
+      "parent": "a559d62f17c0c3129029870146b74da50a81d433",
+      "subject": "no more stickers :-/",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.29
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "0db1c8ccf936f1df726a530c9084035504d990d5",
+      "parent": "7cfc163f505f07df1881d06209e2b0e7b81b21f4",
+      "subject": "Use `IfNode#then?`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.07
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "0db1c8ccf936f1df726a530c9084035504d990d5",
+      "parent": "7cfc163f505f07df1881d06209e2b0e7b81b21f4",
+      "subject": "Use `IfNode#then?`",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.22
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "1860523aa7663d580f3e802b158ef127915e615c",
+      "parent": "92cdeaa3de689ccbb75821ad29125fe3b68cc92e",
+      "subject": "Reduce precision in 'Finished in X.X seconds' message to 5 decimal places (#14851)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.63
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "1860523aa7663d580f3e802b158ef127915e615c",
+      "parent": "92cdeaa3de689ccbb75821ad29125fe3b68cc92e",
+      "subject": "Reduce precision in 'Finished in X.X seconds' message to 5 decimal places (#14851)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.51
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "2544a9e28309436db5c708931ebb39e6f0fa4dea",
+      "parent": "a2165c1f6778da0d0df316bb511c8bdc6915d3db",
+      "subject": "[Fix #8773] Fix false positives in `Style/HashTransform{Keys,Values}`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.17
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "2544a9e28309436db5c708931ebb39e6f0fa4dea",
+      "parent": "a2165c1f6778da0d0df316bb511c8bdc6915d3db",
+      "subject": "[Fix #8773] Fix false positives in `Style/HashTransform{Keys,Values}`",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.13
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "46005a9101fa1fe22e48769c8e5aa6f23b599c01",
+      "parent": "7ca193144219c1497a234445f15f07f2ca053418",
+      "subject": "Fix false negatives in `Style/RedundantParentheses`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.02
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "46005a9101fa1fe22e48769c8e5aa6f23b599c01",
+      "parent": "7ca193144219c1497a234445f15f07f2ca053418",
+      "subject": "Fix false negatives in `Style/RedundantParentheses`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.82
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "762e5eb78764fa9f469291630c123acbc1b7a5fd",
+      "parent": "d3e2ce86e1429532c8ea2bf333b85e1e8b9b3f13",
+      "subject": "Merge pull request #15027 from rubocop/simplify-style-cops",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.23
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "762e5eb78764fa9f469291630c123acbc1b7a5fd",
+      "parent": "d3e2ce86e1429532c8ea2bf333b85e1e8b9b3f13",
+      "subject": "Merge pull request #15027 from rubocop/simplify-style-cops",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 4.16
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.22
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.47
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "bd48b6b2b2c58ec1195780ec1c25fc75dd855a85",
+      "parent": "c4f608b6fda198f60267a0882376f78cd8a8b264",
+      "subject": "Merge pull request #15160 from lovro-bikic/autoload-mixins",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.22
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "bd48b6b2b2c58ec1195780ec1c25fc75dd855a85",
+      "parent": "c4f608b6fda198f60267a0882376f78cd8a8b264",
+      "subject": "Merge pull request #15160 from lovro-bikic/autoload-mixins",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.06
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "c07988f2b2598a8f59e8f9980f55511edf96850a",
+      "parent": "fa648c740f251d18f7dbb8c71da3ebdb91c2a6e2",
+      "subject": "Add rationale to Style cop documentation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.14
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "c07988f2b2598a8f59e8f9980f55511edf96850a",
+      "parent": "fa648c740f251d18f7dbb8c71da3ebdb91c2a6e2",
+      "subject": "Add rationale to Style cop documentation",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.52
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "dbba98d0b46ef30e05a5b8ae110af9a4f6b33b9e",
+      "parent": "a3e272dee0ed8ff18c14c1e43a3fa75e46c06488",
+      "subject": "Adjust range operation and add autocorrect test in `Lint/UselessAssignment`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.57
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "dbba98d0b46ef30e05a5b8ae110af9a4f6b33b9e",
+      "parent": "a3e272dee0ed8ff18c14c1e43a3fa75e46c06488",
+      "subject": "Adjust range operation and add autocorrect test in `Lint/UselessAssignment`",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.85
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "fbf175c46cd6ea09bfa6631b7677861878041efe",
+      "parent": "3fcae5d22baa0f56df0c47ce7b672c2e2b6ada2c",
+      "subject": "Allow disabling cache cleanup",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.26
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "fbf175c46cd6ea09bfa6631b7677861878041efe",
+      "parent": "3fcae5d22baa0f56df0c47ce7b672c2e2b6ada2c",
+      "subject": "Allow disabling cache cleanup",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.67
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+      "parent": "80f7caad62ab536ce7fb3e742ebe00d95ba548e6",
+      "subject": "Adding onDropped callback to throttleLast as a part of #7458 (#7488)",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 7.83
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "1104c09ca970cd89f04f3653291bd4d9ba2da8f3",
+      "parent": "80f7caad62ab536ce7fb3e742ebe00d95ba548e6",
+      "subject": "Adding onDropped callback to throttleLast as a part of #7458 (#7488)",
+      "ok": true,
+      "findings": 11,
+      "duration_s": 6.83
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "171c84677739d63ef778b8893db845ac7abc81e6",
+      "parent": "a99b2e0a01d85f3f792a56c68ac1df9afa3a75c7",
+      "subject": "3.x: Introduce property rx3.scheduler.use-nanotime (#7169)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.92
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "171c84677739d63ef778b8893db845ac7abc81e6",
+      "parent": "a99b2e0a01d85f3f792a56c68ac1df9afa3a75c7",
+      "subject": "3.x: Introduce property rx3.scheduler.use-nanotime (#7169)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.39
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+      "parent": "9ed54168db22da80c5c75495ab3dde9a64faa06d",
+      "subject": "3.x: Remove Maybe.onExceptionResumeNext (#6844)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 5.57
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "1cf5b9d072b912a6bcb3ba6a16368ed3a55d3c84",
+      "parent": "9ed54168db22da80c5c75495ab3dde9a64faa06d",
+      "subject": "3.x: Remove Maybe.onExceptionResumeNext (#6844)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 9.18
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "338f2a11350480cef409f64eff4a2d307be7e05a",
+      "parent": "e46ea36e0743b04601a9e8763820da81293dd3b3",
+      "subject": "Update BlockingFlowableIterable.onNext() to set error before cancel (#7789)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.58
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "338f2a11350480cef409f64eff4a2d307be7e05a",
+      "parent": "e46ea36e0743b04601a9e8763820da81293dd3b3",
+      "subject": "Update BlockingFlowableIterable.onNext() to set error before cancel (#7789)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 8.74
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "82a218a5e0bb7f8788e4e6b0b54e4de9cd28e9ea",
+      "parent": "35702ec5e64e8adc2ce6f9828f9af8f5fde42bbc",
+      "subject": "Clarify the documentation for scan operators (#7093)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 7.98
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "82a218a5e0bb7f8788e4e6b0b54e4de9cd28e9ea",
+      "parent": "35702ec5e64e8adc2ce6f9828f9af8f5fde42bbc",
+      "subject": "Clarify the documentation for scan operators (#7093)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.97
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "939b5ce0bb17dfd1660a5750abe46b9be473d8eb",
+      "parent": "f5ff589fa82d93891f0bdda0a7769063d8fe02e8",
+      "subject": "Align hasCustomOnError behavior of CallbackCompletableObserver with LambdaObserver, ConsumerSingleObserver and so on (#7",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 7.63
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "939b5ce0bb17dfd1660a5750abe46b9be473d8eb",
+      "parent": "f5ff589fa82d93891f0bdda0a7769063d8fe02e8",
+      "subject": "Align hasCustomOnError behavior of CallbackCompletableObserver with LambdaObserver, ConsumerSingleObserver and so on (#7",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 8.81
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+      "parent": "7c59877eb5a1cdd41d5414a14903e8c56d6f57c1",
+      "subject": "-> import static java.util.concurrent.Flow.*; 1",
+      "ok": true,
+      "findings": 10,
+      "duration_s": 7.57
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "a450c1194b7ddddd48cfa897e32fac0c200f4492",
+      "parent": "7c59877eb5a1cdd41d5414a14903e8c56d6f57c1",
+      "subject": "-> import static java.util.concurrent.Flow.*; 1",
+      "ok": true,
+      "findings": 9,
+      "duration_s": 7.9
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "c4d995d57dce44c52f2e687689752cacaae8ec8f",
+      "parent": "78c70d6a5365cb8db532d23397d5a0b4c114b72a",
+      "subject": "3.x: Add Completable.sequenceEqual (#6884)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.51
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "c4d995d57dce44c52f2e687689752cacaae8ec8f",
+      "parent": "78c70d6a5365cb8db532d23397d5a0b4c114b72a",
+      "subject": "3.x: Add Completable.sequenceEqual (#6884)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 15.17
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "eb58c59160ce5f3749396c7002d4c8fe162663a6",
+      "parent": "77c2ef1605302e9405467558d6b0e97b4e9d46c7",
+      "subject": "3.x: Fix Flowable.groupBy eviction logic double decrement and hang (#6975)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 7.01
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "eb58c59160ce5f3749396c7002d4c8fe162663a6",
+      "parent": "77c2ef1605302e9405467558d6b0e97b4e9d46c7",
+      "subject": "3.x: Fix Flowable.groupBy eviction logic double decrement and hang (#6975)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 9.16
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 6.87
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 7.42
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "0997b925d2d6e5ae92b07b9d1e1836b10f5469d4",
+      "parent": "7a1655c450386bfb1c74f91195df9ba4ac9a394b",
+      "subject": "chore: minor refactoring and some comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.45
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "0997b925d2d6e5ae92b07b9d1e1836b10f5469d4",
+      "parent": "7a1655c450386bfb1c74f91195df9ba4ac9a394b",
+      "subject": "chore: minor refactoring and some comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.37
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "21e897b313e994d5378b203d2d39b78171f6191a",
+      "parent": "fffcf726af28cdd1e8a0d19f3e9e4ea149ead135",
+      "subject": "refactor(retry): use new `operate` function.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.33
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "21e897b313e994d5378b203d2d39b78171f6191a",
+      "parent": "fffcf726af28cdd1e8a0d19f3e9e4ea149ead135",
+      "subject": "refactor(retry): use new `operate` function.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.42
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "414a692db7744d9ec2e3d8ac14536fd48d65dc14",
+      "parent": "0c82341b0d4d482394bc6551bc3d6c911ac6df7b",
+      "subject": "fix(asapScheduler): No longer stops after scheduling twice during flush (#7198)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.74
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "414a692db7744d9ec2e3d8ac14536fd48d65dc14",
+      "parent": "0c82341b0d4d482394bc6551bc3d6c911ac6df7b",
+      "subject": "fix(asapScheduler): No longer stops after scheduling twice during flush (#7198)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.5
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "42dac72f31fe609ca093d65597b62a9c4de0b7cc",
+      "parent": "eb0b933347ed184570df27907ae3873f6a4b4b1c",
+      "subject": "refactor(windowTime): use new `operate` function.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.52
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "42dac72f31fe609ca093d65597b62a9c4de0b7cc",
+      "parent": "eb0b933347ed184570df27907ae3873f6a4b4b1c",
+      "subject": "refactor(windowTime): use new `operate` function.",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.52
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.86
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.31
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "a3c94f0d5740d92fe4cc2452c741391d854e568c",
+      "parent": "7d3c4ec727dd1962275c6f959060fdf6bdc0c164",
+      "subject": " fix(debounceTime): appropriately handle synchronous schedulers",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.61
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "a3c94f0d5740d92fe4cc2452c741391d854e568c",
+      "parent": "7d3c4ec727dd1962275c6f959060fdf6bdc0c164",
+      "subject": " fix(debounceTime): appropriately handle synchronous schedulers",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.37
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "c408acda16d654682596822c118c31a814dae5c9",
+      "parent": "27075b6644ec52ac2f9bc1631944e7393187e6e9",
+      "subject": "feat(webSocket): now allows input and output typing to differ",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.15
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "c408acda16d654682596822c118c31a814dae5c9",
+      "parent": "27075b6644ec52ac2f9bc1631944e7393187e6e9",
+      "subject": "feat(webSocket): now allows input and output typing to differ",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.44
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "c65bbbb2e9f38c44cfe54aefc6e59cbd49e83e3f",
+      "parent": "5123a857b07519fadd820d0b98efe5150c9138e9",
+      "subject": "refactor(defaultIfEmpty): use new `operate` function.",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.38
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "c65bbbb2e9f38c44cfe54aefc6e59cbd49e83e3f",
+      "parent": "5123a857b07519fadd820d0b98efe5150c9138e9",
+      "subject": "refactor(defaultIfEmpty): use new `operate` function.",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.23
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "f03c8bf9869052ee96e72334306f3a14d3bc9f33",
+      "parent": "f0bdb96c6def04625e5ecbf30b407355cfc143de",
+      "subject": "feat(combineLatest): remove deprecated spread signature (#7168)",
+      "ok": true,
+      "findings": 35,
+      "duration_s": 1.58
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "f03c8bf9869052ee96e72334306f3a14d3bc9f33",
+      "parent": "f0bdb96c6def04625e5ecbf30b407355cfc143de",
+      "subject": "feat(combineLatest): remove deprecated spread signature (#7168)",
+      "ok": true,
+      "findings": 35,
+      "duration_s": 1.6
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "f69dd27a6bc049a2b3a4203b06e76da8ca08b653",
+      "parent": "63fb293dfbb7a866372c8fe172a45d9450454067",
+      "subject": "chore(test): remove global rxTestScheduler",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.32
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "f69dd27a6bc049a2b3a4203b06e76da8ca08b653",
+      "parent": "63fb293dfbb7a866372c8fe172a45d9450454067",
+      "subject": "chore(test): remove global rxTestScheduler",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.38
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "044c3f69edd1bf926408649361ada7f2146db04e",
+      "parent": "1469b2739ea566a57e0b5f8e6bb104fd19460d24",
+      "subject": "Deprecate InitSpider (#6714)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.77
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "044c3f69edd1bf926408649361ada7f2146db04e",
+      "parent": "1469b2739ea566a57e0b5f8e6bb104fd19460d24",
+      "subject": "Deprecate InitSpider (#6714)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.21
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "09bd8f42318bbd413e16d43900f4f27bdfa50962",
+      "parent": "0e1526ed30f375a169c68d36923bc9e60ce3258f",
+      "subject": "Properly close ftplib.FTP(). (#7256)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.05
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "09bd8f42318bbd413e16d43900f4f27bdfa50962",
+      "parent": "0e1526ed30f375a169c68d36923bc9e60ce3258f",
+      "subject": "Properly close ftplib.FTP(). (#7256)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.33
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "128cb551eb493601d4a4cd6d7a087e09a07d7092",
+      "parent": "82a32451583967a828c2e80a31930f64dbc136ac",
+      "subject": "refactor tests/test_downloadermiddleware_httpcache.py (#6769)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.1
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "128cb551eb493601d4a4cd6d7a087e09a07d7092",
+      "parent": "82a32451583967a828c2e80a31930f64dbc136ac",
+      "subject": "refactor tests/test_downloadermiddleware_httpcache.py (#6769)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.29
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "180ca39b230590a2a2862c8d18c574661b1d16ad",
+      "parent": "5a7e132486f3337956f684fffcac77cb6ad5a8d2",
+      "subject": "Deprecate returning Deferreds from pipeline methods (#7179)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 0.97
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "180ca39b230590a2a2862c8d18c574661b1d16ad",
+      "parent": "5a7e132486f3337956f684fffcac77cb6ad5a8d2",
+      "subject": "Deprecate returning Deferreds from pipeline methods (#7179)",
+      "ok": true,
+      "findings": 6,
+      "duration_s": 0.97
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "2b174e348d88d19dd32135e8e483c4eb784aeca8",
+      "parent": "b9be5ce053cfe2685dce045c98ffbbc8811c1eac",
+      "subject": "Silence the CertificateOptions method warning. (#7410)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.44
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "2b174e348d88d19dd32135e8e483c4eb784aeca8",
+      "parent": "b9be5ce053cfe2685dce045c98ffbbc8811c1eac",
+      "subject": "Silence the CertificateOptions method warning. (#7410)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.24
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.15
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "7b215c6578de037aca85d538083905af4a0474ce",
+      "parent": "4865a500b62fada0be245b9201339cc3d093c6d2",
+      "subject": "UTF-8 BOM at the beginning of the file ignored (#7095)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.75
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "7b215c6578de037aca85d538083905af4a0474ce",
+      "parent": "4865a500b62fada0be245b9201339cc3d093c6d2",
+      "subject": "UTF-8 BOM at the beginning of the file ignored (#7095)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.0
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "86a7ceaa9ff590da04e35992497878f15a7edd8b",
+      "parent": "31bf7c3892df3eb0dfdf5223a0aff5e261f0a7c3",
+      "subject": "Dynamic loading for S3 HTTPS handler (#7370)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.41
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "86a7ceaa9ff590da04e35992497878f15a7edd8b",
+      "parent": "31bf7c3892df3eb0dfdf5223a0aff5e261f0a7c3",
+      "subject": "Dynamic loading for S3 HTTPS handler (#7370)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.81
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "a3daa3612e0458e9eb41ddee2cea1c6935e6d038",
+      "parent": "baa579df625d698bebd52104bcd52e2682a80f0e",
+      "subject": "Rewrite ExecutionEngine.close_spider() to inlineCallbacks. (#6986)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.87
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "a3daa3612e0458e9eb41ddee2cea1c6935e6d038",
+      "parent": "baa579df625d698bebd52104bcd52e2682a80f0e",
+      "subject": "Rewrite ExecutionEngine.close_spider() to inlineCallbacks. (#6986)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.95
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "daa1a7d0b6549f901a002bf4c8bb7c4aed23e068",
+      "parent": "92c18d15b4dbed7c98dc3d5ac329c90abb23950f",
+      "subject": "Remove the chdir fixture, re-enable fancy pytest asserts (#6888)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.97
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "daa1a7d0b6549f901a002bf4c8bb7c4aed23e068",
+      "parent": "92c18d15b4dbed7c98dc3d5ac329c90abb23950f",
+      "subject": "Remove the chdir fixture, re-enable fancy pytest asserts (#6888)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.54
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "227cabf29131a0d9b3cf664d54e3324d7247c574",
+      "parent": "9cc6c7040749514df4ef867d0826b5637f6499cf",
+      "subject": "Fix YARD code block indentation in Sidekiq::Capsule (#6615)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.12
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "227cabf29131a0d9b3cf664d54e3324d7247c574",
+      "parent": "9cc6c7040749514df4ef867d0826b5637f6499cf",
+      "subject": "Fix YARD code block indentation in Sidekiq::Capsule (#6615)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.73
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "54ad22363358c47b3cfc5eef56ce632914360832",
+      "parent": "55cb762577c5d9b2b515f178cf8cc1816d611bf7",
+      "subject": "Add current_object to expose iterated object to around_iteration callback, fixes #6774",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.25
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "54ad22363358c47b3cfc5eef56ce632914360832",
+      "parent": "55cb762577c5d9b2b515f178cf8cc1816d611bf7",
+      "subject": "Add current_object to expose iterated object to around_iteration callback, fixes #6774",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.53
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "589a409b74b1ae2f4194a95613962de1b706d9a0",
+      "parent": "a9c3a89a29f8352e2ec81cc815f5f8122f152852",
+      "subject": "Add and expose capsule data in Sidekiq::Process, see #6295 (#6775)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.2
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "589a409b74b1ae2f4194a95613962de1b706d9a0",
+      "parent": "a9c3a89a29f8352e2ec81cc815f5f8122f152852",
+      "subject": "Add and expose capsule data in Sidekiq::Process, see #6295 (#6775)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.78
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "6545e2a3a615d3cfe0ff7fa5dd2c3ecc4ef8275e",
+      "parent": "442f083a665ad621c9976076ac91b26b7a81668e",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.53
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "6545e2a3a615d3cfe0ff7fa5dd2c3ecc4ef8275e",
+      "parent": "442f083a665ad621c9976076ac91b26b7a81668e",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.5
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "6d3be2c91b97263e37c0b0d8cd3dc92d093b2cb1",
+      "parent": "3ab97e9a1c48298b572eee3cf9b16c20b7cbb74a",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.42
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "6d3be2c91b97263e37c0b0d8cd3dc92d093b2cb1",
+      "parent": "3ab97e9a1c48298b572eee3cf9b16c20b7cbb74a",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.84
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "7557ea539b5722eb9241ff8f3b792ed9da44fec7",
+      "parent": "e4b7970fde6f13716ec248b7c8782ce87a464a38",
+      "subject": "Forward block through RedisClientAdapter#method_missing (#7002)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.73
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "7557ea539b5722eb9241ff8f3b792ed9da44fec7",
+      "parent": "e4b7970fde6f13716ec248b7c8782ce87a464a38",
+      "subject": "Forward block through RedisClientAdapter#method_missing (#7002)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.58
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "91218466303f61d5c07fef2900b7bc81bb9e54aa",
+      "parent": "4d84d013e5f31daf9e79f6bcb43bbcc2fef61efa",
+      "subject": "Reduce default batch size when enqueuing scheduled jobs via `push_bulk` (#6953)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.16
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "91218466303f61d5c07fef2900b7bc81bb9e54aa",
+      "parent": "4d84d013e5f31daf9e79f6bcb43bbcc2fef61efa",
+      "subject": "Reduce default batch size when enqueuing scheduled jobs via `push_bulk` (#6953)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.11
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.7
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.42
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "b065bfb4873a95d84b815f574f0daf6b8742e39c",
+      "parent": "1da602d64ee0acc1f5f25ebfc7546e715fdb9579",
+      "subject": "Conditionally load ActiveJob and Rails integrations (#6669)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.49
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "b065bfb4873a95d84b815f574f0daf6b8742e39c",
+      "parent": "1da602d64ee0acc1f5f25ebfc7546e715fdb9579",
+      "subject": "Conditionally load ActiveJob and Rails integrations (#6669)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.8
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "b7e116c5fa8e5e302512e387baecde2795a43512",
+      "parent": "541dd5b8512be8bb02e2fb7c2bba24ab797a6123",
+      "subject": "Make `created_at`/`enqueued_at` storing integer milliseconds (#6564)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.92
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "b7e116c5fa8e5e302512e387baecde2795a43512",
+      "parent": "541dd5b8512be8bb02e2fb7c2bba24ab797a6123",
+      "subject": "Make `created_at`/`enqueued_at` storing integer milliseconds (#6564)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.42
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "0bb3c7521ac3482f334d6053bfc5bf85d6cbb1d9",
+      "parent": "a3895ef3ef5a3becb7c363658608142de2369ba4",
+      "subject": "Merge pull request #29554 from Kishore96in/fix_return_notimplementederror",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.63
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "0bb3c7521ac3482f334d6053bfc5bf85d6cbb1d9",
+      "parent": "a3895ef3ef5a3becb7c363658608142de2369ba4",
+      "subject": "Merge pull request #29554 from Kishore96in/fix_return_notimplementederror",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.79
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "1deb626bf6e59d770fd58a4ebb0216274b18ecbf",
+      "parent": "4aa71fc5ea2e011e26f7d17fbd43ba60cdeae7a3",
+      "subject": "Add Mul postprocessor for Vector (#28749)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.18
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "1deb626bf6e59d770fd58a4ebb0216274b18ecbf",
+      "parent": "4aa71fc5ea2e011e26f7d17fbd43ba60cdeae7a3",
+      "subject": "Add Mul postprocessor for Vector (#28749)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 12.12
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "1fdc9112629e0da6945e2dca6c62c7c299901561",
+      "parent": "d63131d6bf882f111d1604aadce9a6394536ba9c",
+      "subject": "Fix casus irreducibilis crash. (#29085)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 9.26
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "1fdc9112629e0da6945e2dca6c62c7c299901561",
+      "parent": "d63131d6bf882f111d1604aadce9a6394536ba9c",
+      "subject": "Fix casus irreducibilis crash. (#29085)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.17
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "225b2b461028a60fac5f1dc993b4de560cb5e176",
+      "parent": "f4fea5d4f50d07805d0312a49404be22470686fa",
+      "subject": "Merge pull request #28780 from ANAS727189/fix-issue-15566",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.35
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "225b2b461028a60fac5f1dc993b4de560cb5e176",
+      "parent": "f4fea5d4f50d07805d0312a49404be22470686fa",
+      "subject": "Merge pull request #28780 from ANAS727189/fix-issue-15566",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.21
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "31eef583875470d7f4b290df77cb3e1c30cecc7f",
+      "parent": "f48e26c2401309795b6b07464d5c90cb51072876",
+      "subject": "Merge pull request #29366 from bilichboris/is_normal_abelian",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.19
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "31eef583875470d7f4b290df77cb3e1c30cecc7f",
+      "parent": "f48e26c2401309795b6b07464d5c90cb51072876",
+      "subject": "Merge pull request #29366 from bilichboris/is_normal_abelian",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.69
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "39e29cd3ec2358e6c97b1ea275ba6df3460c0bf1",
+      "parent": "9523e3094e886db153ce22db40fa0d28bf1edae7",
+      "subject": "Merge pull request #29687 from haru-44/remove_eval_binrel",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 9.46
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "39e29cd3ec2358e6c97b1ea275ba6df3460c0bf1",
+      "parent": "9523e3094e886db153ce22db40fa0d28bf1edae7",
+      "subject": "Merge pull request #29687 from haru-44/remove_eval_binrel",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.25
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "6ab9bd2606eb039db507c770b0d8f8bf07b2a7c9",
+      "parent": "c5da1b851b55de70e6d14eb6928f1092506e7d5c",
+      "subject": "Merge pull request #28921 from oscarbenjamin/pr_dataclasses_maunalintegrate",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.31
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "6ab9bd2606eb039db507c770b0d8f8bf07b2a7c9",
+      "parent": "c5da1b851b55de70e6d14eb6928f1092506e7d5c",
+      "subject": "Merge pull request #28921 from oscarbenjamin/pr_dataclasses_maunalintegrate",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.46
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "c3326587bc11b115d3d9ecd0b1a0ba911d73ddeb",
+      "parent": "fbaf3180bdd5387d519a846ecfb8b08a87cb7c12",
+      "subject": "Merge pull request #29204 from Upabjojr/review_summation_karr_docstring",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 9.89
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "c3326587bc11b115d3d9ecd0b1a0ba911d73ddeb",
+      "parent": "fbaf3180bdd5387d519a846ecfb8b08a87cb7c12",
+      "subject": "Merge pull request #29204 from Upabjojr/review_summation_karr_docstring",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.19
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "cb7130e0df6b087d4add847f5d85b6606e7c62af",
+      "parent": "7a943c5a15978e0ac5ade4beebcdbb70660007fd",
+      "subject": "Merge pull request #29032 from jhaayushkumar/fix/geometry-validations",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.73
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "cb7130e0df6b087d4add847f5d85b6606e7c62af",
+      "parent": "7a943c5a15978e0ac5ade4beebcdbb70660007fd",
+      "subject": "Merge pull request #29032 from jhaayushkumar/fix/geometry-validations",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 11.1
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.41
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.21
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "25a24de0e661d86fa059779e87e0605909465f4a",
+      "parent": "c1fa25f3009d6f5374e337b999fe4fe926c8e7f2",
+      "subject": "net: remove PollEvented noise from Debug formats (#7675)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.58
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "25a24de0e661d86fa059779e87e0605909465f4a",
+      "parent": "c1fa25f3009d6f5374e337b999fe4fe926c8e7f2",
+      "subject": "net: remove PollEvented noise from Debug formats (#7675)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.58
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.89
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 2.0
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "33566434bba678c492a5b03b24a013d2f8710c6e",
+      "parent": "7388f2d2ea5311af4b2fa0e088d890facfbf4054",
+      "subject": "metrics: clarify that `num_alive_tasks` is not strongly consistent (#7614)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.75
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "33566434bba678c492a5b03b24a013d2f8710c6e",
+      "parent": "7388f2d2ea5311af4b2fa0e088d890facfbf4054",
+      "subject": "metrics: clarify that `num_alive_tasks` is not strongly consistent (#7614)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.83
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "6d1ae6286880c828c13efb5f11b60c18fb94f947",
+      "parent": "3b5a15dfdfc5dc789dcb80cef0986fb2fa5cac0a",
+      "subject": "sync: close the `broadcast::Sender` in `broadcast::Sender::new()` (#7629)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.54
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "6d1ae6286880c828c13efb5f11b60c18fb94f947",
+      "parent": "3b5a15dfdfc5dc789dcb80cef0986fb2fa5cac0a",
+      "subject": "sync: close the `broadcast::Sender` in `broadcast::Sender::new()` (#7629)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.95
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "8c980ea75a0f8dd2799403777db700c2e8f4cda4",
+      "parent": "e35fd6d6b7d9a8ba37ee621835ef91372c2565cb",
+      "subject": "io: add `write_all_vectored` to `tokio-util` (#7768)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.84
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "8c980ea75a0f8dd2799403777db700c2e8f4cda4",
+      "parent": "e35fd6d6b7d9a8ba37ee621835ef91372c2565cb",
+      "subject": "io: add `write_all_vectored` to `tokio-util` (#7768)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.72
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "8f81e0814bd121683ebdfa21b494d1b77fb36403",
+      "parent": "47cc31590fbc5662241355c86e331c42e6152775",
+      "subject": "time: avoid stack overflow in runtime constructor (#8093)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.52
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "8f81e0814bd121683ebdfa21b494d1b77fb36403",
+      "parent": "47cc31590fbc5662241355c86e331c42e6152775",
+      "subject": "time: avoid stack overflow in runtime constructor (#8093)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.94
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "9a1b076c0084e2bca8558818bffd2273ec5ae5bd",
+      "parent": "c434ed786509792db580e800f796adcad6a5915c",
+      "subject": "io: replace `Result<T, io::Error>` with `io::Result<T>` in `AsyncWrite` (#7740)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.78
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "9a1b076c0084e2bca8558818bffd2273ec5ae5bd",
+      "parent": "c434ed786509792db580e800f796adcad6a5915c",
+      "subject": "io: replace `Result<T, io::Error>` with `io::Result<T>` in `AsyncWrite` (#7740)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.88
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "ad8c59add6a1988d8c327fb3358beeeae3bbb5cd",
+      "parent": "654d38b13228a13498e793d8bb4f6ba50fd1016a",
+      "subject": "net: surface errors from `SO_ERROR` on `recv` for UDP sockets on Linux (#8001)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 1.95
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "ad8c59add6a1988d8c327fb3358beeeae3bbb5cd",
+      "parent": "654d38b13228a13498e793d8bb4f6ba50fd1016a",
+      "subject": "net: surface errors from `SO_ERROR` on `recv` for UDP sockets on Linux (#8001)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 2.06
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "d89e998922724de80996802721e167d9ca24f4d7",
+      "parent": "306ed1c30b67d78c8158e601acfda3b8650008dd",
+      "subject": "net: fix GET_BUF_SIZE constant for `target_os = \"android\"` (#7889)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.28
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "d89e998922724de80996802721e167d9ca24f4d7",
+      "parent": "306ed1c30b67d78c8158e601acfda3b8650008dd",
+      "subject": "net: fix GET_BUF_SIZE constant for `target_os = \"android\"` (#7889)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.6
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "ff9681b3c62d63ca2703976d4767f29442bc87f2",
+      "parent": "f1cb007a281d49104e7b0e29d4ba5c6e7a06af11",
+      "subject": "runtime: avoid lock acquisition after uring init (#7843)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.66
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "ff9681b3c62d63ca2703976d4767f29442bc87f2",
+      "parent": "f1cb007a281d49104e7b0e29d4ba5c6e7a06af11",
+      "subject": "runtime: avoid lock acquisition after uring init (#7843)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.21
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add checked final #675 divergent-edit closeout replay summary and policy reproduction artifacts
- make `eval/divergence_fire/replay.py check-artifacts` validate the final clean `a38ecb8b` replay evidence
- update `RESULTS.md` and `CHANGELOG.md` so the final replay evidence no longer depends only on `/tmp` scratch summaries

## Issue

Closes #682.
Part of #681.

## Validation

```sh
python3 eval/divergence_fire/replay.py selftest
python3 eval/divergence_fire/replay.py check-artifacts
./scripts/check-docs.sh
```

Also passed the repository pre-push fast local CI gate while pushing the branch.
