### PR TITLE
Package divergent gate GitHub Actions examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added #686 GitHub Actions divergent-edit rollout examples for observe-only
+  SARIF reporting and enforcing strict failures, with step-summary counts and
+  docs-example validation.
 - Added #685 divergent-edit gate hardening fixtures for report-only and suppression
   edges: `base=` now honors config-relative `ignore-file`, malformed ignores fail
   before empty-diff short-circuiting, path/language suppressions keep all-members

--- a/crates/nose-cli/src/divergence/detect.rs
+++ b/crates/nose-cli/src/divergence/detect.rs
@@ -1,6 +1,6 @@
 use super::git::{
-    canonical, git_changed_ranges_and_entries, git_repo_root, repo_relative_paths, reroot_paths,
-    BaseWorktree, DiffEntry,
+    canonical, ensure_base_ref_available, git_changed_ranges_and_entries, git_repo_root,
+    repo_relative_paths, reroot_paths, BaseWorktree, DiffEntry,
 };
 use super::*;
 use crate::detect_pipeline::detect_divergence_base_families;
@@ -32,6 +32,7 @@ pub(crate) fn detect_divergences(
     }
 
     let divergence_paths = repo_relative_paths(&args.paths, &root);
+    ensure_base_ref_available(&root, &args.base)?;
     let (changed, current_changed, diff_entries) =
         git_changed_ranges_and_entries(&root, &args.base, &divergence_paths)?;
     let current_lane_requested = has_current_tree_new_copy_trigger(&diff_entries);

--- a/crates/nose-cli/src/divergence/git.rs
+++ b/crates/nose-cli/src/divergence/git.rs
@@ -38,6 +38,15 @@ pub(super) fn git_repo_root() -> Result<PathBuf> {
     ))
 }
 
