### PR TITLE
Operationalize divergent gate pilot evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added #687 divergent gate productization evidence: history-mining artifacts now
+  have a validator, hardened provenance/counts, and checked nose-on-nose
+  maintainer-pilot summaries that keep history mining offline and the PR gate
+  observe-only unless explicitly enforced.
 - Added #686 GitHub Actions divergent-edit rollout examples for observe-only
   SARIF reporting and enforcing strict failures, with step-summary counts and
   docs-example validation.

--- a/bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json
@@ -1,0 +1,12648 @@
+{
+  "artifact_kind": "divergent-history-mining-run",
+  "bounds": {
+    "max_commits": 12,
+    "offline_only": true,
+    "pr_ci": false
+  },
+  "commits": [
+    {
+      "author_time": 1783293504,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=4283439e8e6209c8e8bb600d8a142e9963f27b32 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "df2aab26908c47f83ae4ea8c743f3b679bbd2467",
+      "items": [],
+      "parent": "4283439e8e6209c8e8bb600d8a142e9963f27b32",
+      "parents": [
+        "4283439e8e6209c8e8bb600d8a142e9963f27b32"
+      ],
+      "query_base": "4283439e8e6209c8e8bb600d8a142e9963f27b32",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Add divergent history mining harness",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783294506,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=df2aab26908c47f83ae4ea8c743f3b679bbd2467 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "ada4b0862b2a377ec0630bca75ac639c21c0986f",
+      "items": [],
+      "parent": "df2aab26908c47f83ae4ea8c743f3b679bbd2467",
+      "parents": [
+        "df2aab26908c47f83ae4ea8c743f3b679bbd2467"
+      ],
+      "query_base": "df2aab26908c47f83ae4ea8c743f3b679bbd2467",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Close Rust block_on residual tranche",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783295989,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=ada4b0862b2a377ec0630bca75ac639c21c0986f --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "9782ede981ba68f6ee50c1abfba08d131a8afe32",
+      "items": [],
+      "parent": "ada4b0862b2a377ec0630bca75ac639c21c0986f",
+      "parents": [
+        "ada4b0862b2a377ec0630bca75ac639c21c0986f"
+      ],
+      "query_base": "ada4b0862b2a377ec0630bca75ac639c21c0986f",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Add semantic-pack promotion audit",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783297677,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=9782ede981ba68f6ee50c1abfba08d131a8afe32 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "de33d34ea731ca8efbad0e3289077de50247da10",
+      "items": [],
+      "parent": "9782ede981ba68f6ee50c1abfba08d131a8afe32",
+      "parents": [
+        "9782ede981ba68f6ee50c1abfba08d131a8afe32"
+      ],
+      "query_base": "9782ede981ba68f6ee50c1abfba08d131a8afe32",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Burn down dogfooding resolver debt",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783298971,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=de33d34ea731ca8efbad0e3289077de50247da10 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "ab9d3237a26aa03216f2a0bab264cc8c4a798651",
+      "items": [],
+      "parent": "de33d34ea731ca8efbad0e3289077de50247da10",
+      "parents": [
+        "de33d34ea731ca8efbad0e3289077de50247da10"
+      ],
+      "query_base": "de33d34ea731ca8efbad0e3289077de50247da10",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Record closeout review evidence",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783299439,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=ab9d3237a26aa03216f2a0bab264cc8c4a798651 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "551758d5139372a58645f411ac3b887d679c755a",
+      "items": [],
+      "parent": "ab9d3237a26aa03216f2a0bab264cc8c4a798651",
+      "parents": [
+        "ab9d3237a26aa03216f2a0bab264cc8c4a798651"
+      ],
+      "query_base": "ab9d3237a26aa03216f2a0bab264cc8c4a798651",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Record final closeout review round",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783306134,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=551758d5139372a58645f411ac3b887d679c755a --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+      "items": [],
+      "parent": "551758d5139372a58645f411ac3b887d679c755a",
+      "parents": [
+        "551758d5139372a58645f411ac3b887d679c755a"
+      ],
+      "query_base": "551758d5139372a58645f411ac3b887d679c755a",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Add final divergent replay artifacts (#690)",
+      "summary": {
+        "changed_files": 0,
+        "divergences": 0,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 0,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783307347,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=7e03737c51fbf31069345e89ad6e2fcaecf67125 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "items": [
+        {
+          "base_family_id": "61dbf90da78fcf2b",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 276,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 13,
+          "family_id": "61dbf90da78fcf2b",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 410,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 331,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 331,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 295,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 221,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/typed_defaults.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 221,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 162,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/string_affix.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 162,
+              "span_tokens": 10,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/object_keys.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 150,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 131,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/map_keys.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 131,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "53516dd2428fd649",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 356,
+              "span_tokens": 10,
+              "start_line": 1,
+              "touches_shared": false,
+              "tree": "base"
+            }
+          ],
+          "complexity": 10,
+          "family_id": "53516dd2428fd649",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 415,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 415,
+              "span_tokens": 10,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 84,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 84,
+              "span_tokens": 10,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 62,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 62,
+              "span_tokens": 10,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_not_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "f889401a831e2a60",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 559,
+                "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+                "kind": "Function",
+                "name": "query_dashboard_filter_and_family",
+                "start_line": 250,
+                "unit_key": "crates/nose-cli/tests/cli/commands/proposal_query.rs:Function:250-559:query_dashboard_filter_and_family"
+              },
+              "end_line": 559,
+              "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 310,
+              "span_tokens": 10,
+              "start_line": 250,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 10,
+          "family_id": "f889401a831e2a60",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_literal_collection_membership",
+                "start_line": 10,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs:Function:10-194:query_mode_semantic_proves_literal_collection_membership"
+              },
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 185,
+              "span_tokens": 10,
+              "start_line": 10,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 75,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_null_presence_predicates",
+                "start_line": 7,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs:Function:7-75:query_mode_semantic_proves_null_presence_predicates"
+              },
+              "end_line": 75,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 69,
+              "span_tokens": 10,
+              "start_line": 7,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 251,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "broken_pipe_exits_cleanly",
+                "start_line": 194,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:194-251:broken_pipe_exits_cleanly"
+              },
+              "end_line": 251,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 58,
+              "span_tokens": 10,
+              "start_line": 194,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 59,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_regex_literal_predicate_matches",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs:Function:4-59:query_mode_semantic_proves_regex_literal_predicate_matches"
+              },
+              "end_line": 59,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 56,
+              "span_tokens": 10,
+              "start_line": 4,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Function",
+                "name": "rust_binding_patterns_lower_without_raw",
+                "start_line": 35,
+                "unit_key": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs:Function:35-76:rust_binding_patterns_lower_without_raw"
+              },
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 35,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 72,
+                "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+                "kind": "Function",
+                "name": "feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks",
+                "start_line": 33,
+                "unit_key": "crates/nose-cli/tests/cli/exact_fragments.rs:Function:33-72:feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks"
+              },
+              "end_line": 72,
+              "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 33,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 90,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity",
+                "start_line": 64,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:64-90:query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity"
+              },
+              "end_line": 90,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 10,
+              "start_line": 64,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "recursive_hof_callback_fragment_does_not_overflow",
+                "start_line": 332,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:332-356:recursive_hof_callback_fragment_does_not_overflow"
+              },
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 25,
+              "span_tokens": 10,
+              "start_line": 332,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 58,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity",
+                "start_line": 34,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:34-58:query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity"
+              },
+              "end_line": 58,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 25,
+              "span_tokens": 10,
+              "start_line": 34,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 118,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "verify_oracle_agrees_with_three_way_selection_canon",
+                "start_line": 98,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:98-118:verify_oracle_agrees_with_three_way_selection_canon"
+              },
+              "end_line": 118,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 21,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 20,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Function",
+                "name": "inline_nose_ignore_suppresses_a_site",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs:Function:4-20:inline_nose_ignore_suppresses_a_site"
+              },
+              "end_line": 20,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 17,
+              "span_tokens": 10,
+              "start_line": 4,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 267,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "deeply_nested_file_does_not_overflow",
+                "start_line": 254,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:254-267:deeply_nested_file_does_not_overflow"
+              },
+              "end_line": 267,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 14,
+              "span_tokens": 10,
+              "start_line": 254,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 202,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "make_fire_policy_project",
+                "start_line": 193,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:193-202:make_fire_policy_project"
+              },
+              "end_line": 202,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 10,
+              "span_tokens": 10,
+              "start_line": 193,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "9b0601640770e7b3",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 67,
+              "span_tokens": 10,
+              "start_line": 64,
+              "touches_shared": false,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 56,
+              "span_tokens": 10,
+              "start_line": 75,
+              "touches_shared": true,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 420,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 24,
+              "span_tokens": 11,
+              "start_line": 397,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 11,
+          "family_id": "9b0601640770e7b3",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 153,
+              "span_tokens": 10,
+              "start_line": 181,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 150,
+              "span_tokens": 10,
+              "start_line": 33,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 93,
+              "span_tokens": 10,
+              "start_line": 184,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 91,
+              "span_tokens": 10,
+              "start_line": 172,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 81,
+              "span_tokens": 10,
+              "start_line": 149,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 80,
+              "span_tokens": 10,
+              "start_line": 261,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 79,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 77,
+              "span_tokens": 11,
+              "start_line": 293,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 71,
+              "span_tokens": 10,
+              "start_line": 71,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 409,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 65,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 59,
+              "span_tokens": 10,
+              "start_line": 70,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 58,
+              "span_tokens": 11,
+              "start_line": 19,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 185,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 129,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 185,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 129,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 56,
+              "span_tokens": 10,
+              "start_line": 355,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 55,
+              "span_tokens": 10,
+              "start_line": 222,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 118,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 170,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 242,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 52,
+              "span_tokens": 10,
+              "start_line": 218,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 167,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 52,
+              "span_tokens": 10,
+              "start_line": 116,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 51,
+              "span_tokens": 11,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 50,
+              "span_tokens": 11,
+              "start_line": 368,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 46,
+              "span_tokens": 10,
+              "start_line": 74,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 11,
+              "start_line": 39,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 10,
+              "start_line": 129,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 354,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 311,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 367,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 454,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 312,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 271,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 275,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 315,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 58,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 416,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 11,
+              "start_line": 152,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 272,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 233,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 66,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 115,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 11,
+              "start_line": 219,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 10,
+              "start_line": 268,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 11,
+              "start_line": 135,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 10,
+              "start_line": 332,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 32,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 11,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 398,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 368,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 140,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 298,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 11,
+              "start_line": 271,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 323,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 11,
+              "start_line": 297,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 96,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 194,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 24,
+              "span_tokens": 10,
+              "start_line": 29,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 23,
+              "span_tokens": 10,
+              "start_line": 51,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "af6ee52590563481",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_json_contract",
+                "start_line": 29,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:29-73:assert_json_contract"
+              },
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 12,
+              "start_line": 29,
+              "touches_shared": true,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 106,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_sarif_contract",
+                "start_line": 75,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:75-106:assert_sarif_contract"
+              },
+              "end_line": 106,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 32,
+              "span_tokens": 12,
+              "start_line": 75,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 12,
+          "family_id": "af6ee52590563481",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 27,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_human_report_names_changed_and_skipped",
+                "start_line": 20,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:20-27:assert_human_report_names_changed_and_skipped"
+              },
+              "end_line": 27,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 8,
+              "span_tokens": 12,
+              "start_line": 20,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "4f1107f4527001b6",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 241,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "assert_varying_spot_is_review",
+                "start_line": 218,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:218-241:assert_varying_spot_is_review"
+              },
+              "end_line": 241,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 24,
+              "span_tokens": 13,
+              "start_line": 218,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 13,
+          "family_id": "4f1107f4527001b6",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 270,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "assert_shared_logic_is_strict",
+                "start_line": 243,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:243-270:assert_shared_logic_is_strict"
+              },
+              "end_line": 270,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 13,
+              "start_line": 243,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "c847df560e4e728e",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 43,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 8,
+              "span_tokens": 31,
+              "start_line": 36,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 31,
+          "family_id": "c847df560e4e728e",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 185,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_exact_renamed_twin_remains_strict",
+                "start_line": 133,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:133-185:query_base_exact_renamed_twin_remains_strict"
+              },
+              "end_line": 163,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 16,
+              "span_tokens": 25,
+              "start_line": 148,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_json_includes_fragment_context",
+                "start_line": 237,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:237-272:query_base_json_includes_fragment_context"
+              },
+              "end_line": 255,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 11,
+              "span_tokens": 31,
+              "start_line": 245,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 65,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_mixed_scope_is_report_only_not_strict",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+              },
+              "end_line": 28,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 11,
+              "span_tokens": 40,
+              "start_line": 18,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_all_test_scope_is_report_only_not_strict",
+                "start_line": 68,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+              },
+              "end_line": 105,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 11,
+              "span_tokens": 39,
+              "start_line": 95,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 149,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 8,
+              "span_tokens": 31,
+              "start_line": 142,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 254,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 8,
+              "span_tokens": 31,
+              "start_line": 247,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 312,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_uses_supported_language_extensions",
+                "start_line": 275,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+              },
+              "end_line": 300,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 8,
+              "span_tokens": 31,
+              "start_line": 293,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "dad0d6cff1baabaa",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 33,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 13,
+              "span_tokens": 22,
+              "start_line": 21,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 22,
+          "family_id": "dad0d6cff1baabaa",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 354,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                "start_line": 315,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+              },
+              "end_line": 332,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 16,
+              "span_tokens": 22,
+              "start_line": 317,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "486197ecf7f437c6",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 88,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 84,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 13,
+          "family_id": "486197ecf7f437c6",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 234,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_flags_a_clone_changed_in_one_copy_only",
+                "start_line": 194,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:194-234:query_base_flags_a_clone_changed_in_one_copy_only"
+              },
+              "end_line": 231,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 227,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 164,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 160,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 265,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 354,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                "start_line": 315,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+              },
+              "end_line": 351,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 347,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 65,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_mixed_scope_is_report_only_not_strict",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+              },
+              "end_line": 62,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 58,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_all_test_scope_is_report_only_not_strict",
+                "start_line": 68,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+              },
+              "end_line": 127,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 13,
+              "start_line": 123,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "7ee0306d63c13351",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 33,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 9,
+              "span_tokens": 15,
+              "start_line": 25,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 15,
+          "family_id": "7ee0306d63c13351",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 244,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 11,
+              "span_tokens": 15,
+              "start_line": 234,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 312,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_uses_supported_language_extensions",
+                "start_line": 275,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+              },
+              "end_line": 290,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 7,
+              "span_tokens": 13,
+              "start_line": 284,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "cc87791e18913c18",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 27,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 7,
+              "span_tokens": 12,
+              "start_line": 21,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 12,
+          "family_id": "cc87791e18913c18",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 131,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 10,
+              "span_tokens": 12,
+              "start_line": 122,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "1fa4bb1b2f2cc58e",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 95,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 6,
+              "span_tokens": 14,
+              "start_line": 90,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 14,
+          "family_id": "1fa4bb1b2f2cc58e",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 420,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_machine_formats_emit_json_when_no_changes_exist",
+                "start_line": 401,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:401-420:query_base_machine_formats_emit_json_when_no_changes_exist"
+              },
+              "end_line": 415,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 2,
+              "span_tokens": 14,
+              "start_line": 414,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        }
+      ],
+      "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+      "parents": [
+        "7e03737c51fbf31069345e89ad6e2fcaecf67125"
+      ],
+      "query_base": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Stabilize query-base v8 wrapper contract (#691)",
+      "summary": {
+        "changed_files": 8,
+        "divergences": 12,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 12,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783308690,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=e14e7c0b49a765b76fb35a61bf93454721817ab9 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+      "items": [
+        {
+          "base_family_id": "b81f8634104e4a2e",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 50,
+              "span_tokens": 14,
+              "start_line": 320,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 14,
+          "family_id": "b81f8634104e4a2e",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 29,
+              "span_tokens": 15,
+              "start_line": 142,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 15,
+              "start_line": 94,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 15,
+              "start_line": 118,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        }
+      ],
+      "parent": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "parents": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "query_base": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Audit divergent strict policy taxonomy (#692)",
+      "summary": {
+        "changed_files": 1,
+        "divergences": 1,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 1,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783310120,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=64a9ded3aa3a08e0e79f953bae141a3051286865 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+      "items": [
+        {
+          "base_family_id": "51fa9afd3eaa3042",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 226,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 52,
+              "span_tokens": 10,
+              "start_line": 175,
+              "touches_shared": true,
+              "tree": "base"
+            }
+          ],
+          "complexity": 10,
+          "family_id": "51fa9afd3eaa3042",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 153,
+              "span_tokens": 10,
+              "start_line": 181,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 150,
+              "span_tokens": 10,
+              "start_line": 33,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 280,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 93,
+              "span_tokens": 10,
+              "start_line": 188,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 91,
+              "span_tokens": 10,
+              "start_line": 172,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 81,
+              "span_tokens": 10,
+              "start_line": 149,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 80,
+              "span_tokens": 10,
+              "start_line": 261,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 79,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 152,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 78,
+              "span_tokens": 10,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 77,
+              "span_tokens": 11,
+              "start_line": 293,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 71,
+              "span_tokens": 10,
+              "start_line": 71,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 409,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 65,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 134,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 60,
+              "span_tokens": 10,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 59,
+              "span_tokens": 10,
+              "start_line": 70,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 58,
+              "span_tokens": 11,
+              "start_line": 19,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 189,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 133,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 207,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 151,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 56,
+              "span_tokens": 10,
+              "start_line": 355,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 55,
+              "span_tokens": 10,
+              "start_line": 222,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 118,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 170,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 242,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 52,
+              "span_tokens": 10,
+              "start_line": 218,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 51,
+              "span_tokens": 11,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 50,
+              "span_tokens": 11,
+              "start_line": 368,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 473,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 46,
+              "span_tokens": 11,
+              "start_line": 428,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 46,
+              "span_tokens": 10,
+              "start_line": 74,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 11,
+              "start_line": 39,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 10,
+              "start_line": 129,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 413,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 370,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 367,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 454,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 371,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 330,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 275,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 315,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 58,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 416,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 11,
+              "start_line": 152,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 272,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 233,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 66,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 115,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 11,
+              "start_line": 219,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 10,
+              "start_line": 268,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 11,
+              "start_line": 135,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 10,
+              "start_line": 332,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 32,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 11,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 429,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 399,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 140,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 298,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 11,
+              "start_line": 271,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 323,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 11,
+              "start_line": 297,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 96,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 194,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 24,
+              "span_tokens": 10,
+              "start_line": 29,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 23,
+              "span_tokens": 10,
+              "start_line": 51,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        }
+      ],
+      "parent": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+      "parents": [
+        "64a9ded3aa3a08e0e79f953bae141a3051286865"
+      ],
+      "query_base": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Harden divergent gate edge fixtures (#693)",
+      "summary": {
+        "changed_files": 4,
+        "divergences": 1,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 1,
+        "strict": 0
+      }
+    },
+    {
+      "author_time": 1783311512,
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55 --format json top=0 --mode syntax,semantic --min-size 8",
+      "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "items": [
+        {
+          "base_family_id": "f3ba64af069df952",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 157,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 157,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "complexity": 13,
+          "family_id": "f3ba64af069df952",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 551,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 551,
+              "span_tokens": 13,
+              "start_line": 1,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_unproven",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "5d11a23bffe5c90a",
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 157,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 33,
+              "span_tokens": 10,
+              "start_line": 125,
+              "touches_shared": false,
+              "tree": "base"
+            }
+          ],
+          "complexity": 10,
+          "family_id": "5d11a23bffe5c90a",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 153,
+              "span_tokens": 10,
+              "start_line": 181,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 150,
+              "span_tokens": 10,
+              "start_line": 33,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 280,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 93,
+              "span_tokens": 10,
+              "start_line": 188,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 91,
+              "span_tokens": 10,
+              "start_line": 172,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 81,
+              "span_tokens": 10,
+              "start_line": 149,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 80,
+              "span_tokens": 10,
+              "start_line": 261,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 79,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 152,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 78,
+              "span_tokens": 10,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 77,
+              "span_tokens": 11,
+              "start_line": 293,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 71,
+              "span_tokens": 10,
+              "start_line": 71,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 409,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 66,
+              "span_tokens": 10,
+              "start_line": 65,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 511,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 63,
+              "span_tokens": 10,
+              "start_line": 449,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 134,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 60,
+              "span_tokens": 10,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 59,
+              "span_tokens": 10,
+              "start_line": 70,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 58,
+              "span_tokens": 11,
+              "start_line": 19,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 189,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 133,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 207,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 57,
+              "span_tokens": 10,
+              "start_line": 151,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 56,
+              "span_tokens": 10,
+              "start_line": 355,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 55,
+              "span_tokens": 10,
+              "start_line": 222,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 118,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 170,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 54,
+              "span_tokens": 10,
+              "start_line": 242,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 52,
+              "span_tokens": 10,
+              "start_line": 218,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 51,
+              "span_tokens": 11,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 50,
+              "span_tokens": 11,
+              "start_line": 368,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 48,
+              "span_tokens": 10,
+              "start_line": 144,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 477,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 46,
+              "span_tokens": 11,
+              "start_line": 432,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 46,
+              "span_tokens": 10,
+              "start_line": 74,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 11,
+              "start_line": 39,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 45,
+              "span_tokens": 10,
+              "start_line": 129,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 450,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 407,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 367,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 44,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 454,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 11,
+              "start_line": 75,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 408,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 367,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 551,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 510,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 275,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 315,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 42,
+              "span_tokens": 10,
+              "start_line": 58,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 416,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 11,
+              "start_line": 152,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 40,
+              "span_tokens": 10,
+              "start_line": 237,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 66,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 11,
+              "start_line": 115,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 213,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 39,
+              "span_tokens": 10,
+              "start_line": 175,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 11,
+              "start_line": 219,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 38,
+              "span_tokens": 10,
+              "start_line": 268,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 11,
+              "start_line": 135,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 37,
+              "span_tokens": 10,
+              "start_line": 332,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 162,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 35,
+              "span_tokens": 10,
+              "start_line": 128,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 126,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 34,
+              "span_tokens": 10,
+              "start_line": 93,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 129,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 32,
+              "span_tokens": 10,
+              "start_line": 98,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 32,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 11,
+              "start_line": 190,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 433,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 403,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 31,
+              "span_tokens": 10,
+              "start_line": 140,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 77,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 30,
+              "span_tokens": 10,
+              "start_line": 48,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 10,
+              "start_line": 46,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 302,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 28,
+              "span_tokens": 11,
+              "start_line": 275,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 10,
+              "start_line": 169,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 327,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 27,
+              "span_tokens": 11,
+              "start_line": 301,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 72,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 96,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 26,
+              "span_tokens": 10,
+              "start_line": 194,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 204,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 25,
+              "span_tokens": 11,
+              "start_line": 180,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 24,
+              "span_tokens": 10,
+              "start_line": 29,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 23,
+              "span_tokens": 10,
+              "start_line": 51,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 181,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 21,
+              "span_tokens": 10,
+              "start_line": 161,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 94,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 19,
+              "span_tokens": 10,
+              "start_line": 76,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_not_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        },
+        {
+          "base_family_id": "46ae30da2af5a2d4",
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 157,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Function",
+                "name": "query_base_missing_base_ref_fails_clearly",
+                "start_line": 129,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/edge_cases.rs:Function:129-157:query_base_missing_base_ref_fails_clearly"
+              },
+              "end_line": 154,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 11,
+              "start_line": 150,
+              "touches_shared": false,
+              "tree": "base"
+            }
+          ],
+          "complexity": 11,
+          "family_id": "46ae30da2af5a2d4",
+          "fire_eligible": false,
+          "gate": {
+            "eligible": false,
+            "fail_default": false,
+            "policy": "divergent-edit-v2-strict"
+          },
+          "graded": null,
+          "lane": "base-divergence",
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 262,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "broken_pipe_exits_cleanly",
+                "start_line": 205,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:205-262:broken_pipe_exits_cleanly"
+              },
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 11,
+              "start_line": 252,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 162,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_expired_ignore_warns_and_does_not_suppress",
+                "start_line": 132,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:132-162:query_base_expired_ignore_warns_and_does_not_suppress"
+              },
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 11,
+              "start_line": 149,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 181,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_malformed_ignore_fails_hard",
+                "start_line": 165,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:165-181:query_base_malformed_ignore_fails_hard"
+              },
+              "end_line": 178,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 11,
+              "start_line": 174,
+              "touches_shared": null,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 204,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_malformed_ignore_fails_even_when_diff_is_empty",
+                "start_line": 184,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:184-204:query_base_malformed_ignore_fails_even_when_diff_is_empty"
+              },
+              "end_line": 201,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "fragment_kind": null,
+              "is_fragment": false,
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "reason_code": null,
+              "span_lines": 5,
+              "span_tokens": 11,
+              "start_line": 197,
+              "touches_shared": null,
+              "tree": "base"
+            }
+          ],
+          "scope": "test",
+          "similarity": 1.0,
+          "suppression": null,
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only",
+          "tier_reasons": [
+            "shared_logic_not_touched",
+            "test_scope",
+            "test_scaffolding"
+          ],
+          "witness_kind": "copy-paste-run"
+        }
+      ],
+      "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+      "parents": [
+        "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55"
+      ],
+      "query_base": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+      "query_path": "crates/nose-cli/tests/cli",
+      "query_schema_version": 8,
+      "query_tool": "nose",
+      "query_view": "base",
+      "status": "ok",
+      "subject": "Package divergent gate GitHub Actions examples (#694)",
+      "summary": {
+        "changed_files": 1,
+        "divergences": 3,
+        "fire_eligible": 0,
+        "limit": null,
+        "shown_divergences": 3,
+        "strict": 0
+      }
+    }
+  ],
+  "generated_at": "2026-07-06T04:29:26+00:00",
+  "groups": [
+    {
+      "base_family_ids": [
+        "b81f8634104e4a2e"
+      ],
+      "commits": [
+        "64a9ded3aa3a08e0e79f953bae141a3051286865"
+      ],
+      "family_ids": [
+        "b81f8634104e4a2e"
+      ],
+      "first_commit": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+      "gate_fail_default": false,
+      "key": "3a1df3e2838123a2",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "b81f8634104e4a2e",
+          "commit": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+          "family_id": "b81f8634104e4a2e",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 369,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 320,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 121,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 94,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 145,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 118,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 170,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 142,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "b81f8634104e4a2e",
+        "commit": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+        "family_id": "b81f8634104e4a2e",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 320,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 94,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 118,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 142,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "51fa9afd3eaa3042"
+      ],
+      "commits": [
+        "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55"
+      ],
+      "family_ids": [
+        "51fa9afd3eaa3042"
+      ],
+      "first_commit": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+      "gate_fail_default": false,
+      "key": "c19ddf38d7702618",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "51fa9afd3eaa3042",
+          "commit": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+          "family_id": "51fa9afd3eaa3042",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 226,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 175,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 104,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 66,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 135,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 83,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 39,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 369,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 293,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 417,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 368,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 455,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 416,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 495,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 454,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 19,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 116,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 153,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 115,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 152,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 220,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 256,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 219,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 134,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 189,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 133,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 280,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 188,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 97,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 121,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 96,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 195,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 219,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 194,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 269,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 218,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 305,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 268,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 233,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 298,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 271,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 323,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 297,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 429,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 399,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 473,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 428,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 371,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 330,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 413,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 370,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 152,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 207,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 151,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 52,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 29,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 51,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 150,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 229,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 149,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 182,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 33,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 333,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 181,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 368,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 332,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 367,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 119,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 74,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 118,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 223,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 170,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 222,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 316,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 275,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 315,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 355,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 474,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 409,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 65,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 173,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 129,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 262,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 172,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 340,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 261,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 58,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 170,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 140,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 200,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 71,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 128,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 70,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 145,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 243,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 295,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 242,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "51fa9afd3eaa3042",
+        "commit": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+        "family_id": "51fa9afd3eaa3042",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "64a9ded3aa3a08e0e79f953bae141a3051286865",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 226,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 175,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 66,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 135,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 39,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 293,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 368,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 416,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 454,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 19,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 115,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 152,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 219,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 134,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 189,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 133,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 280,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 188,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 96,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 194,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 218,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 268,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 272,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 233,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 298,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 271,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 323,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 297,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 429,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 399,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 473,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 428,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 371,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 330,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 413,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 370,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 152,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 207,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 151,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 29,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 51,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 149,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 33,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 181,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 332,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 367,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 74,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 118,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 170,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 222,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 275,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 315,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 355,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 409,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 65,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 129,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 172,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 261,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 58,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 140,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 71,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 70,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 242,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "1fa4bb1b2f2cc58e"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "1fa4bb1b2f2cc58e"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "213b19836edb388c",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "1fa4bb1b2f2cc58e",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "1fa4bb1b2f2cc58e",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 95,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 90,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 420,
+                  "file": "crates/nose-cli/tests/cli/query_base.rs",
+                  "kind": "Function",
+                  "name": "query_base_machine_formats_emit_json_when_no_changes_exist",
+                  "start_line": 401,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:401-420:query_base_machine_formats_emit_json_when_no_changes_exist"
+                },
+                "end_line": 415,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 414,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "1fa4bb1b2f2cc58e",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "1fa4bb1b2f2cc58e",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 95,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 90,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 420,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_machine_formats_emit_json_when_no_changes_exist",
+                "start_line": 401,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:401-420:query_base_machine_formats_emit_json_when_no_changes_exist"
+              },
+              "end_line": 415,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 414,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "dad0d6cff1baabaa"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "dad0d6cff1baabaa"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "2a792320ec2917f1",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "dad0d6cff1baabaa",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "dad0d6cff1baabaa",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 33,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 21,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 354,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                  "start_line": 315,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+                },
+                "end_line": 332,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 317,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "dad0d6cff1baabaa",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "dad0d6cff1baabaa",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 33,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 21,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 354,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                "start_line": 315,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+              },
+              "end_line": 332,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 317,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "9b0601640770e7b3"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "9b0601640770e7b3"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "455f95d60776448c",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "9b0601640770e7b3",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "9b0601640770e7b3",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 420,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 397,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 64,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 104,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 66,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 135,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 83,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 39,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 369,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 293,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 417,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 368,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 455,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 416,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 495,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 454,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 19,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 116,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 153,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 115,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 152,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 220,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 256,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 219,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 185,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 129,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 184,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 97,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 121,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 96,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 195,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 219,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 194,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 269,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 218,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 305,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 268,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 233,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 298,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 271,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 323,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 297,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 398,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 368,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 116,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 312,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 271,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 354,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 311,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 185,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 129,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 52,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 29,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 51,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 150,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 229,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 149,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 182,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 33,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 333,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 181,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 368,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 332,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 367,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 119,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 74,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 118,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 223,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 170,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 222,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 316,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 275,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 315,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 355,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 474,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 409,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 65,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 173,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 129,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 262,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 172,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 340,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 261,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 58,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 170,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 140,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 200,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 71,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 128,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 70,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 145,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 243,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 295,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 242,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "9b0601640770e7b3",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "9b0601640770e7b3",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 420,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 397,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 64,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 66,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 135,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 39,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 293,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 368,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 416,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 454,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 19,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 115,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 152,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 219,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 185,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 129,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 184,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 96,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 194,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 218,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 268,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 272,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 233,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 298,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 271,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 323,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 297,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 398,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 368,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 167,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 116,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 312,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 271,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 354,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 311,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 185,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 129,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 29,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 51,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 149,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 33,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 181,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 332,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 367,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 74,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 118,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 170,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 222,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 275,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 315,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 355,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 409,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 65,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 129,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 172,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 261,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 58,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 140,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 71,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 70,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 242,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "af6ee52590563481"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "af6ee52590563481"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "4d95d4d4492a295e",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "af6ee52590563481",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "af6ee52590563481",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 73,
+                  "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                  "kind": "Function",
+                  "name": "assert_json_contract",
+                  "start_line": 29,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:29-73:assert_json_contract"
+                },
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 29,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 106,
+                  "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                  "kind": "Function",
+                  "name": "assert_sarif_contract",
+                  "start_line": 75,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:75-106:assert_sarif_contract"
+                },
+                "end_line": 106,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 27,
+                  "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                  "kind": "Function",
+                  "name": "assert_human_report_names_changed_and_skipped",
+                  "start_line": 20,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:20-27:assert_human_report_names_changed_and_skipped"
+                },
+                "end_line": 27,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 20,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "af6ee52590563481",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "af6ee52590563481",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_json_contract",
+                "start_line": 29,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:29-73:assert_json_contract"
+              },
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 29,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 106,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_sarif_contract",
+                "start_line": 75,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:75-106:assert_sarif_contract"
+              },
+              "end_line": 106,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 27,
+                "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+                "kind": "Function",
+                "name": "assert_human_report_names_changed_and_skipped",
+                "start_line": 20,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/core_contract.rs:Function:20-27:assert_human_report_names_changed_and_skipped"
+              },
+              "end_line": 27,
+              "file": "crates/nose-cli/tests/cli/query_base/core_contract.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 20,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "61dbf90da78fcf2b"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "61dbf90da78fcf2b"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "55d50343a836c292",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "61dbf90da78fcf2b",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "61dbf90da78fcf2b",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 331,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 295,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 131,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/map_keys.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 150,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/object_keys.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 221,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/typed_defaults.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 162,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/string_affix.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "61dbf90da78fcf2b",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "61dbf90da78fcf2b",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 331,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 131,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/map_keys.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/object_keys.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 221,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/map_keys_defaults/typed_defaults.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 162,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/string_affix.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "cc87791e18913c18"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "cc87791e18913c18"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "7e2ad08010ebfe7a",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "cc87791e18913c18",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "cc87791e18913c18",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 27,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 21,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 167,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                  "start_line": 120,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 131,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 122,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "cc87791e18913c18",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "cc87791e18913c18",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 27,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 21,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 131,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 122,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "7ee0306d63c13351"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "7ee0306d63c13351"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "8a035a9847e0ebe4",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "7ee0306d63c13351",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "7ee0306d63c13351",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 33,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 25,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 272,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_new_copy_handles_paths_with_spaces",
+                  "start_line": 228,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+                },
+                "end_line": 244,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 234,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 312,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_new_copy_uses_supported_language_extensions",
+                  "start_line": 275,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+                },
+                "end_line": 290,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 284,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "7ee0306d63c13351",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "7ee0306d63c13351",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 33,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 25,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 244,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 234,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 312,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_uses_supported_language_extensions",
+                "start_line": 275,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+              },
+              "end_line": 290,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 284,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "53516dd2428fd649"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "53516dd2428fd649"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "a4691ee0b3ecd924",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "53516dd2428fd649",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "53516dd2428fd649",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 84,
+                "file": "crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 62,
+                "file": "crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 415,
+                "file": "crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "53516dd2428fd649",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "53516dd2428fd649",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 84,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 62,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 415,
+              "file": "crates/nose-cli/tests/cli/commands/semantic_pack_inventory.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "c847df560e4e728e"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "c847df560e4e728e"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "b79db3a41e6980b7",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "c847df560e4e728e",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "c847df560e4e728e",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 43,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 36,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 272,
+                  "file": "crates/nose-cli/tests/cli/query_base.rs",
+                  "kind": "Function",
+                  "name": "query_base_json_includes_fragment_context",
+                  "start_line": 237,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:237-272:query_base_json_includes_fragment_context"
+                },
+                "end_line": 255,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 245,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 167,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                  "start_line": 120,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 149,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 142,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 272,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_new_copy_handles_paths_with_spaces",
+                  "start_line": 228,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+                },
+                "end_line": 254,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 247,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 312,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_new_copy_uses_supported_language_extensions",
+                  "start_line": 275,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+                },
+                "end_line": 300,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 293,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 65,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "query_base_mixed_scope_is_report_only_not_strict",
+                  "start_line": 4,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+                },
+                "end_line": 28,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 18,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 130,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "query_base_all_test_scope_is_report_only_not_strict",
+                  "start_line": 68,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+                },
+                "end_line": 105,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 95,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 185,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "query_base_exact_renamed_twin_remains_strict",
+                  "start_line": 133,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:133-185:query_base_exact_renamed_twin_remains_strict"
+                },
+                "end_line": 163,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 148,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "c847df560e4e728e",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "c847df560e4e728e",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 43,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 36,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_json_includes_fragment_context",
+                "start_line": 237,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:237-272:query_base_json_includes_fragment_context"
+              },
+              "end_line": 255,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 245,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 149,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 142,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 254,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 247,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 312,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_uses_supported_language_extensions",
+                "start_line": 275,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:275-312:query_base_new_copy_uses_supported_language_extensions"
+              },
+              "end_line": 300,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 293,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 65,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_mixed_scope_is_report_only_not_strict",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+              },
+              "end_line": 28,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 18,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_all_test_scope_is_report_only_not_strict",
+                "start_line": 68,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+              },
+              "end_line": 105,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 95,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 185,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_exact_renamed_twin_remains_strict",
+                "start_line": 133,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:133-185:query_base_exact_renamed_twin_remains_strict"
+              },
+              "end_line": 163,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 148,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "f889401a831e2a60"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "f889401a831e2a60"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "c95c0cd6adcaef90",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "f889401a831e2a60",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "f889401a831e2a60",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 559,
+                  "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+                  "kind": "Function",
+                  "name": "query_dashboard_filter_and_family",
+                  "start_line": 250,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/proposal_query.rs:Function:250-559:query_dashboard_filter_and_family"
+                },
+                "end_line": 559,
+                "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 250,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 251,
+                  "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                  "kind": "Function",
+                  "name": "broken_pipe_exits_cleanly",
+                  "start_line": 194,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:194-251:broken_pipe_exits_cleanly"
+                },
+                "end_line": 251,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 194,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 267,
+                  "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                  "kind": "Function",
+                  "name": "deeply_nested_file_does_not_overflow",
+                  "start_line": 254,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:254-267:deeply_nested_file_does_not_overflow"
+                },
+                "end_line": 267,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 254,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 356,
+                  "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                  "kind": "Function",
+                  "name": "recursive_hof_callback_fragment_does_not_overflow",
+                  "start_line": 332,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:332-356:recursive_hof_callback_fragment_does_not_overflow"
+                },
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 332,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 20,
+                  "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                  "kind": "Function",
+                  "name": "inline_nose_ignore_suppresses_a_site",
+                  "start_line": 4,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs:Function:4-20:inline_nose_ignore_suppresses_a_site"
+                },
+                "end_line": 20,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 4,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 76,
+                  "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                  "kind": "Function",
+                  "name": "rust_binding_patterns_lower_without_raw",
+                  "start_line": 35,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs:Function:35-76:rust_binding_patterns_lower_without_raw"
+                },
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 35,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 72,
+                  "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+                  "kind": "Function",
+                  "name": "feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks",
+                  "start_line": 33,
+                  "unit_key": "crates/nose-cli/tests/cli/exact_fragments.rs:Function:33-72:feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks"
+                },
+                "end_line": 72,
+                "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 33,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 202,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "make_fire_policy_project",
+                  "start_line": 193,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:193-202:make_fire_policy_project"
+                },
+                "end_line": 202,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 193,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 75,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                  "kind": "Function",
+                  "name": "query_mode_semantic_proves_null_presence_predicates",
+                  "start_line": 7,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs:Function:7-75:query_mode_semantic_proves_null_presence_predicates"
+                },
+                "end_line": 75,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 7,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 59,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                  "kind": "Function",
+                  "name": "query_mode_semantic_proves_regex_literal_predicate_matches",
+                  "start_line": 4,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs:Function:4-59:query_mode_semantic_proves_regex_literal_predicate_matches"
+                },
+                "end_line": 59,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 4,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 194,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+                  "kind": "Function",
+                  "name": "query_mode_semantic_proves_literal_collection_membership",
+                  "start_line": 10,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs:Function:10-194:query_mode_semantic_proves_literal_collection_membership"
+                },
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 10,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 58,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                  "kind": "Function",
+                  "name": "query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity",
+                  "start_line": 34,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:34-58:query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity"
+                },
+                "end_line": 58,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 34,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 90,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                  "kind": "Function",
+                  "name": "query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity",
+                  "start_line": 64,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:64-90:query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity"
+                },
+                "end_line": 90,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 64,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 118,
+                  "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                  "kind": "Function",
+                  "name": "verify_oracle_agrees_with_three_way_selection_canon",
+                  "start_line": 98,
+                  "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:98-118:verify_oracle_agrees_with_three_way_selection_canon"
+                },
+                "end_line": 118,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "f889401a831e2a60",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "f889401a831e2a60",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 559,
+                "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+                "kind": "Function",
+                "name": "query_dashboard_filter_and_family",
+                "start_line": 250,
+                "unit_key": "crates/nose-cli/tests/cli/commands/proposal_query.rs:Function:250-559:query_dashboard_filter_and_family"
+              },
+              "end_line": 559,
+              "file": "crates/nose-cli/tests/cli/commands/proposal_query.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 250,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 251,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "broken_pipe_exits_cleanly",
+                "start_line": 194,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:194-251:broken_pipe_exits_cleanly"
+              },
+              "end_line": 251,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 194,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 267,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "deeply_nested_file_does_not_overflow",
+                "start_line": 254,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:254-267:deeply_nested_file_does_not_overflow"
+              },
+              "end_line": 267,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 254,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "recursive_hof_callback_fragment_does_not_overflow",
+                "start_line": 332,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:332-356:recursive_hof_callback_fragment_does_not_overflow"
+              },
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 332,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 20,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Function",
+                "name": "inline_nose_ignore_suppresses_a_site",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs:Function:4-20:inline_nose_ignore_suppresses_a_site"
+              },
+              "end_line": 20,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 4,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Function",
+                "name": "rust_binding_patterns_lower_without_raw",
+                "start_line": 35,
+                "unit_key": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs:Function:35-76:rust_binding_patterns_lower_without_raw"
+              },
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 35,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 72,
+                "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+                "kind": "Function",
+                "name": "feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks",
+                "start_line": 33,
+                "unit_key": "crates/nose-cli/tests/cli/exact_fragments.rs:Function:33-72:feature_extraction_keeps_dense_small_functions_and_exact_fragments_but_not_small_control_blocks"
+              },
+              "end_line": 72,
+              "file": "crates/nose-cli/tests/cli/exact_fragments.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 33,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 202,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "make_fire_policy_project",
+                "start_line": 193,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:193-202:make_fire_policy_project"
+              },
+              "end_line": 202,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 193,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 75,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_null_presence_predicates",
+                "start_line": 7,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs:Function:7-75:query_mode_semantic_proves_null_presence_predicates"
+              },
+              "end_line": 75,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 7,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 59,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_regex_literal_predicate_matches",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs:Function:4-59:query_mode_semantic_proves_regex_literal_predicate_matches"
+              },
+              "end_line": 59,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 4,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_proves_literal_collection_membership",
+                "start_line": 10,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs:Function:10-194:query_mode_semantic_proves_literal_collection_membership"
+              },
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literal_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 10,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 58,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity",
+                "start_line": 34,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:34-58:query_mode_semantic_keeps_python_try_else_wrapper_apart_from_identity"
+              },
+              "end_line": 58,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 34,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 90,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity",
+                "start_line": 64,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:64-90:query_mode_semantic_keeps_ruby_begin_else_wrapper_apart_from_identity"
+              },
+              "end_line": 90,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 64,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 118,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+                "kind": "Function",
+                "name": "verify_oracle_agrees_with_three_way_selection_canon",
+                "start_line": 98,
+                "unit_key": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs:Function:98-118:verify_oracle_agrees_with_three_way_selection_canon"
+              },
+              "end_line": 118,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/try_wrappers.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "4f1107f4527001b6"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "4f1107f4527001b6"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "e9d65468cb7f28a3",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "4f1107f4527001b6",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "4f1107f4527001b6",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 241,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "assert_varying_spot_is_review",
+                  "start_line": 218,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:218-241:assert_varying_spot_is_review"
+                },
+                "end_line": 241,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 218,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 270,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "assert_shared_logic_is_strict",
+                  "start_line": 243,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:243-270:assert_shared_logic_is_strict"
+                },
+                "end_line": 270,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 243,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "4f1107f4527001b6",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "4f1107f4527001b6",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 241,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "assert_varying_spot_is_review",
+                "start_line": 218,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:218-241:assert_varying_spot_is_review"
+              },
+              "end_line": 241,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 218,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 270,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "assert_shared_logic_is_strict",
+                "start_line": 243,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:243-270:assert_shared_logic_is_strict"
+              },
+              "end_line": 270,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 243,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "486197ecf7f437c6"
+      ],
+      "commits": [
+        "e14e7c0b49a765b76fb35a61bf93454721817ab9"
+      ],
+      "family_ids": [
+        "486197ecf7f437c6"
+      ],
+      "first_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "gate_fail_default": false,
+      "key": "fe3f73ab00e4b784",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "486197ecf7f437c6",
+          "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+          "family_id": "486197ecf7f437c6",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 117,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                  "start_line": 19,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 88,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 84,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 234,
+                  "file": "crates/nose-cli/tests/cli/query_base.rs",
+                  "kind": "Function",
+                  "name": "query_base_flags_a_clone_changed_in_one_copy_only",
+                  "start_line": 194,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:194-234:query_base_flags_a_clone_changed_in_one_copy_only"
+                },
+                "end_line": 231,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 227,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 167,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                  "start_line": 120,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+                },
+                "end_line": 164,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 160,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 272,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_new_copy_handles_paths_with_spaces",
+                  "start_line": 228,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+                },
+                "end_line": 269,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 265,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 354,
+                  "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                  "kind": "Function",
+                  "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                  "start_line": 315,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+                },
+                "end_line": 351,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 347,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 65,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "query_base_mixed_scope_is_report_only_not_strict",
+                  "start_line": 4,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+                },
+                "end_line": 62,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 58,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 130,
+                  "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                  "kind": "Function",
+                  "name": "query_base_all_test_scope_is_report_only_not_strict",
+                  "start_line": 68,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+                },
+                "end_line": 127,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 123,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "486197ecf7f437c6",
+        "commit": "e14e7c0b49a765b76fb35a61bf93454721817ab9",
+        "family_id": "486197ecf7f437c6",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7e03737c51fbf31069345e89ad6e2fcaecf67125",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 117,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_added_clone_is_report_only_new_copy_lane",
+                "start_line": 19,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:19-117:query_base_added_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 88,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 84,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 234,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Function",
+                "name": "query_base_flags_a_clone_changed_in_one_copy_only",
+                "start_line": 194,
+                "unit_key": "crates/nose-cli/tests/cli/query_base.rs:Function:194-234:query_base_flags_a_clone_changed_in_one_copy_only"
+              },
+              "end_line": 231,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 227,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 167,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_moved_clone_is_report_only_new_copy_lane",
+                "start_line": 120,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:120-167:query_base_moved_clone_is_report_only_new_copy_lane"
+              },
+              "end_line": 164,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 160,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 272,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_new_copy_handles_paths_with_spaces",
+                "start_line": 228,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:228-272:query_base_new_copy_handles_paths_with_spaces"
+              },
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 265,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 354,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Function",
+                "name": "query_base_unrelated_added_code_does_not_emit_new_copy_lane",
+                "start_line": 315,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/new_copy.rs:Function:315-354:query_base_unrelated_added_code_does_not_emit_new_copy_lane"
+              },
+              "end_line": 351,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 347,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 65,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_mixed_scope_is_report_only_not_strict",
+                "start_line": 4,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:4-65:query_base_mixed_scope_is_report_only_not_strict"
+              },
+              "end_line": 62,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 58,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Function",
+                "name": "query_base_all_test_scope_is_report_only_not_strict",
+                "start_line": 68,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/tier_policy.rs:Function:68-130:query_base_all_test_scope_is_report_only_not_strict"
+              },
+              "end_line": 127,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 123,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "5d11a23bffe5c90a"
+      ],
+      "commits": [
+        "e8c2b53f410307013d684da253b82dd8e269f99e"
+      ],
+      "family_ids": [
+        "5d11a23bffe5c90a"
+      ],
+      "first_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "gate_fail_default": false,
+      "key": "8b13bb2b9a22cdba",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "5d11a23bffe5c90a",
+          "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+          "family_id": "5d11a23bffe5c90a",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 157,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 125,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 104,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 66,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 135,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 83,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 39,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 194,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 369,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 293,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 417,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 368,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 455,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 416,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 495,
+                "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 454,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 76,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 19,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 116,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 153,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 115,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 152,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 220,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 256,
+                "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 219,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 134,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 189,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 133,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 280,
+                "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 188,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 97,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 121,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 96,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 195,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 219,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 194,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 269,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 218,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 305,
+                "file": "crates/nose-cli/tests/cli/modes.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 268,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 237,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 302,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 275,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 327,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 301,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 433,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 403,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 477,
+                "file": "crates/nose-cli/tests/cli/query_base.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 432,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 77,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 48,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 94,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 76,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 126,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 93,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 213,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 175,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 408,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 367,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 450,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 407,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 511,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 449,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 551,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 510,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 129,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 162,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 128,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 181,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 161,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 204,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 180,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 152,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 75,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 207,
+                "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 151,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 52,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 29,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 73,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 51,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 150,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 72,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 229,
+                "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 149,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 182,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 33,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 333,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 181,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 368,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 332,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 367,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 119,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 74,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 171,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 118,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 223,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 170,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 276,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 222,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 316,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 275,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 356,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 315,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 410,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 355,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 474,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 409,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 130,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 65,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 173,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 129,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 262,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 172,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 340,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 261,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 58,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 170,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 140,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 200,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 169,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 141,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 71,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 128,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 70,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 99,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 46,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 145,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 98,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 191,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 144,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 243,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 190,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": null,
+                "end_line": 295,
+                "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 242,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "5d11a23bffe5c90a",
+        "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+        "family_id": "5d11a23bffe5c90a",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 157,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 125,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 104,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 66,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/commands/baseline.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 135,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 83,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 39,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 194,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 369,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 293,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 417,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 368,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 455,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 416,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 495,
+              "file": "crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 454,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 76,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 19,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 116,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 115,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 152,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 220,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/ignores_sarif.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 219,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 134,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 189,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 133,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 280,
+              "file": "crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 188,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 97,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 121,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 96,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 195,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 219,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 194,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 269,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 218,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 305,
+              "file": "crates/nose-cli/tests/cli/modes.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 268,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 237,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 302,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 275,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 327,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 301,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 433,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 403,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 477,
+              "file": "crates/nose-cli/tests/cli/query_base.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 432,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 77,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 48,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 94,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 76,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 126,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 93,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 213,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 175,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 408,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 367,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 450,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 407,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 511,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 449,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 551,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 510,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 129,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 162,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 128,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 181,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 161,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 204,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 180,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 152,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 75,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 207,
+              "file": "crates/nose-cli/tests/cli/query_base/tier_policy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 151,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 52,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 29,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 73,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 51,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 150,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 72,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 229,
+              "file": "crates/nose-cli/tests/cli/semantic_core.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 149,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 182,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 33,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 333,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 181,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 368,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 332,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/dynamic_membership.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 367,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 119,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 74,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 171,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 118,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 223,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 170,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 276,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 222,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 316,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 275,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 356,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 315,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 410,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 355,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 474,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 409,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 130,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 65,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 173,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 129,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 262,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 172,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 340,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/guards/nullish_and_object.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 261,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 58,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 170,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 140,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 200,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/core_builtins.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 169,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 141,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/extreme_and_collection.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 71,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 128,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/library_api/go_strings.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 70,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 99,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 46,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 145,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 98,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 191,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 144,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 243,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 190,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": null,
+              "end_line": 295,
+              "file": "crates/nose-cli/tests/cli/semantic_idioms/literals.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 242,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "46ae30da2af5a2d4"
+      ],
+      "commits": [
+        "e8c2b53f410307013d684da253b82dd8e269f99e"
+      ],
+      "family_ids": [
+        "46ae30da2af5a2d4"
+      ],
+      "first_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "gate_fail_default": false,
+      "key": "cb86e879c1b02099",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "46ae30da2af5a2d4",
+          "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+          "family_id": "46ae30da2af5a2d4",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": {
+                  "end_line": 157,
+                  "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                  "kind": "Function",
+                  "name": "query_base_missing_base_ref_fails_clearly",
+                  "start_line": 129,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/edge_cases.rs:Function:129-157:query_base_missing_base_ref_fails_clearly"
+                },
+                "end_line": 154,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 150,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": {
+                  "end_line": 262,
+                  "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                  "kind": "Function",
+                  "name": "broken_pipe_exits_cleanly",
+                  "start_line": 205,
+                  "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:205-262:broken_pipe_exits_cleanly"
+                },
+                "end_line": 256,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 252,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 162,
+                  "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                  "kind": "Function",
+                  "name": "query_base_expired_ignore_warns_and_does_not_suppress",
+                  "start_line": 132,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:132-162:query_base_expired_ignore_warns_and_does_not_suppress"
+                },
+                "end_line": 153,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 149,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 181,
+                  "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                  "kind": "Function",
+                  "name": "query_base_malformed_ignore_fails_hard",
+                  "start_line": 165,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:165-181:query_base_malformed_ignore_fails_hard"
+                },
+                "end_line": 178,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 174,
+                "tree": "base"
+              },
+              {
+                "enclosing_unit": {
+                  "end_line": 204,
+                  "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                  "kind": "Function",
+                  "name": "query_base_malformed_ignore_fails_even_when_diff_is_empty",
+                  "start_line": 184,
+                  "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:184-204:query_base_malformed_ignore_fails_even_when_diff_is_empty"
+                },
+                "end_line": 201,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 197,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "46ae30da2af5a2d4",
+        "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+        "family_id": "46ae30da2af5a2d4",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": {
+                "end_line": 157,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Function",
+                "name": "query_base_missing_base_ref_fails_clearly",
+                "start_line": 129,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/edge_cases.rs:Function:129-157:query_base_missing_base_ref_fails_clearly"
+              },
+              "end_line": 154,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 150,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": {
+                "end_line": 262,
+                "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+                "kind": "Function",
+                "name": "broken_pipe_exits_cleanly",
+                "start_line": 205,
+                "unit_key": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs:Function:205-262:broken_pipe_exits_cleanly"
+              },
+              "end_line": 256,
+              "file": "crates/nose-cli/tests/cli/commands/capabilities_robustness.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 252,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 162,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_expired_ignore_warns_and_does_not_suppress",
+                "start_line": 132,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:132-162:query_base_expired_ignore_warns_and_does_not_suppress"
+              },
+              "end_line": 153,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 149,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 181,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_malformed_ignore_fails_hard",
+                "start_line": 165,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:165-181:query_base_malformed_ignore_fails_hard"
+              },
+              "end_line": 178,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 174,
+              "tree": "base"
+            },
+            {
+              "enclosing_unit": {
+                "end_line": 204,
+                "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+                "kind": "Function",
+                "name": "query_base_malformed_ignore_fails_even_when_diff_is_empty",
+                "start_line": 184,
+                "unit_key": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs:Function:184-204:query_base_malformed_ignore_fails_even_when_diff_is_empty"
+              },
+              "end_line": 201,
+              "file": "crates/nose-cli/tests/cli/query_base/suppression_edges.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 197,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    },
+    {
+      "base_family_ids": [
+        "f3ba64af069df952"
+      ],
+      "commits": [
+        "e8c2b53f410307013d684da253b82dd8e269f99e"
+      ],
+      "family_ids": [
+        "f3ba64af069df952"
+      ],
+      "first_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "gate_fail_default": false,
+      "key": "f84bea73039204ee",
+      "lanes": [
+        "base-divergence"
+      ],
+      "last_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+      "occurrence_count": 1,
+      "occurrences": [
+        {
+          "base_family_id": "f3ba64af069df952",
+          "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+          "family_id": "f3ba64af069df952",
+          "gate_fail_default": false,
+          "lane": "base-divergence",
+          "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+          "sites": {
+            "changed": [
+              {
+                "enclosing_unit": null,
+                "end_line": 157,
+                "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ],
+            "not_updated": [
+              {
+                "enclosing_unit": null,
+                "end_line": 551,
+                "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+                "kind": "Block",
+                "lang": "rust",
+                "name": null,
+                "start_line": 1,
+                "tree": "base"
+              }
+            ]
+          },
+          "taxonomy_hint": "test_scaffolding",
+          "tier": "report-only"
+        }
+      ],
+      "representative": {
+        "base_family_id": "f3ba64af069df952",
+        "commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+        "family_id": "f3ba64af069df952",
+        "gate_fail_default": false,
+        "lane": "base-divergence",
+        "parent": "7a4f2fd2d11f6ec67b03fa00dd7aa80727b85a55",
+        "sites": {
+          "changed": [
+            {
+              "enclosing_unit": null,
+              "end_line": 157,
+              "file": "crates/nose-cli/tests/cli/query_base/edge_cases.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ],
+          "not_updated": [
+            {
+              "enclosing_unit": null,
+              "end_line": 551,
+              "file": "crates/nose-cli/tests/cli/query_base/new_copy.rs",
+              "kind": "Block",
+              "lang": "rust",
+              "name": null,
+              "start_line": 1,
+              "tree": "base"
+            }
+          ]
+        },
+        "taxonomy_hint": "test_scaffolding",
+        "tier": "report-only"
+      },
+      "taxonomy_hints": [
+        "test_scaffolding"
+      ],
+      "tiers": [
+        "report-only"
+      ]
+    }
+  ],
+  "parameters": {
+    "exclude": [],
+    "first_parent": true,
+    "ignore_file": null,
+    "ignore_file_sha256": null,
+    "max_commits": 12,
+    "merge_policy": "skip",
+    "min_lines": null,
+    "min_size": 8,
+    "mode": "syntax,semantic",
+    "path": "crates/nose-cli/tests/cli"
+  },
+  "provenance": {
+    "argv": [
+      "scripts/divergent-history-mining.py",
+      "--repo",
+      ".",
+      "--range",
+      "df2aab26~1..HEAD",
+      "--path",
+      "crates/nose-cli/tests/cli",
+      "--mode",
+      "syntax,semantic",
+      "--min-size",
+      "8",
+      "--max-commits",
+      "12",
+      "--first-parent",
+      "--merge-policy",
+      "skip",
+      "--nose",
+      "target/release/nose",
+      "--output",
+      "bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json"
+    ],
+    "command": "scripts/divergent-history-mining.py --repo . --range 'df2aab26~1..HEAD' --path crates/nose-cli/tests/cli --mode syntax,semantic --min-size 8 --max-commits 12 --first-parent --merge-policy skip --nose target/release/nose --output bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json",
+    "current_branch": "main",
+    "current_head": "e8c2b53f410307013d684da253b82dd8e269f99e",
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "nose_version": {
+      "status": "ok",
+      "text": "nose 0.17.0"
+    },
+    "range": "df2aab26~1..HEAD",
+    "range_first_commit": "df2aab26908c47f83ae4ea8c743f3b679bbd2467",
+    "range_last_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+    "repo": ".",
+    "repo_root": "/Users/ak/prjs/cc/nose",
+    "script": "scripts/divergent-history-mining.py",
+    "script_sha256": "28488ab802fa730fdb110c2d976fd87fd60ec563160646b8d2d696374dbc1e67",
+    "source_dirty": true,
+    "source_status": [
+      "M scripts/divergent-history-mining.py"
+    ]
+  },
+  "raw_records": null,
+  "redaction": {
+    "diffs": "omitted",
+    "paths": "public-repository-relative",
+    "source_bearing_keys_forbidden": [
+      "base_code",
+      "change_diff",
+      "current_code",
+      "diff",
+      "patch",
+      "snippet",
+      "snippets",
+      "source_text"
+    ],
+    "source_snippets": "omitted",
+    "symbols": "public-repository-symbol-names"
+  },
+  "schema": "nose.divergent_history.v1",
+  "schema_revision": 2,
+  "skipped_commits": [],
+  "summary": {
+    "commits_analyzed": 11,
+    "commits_considered": 11,
+    "commits_skipped": 0,
+    "findings": 17,
+    "gate_fail_default_findings": 0,
+    "gate_fail_default_groups": 0,
+    "groups": 17,
+    "lane_counts": {
+      "base-divergence": 17
+    },
+    "query_failed_commits": 0,
+    "report_only_findings": 17,
+    "review_findings": 0,
+    "strict_findings": 0,
+    "strict_groups": 0,
+    "taxonomy_hint_counts": {
+      "test_scaffolding": 17
+    },
+    "tier_counts": {
+      "report-only": 17
+    }
+  },
+  "suppression_behavior": {
+    "active_output_omits_suppressed": true,
+    "applied_before_grouping": true,
+    "ignore_file": null,
+    "source": "The underlying base=<parent> query applies nose.ignore.json, --ignore-file, and configured ignore-file rules before this harness groups findings."
+  },
+  "target": {
+    "commit_count": 11,
+    "commit_list_sha256": "3fc973bbf5d4008714a1a3d0ec7457ed3dd01f95621f50c5d7371f53c516fc62",
+    "first_commit": "df2aab26908c47f83ae4ea8c743f3b679bbd2467",
+    "last_commit": "e8c2b53f410307013d684da253b82dd8e269f99e",
+    "repo": ".",
+    "resolved_range": "df2aab26~1..HEAD"
+  }
+}

--- a/bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json
@@ -1,0 +1,127 @@
+{
+  "artifact_kind": "maintainer-pilot-summary",
+  "bounds": {
+    "offline_history_mining_only": true,
+    "pr_ci_required": false,
+    "production_rollout": false
+  },
+  "commands": {
+    "build": "cargo build --release -p nose-cli",
+    "history_mining": "python3 scripts/divergent-history-mining.py --repo . --range df2aab26~1..HEAD --path crates/nose-cli/tests/cli --mode syntax,semantic --min-size 8 --max-commits 12 --first-parent --merge-policy skip --nose target/release/nose --output bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json",
+    "observe_only_query": "target/release/nose query crates/nose-cli/tests/cli base=HEAD~1 --mode syntax,semantic --format json top=0 > target/divergent-history/issue-687/observe-only-head.query-v8.json"
+  },
+  "generated_on": "2026-07-06",
+  "history_artifact": {
+    "path": "bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json",
+    "schema": "nose.divergent_history.v1",
+    "sha256": "a374215dba130a43bd1a39f17b7583b64f61c4fbca03f8192c5809394f1f97d5",
+    "summary": {
+      "commits_analyzed": 11,
+      "commits_considered": 11,
+      "commits_skipped": 0,
+      "findings": 17,
+      "gate_fail_default_findings": 0,
+      "gate_fail_default_groups": 0,
+      "groups": 17,
+      "lane_counts": {
+        "base-divergence": 17
+      },
+      "query_failed_commits": 0,
+      "report_only_findings": 17,
+      "review_findings": 0,
+      "strict_findings": 0,
+      "strict_groups": 0,
+      "taxonomy_hint_counts": {
+        "test_scaffolding": 17
+      },
+      "tier_counts": {
+        "report-only": 17
+      }
+    }
+  },
+  "issue": 687,
+  "maintainer_disposition": {
+    "default_on_readiness_claim": false,
+    "disposition_counts": {
+      "edits_propagated": 0,
+      "grouping_artifact_not_a_clone": 0,
+      "intentional_variant": 0,
+      "no_propagation_needed": 0,
+      "should_propagate": 0,
+      "structured_ignores_added": 0,
+      "test_scaffolding_report_only": 17,
+      "unclear": 0
+    },
+    "finding_denominator": {
+      "history_groups_reviewed": 17,
+      "history_strict_groups_reviewed": 0,
+      "observe_only_findings_reviewed": 0,
+      "representative_runs": 1
+    },
+    "notes": [
+      "The bounded history slice produced only report-only test_scaffolding groups.",
+      "The representative observe-only query produced no findings and no default-failing results.",
+      "This pilot records opt-in tolerability evidence only; it does not promote the gate to default-on."
+    ],
+    "suppression_rate": {
+      "accepted_suppressions": 0,
+      "reviewed_groups": 17,
+      "structured_ignores_added": 0
+    }
+  },
+  "observe_only_run": {
+    "counts": {
+      "gate_fail_default": 0,
+      "items": 0,
+      "new_copy": 0,
+      "report_only": 0,
+      "review": 0,
+      "strict": 0
+    },
+    "raw_query": {
+      "path": "target/divergent-history/issue-687/observe-only-head.query-v8.json",
+      "schema_version": 8,
+      "sha256": "a700eb89cec062760991082cd08e19001e555b2e56ffce6a35974f80df6b01f0",
+      "tracked": false
+    },
+    "summary": {
+      "changed_files": 1,
+      "divergences": 0,
+      "fire_eligible": 0,
+      "limit": null,
+      "shown_divergences": 0,
+      "strict": 0
+    }
+  },
+  "schema": "nose.divergent_gate_pilot.v1",
+  "source_policy": {
+    "checked_artifact_contains_source": false,
+    "raw_query_tracked": false,
+    "source_snippets": "omitted"
+  },
+  "validation_commands": [
+    {
+      "command": "cargo build --release -p nose-cli",
+      "status": "passed"
+    },
+    {
+      "command": "python3 scripts/divergent-history-mining.py --self-test",
+      "status": "passed"
+    },
+    {
+      "command": "python3 scripts/divergent-history-mining.py --check-artifact bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json",
+      "status": "passed"
+    },
+    {
+      "command": "target/release/nose query crates/nose-cli/tests/cli base=HEAD~1 --mode syntax,semantic --format json top=0",
+      "status": "passed"
+    }
+  ],
+  "workflow": {
+    "base": "HEAD~1",
+    "mode": "syntax,semantic",
+    "path": "crates/nose-cli/tests/cli",
+    "surface": "local representative observe-only run",
+    "top": 0
+  }
+}

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -278,6 +278,21 @@ decision themselves from `gate.fail_default`. That preserves upload-before-fail 
 and avoids accidental failures from `fire_eligible`, SARIF severity, human output,
 `summary.strict`, `scope`, `touches_shared`, or `tier` alone.
 
+### Maintainer observe-only pilot
+
+For an adoption pilot, start with the observe-only workflow as a non-required PR
+check. Record the number of scanned PRs, PRs with findings, findings reviewed,
+strict/default-failing findings, report-only findings, structured ignores added,
+and maintainer disposition buckets such as `should-propagate`,
+`intentional-variant`, `no-propagation-needed`, `test-scaffolding`, and
+`unclear`.
+
+Keep the pilot language narrow: a strict finding "would fail under the opt-in
+enforcing workflow"; it is not a default-on readiness claim. History mining is a
+separate offline maintainer tool and should not be added to PR-time CI. See the
+checked #687 nose-on-nose [divergent history pilot](divergent-history-mining-pilot-687.md)
+for the recorded artifact and disposition shape.
+
 ## Fast re-runs: `--cache-dir`
 
 `--cache-dir <dir>` caches each file's analysis keyed by content hash. Unchanged

--- a/docs/divergent-history-mining-pilot-687.md
+++ b/docs/divergent-history-mining-pilot-687.md
@@ -1,0 +1,117 @@
+# Divergent History Mining Pilot 687
+
+Issue #687 operationalizes the divergent-edit gate evidence from #681 without
+promoting the gate to default-on. It records one bounded offline history-mining
+run and one local observe-only pilot summary.
+
+## Checked Artifacts
+
+- History artifact: [issue-687-cli-tests-2026-07-06.v1.json](../bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json)
+  is the checked `nose.divergent_history.v1` history-mining artifact.
+- Pilot summary: [issue-687-maintainer-pilot-2026-07-06.v1.json](../bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json)
+  records aggregate counts, maintainer disposition, the raw-query hash, and the history artifact hash.
+
+The raw observe-only query JSON is intentionally untracked under
+`target/divergent-history/issue-687/`. The checked pilot summary records its
+sha256 but does not check in full query rows.
+
+## History Run
+
+The bounded run used a rebuilt release binary and replayed the divergent-edit
+query across the recent nose-on-nose CLI-test slice:
+
+```sh
+cargo build --release -p nose-cli
+python3 scripts/divergent-history-mining.py --self-test
+
+python3 scripts/divergent-history-mining.py \
+  --repo . \
+  --range "df2aab26~1..HEAD" \
+  --path crates/nose-cli/tests/cli \
+  --mode syntax,semantic \
+  --min-size 8 \
+  --max-commits 12 \
+  --first-parent \
+  --merge-policy skip \
+  --nose target/release/nose \
+  --output bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json
+```
+
+Result:
+
+| count | value |
+|---|---:|
+| commits considered | 11 |
+| commits analyzed | 11 |
+| skipped commits | 0 |
+| findings | 17 |
+| groups | 17 |
+| strict/default-failing findings | 0 |
+| report-only findings | 17 |
+| taxonomy | 17 `test_scaffolding` |
+
+All groups were `base-divergence` lane, `report-only` tier. The artifact
+records the exact command, script hash, nose binary hash, nose version, dirty
+state, range, parameters, grouped findings, strict counts, skipped commits, and
+suppression behavior.
+
+## Maintainer Review
+
+Maintainers review `groups[]` once, not every repeated per-commit occurrence.
+Use each group's `representative` row for the review surface and
+`occurrences[]` only to understand when the pattern appeared.
+
+Record disposition with these buckets:
+
+| bucket | #687 count |
+|---|---:|
+| should-propagate | 0 |
+| intentional-variant | 0 |
+| no-propagation-needed | 0 |
+| test-scaffolding/report-only | 17 |
+| grouping-artifact/not-a-clone | 0 |
+| unclear | 0 |
+| structured ignores added | 0 |
+
+Accepted intentional findings should use structured ignores with reason, owner,
+and expiry. Do not teach CI wrappers to reinterpret a finding that the runtime
+already classifies.
+
+## Observe-Only Pilot
+
+The representative observe-only run used the normal PR-time query shape but no
+failure step:
+
+```sh
+target/release/nose query crates/nose-cli/tests/cli base=HEAD~1 \
+  --mode syntax,semantic --format json top=0 \
+  > target/divergent-history/issue-687/observe-only-head.query-v8.json
+```
+
+Result:
+
+| count | value |
+|---|---:|
+| changed files | 1 |
+| findings | 0 |
+| strict | 0 |
+| review | 0 |
+| report-only | 0 |
+| default-failing (`items[].gate.fail_default`) | 0 |
+
+This is opt-in tolerability evidence only. It is not a default-on readiness
+claim, and it does not add history mining to PR-time CI.
+
+## Validation
+
+The checked artifacts are validated by the docs gate:
+
+```sh
+python3 scripts/divergent-history-mining.py --check-artifact \
+  bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json
+python3 scripts/check-divergent-history-artifacts.py
+```
+
+The validator recomputes summary counts and group keys, checks bounded/offline
+metadata, rejects source-bearing keys such as snippets or patches, and ensures
+the pilot summary still points at the checked history artifact hash.

--- a/docs/divergent-history-mining.md
+++ b/docs/divergent-history-mining.md
@@ -21,6 +21,9 @@ python3 scripts/divergent-history-mining.py \
   --mode syntax,semantic \
   --nose target/release/nose \
   --output target/divergent-history.json
+
+python3 scripts/divergent-history-mining.py \
+  --check-artifact target/divergent-history.json
 ```
 
 Use `--max-commits` to keep exploratory runs bounded. Merge commits are skipped
@@ -32,11 +35,15 @@ by default because a single parent diff is easier to audit; pass
 The JSON schema is `nose.divergent_history.v1`. It records:
 
 - run provenance, including the repository, revision range, and nose binary hash;
+- hardened revision-2 provenance for new artifacts, including the exact argv,
+  script hash, nose version, dirty tracked-file state, bounded/offline metadata,
+  and source-redaction policy;
 - per-commit `base=<parent>` summaries and item JSON copied from the normal
   divergent-edit v2 output, including the underlying query JSON schema version;
 - grouped findings keyed by lane, base family id, taxonomy hint, and stable site
   identity;
-- strict-finding and strict-group counts for triage.
+- strict, review, report-only, lane, taxonomy, and default-failing counts for
+  triage.
 
 The grouped output preserves the active v2 `strict`, `review`, and `report-only`
 vocabulary from [divergent edits](divergent-edits.md). Structured ignores are
@@ -44,6 +51,32 @@ applied by the underlying `base=<ref>` run before grouping, so accepted findings
 drop out of active history results rather than appearing as repeated groups.
 History mining does not change `base=<ref> --fail-on any`: report-only
 `new-copy` evidence remains advisory and never becomes a default-failing gate.
+
+## Maintainer Grouped Review Workflow
+
+Review `groups[]` first. Each group has one `representative` occurrence for the
+main decision surface and an `occurrences[]` list for commit provenance. That
+keeps a long-lived skipped sibling from becoming a new review task every time it
+appears in the selected history range.
+
+Record disposition separately from the artifact. Use buckets such as
+`should-propagate`, `intentional-variant`, `no-propagation-needed`,
+`test-scaffolding`, `grouping-artifact/not-a-clone`, and `unclear`. A strict
+finding means "would fail under the opt-in enforcing workflow," not "must block"
+or "is ground truth." If the team accepts a strict finding as intentional, add a
+structured ignore and rerun the same bounded command with `--ignore-file` so the
+group drops out of active history output.
+
+Do not run this script in PR-time CI. PR workflows should use the normal
+observe-only or enforcing examples from [continuous integration](continuous-integration.md)
+and make decisions from `items[].gate.fail_default`.
+
+## Checked Pilot
+
+The #687 maintainer pilot is recorded in the checked
+[divergent history pilot](divergent-history-mining-pilot-687.md). It validates
+the checked history artifact, records a local observe-only pilot, and explicitly
+keeps the result as opt-in evidence rather than a default-on readiness claim.
 
 ## Suppression Workflow
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -148,6 +148,7 @@ fundamentals; the rest is grouped by area.
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.
 - [dogfooding](dogfooding.md) — the current nose-on-nose duplication gate and baseline workflow.
 - [dogfooding history](dogfooding-history.md) — detailed nose-on-nose review log and accepted-family decisions.
+- [divergent-history-mining-pilot-687](divergent-history-mining-pilot-687.md) — checked #687 evidence for bounded divergent history mining and a non-required observe-only pilot.
 - [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.
 - [query-json-agent-audit-2026-06-10](query-json-agent-audit-2026-06-10.md) — machine-contract audit for consumer 1's evidence surface.
 - [query-json-agent-audit-2026-06-13](query-json-agent-audit-2026-06-13.md) — re-validation after the gap fixes (incl. the graded witness): all five gaps closed, 8/8 decidable from JSON alone.

--- a/scripts/check-divergent-history-artifacts.py
+++ b/scripts/check-divergent-history-artifacts.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate checked divergent-history evidence artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+HISTORY_ARTIFACT = ROOT / "bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json"
+PILOT_ARTIFACT = ROOT / "bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    require(path.exists(), f"missing artifact: {path.relative_to(ROOT)}")
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/divergent-history-mining.py",
+            "--check-artifact",
+            HISTORY_ARTIFACT.relative_to(ROOT).as_posix(),
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    history = load_json(HISTORY_ARTIFACT)
+    pilot = load_json(PILOT_ARTIFACT)
+    require(
+        pilot.get("schema") == "nose.divergent_gate_pilot.v1",
+        "pilot schema mismatch",
+    )
+    require(
+        pilot.get("bounds", {}).get("pr_ci_required") is False,
+        "pilot must not be a required PR CI claim",
+    )
+    require(
+        pilot.get("maintainer_disposition", {}).get("default_on_readiness_claim") is False,
+        "pilot must not claim default-on readiness",
+    )
+    require(
+        pilot.get("source_policy", {}).get("raw_query_tracked") is False,
+        "pilot raw query must stay outside git",
+    )
+    recorded_history = pilot.get("history_artifact", {})
+    require(
+        recorded_history.get("sha256") == sha256_file(HISTORY_ARTIFACT),
+        "pilot history artifact sha256 is stale",
+    )
+    require(
+        recorded_history.get("summary") == history.get("summary"),
+        "pilot history summary is stale",
+    )
+    raw_query = pilot.get("observe_only_run", {}).get("raw_query", {})
+    require(
+        raw_query.get("tracked") is False
+        and str(raw_query.get("path", "")).startswith("target/"),
+        "pilot raw query path must be an untracked target/ artifact",
+    )
+    print("divergent history checked artifacts OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -16,6 +16,7 @@ cd "$(dirname "$0")/.."
 if command -v python3 >/dev/null 2>&1; then
     python3 scripts/check-semantic-pack-examples.py
     python3 scripts/check-ci-examples.py
+    python3 scripts/check-divergent-history-artifacts.py
 else
     echo "skipped semantic-pack example check — python3 not installed"
 fi

--- a/scripts/divergent-history-mining.py
+++ b/scripts/divergent-history-mining.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
+from datetime import datetime, timezone
 import hashlib
 import json
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -14,7 +17,18 @@ from typing import Any
 
 
 SCHEMA = "nose.divergent_history.v1"
+SCHEMA_REVISION = 2
 DEFAULT_MAX_COMMITS = 25
+SOURCE_BEARING_KEYS = {
+    "base_code",
+    "change_diff",
+    "current_code",
+    "diff",
+    "patch",
+    "snippet",
+    "snippets",
+    "source_text",
+}
 
 
 def run(
@@ -55,12 +69,43 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
 def repository_root(path: Path) -> Path:
     root = run(
         ["git", "-C", path.as_posix(), "rev-parse", "--show-toplevel"],
         check=True,
     ).stdout.strip()
     return Path(root)
+
+
+def display_path(path: Path, repo: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def git_status_lines(repo: Path) -> list[str]:
+    return [
+        line
+        for line in git_output(repo, ["status", "--short", "--untracked-files=no"]).splitlines()
+        if line
+    ]
+
+
+def binary_version(binary: Path) -> dict[str, Any]:
+    result = run([binary.as_posix(), "--version"], check=False)
+    if result.returncode != 0:
+        return {
+            "status": "error",
+            "stderr": result.stderr.strip(),
+            "stdout": result.stdout.strip(),
+        }
+    return {"status": "ok", "text": result.stdout.strip()}
 
 
 def rev_list(
@@ -245,6 +290,70 @@ def group_findings(commits: list[dict[str, Any]]) -> list[dict[str, Any]]:
     )
 
 
+def sorted_counts(values: list[str | None]) -> dict[str, int]:
+    counter = Counter(value or "none" for value in values)
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def history_summary(
+    commit_rows: list[dict[str, Any]],
+    skipped: list[dict[str, Any]],
+    groups: list[dict[str, Any]],
+) -> dict[str, Any]:
+    ok_rows = [row for row in commit_rows if row.get("status") == "ok"]
+    non_ok_rows = [row for row in commit_rows if row.get("status") != "ok"]
+    items = [item for row in ok_rows for item in row.get("items", [])]
+    gate_fail_default_findings = sum(
+        1 for item in items if (item.get("gate") or {}).get("fail_default")
+    )
+    tier_counts = sorted_counts([item.get("tier") for item in items])
+    lane_counts = sorted_counts([item.get("lane") for item in items])
+    taxonomy_hint_counts = sorted_counts([item.get("taxonomy_hint") for item in items])
+    return {
+        "commits_considered": len(commit_rows) + len(skipped),
+        "commits_analyzed": len(ok_rows),
+        "commits_skipped": len(skipped) + len(non_ok_rows),
+        "findings": len(items),
+        "strict_findings": gate_fail_default_findings,
+        "review_findings": tier_counts.get("review", 0),
+        "report_only_findings": tier_counts.get("report-only", 0),
+        "gate_fail_default_findings": gate_fail_default_findings,
+        "groups": len(groups),
+        "strict_groups": sum(1 for group in groups if group["gate_fail_default"]),
+        "gate_fail_default_groups": sum(
+            1 for group in groups if group["gate_fail_default"]
+        ),
+        "query_failed_commits": sum(
+            1 for row in commit_rows if row.get("status") == "query-failed"
+        ),
+        "tier_counts": tier_counts,
+        "lane_counts": lane_counts,
+        "taxonomy_hint_counts": taxonomy_hint_counts,
+    }
+
+
+def suppression_behavior(ignore_file: Path | None) -> dict[str, Any]:
+    return {
+        "applied_before_grouping": True,
+        "active_output_omits_suppressed": True,
+        "source": (
+            "The underlying base=<parent> query applies nose.ignore.json, "
+            "--ignore-file, and configured ignore-file rules before this harness groups findings."
+        ),
+        "ignore_file": ignore_file.as_posix() if ignore_file else None,
+    }
+
+
+def redaction_policy() -> dict[str, Any]:
+    return {
+        "source_snippets": "omitted",
+        "diffs": "omitted",
+        "paths": "public-repository-relative",
+        "symbols": "public-repository-symbol-names",
+        "source_bearing_keys_forbidden": sorted(SOURCE_BEARING_KEYS),
+    }
+
+
 def query_args(args: argparse.Namespace, parent: str) -> list[str]:
     command = ["query", args.path, f"base={parent}", "--format", "json", "top=0"]
     if args.mode:
@@ -285,7 +394,7 @@ def analyze_commit(
         **commit_metadata(worktree, commit),
         "parent": parent,
         "status": "ok" if result.returncode == 0 else "query-failed",
-        "command": " ".join(command_for_output),
+        "command": shlex.join(command_for_output),
         "items": [],
         "summary": {},
     }
@@ -330,6 +439,8 @@ def mine_history(args: argparse.Namespace) -> dict[str, Any]:
     nose = args.nose.resolve()
     if not nose.exists():
         raise SystemExit(f"missing nose binary: {nose}")
+    script = Path(__file__).resolve()
+    source_status = git_status_lines(repo)
     commits = rev_list(
         repo,
         args.rev_range,
@@ -381,25 +492,41 @@ def mine_history(args: argparse.Namespace) -> dict[str, Any]:
                 git(repo, ["worktree", "prune"], check=False)
 
     groups = group_findings([row for row in commit_rows if row.get("status") == "ok"])
-    ok_rows = [row for row in commit_rows if row.get("status") == "ok"]
-    findings = sum(len(row.get("items", [])) for row in ok_rows)
-    strict_findings = sum(
-        1
-        for row in ok_rows
-        for item in row.get("items", [])
-        if (item.get("gate") or {}).get("fail_default")
-    )
     return {
         "schema": SCHEMA,
+        "schema_revision": SCHEMA_REVISION,
+        "artifact_kind": "divergent-history-mining-run",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "bounds": {
+            "offline_only": True,
+            "pr_ci": False,
+            "max_commits": args.max_commits,
+        },
         "provenance": {
             "repo": args.repo.as_posix(),
+            "repo_root": repo.as_posix(),
             "range": args.rev_range,
             "current_head": git_output(repo, ["rev-parse", "HEAD"]),
+            "current_branch": git_output(repo, ["rev-parse", "--abbrev-ref", "HEAD"]),
+            "source_dirty": bool(source_status),
+            "source_status": source_status,
             "range_first_commit": commits[0],
             "range_last_commit": commits[-1],
             "nose_binary": args.nose.as_posix(),
             "nose_binary_sha256": sha256_file(nose),
-            "script": "scripts/divergent-history-mining.py",
+            "nose_version": binary_version(nose),
+            "script": display_path(script, repo),
+            "script_sha256": sha256_file(script),
+            "argv": sys.argv,
+            "command": shlex.join(sys.argv),
+        },
+        "target": {
+            "repo": args.repo.as_posix(),
+            "resolved_range": args.rev_range,
+            "first_commit": commits[0],
+            "last_commit": commits[-1],
+            "commit_count": len(commits),
+            "commit_list_sha256": sha256_text("\n".join(commits) + "\n"),
         },
         "parameters": {
             "path": args.path,
@@ -408,24 +535,197 @@ def mine_history(args: argparse.Namespace) -> dict[str, Any]:
             "min_lines": args.min_lines,
             "exclude": args.exclude,
             "ignore_file": args.ignore_file.as_posix() if args.ignore_file else None,
+            "ignore_file_sha256": (
+                sha256_file(args.ignore_file)
+                if args.ignore_file and args.ignore_file.exists()
+                else None
+            ),
             "max_commits": args.max_commits,
             "first_parent": args.first_parent,
             "merge_policy": args.merge_policy,
         },
-        "summary": {
-            "commits_considered": len(commits),
-            "commits_analyzed": len(ok_rows),
-            "commits_skipped": len(skipped)
-            + len([row for row in commit_rows if row.get("status") != "ok"]),
-            "findings": findings,
-            "strict_findings": strict_findings,
-            "groups": len(groups),
-            "strict_groups": sum(1 for group in groups if group["gate_fail_default"]),
-        },
+        "summary": history_summary(commit_rows, skipped, groups),
+        "suppression_behavior": suppression_behavior(args.ignore_file),
+        "redaction": redaction_policy(),
+        "raw_records": None,
         "commits": commit_rows,
         "skipped_commits": skipped,
         "groups": groups,
     }
+
+
+def find_source_bearing_keys(value: Any, path: str = "$") -> list[str]:
+    matches: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            next_path = f"{path}.{key}"
+            if key in SOURCE_BEARING_KEYS:
+                matches.append(next_path)
+            matches.extend(find_source_bearing_keys(nested, next_path))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            matches.extend(find_source_bearing_keys(nested, f"{path}[{index}]"))
+    return matches
+
+
+def require(errors: list[str], condition: bool, message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def validate_history_artifact(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    require(errors, data.get("schema") == SCHEMA, f"schema must be {SCHEMA!r}")
+    revision = data.get("schema_revision", 1)
+    require(errors, isinstance(revision, int), "schema_revision must be an integer")
+
+    for key in ("provenance", "parameters", "summary", "commits", "skipped_commits", "groups"):
+        require(errors, key in data, f"missing top-level {key}")
+    if errors:
+        return errors
+
+    commits = data["commits"]
+    skipped = data["skipped_commits"]
+    groups = data["groups"]
+    require(errors, isinstance(commits, list), "commits must be a list")
+    require(errors, isinstance(skipped, list), "skipped_commits must be a list")
+    require(errors, isinstance(groups, list), "groups must be a list")
+    if errors:
+        return errors
+
+    ok_rows = [row for row in commits if row.get("status") == "ok"]
+    recomputed_groups = group_findings(ok_rows)
+    expected_summary = history_summary(commits, skipped, recomputed_groups)
+    summary = data["summary"]
+    legacy_summary_keys = (
+        "commits_considered",
+        "commits_analyzed",
+        "commits_skipped",
+        "findings",
+        "strict_findings",
+        "groups",
+        "strict_groups",
+    )
+    revision2_summary_keys = (
+        "review_findings",
+        "report_only_findings",
+        "gate_fail_default_findings",
+        "gate_fail_default_groups",
+        "query_failed_commits",
+        "tier_counts",
+        "lane_counts",
+        "taxonomy_hint_counts",
+    )
+    for key in legacy_summary_keys:
+        require(errors, key in summary, f"summary missing {key}")
+        if key in summary:
+            require(
+                errors,
+                summary[key] == expected_summary[key],
+                f"summary.{key} is stale: expected {expected_summary[key]!r}, got {summary[key]!r}",
+            )
+    for key in revision2_summary_keys:
+        if revision >= 2:
+            require(errors, key in summary, f"summary missing {key}")
+        if key in summary:
+            require(
+                errors,
+                summary[key] == expected_summary[key],
+                f"summary.{key} is stale: expected {expected_summary[key]!r}, got {summary[key]!r}",
+            )
+
+    existing_by_key = {group.get("key"): group for group in groups}
+    recomputed_by_key = {group["key"]: group for group in recomputed_groups}
+    require(errors, len(existing_by_key) == len(groups), "groups contain duplicate or missing keys")
+    require(errors, set(existing_by_key) == set(recomputed_by_key), "groups do not match recomputed keys")
+    for key, expected in recomputed_by_key.items():
+        existing = existing_by_key.get(key)
+        if not existing:
+            continue
+        for field in ("occurrence_count", "gate_fail_default", "first_commit", "last_commit"):
+            require(
+                errors,
+                existing.get(field) == expected.get(field),
+                f"group {key}.{field} is stale",
+            )
+
+    parameters = data["parameters"]
+    max_commits = parameters.get("max_commits")
+    require(errors, isinstance(max_commits, int), "parameters.max_commits must be an integer")
+    if isinstance(max_commits, int):
+        require(
+            errors,
+            expected_summary["commits_considered"] <= max_commits,
+            "commits_considered exceeds parameters.max_commits",
+        )
+
+    if revision >= 2:
+        for key in (
+            "artifact_kind",
+            "bounds",
+            "provenance",
+            "target",
+            "suppression_behavior",
+            "redaction",
+            "raw_records",
+        ):
+            require(errors, key in data, f"revision 2 artifact missing {key}")
+        provenance = data["provenance"]
+        for key in (
+            "repo_root",
+            "current_branch",
+            "source_dirty",
+            "source_status",
+            "nose_version",
+            "script_sha256",
+            "argv",
+            "command",
+        ):
+            require(errors, key in provenance, f"provenance missing {key}")
+        bounds = data.get("bounds") or {}
+        require(errors, bounds.get("offline_only") is True, "bounds.offline_only must be true")
+        require(errors, bounds.get("pr_ci") is False, "bounds.pr_ci must be false")
+        require(errors, bounds.get("max_commits") == max_commits, "bounds.max_commits mismatch")
+        suppression = data.get("suppression_behavior") or {}
+        require(
+            errors,
+            suppression.get("applied_before_grouping") is True,
+            "suppression_behavior.applied_before_grouping must be true",
+        )
+        require(
+            errors,
+            suppression.get("active_output_omits_suppressed") is True,
+            "suppression_behavior.active_output_omits_suppressed must be true",
+        )
+
+    source_bearing = find_source_bearing_keys(data)
+    require(
+        errors,
+        not source_bearing,
+        f"artifact contains source-bearing keys: {', '.join(source_bearing)}",
+    )
+    return errors
+
+
+def check_artifact(path: Path) -> None:
+    data = json.loads(path.read_text())
+    errors = validate_history_artifact(data)
+    if errors:
+        raise SystemExit(
+            "divergent history artifact check failed:\n"
+            + "\n".join(f"- {error}" for error in errors)
+        )
+    summary = data["summary"]
+    default_failing = summary.get(
+        "gate_fail_default_findings",
+        summary.get("strict_findings", 0),
+    )
+    print(
+        "divergent history artifact OK: "
+        f"{path} ({summary['commits_analyzed']} commits, "
+        f"{summary['groups']} groups, "
+        f"{default_failing} default-failing findings)"
+    )
 
 
 def run_self_test() -> None:
@@ -503,11 +803,66 @@ def run_self_test() -> None:
             ],
         },
     ]
+    for row in sample_commits:
+        row["status"] = "ok"
     groups = group_findings(sample_commits)
     assert len(groups) == 1
     assert groups[0]["occurrence_count"] == 2
     assert groups[0]["gate_fail_default"] is True
     assert groups[0]["commits"] == ["c1", "c2"]
+    sample_artifact = {
+        "schema": SCHEMA,
+        "schema_revision": SCHEMA_REVISION,
+        "artifact_kind": "divergent-history-mining-run",
+        "bounds": {"offline_only": True, "pr_ci": False, "max_commits": 2},
+        "provenance": {
+            "repo": ".",
+            "repo_root": ".",
+            "range": "p1..c2",
+            "current_head": "c2",
+            "current_branch": "main",
+            "source_dirty": False,
+            "source_status": [],
+            "range_first_commit": "c1",
+            "range_last_commit": "c2",
+            "nose_binary": "target/release/nose",
+            "nose_binary_sha256": "x",
+            "nose_version": {"status": "ok", "text": "nose 0.0.0"},
+            "script": "scripts/divergent-history-mining.py",
+            "script_sha256": "y",
+            "argv": ["scripts/divergent-history-mining.py"],
+            "command": "scripts/divergent-history-mining.py",
+        },
+        "target": {
+            "repo": ".",
+            "resolved_range": "p1..c2",
+            "first_commit": "c1",
+            "last_commit": "c2",
+            "commit_count": 2,
+            "commit_list_sha256": "z",
+        },
+        "parameters": {
+            "path": ".",
+            "mode": "syntax,semantic",
+            "min_size": 8,
+            "min_lines": None,
+            "exclude": [],
+            "ignore_file": None,
+            "ignore_file_sha256": None,
+            "max_commits": 2,
+            "first_parent": True,
+            "merge_policy": "skip",
+        },
+        "summary": history_summary(sample_commits, [], groups),
+        "suppression_behavior": suppression_behavior(None),
+        "redaction": redaction_policy(),
+        "raw_records": None,
+        "commits": sample_commits,
+        "skipped_commits": [],
+        "groups": groups,
+    }
+    errors = validate_history_artifact(sample_artifact)
+    assert not errors, errors
     print("divergent history mining self-test passed")
 
 
@@ -531,8 +886,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--fail-fast", action="store_true")
     parser.add_argument("--keep-worktree", action="store_true")
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--check-artifact", type=Path)
     args = parser.parse_args()
-    if args.self_test:
+    if args.self_test or args.check_artifact:
         return args
     if not args.rev_range:
         if not args.base:
@@ -549,6 +905,9 @@ def main() -> int:
     args = parse_args()
     if args.self_test:
         run_self_test()
+        return 0
+    if args.check_artifact:
+        check_artifact(args.check_artifact)
         return 0
     output = mine_history(args)
     text = json.dumps(output, indent=2, sort_keys=True) + "\n"


### PR DESCRIPTION
## Summary
- harden `scripts/divergent-history-mining.py` with revision-2 provenance, summary rollups, source-redaction metadata, and `--check-artifact` validation
- add checked #687 history-mining and maintainer-pilot artifacts for a bounded nose-on-nose CLI-test slice
- document grouped maintainer review, observe-only pilot language, and keep history mining offline/out of PR CI

Closes #687

## Validation
- `python3 scripts/divergent-history-mining.py --self-test`
- `python3 scripts/check-divergent-history-artifacts.py`
- `python3 -m py_compile scripts/divergent-history-mining.py scripts/check-divergent-history-artifacts.py`
- `python3 scripts/check-ci-examples.py`
- `./scripts/check-docs.sh`
- `cargo test -p nose-cli --test cli query_base`
- `cargo test -p nose-cli --lib`
- `cargo clippy -p nose-cli --all-targets --all-features -- -D warnings`
- `git diff --check`
- pre-push fast local CI
