### PR TITLE
Harden divergent gate edge fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added #685 divergent-edit gate hardening fixtures for report-only and suppression
+  edges: `base=` now honors config-relative `ignore-file`, malformed ignores fail
+  before empty-diff short-circuiting, path/language suppressions keep all-members
+  semantics, and copied/new-copy plus deletion/insertion/rename edge cases are pinned.
 - Added the #684 divergent-edit strict-policy taxonomy audit: checked policy
   artifacts now record `gate.fail_default`-based tier/taxonomy confusion counts,
   strict false-positive buckets, and strict-positive retention against the

--- a/crates/nose-cli/src/divergence/detect.rs
+++ b/crates/nose-cli/src/divergence/detect.rs
@@ -20,6 +20,17 @@ pub(crate) fn detect_divergences(
     let root = git_repo_root().context(
         "nose needs a git repository to compare the working tree to a git ref (`base=`/`--base`)",
     )?;
+    let cfg = crate::config::load_query(args.config.as_deref())?;
+    let ignore_file = args.ignore_file.clone().or_else(|| cfg.ignore_file.clone());
+
+    // Structured ignores suppress accepted divergences, so an intentional fork doesn't
+    // re-fail every PR. Load them before diff short-circuiting so malformed ignore files
+    // fail consistently even on empty diffs.
+    let ignore_set = crate::ignores::load_for_query(ignore_file.as_deref())?;
+    if let Some(set) = &ignore_set {
+        set.warn_expired();
+    }
+
     let divergence_paths = repo_relative_paths(&args.paths, &root);
     let (changed, current_changed, diff_entries) =
         git_changed_ranges_and_entries(&root, &args.base, &divergence_paths)?;
@@ -30,7 +41,6 @@ pub(crate) fn detect_divergences(
     // Detect clone families at the base, where every copy is still intact. A temporary
     // worktree gives the base tree on disk without disturbing the user's working tree.
     let base_tree = BaseWorktree::create(&root, &args.base)?;
-    let cfg = crate::config::load_query(args.config.as_deref())?;
     let mut exclude = cfg.exclude.clone();
     exclude.extend(args.exclude.iter().cloned());
     let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
@@ -44,13 +54,6 @@ pub(crate) fn detect_divergences(
         min_tokens,
         min_lines,
     )?;
-
-    // Structured ignores suppress accepted divergences, so an intentional fork doesn't
-    // re-fail every PR.
-    let ignore_set = crate::ignores::load_for_query(args.ignore_file.as_deref())?;
-    if let Some(set) = &ignore_set {
-        set.warn_expired();
-    }
 
     // Normalization knobs for the per-flagged-family graded-witness enrichment; must
     // match how `detect_divergence_base_families` lowered (cfg_norm/dce/block_units default), so the

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -143,6 +143,31 @@ rename to moved.py
 }
 
 #[test]
+fn patch_entries_track_copied_and_deleted_paths() {
+    let diff = "\
+diff --git a/template.py b/copied.py
+similarity index 100%
+copy from template.py
+copy to copied.py
+--- a/template.py
++++ b/copied.py
+diff --git a/old.py b/old.py
+deleted file mode 100644
+--- a/old.py
++++ /dev/null
+@@ -1 +0,0 @@
+-print('old')
+";
+    let entries = parse_patch_entries(diff);
+    assert_eq!(entries[0].status, DiffStatus::Copied);
+    assert_eq!(entries[0].old_path.as_deref(), Some("template.py"));
+    assert_eq!(entries[0].new_path.as_deref(), Some("copied.py"));
+    assert_eq!(entries[1].status, DiffStatus::Deleted);
+    assert_eq!(entries[1].old_path.as_deref(), Some("old.py"));
+    assert_eq!(entries[1].new_path, None);
+}
+
+#[test]
 fn patch_entries_track_added_paths_with_spaces() {
     let diff = "\
 diff --git a/src dir/new copy.py b/src dir/new copy.py

--- a/crates/nose-cli/src/ignores.rs
+++ b/crates/nose-cli/src/ignores.rs
@@ -485,3 +485,92 @@ mod parse_id_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod match_tests {
+    use super::load;
+    use nose_detect::{LineSpan, Loc, LocInit, RefactorFamily};
+
+    fn loc(file: &str, lang: &str) -> Loc {
+        Loc::new(LocInit {
+            file: file.into(),
+            source_span: LineSpan::new(1, 8),
+            lang: lang.into(),
+            kind: nose_il::UnitKind::Function,
+            origin: Default::default(),
+            name: Some("f".into()),
+            sem: 24,
+            span_tokens: 24,
+        })
+    }
+
+    fn family(langs: &[&str]) -> RefactorFamily {
+        RefactorFamily {
+            value: 1.0,
+            members: langs.len(),
+            files: langs.len(),
+            modules: 1,
+            languages: langs.len(),
+            mean_score: 1.0,
+            mean_lines: 8,
+            dup_lines: 8,
+            shared_lines: 8,
+            params: 0,
+            shared_weight: 8.0,
+            locations: langs
+                .iter()
+                .enumerate()
+                .map(|(index, lang)| loc(&format!("{lang}/{index}.txt"), lang))
+                .collect(),
+            mean_sem: 24.0,
+            scope: "prod",
+            discount: 1.0,
+            abstraction_witness: None,
+            witness: None,
+            varying_spots: Vec::new(),
+            semantic_laws: Vec::new(),
+        }
+    }
+
+    fn ignore_set(tag: &str, body: &str) -> super::IgnoreSet {
+        let thread_name = std::thread::current()
+            .name()
+            .unwrap_or("test")
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+            .collect::<String>();
+        let path = std::env::temp_dir().join(format!(
+            "nose_ignore_match_{tag}_{}_{}.json",
+            std::process::id(),
+            thread_name
+        ));
+        std::fs::write(&path, body).unwrap();
+        let set = load(&path).expect("ignore file should load");
+        let _ = std::fs::remove_file(path);
+        set
+    }
+
+    #[test]
+    fn language_ignore_requires_every_family_member_to_match() {
+        let set = ignore_set(
+            "partial_language",
+            "{\"ignores\":[{\"languages\":[\"python\"],\"reason\":\"accepted-python\"}]}\n",
+        );
+        assert!(
+            set.match_family(&family(&["python", "rust"])).is_none(),
+            "a language selector covering only one member must not hide the family"
+        );
+    }
+
+    #[test]
+    fn language_ignore_matches_when_all_members_match_case_insensitively() {
+        let set = ignore_set(
+            "all_language",
+            "{\"ignores\":[{\"languages\":[\"Python\"],\"reason\":\"accepted-python\"}]}\n",
+        );
+        let matched = set
+            .match_family(&family(&["python", "python"]))
+            .expect("all-python family should be ignored");
+        assert_eq!(matched.matched_languages, vec!["python"]);
+    }
+}

--- a/crates/nose-cli/tests/cli/query_base.rs
+++ b/crates/nose-cli/tests/cli/query_base.rs
@@ -2,12 +2,16 @@ use super::*;
 
 #[path = "query_base/core_contract.rs"]
 mod core_contract;
+#[path = "query_base/edge_cases.rs"]
+mod edge_cases;
 #[path = "query_base/new_copy.rs"]
 mod new_copy;
 #[path = "query_base/sarif.rs"]
 mod sarif;
 #[path = "query_base/semantic_packs.rs"]
 mod semantic_packs;
+#[path = "query_base/suppression_edges.rs"]
+mod suppression_edges;
 #[path = "query_base/tier_policy.rs"]
 mod tier_policy;
 

--- a/crates/nose-cli/tests/cli/query_base/edge_cases.rs
+++ b/crates/nose-cli/tests/cli/query_base/edge_cases.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+fn edge_body(name: &str, acc: &str, it: &str) -> String {
+    format!(
+        "def {name}(items):\n    {acc} = 0\n    for {it} in items:\n        if {it} > 0:\n            {acc} = {acc} + {it} * {it}\n    return {acc}\n"
+    )
+}
+
+fn edge_project(tag: &str) -> PathBuf {
+    let dir = make_temp_dir(tag);
+    write_files(
+        &dir,
+        &[
+            ("a/f.py", &edge_body("first", "total", "x")),
+            ("b/f.py", &edge_body("second", "acc", "v")),
+        ],
+    );
+    init_git_repo(&dir);
+    dir
+}
+
+fn query_base_json(dir: &Path) -> serde_json::Value {
+    let out = nose_query_base(dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "query base JSON should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("query base JSON")
+}
+
+#[test]
+fn query_base_pure_rename_without_content_change_stays_quiet() {
+    let dir = edge_project("query_base_pure_rename");
+    git_in(&dir, &["mv", "a/f.py", "a/moved.py"]);
+
+    let json = query_base_json(&dir);
+    assert_eq!(
+        json["summary"]["divergences"], 0,
+        "pure moves do not create base or new-copy gate findings: {json}"
+    );
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        gated.status.success(),
+        "pure moves must not trip the default gate"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_deleted_copy_is_strict_base_divergence() {
+    let dir = edge_project("query_base_deleted_copy");
+    fs::remove_file(dir.join("a/f.py")).unwrap();
+
+    let json = query_base_json(&dir);
+    let item = json["items"]
+        .as_array()
+        .and_then(|items| items.first())
+        .unwrap_or_else(|| panic!("deleted copy should leave a base divergence: {json}"));
+    assert_eq!(item["lane"], "base-divergence");
+    assert_eq!(item["tier"], "strict");
+    assert_eq!(item["gate"]["fail_default"], true);
+    assert!(
+        item["changed"].to_string().contains("a/f.py")
+            && item["not_updated"].to_string().contains("b/f.py"),
+        "deleted member is the changed side and sibling remains not-updated: {json}"
+    );
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        !gated.status.success(),
+        "deleting one prod copy is a strict base divergence under the current policy"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_pure_insertion_after_member_boundary_stays_quiet() {
+    let dir = edge_project("query_base_boundary_insertion");
+    let a = dir.join("a/f.py");
+    let mut src = fs::read_to_string(&a).unwrap();
+    src.push_str("\n# trailing file comment outside the member\n");
+    fs::write(&a, src).unwrap();
+
+    let json = query_base_json(&dir);
+    assert_eq!(
+        json["summary"]["divergences"], 0,
+        "an insertion after the member span should not mark the member changed: {json}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_pure_insertion_inside_shared_logic_is_strict() {
+    let dir = edge_project("query_base_inner_insertion");
+    let a = dir.join("a/f.py");
+    let src = fs::read_to_string(&a).unwrap();
+    fs::write(
+        &a,
+        src.replace(
+            "    return total",
+            "    total = total + 1\n    return total",
+        ),
+    )
+    .unwrap();
+
+    let json = query_base_json(&dir);
+    let item = json["items"]
+        .as_array()
+        .and_then(|items| items.first())
+        .unwrap_or_else(|| panic!("inner insertion should be a divergence: {json}"));
+    assert_eq!(item["tier"], "strict");
+    assert_eq!(item["changed"][0]["touches_shared"], true);
+    assert_eq!(item["gate"]["fail_default"], true);
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        !gated.status.success(),
+        "inserting inside shared logic trips the strict default gate"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_missing_base_ref_fails_clearly() {
+    let dir = edge_project("query_base_missing_base_ref");
+    let out = Command::new(bin())
+        .current_dir(&dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_OBJECT_DIRECTORY")
+        .env_remove("GIT_COMMON_DIR")
+        .args([
+            "query",
+            ".",
+            "base=HEAD~1",
+            "--min-size",
+            "8",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run query base with missing ref");
+    assert!(!out.status.success(), "missing base ref should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("`git diff HEAD~1` failed") || stderr.contains("unknown revision"),
+        "missing base-ref error should be actionable: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/nose-cli/tests/cli/query_base/new_copy.rs
+++ b/crates/nose-cli/tests/cli/query_base/new_copy.rs
@@ -176,6 +176,43 @@ fn query_base_added_clone_is_report_only_new_copy_lane() {
 }
 
 #[test]
+fn query_base_copied_clone_is_report_only_new_copy_lane() {
+    let dir = make_temp_dir("query_base_copied_clone");
+    write_files(
+        &dir,
+        &[(
+            "src/original.py",
+            &added_clone_body("original", "total", "x"),
+        )],
+    );
+    init_git_repo(&dir);
+
+    fs::copy(dir.join("src/original.py"), dir.join("src/new_copy.py")).unwrap();
+    git_in(&dir, &["add", "src/new_copy.py"]);
+
+    let out = nose_query_base(&dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "query base JSON should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("query base JSON");
+    assert_new_copy_json_contract(&json);
+
+    let sarif = nose_query_base(&dir, &["--format", "sarif"]);
+    assert!(
+        sarif.status.success(),
+        "query base SARIF should succeed: {}",
+        String::from_utf8_lossy(&sarif.stderr)
+    );
+    let sarif_json: serde_json::Value =
+        serde_json::from_slice(&sarif.stdout).expect("query base SARIF");
+    assert_new_copy_sarif_contract(&sarif_json);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn query_base_moved_clone_is_report_only_new_copy_lane() {
     let dir = make_temp_dir("query_base_moved_clone");
     write_files(
@@ -407,6 +444,107 @@ fn query_base_unrelated_added_code_does_not_emit_new_copy_lane() {
     assert!(
         gated.status.success(),
         "--fail must stay quiet with no new-copy finding"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_new_copy_full_path_ignore_suppresses_advisory_lane() {
+    let dir = make_temp_dir("query_base_new_copy_ignore");
+    write_files(
+        &dir,
+        &[(
+            "src/original.py",
+            &added_clone_body("original", "total", "x"),
+        )],
+    );
+    init_git_repo(&dir);
+    write_files(
+        &dir,
+        &[("src/new_copy.py", &added_clone_body("new_copy", "acc", "v"))],
+    );
+    git_in(&dir, &["add", "src/new_copy.py"]);
+    fs::write(
+        dir.join("nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"src/**\"],\"reason\":\"accepted-generated-copy\"}]}\n",
+    )
+    .unwrap();
+
+    let out = nose_query_base(&dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "query base JSON should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("query base JSON");
+    assert_eq!(
+        json["items"].as_array().expect("items").len(),
+        0,
+        "all-member path ignore suppresses new-copy evidence: {json}"
+    );
+
+    let sarif = nose_query_base(&dir, &["--format", "sarif"]);
+    assert!(
+        sarif.status.success(),
+        "query base SARIF should succeed: {}",
+        String::from_utf8_lossy(&sarif.stderr)
+    );
+    let sarif_json: serde_json::Value =
+        serde_json::from_slice(&sarif.stdout).expect("query base SARIF");
+    assert_eq!(
+        sarif_json["runs"][0]["results"]
+            .as_array()
+            .expect("SARIF results")
+            .len(),
+        0,
+        "all-member path ignore suppresses new-copy SARIF: {sarif_json}"
+    );
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        gated.status.success(),
+        "suppressed new-copy evidence never trips default CI"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_new_copy_partial_path_ignore_keeps_advisory_lane_visible() {
+    let dir = make_temp_dir("query_base_new_copy_partial_ignore");
+    write_files(
+        &dir,
+        &[(
+            "src/original.py",
+            &added_clone_body("original", "total", "x"),
+        )],
+    );
+    init_git_repo(&dir);
+    write_files(
+        &dir,
+        &[("src/new_copy.py", &added_clone_body("new_copy", "acc", "v"))],
+    );
+    git_in(&dir, &["add", "src/new_copy.py"]);
+    fs::write(
+        dir.join("nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"src/new_copy.py\"],\"reason\":\"partial-copy\"}]}\n",
+    )
+    .unwrap();
+
+    let out = nose_query_base(&dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "query base JSON should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("query base JSON");
+    assert_new_copy_json_contract(&json);
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        gated.status.success(),
+        "visible new-copy evidence is still report-only"
     );
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/nose-cli/tests/cli/query_base/suppression_edges.rs
+++ b/crates/nose-cli/tests/cli/query_base/suppression_edges.rs
@@ -1,0 +1,204 @@
+use super::*;
+
+fn strict_base_project(tag: &str) -> PathBuf {
+    let dir = make_project(tag);
+    fs::remove_dir_all(dir.join("tests")).unwrap();
+    init_git_repo(&dir);
+
+    let a = dir.join("a/f.py");
+    let src = fs::read_to_string(&a).unwrap();
+    fs::write(
+        &a,
+        src.replace(
+            "    return total",
+            "    total = total + 1\n    return total",
+        ),
+    )
+    .unwrap();
+    dir
+}
+
+fn write_ignore(dir: &Path, body: &str) {
+    fs::write(dir.join("nose.ignore.json"), body).unwrap();
+}
+
+fn query_base_json(dir: &Path) -> (std::process::Output, serde_json::Value) {
+    let out = nose_query_base(dir, &["--format", "json"]);
+    let json = serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
+        panic!(
+            "query base JSON parse failed: {err}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    (out, json)
+}
+
+fn query_base_sarif(dir: &Path) -> (std::process::Output, serde_json::Value) {
+    let out = nose_query_base(dir, &["--format", "sarif"]);
+    let json = serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
+        panic!(
+            "query base SARIF parse failed: {err}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    (out, json)
+}
+
+#[test]
+fn query_base_honors_config_relative_ignore_file() {
+    let dir = strict_base_project("query_base_config_ignore");
+    fs::create_dir_all(dir.join("suppressions")).unwrap();
+    fs::write(
+        dir.join("suppressions/nose.ignore.json"),
+        "{\"ignores\":[{\"paths\":[\"a/**\",\"b/**\"],\"reason\":\"accepted-divergence\"}]}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("nose.toml"),
+        "[query]\nignore-file = \"suppressions/nose.ignore.json\"\n",
+    )
+    .unwrap();
+
+    let (out, json) = query_base_json(&dir);
+    assert!(
+        out.status.success(),
+        "config ignore query should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        json["items"].as_array().expect("items").len(),
+        0,
+        "config ignore suppresses base findings: {json}"
+    );
+    assert_eq!(json["summary"]["divergences"], 0);
+
+    let (sarif_out, sarif) = query_base_sarif(&dir);
+    assert!(
+        sarif_out.status.success(),
+        "config ignore SARIF should succeed: {}",
+        String::from_utf8_lossy(&sarif_out.stderr)
+    );
+    assert_eq!(
+        sarif["runs"][0]["results"]
+            .as_array()
+            .expect("SARIF results")
+            .len(),
+        0,
+        "config ignore suppresses SARIF findings: {sarif}"
+    );
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        gated.status.success(),
+        "config ignore suppresses before default gate evaluation"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_partial_path_ignore_does_not_hide_uncovered_members() {
+    let dir = strict_base_project("query_base_partial_path_ignore");
+    write_ignore(
+        &dir,
+        "{\"ignores\":[{\"paths\":[\"a/**\"],\"reason\":\"vendor-copy\"}]}\n",
+    );
+
+    let (out, json) = query_base_json(&dir);
+    assert!(
+        out.status.success(),
+        "partial ignore query should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let item = json["items"]
+        .as_array()
+        .and_then(|items| items.first())
+        .unwrap_or_else(|| panic!("partial ignore must leave a finding: {json}"));
+    assert_eq!(item["tier"], "strict", "uncovered member remains strict");
+    assert_eq!(item["gate"]["fail_default"], true);
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        !gated.status.success(),
+        "partial path ignores must not hide strict base divergences"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_expired_ignore_warns_and_does_not_suppress() {
+    let dir = strict_base_project("query_base_expired_ignore");
+    write_ignore(
+        &dir,
+        "{\"ignores\":[{\"paths\":[\"a/**\",\"b/**\"],\"reason\":\"temporary-waiver\",\"owner\":\"platform\",\"expires_at\":\"2000-01-01\"}]}\n",
+    );
+
+    let (out, json) = query_base_json(&dir);
+    assert!(
+        out.status.success(),
+        "expired ignore query should still succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !json["items"].as_array().expect("items").is_empty(),
+        "expired ignore does not suppress: {json}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("expired on 2000-01-01") && stderr.contains("not applied"),
+        "expired ignore warning: {stderr}"
+    );
+
+    let gated = nose_query_base(&dir, &["--fail"]);
+    assert!(
+        !gated.status.success(),
+        "expired ignore must not suppress the strict default gate"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_malformed_ignore_fails_hard() {
+    let dir = strict_base_project("query_base_bad_ignore");
+    write_ignore(
+        &dir,
+        "{\"ignores\":[{\"paths\":[\"a/**\",\"b/**\"],\"note\":\"missing reason\"}]}\n",
+    );
+
+    let out = nose_query_base(&dir, &["--format", "json"]);
+    assert!(!out.status.success(), "malformed ignore must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("parsing ignore file") || stderr.contains("validating ignore file"),
+        "error should name the ignore problem: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_malformed_ignore_fails_even_when_diff_is_empty() {
+    let dir = make_project("query_base_bad_ignore_empty");
+    init_git_repo(&dir);
+    write_ignore(
+        &dir,
+        "{\"ignores\":[{\"paths\":[\"a/**\"],\"note\":\"missing reason\"}]}\n",
+    );
+
+    let out = nose_query_base(&dir, &["--format", "json"]);
+    assert!(
+        !out.status.success(),
+        "malformed ignore files should fail before empty-diff short-circuiting"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("parsing ignore file") || stderr.contains("validating ignore file"),
+        "error should name the ignore problem: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -235,6 +235,12 @@ must not fail default CI. Newly added clone evidence appears as `lane="new-copy"
 `tier="report-only"`, `base_family_id=null`, and current-tree `current_only[]` sites;
 `properties.gate.fail_default` remains `false` in SARIF.
 
+When a strict divergent-edit finding is accepted as intentional, commit a structured
+ignore with a reason/owner/expiry instead of teaching the wrapper to reinterpret the
+finding. The `base=` view auto-reads `nose.ignore.json`, accepts `--ignore-file`, and
+honors `[query] ignore-file = "..."` from `nose.toml`; path and language selectors must
+cover every member of the reported family before they suppress it.
+
 Base-divergence SARIF locations point at the skipped sibling, where a propagated edit
 may be missing; changed copies are attached as related locations. `new-copy` report-only
 SARIF locations point at the current-tree added/copied/renamed copy and link its clone

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -201,7 +201,33 @@ So a true fork doesn't re-fail every PR, the `base=` view honors the same
 [structured ignores](structured-ignores.md) as the rest of `nose query`: copy
 `items[].family_id` from `--format json` into the `family_id` of a `nose.ignore.json`
 entry, with a reason. nose auto-reads that file from the current working directory,
-and the suppressed family no longer trips `--fail-on any`.
+or from `[query] ignore-file = "..."` in `nose.toml`; the suppressed family no
+longer appears in active human/JSON/SARIF output and no longer trips
+`--fail-on any`.
+
+For a strict finding (`gate.fail_default=true`), use one of two outcomes:
+
+1. propagate the edit to the skipped sibling, or otherwise change the code so the
+   family is no longer divergent;
+2. commit an audited structured ignore when the divergence is intentional.
+
+Keep ignores narrow. A `paths` or `languages` selector applies only when every
+member of the reported family matches it; an entry covering just the changed copy
+does not hide the un-updated sibling. Prefer `family_id` for a one-off accepted
+divergence:
+
+```json
+{
+  "ignores": [
+    {
+      "family_id": "479389f590c1234a",
+      "reason": "intentional-variant",
+      "owner": "runtime",
+      "expires_at": "2026-12-31"
+    }
+  ]
+}
+```
 
 ## In CI
 


### PR DESCRIPTION
Closes #685

## Summary
- load `base=` structured ignores through the same config-aware path as normal query, and fail malformed ignores before empty-diff short-circuiting
- add query-base fixtures for config ignores, partial/expired/malformed suppressions, copied/new-copy advisory routing, deletion/rename/insertion edge cases, missing base refs, and all-member path/language semantics
- document strict divergent-edit fix-or-suppress handling with `nose.ignore.json` and CI wrapper guidance

## Notes
- no suppressed/debug output surface is added here; suppression remains full removal from active human/JSON/SARIF output before gate evaluation
- deleted-copy behavior is pinned to the current strict base-divergence policy

## Validation
- `cargo fmt`
- `cargo test -p nose-cli --lib`
- `cargo test -p nose-cli --test cli query_base`
- `cargo test -p nose-cli --test cli ignores_sarif`
- `cargo test -p nose-cli --test cli`
- `cargo clippy -p nose-cli --all-targets --all-features -- -D warnings`
- `./scripts/check-docs.sh`
- `git diff --check`
- push hook fast local CI passed