+pub(super) fn ensure_base_ref_available(root: &Path, base: &str) -> Result<()> {
+    let commit_ref = format!("{base}^{{commit}}");
+    let out = git(root, &["rev-parse", "--verify", "--quiet", &commit_ref])?;
+    if !out.status.success() {
+        anyhow::bail!("base ref `{base}` is not available locally; fetch it before running nose");
+    }
+    Ok(())
+}
+
 /// A throwaway worktree checked out at `base`, removed on drop.
 pub(super) struct BaseWorktree {
     root: PathBuf,

--- a/crates/nose-cli/tests/cli/query_base/edge_cases.rs
+++ b/crates/nose-cli/tests/cli/query_base/edge_cases.rs
@@ -149,7 +149,8 @@ fn query_base_missing_base_ref_fails_clearly() {
     assert!(!out.status.success(), "missing base ref should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("`git diff HEAD~1` failed") || stderr.contains("unknown revision"),
+        stderr.contains("base ref `HEAD~1` is not available locally")
+            && stderr.contains("fetch it before running nose"),
         "missing base-ref error should be actionable: {stderr}"
     );
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -170,6 +170,13 @@ findings as inline PR annotations:
 nose query src --mode syntax --format sarif top=0 > nose.sarif   # then upload via github/codeql-action/upload-sarif
 ```
 
+For GitHub Actions, upload third-party SARIF with
+`github/codeql-action/upload-sarif@v4`. The job needs `security-events: write`,
+`contents: read`, and, for private repositories, `actions: read`; private and internal
+repositories also need GitHub Code Security enabled. Public fork pull requests usually do
+not receive a token that can write code-scanning results, so PR workflows should not use
+`pull_request_target` as a workaround for untrusted code.
+
 **Pass `top=0` for a complete upload.** Every output format truncates to the row limit —
 `top=N` (default 30); `top=0` means *all*.
 Without it a repo with more than 30 families uploads only the first 30. The SARIF run records
@@ -245,6 +252,31 @@ Base-divergence SARIF locations point at the skipped sibling, where a propagated
 may be missing; changed copies are attached as related locations. `new-copy` report-only
 SARIF locations point at the current-tree added/copied/renamed copy and link its clone
 siblings as related locations.
+
+### GitHub Actions rollout examples
+
+Copy one of these PR workflows into `.github/workflows/` and pin `NOSE_VERSION` to a
+reviewed release:
+
+- [docs/examples/ci/divergent-edit-observe-only.yml](examples/ci/divergent-edit-observe-only.yml) writes JSON/SARIF, uploads SARIF when the token can do so, and adds a step summary without failing on findings.
+- [docs/examples/ci/divergent-edit-enforcing.yml](examples/ci/divergent-edit-enforcing.yml) does the same, then fails only when `items[].gate.fail_default == true`.
+
+Both examples use `on: pull_request`, `actions/checkout@v7` with `fetch-depth: 0`,
+`persist-credentials: false`, a `nose capabilities` preflight, an explicit fetch and
+`git rev-parse --verify --quiet "${BASE_REF}^{commit}"` base-ref check, pinned
+`--mode syntax,semantic`, and complete JSON/SARIF output with `top=0`.
+
+The enforcing workflow uploads SARIF before its final failing step so code-scanning
+results are available when GitHub accepts the upload. It still treats the step summary as
+the reliable PR surface: GitHub only displays inline code-scanning annotations for alerts
+whose locations are in the pull request diff, while a divergent-edit SARIF result often
+anchors on the skipped sibling. Fork PRs may skip SARIF upload because the token is
+read-only; do not switch to `pull_request_target` for untrusted PR code.
+
+The examples intentionally run JSON and SARIF without `--fail-on any` and make the final
+decision themselves from `gate.fail_default`. That preserves upload-before-fail ordering
+and avoids accidental failures from `fire_eligible`, SARIF severity, human output,
+`summary.strict`, `scope`, `touches_shared`, or `tier` alone.
 
 ## Fast re-runs: `--cache-dir`
 

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -236,7 +236,7 @@ lands in one copy but not its clones:
 
 ```sh
 nose query . base="origin/${GITHUB_BASE_REF}" --mode syntax,semantic --fail-on any
-# or, for inline PR annotations on the un-updated copies:
+# or, for code-scanning results:
 nose query . base="origin/${GITHUB_BASE_REF}" --mode syntax,semantic --format sarif top=0 > nose-divergence.sarif
 ```
 
@@ -246,9 +246,12 @@ findings, including mixed/test scope and `new-copy` current-tree evidence, remai
 but do not fail the default gate.
 
 Base-divergence SARIF results are anchored on the **un-updated sibling** (where the fix
-may be missing), so a code-scanning annotation lands on the copy the change skipped. The
-rule id, level, message, and `properties.tier` identify whether a finding is `strict`,
-`review`, or `report-only`.
+may be missing). GitHub can show inline code-scanning annotations only when the reported
+location is in the pull request diff, so a skipped-sibling result may be visible in code
+scanning without appearing inline on the Conversation or Files changed tabs. Use the
+GitHub Actions examples in [continuous integration](continuous-integration.md#github-actions-rollout-examples)
+for a step summary that always reports strict/review/report-only counts and fails only
+from `gate.fail_default`.
 
 ## History Mining
 

--- a/docs/examples/ci/divergent-edit-enforcing.yml
+++ b/docs/examples/ci/divergent-edit-enforcing.yml
@@ -1,0 +1,135 @@
+name: nose divergent-edit enforcing
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  divergent-edit:
+    runs-on: ubuntu-latest
+    env:
+      NOSE_VERSION: v0.17.0
+      BASE_REF: origin/${{ github.base_ref }}
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install nose
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/corca-ai/nose/releases/download/${NOSE_VERSION}/nose-cli-installer.sh" \
+            | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Check divergent-edit capabilities
+        run: |
+          nose capabilities > nose-capabilities.json
+          python3 - <<'PY'
+          import json
+          import sys
+
+          with open("nose-capabilities.json", encoding="utf-8") as handle:
+              caps = json.load(handle)
+
+          query = caps.get("query", {})
+          query_caps = query.get("capabilities", {})
+          missing = []
+          if 8 not in caps.get("schemas", {}).get("query_json", []):
+              missing.append("schemas.query_json=8")
+          for fmt in ["json", "sarif"]:
+              if fmt not in query.get("output_formats", []):
+                  missing.append(f"query.output_formats.{fmt}")
+          for key in [
+              "base_divergence",
+              "query_base_json_v8",
+              "query_base_gate_fail_default",
+              "query_base_sarif",
+              "structured_ignores",
+              "query_base_structured_ignores",
+          ]:
+              if query_caps.get(key) is not True:
+                  missing.append(f"query.capabilities.{key}")
+          if missing:
+              print("Installed nose does not support the divergent-edit CI contract:", ", ".join(missing), file=sys.stderr)
+              raise SystemExit(2)
+          PY
+
+      - name: Fetch and validate base ref
+        run: |
+          git fetch --no-tags origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
+            echo "::error::Base ref ${BASE_REF} is not available locally; fetch it before running nose"
+            exit 2
+          }
+
+      - name: Run divergent-edit reports
+        run: |
+          nose query . "base=${BASE_REF}" --mode syntax,semantic --format json top=0 > nose-divergence.json
+          nose query . "base=${BASE_REF}" --mode syntax,semantic --format sarif top=0 > nose-divergence.sarif
+
+      - name: Write divergent-edit summary
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from collections import Counter
+
+          with open("nose-divergence.json", encoding="utf-8") as handle:
+              doc = json.load(handle)
+
+          items = doc.get("items", [])
+          summary = doc.get("summary", {})
+          tiers = Counter(item.get("tier", "unknown") for item in items)
+          lanes = Counter(item.get("lane", "unknown") for item in items)
+          fail_default = sum(1 for item in items if item.get("gate", {}).get("fail_default") is True)
+
+          lines = [
+              "## nose divergent-edit gate",
+              "",
+              f"- changed files: {summary.get('changed_files', 0)}",
+              f"- findings: {summary.get('divergences', len(items))}",
+              f"- shown findings: {summary.get('shown_divergences', len(items))}",
+              f"- default-failing findings: {fail_default}",
+              f"- strict: {tiers.get('strict', 0)}",
+              f"- review: {tiers.get('review', 0)}",
+              f"- report-only: {tiers.get('report-only', 0)}",
+              f"- new-copy advisory: {lanes.get('new-copy', 0)}",
+              "",
+              "Only findings with `gate.fail_default=true` are default blockers. Review, report-only, new-copy, and suppressed findings do not fail this gate.",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          print(f"nose divergent-edit default-failing findings: {fail_default}")
+          PY
+
+      - name: Upload divergent-edit SARIF
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: nose-divergence.sarif
+          category: nose-divergent-edit
+
+      - name: Fail on strict divergent edits
+        run: |
+          python3 - <<'PY'
+          import json
+
+          with open("nose-divergence.json", encoding="utf-8") as handle:
+              doc = json.load(handle)
+
+          fail_default = [
+              item for item in doc.get("items", [])
+              if item.get("gate", {}).get("fail_default") is True
+          ]
+          if fail_default:
+              print(f"::error::{len(fail_default)} default-failing divergent edit(s) found")
+              raise SystemExit(1)
+          PY

--- a/docs/examples/ci/divergent-edit-observe-only.yml
+++ b/docs/examples/ci/divergent-edit-observe-only.yml
@@ -1,0 +1,118 @@
+name: nose divergent-edit observe-only
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  divergent-edit:
+    runs-on: ubuntu-latest
+    env:
+      NOSE_VERSION: v0.17.0
+      BASE_REF: origin/${{ github.base_ref }}
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install nose
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/corca-ai/nose/releases/download/${NOSE_VERSION}/nose-cli-installer.sh" \
+            | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Check divergent-edit capabilities
+        run: |
+          nose capabilities > nose-capabilities.json
+          python3 - <<'PY'
+          import json
+          import sys
+
+          with open("nose-capabilities.json", encoding="utf-8") as handle:
+              caps = json.load(handle)
+
+          query = caps.get("query", {})
+          query_caps = query.get("capabilities", {})
+          missing = []
+          if 8 not in caps.get("schemas", {}).get("query_json", []):
+              missing.append("schemas.query_json=8")
+          for fmt in ["json", "sarif"]:
+              if fmt not in query.get("output_formats", []):
+                  missing.append(f"query.output_formats.{fmt}")
+          for key in [
+              "base_divergence",
+              "query_base_json_v8",
+              "query_base_gate_fail_default",
+              "query_base_sarif",
+              "structured_ignores",
+              "query_base_structured_ignores",
+          ]:
+              if query_caps.get(key) is not True:
+                  missing.append(f"query.capabilities.{key}")
+          if missing:
+              print("Installed nose does not support the divergent-edit CI contract:", ", ".join(missing), file=sys.stderr)
+              raise SystemExit(2)
+          PY
+
+      - name: Fetch and validate base ref
+        run: |
+          git fetch --no-tags origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
+            echo "::error::Base ref ${BASE_REF} is not available locally; fetch it before running nose"
+            exit 2
+          }
+
+      - name: Run divergent-edit reports
+        run: |
+          nose query . "base=${BASE_REF}" --mode syntax,semantic --format json top=0 > nose-divergence.json
+          nose query . "base=${BASE_REF}" --mode syntax,semantic --format sarif top=0 > nose-divergence.sarif
+
+      - name: Write divergent-edit summary
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from collections import Counter
+
+          with open("nose-divergence.json", encoding="utf-8") as handle:
+              doc = json.load(handle)
+
+          items = doc.get("items", [])
+          summary = doc.get("summary", {})
+          tiers = Counter(item.get("tier", "unknown") for item in items)
+          lanes = Counter(item.get("lane", "unknown") for item in items)
+          fail_default = sum(1 for item in items if item.get("gate", {}).get("fail_default") is True)
+
+          lines = [
+              "## nose divergent-edit gate",
+              "",
+              f"- changed files: {summary.get('changed_files', 0)}",
+              f"- findings: {summary.get('divergences', len(items))}",
+              f"- shown findings: {summary.get('shown_divergences', len(items))}",
+              f"- default-failing findings: {fail_default}",
+              f"- strict: {tiers.get('strict', 0)}",
+              f"- review: {tiers.get('review', 0)}",
+              f"- report-only: {tiers.get('report-only', 0)}",
+              f"- new-copy advisory: {lanes.get('new-copy', 0)}",
+              "",
+              "Only findings with `gate.fail_default=true` are default blockers. Review, report-only, new-copy, and suppressed findings do not fail this gate.",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines))
+              handle.write("\n")
+          print(f"nose divergent-edit default-failing findings: {fail_default}")
+          PY
+
+      - name: Upload divergent-edit SARIF
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: nose-divergence.sarif
+          category: nose-divergent-edit

--- a/scripts/check-ci-examples.py
+++ b/scripts/check-ci-examples.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Validate copyable CI workflow examples in docs/examples/ci."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = ROOT / "docs" / "examples" / "ci"
+OBSERVE = EXAMPLE_DIR / "divergent-edit-observe-only.yml"
+ENFORCE = EXAMPLE_DIR / "divergent-edit-enforcing.yml"
+CI_DOC = ROOT / "docs" / "continuous-integration.md"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"ci example check failed: {message}")
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as err:
+        raise SystemExit(f"ci example check failed: read {path}: {err}") from err
+
+
+def check_workflow(path: Path, *, enforcing: bool) -> None:
+    text = read(path)
+    require("pull_request_target" not in text, f"{path} must not use pull_request_target")
+    for needle in [
+        "pull_request:",
+        "contents: read",
+        "security-events: write",
+        "actions: read",
+        "actions/checkout@v7",
+        "fetch-depth: 0",
+        "persist-credentials: false",
+        "nose capabilities > nose-capabilities.json",
+        "schemas.query_json=8",
+        "query.output_formats",
+        "base_divergence",
+        "query_base_json_v8",
+        "query_base_gate_fail_default",
+        "query_base_sarif",
+        "structured_ignores",
+        "query_base_structured_ignores",
+        'git rev-parse --verify --quiet "${BASE_REF}^{commit}"',
+        '--mode syntax,semantic --format json top=0',
+        '--mode syntax,semantic --format sarif top=0',
+        "GITHUB_STEP_SUMMARY",
+        "gate.fail_default",
+        "github/codeql-action/upload-sarif@v4",
+        "category: nose-divergent-edit",
+    ]:
+        require(needle in text, f"{path} missing `{needle}`")
+    require("fire_eligible" not in text, f"{path} must not decide from fire_eligible")
+    require("summary.strict" not in text, f"{path} must not decide from summary.strict")
+
+    upload_at = text.find("- name: Upload divergent-edit SARIF")
+    fail_at = text.find("- name: Fail on strict divergent edits")
+    if enforcing:
+        require(fail_at != -1, f"{path} missing final fail step")
+        require(upload_at != -1 and upload_at < fail_at, f"{path} must upload SARIF before failing")
+    else:
+        require(fail_at == -1, f"{path} must stay observe-only")
+
+
+def extract_python_block(workflow: str, step_name: str) -> str:
+    marker = f"- name: {step_name}"
+    start = workflow.find(marker)
+    require(start != -1, f"missing step `{step_name}`")
+    heredoc = workflow.find("python3 - <<'PY'", start)
+    require(heredoc != -1, f"missing Python heredoc under `{step_name}`")
+    code_start = workflow.find("\n", heredoc) + 1
+    code_end = workflow.find("\n          PY", code_start)
+    require(code_end != -1, f"unterminated Python heredoc under `{step_name}`")
+    return textwrap.dedent(workflow[code_start:code_end])
+
+
+def run_python_block(code: str, data: dict, *, expect_exit: int = 0) -> str:
+    with tempfile.TemporaryDirectory(prefix="nose-ci-example-") as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "nose-divergence.json").write_text(json.dumps(data), encoding="utf-8")
+        summary = tmp_path / "summary.md"
+        env = os.environ.copy()
+        env["GITHUB_STEP_SUMMARY"] = str(summary)
+        script = tmp_path / "block.py"
+        script.write_text(code, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=tmp_path,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        require(
+            result.returncode == expect_exit,
+            f"Python block exited {result.returncode}, expected {expect_exit}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        return summary.read_text(encoding="utf-8") if summary.exists() else ""
+
+
+def sample_doc(*, fail_default: bool) -> dict:
+    return {
+        "schema_version": 8,
+        "view": "base",
+        "summary": {
+            "changed_files": 4,
+            "divergences": 3,
+            "shown_divergences": 3,
+        },
+        "items": [
+            {"tier": "strict", "lane": "base-divergence", "gate": {"fail_default": fail_default}},
+            {"tier": "review", "lane": "base-divergence", "gate": {"fail_default": False}},
+            {"tier": "report-only", "lane": "new-copy", "gate": {"fail_default": False}},
+        ],
+    }
+
+
+def check_summary_block(path: Path) -> None:
+    workflow = read(path)
+    code = extract_python_block(workflow, "Write divergent-edit summary")
+    summary = run_python_block(code, sample_doc(fail_default=True))
+    for needle in [
+        "changed files: 4",
+        "findings: 3",
+        "shown findings: 3",
+        "default-failing findings: 1",
+        "strict: 1",
+        "review: 1",
+        "report-only: 1",
+        "new-copy advisory: 1",
+        "gate.fail_default=true",
+    ]:
+        require(needle in summary, f"{path} summary block missing `{needle}`")
+
+
+def check_enforcing_block() -> None:
+    workflow = read(ENFORCE)
+    code = extract_python_block(workflow, "Fail on strict divergent edits")
+    _ = run_python_block(code, sample_doc(fail_default=False), expect_exit=0)
+    _ = run_python_block(code, sample_doc(fail_default=True), expect_exit=1)
+
+
+def check_docs_link_examples() -> None:
+    text = read(CI_DOC)
+    for needle in [
+        "docs/examples/ci/divergent-edit-observe-only.yml",
+        "docs/examples/ci/divergent-edit-enforcing.yml",
+        "pull_request_target",
+        "github/codeql-action/upload-sarif@v4",
+        "security-events: write",
+        "actions: read",
+        "gate.fail_default",
+        "top=0",
+    ]:
+        require(needle in text, f"{CI_DOC} missing `{needle}`")
+
+
+def main() -> None:
+    check_workflow(OBSERVE, enforcing=False)
+    check_workflow(ENFORCE, enforcing=True)
+    check_summary_block(OBSERVE)
+    check_summary_block(ENFORCE)
+    check_enforcing_block()
+    check_docs_link_examples()
+    print("validated 2 divergent-edit GitHub Actions example(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -15,6 +15,7 @@ cd "$(dirname "$0")/.."
 
 if command -v python3 >/dev/null 2>&1; then
     python3 scripts/check-semantic-pack-examples.py
+    python3 scripts/check-ci-examples.py
 else
     echo "skipped semantic-pack example check — python3 not installed"
 fi


### PR DESCRIPTION
Closes #686

## Summary
- add observe-only and enforcing GitHub Actions examples for the divergent-edit gate
- validate the examples in the docs gate, including capability preflight, base-ref checks, `top=0`, SARIF upload ordering, and `gate.fail_default` failure logic
- improve missing-base-ref diagnostics before `git diff`, and update CI/divergent-edit docs for SARIF permissions, fork limits, and skipped-sibling annotation limits

## Notes
- examples use `pull_request`, not `pull_request_target`, and pin `--mode syntax,semantic`
- enforcing workflow uploads SARIF before failing and fails only from `items[].gate.fail_default == true`
- no fixture repo is added; the workflow snippets and summary logic are validated by `scripts/check-ci-examples.py`, while divergent behavior is covered by `query_base` fixtures

## Validation
- `cargo fmt`
- `python3 scripts/check-ci-examples.py`
- `python3 -m py_compile scripts/check-ci-examples.py`
- `cargo test -p nose-cli --test cli query_base_missing_base_ref_fails_clearly`
- `cargo test -p nose-cli --test cli query_base`
- `cargo test -p nose-cli --lib`
- `cargo test -p nose-cli --test cli capabilities`
- `cargo clippy -p nose-cli --all-targets --all-features -- -D warnings`
- `cargo test -p nose-cli --test cli`
- `./scripts/check-docs.sh`
- `git diff --check`
- push hook fast local CI passed
