### PR TITLE
Record divergent gate product runtime evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ break.
   splitting `diff --git` headers on whitespace.
 
 ### Performance
+- Recorded #688 divergent-gate product-output and runtime evidence: all 120
+  non-`base=` corpus queries kept identical hashes, byte counts, and family
+  counts across the #681 productization range, the focused nose slice stayed
+  stable, and bounded `base=` replay counts/timings stayed below the runtime
+  investigation threshold.
 - Verified the #677 Rust `block_on` residual closeout with no product-output
   drift or reproduced runtime degradation: the focused Rust query-regression
   slice kept identical hashes and family counts across `hyperfine`, `nushell`,

--- a/bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json
@@ -1,0 +1,9869 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-688/nose-551758d5",
+    "baseline_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+    "baseline_source_ref": "551758d5",
+    "baseline_source_sha": "551758d5139372a58645f411ac3b887d679c755a",
+    "current_binary": "/private/tmp/nose-688/nose-08052e90",
+    "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "current_source_ref": "08052e90",
+    "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json",
+    "working_tree_status_before_measurement": ""
+  },
+  "repos": [
+    "alacritty",
+    "alamofire",
+    "antlr4",
+    "arrow",
+    "asciidoctor",
+    "axios",
+    "badger",
+    "bat",
+    "black",
+    "boltons",
+    "chi",
+    "clap",
+    "click",
+    "cmark",
+    "cobra",
+    "commons-lang",
+    "curl",
+    "date-fns",
+    "delve",
+    "devise",
+    "drizzle-orm",
+    "esbuild",
+    "etcd",
+    "execa",
+    "faraday",
+    "fastlane",
+    "fd",
+    "flask",
+    "fzf",
+    "gin",
+    "git",
+    "gorm",
+    "graphhopper",
+    "gson",
+    "guava",
+    "h2database",
+    "httpie",
+    "httpx",
+    "hugo",
+    "hyperfine",
+    "image",
+    "jackson-core",
+    "jedis",
+    "jekyll",
+    "jest",
+    "jq",
+    "jsoup",
+    "junit5",
+    "kingfisher",
+    "kramdown",
+    "ky",
+    "libgdx",
+    "libsodium",
+    "libuv",
+    "liquid",
+    "lua",
+    "marked",
+    "marshmallow",
+    "meilisearch",
+    "minio",
+    "mockito",
+    "nats-server",
+    "netty",
+    "nginx",
+    "nimble",
+    "nushell",
+    "packaging",
+    "pixijs",
+    "poetry",
+    "prettier",
+    "prometheus",
+    "pry",
+    "puma",
+    "quick",
+    "rack",
+    "radash",
+    "raylib",
+    "redis",
+    "regex",
+    "requests",
+    "retrofit",
+    "rich",
+    "ripgrep",
+    "rspec-core",
+    "rubocop",
+    "rustls",
+    "rxjava",
+    "rxjs",
+    "rxswift",
+    "scrapy",
+    "serde_json",
+    "sidekiq",
+    "sinatra",
+    "sled",
+    "sqlalchemy",
+    "sqlite",
+    "swift-algorithms",
+    "swift-argument-parser",
+    "swift-collections",
+    "swift-composable-architecture",
+    "swift-log",
+    "swift-metrics",
+    "swift-nio",
+    "swift-service-lifecycle",
+    "swiftlint",
+    "swr",
+    "sympy",
+    "thor",
+    "tmux",
+    "tokei",
+    "tokio",
+    "trpc",
+    "urfave-cli",
+    "vapor",
+    "vim",
+    "wrk",
+    "zap",
+    "zod",
+    "zstd",
+    "zustand"
+  ],
+  "runs": [
+    {
+      "bytes": 30552,
+      "elapsed_ms": 244.99454209581017,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1687.6058327034116,
+      "families": 3488,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 519.847166724503,
+      "families": 197,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 130.55050000548363,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 168.41450007632375,
+      "families": 148,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 300.89504225179553,
+      "families": 18,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 115.54016591981053,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 259.41329170018435,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 375.6855418905616,
+      "families": 19,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 107.01504210010171,
+      "families": 41,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 54.53937500715256,
+      "families": 4,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 286.9636253453791,
+      "families": 11,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 98.2420826330781,
+      "families": 34,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 73.24470905587077,
+      "families": 10,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 55.43358298018575,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 547.5702919065952,
+      "families": 156,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 638.5052497498691,
+      "families": 115,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 349.41525012254715,
+      "families": 27,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 405.0769582390785,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 68.76304186880589,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1042.580250184983,
+      "families": 63,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1789.8662080988288,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 460.3649158962071,
+      "families": 32,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 172.3660840652883,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 51.59137537702918,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 719.4948340766132,
+      "families": 28,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 53.10900043696165,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 80.98804159089923,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 384.56075033172965,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 75.35854168236256,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 902.4559580720961,
+      "families": 111,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 133.6788753978908,
+      "families": 13,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 683.5178751498461,
+      "families": 245,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 212.59537525475025,
+      "families": 79,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2785.0131671875715,
+      "families": 1796,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1222.5230829790235,
+      "families": 515,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 77.9058332554996,
+      "families": 17,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 68.65720776841044,
+      "families": 16,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 653.8838748820126,
+      "families": 51,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 36.21566668152809,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 221.41091711819172,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 293.77508303150535,
+      "families": 84,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1246.1971659213305,
+      "families": 267,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 99.69004103913903,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 483.42754133045673,
+      "families": 45,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 76.26033294945955,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 250.50095794722438,
+      "families": 64,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 849.6275409124792,
+      "families": 327,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 119.3622499704361,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 90.7748332247138,
+      "families": 62,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 70.09924994781613,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 1979.493500199169,
+      "families": 1068,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 501.15099968388677,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 150.82879178225994,
+      "families": 31,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 56.41412502154708,
+      "families": 4,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 105.25612533092499,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 75.30520763248205,
+      "families": 113,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 70.77941624447703,
+      "families": 17,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 841.646374668926,
+      "families": 15,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 881.9726668298244,
+      "families": 54,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 309.48575027287006,
+      "families": 102,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1179.2479171417654,
+      "families": 27,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2178.8707091473043,
+      "families": 879,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 443.1231669150293,
+      "families": 44,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 83.60495837405324,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1499.9865829013288,
+      "families": 59,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 106.75250040367246,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 797.0126247964799,
+      "families": 52,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 238.65945916622877,
+      "families": 168,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1041.5974170900881,
+      "families": 151,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 847.5188328884542,
+      "families": 66,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 115.40929228067398,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 112.97545908018947,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 245.9192918613553,
+      "families": 428,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 86.48674981668591,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 57.16570792719722,
+      "families": 37,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2081.1580000445247,
+      "families": 148,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 687.3964173719287,
+      "families": 30,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 511.7339580319822,
+      "families": 34,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 76.7059582285583,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 150.4314998164773,
+      "families": 81,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 172.03270783647895,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 723.060917109251,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 141.06795890256763,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 713.7033748440444,
+      "families": 104,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 311.20654195547104,
+      "families": 20,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1426.6766672953963,
+      "families": 618,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 294.05345814302564,
+      "families": 33,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 584.1105422005057,
+      "families": 426,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 273.05829199030995,
+      "families": 134,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 153.29437470063567,
+      "families": 12,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 94.18120793998241,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 87.14537508785725,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 76.01058389991522,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1412.8247080370784,
+      "families": 391,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1149.7296248562634,
+      "families": 112,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 54.75466698408127,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 96.01145796477795,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 379.01329109445214,
+      "families": 51,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 289.03112513944507,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 43.238500133156776,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 43.827875051647425,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 581.6607498563826,
+      "families": 52,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 65.35979174077511,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 266.0819999873638,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 100.30683409422636,
+      "families": 49,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3086.6631250828505,
+      "families": 645,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 68.8671669922769,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 222.49454213306308,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 36.23162489384413,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 492.68641602247953,
+      "families": 37,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 320.4262498766184,
+      "families": 64,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 62.329291831701994,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 126.31708290427923,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1189.9470412172377,
+      "families": 39,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 38.27999997884035,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 66.63566688075662,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 308.8079998269677,
+      "families": 21,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 325.18166676163673,
+      "families": 39,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 74.54191660508513,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 282.6869999989867,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1677.289083134383,
+      "families": 3488,
+      "iteration": 1,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 532.3021248914301,
+      "families": 197,
+      "iteration": 1,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 162.9550000652671,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 134.1550420038402,
+      "families": 148,
+      "iteration": 1,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 269.55537497997284,
+      "families": 18,
+      "iteration": 1,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 118.03104216232896,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 282.66337467357516,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 363.7262498959899,
+      "families": 19,
+      "iteration": 1,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 72.16983288526535,
+      "families": 41,
+      "iteration": 1,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 67.20512500032783,
+      "families": 4,
+      "iteration": 1,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 307.6157090254128,
+      "families": 11,
+      "iteration": 1,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 107.37220803275704,
+      "families": 34,
+      "iteration": 1,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 84.29662510752678,
+      "families": 10,
+      "iteration": 1,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 68.44499986618757,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 575.2576249651611,
+      "families": 156,
+      "iteration": 1,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 628.9296657778323,
+      "families": 115,
+      "iteration": 1,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 373.42941714450717,
+      "families": 27,
+      "iteration": 1,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 435.82416605204344,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 72.05520896241069,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1012.8643750213087,
+      "families": 63,
+      "iteration": 1,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1808.9924580417573,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 414.553249720484,
+      "families": 32,
+      "iteration": 1,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 128.3089159987867,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 85.77762497588992,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 804.1913341730833,
+      "families": 28,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 45.804624911397696,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 90.80929215997458,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 372.49554181471467,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 88.13641732558608,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 952.1457920782268,
+      "families": 111,
+      "iteration": 1,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 119.16462518274784,
+      "families": 13,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 737.6645412296057,
+      "families": 245,
+      "iteration": 1,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 215.3359167277813,
+      "families": 79,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2732.9094167798758,
+      "families": 1796,
+      "iteration": 1,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1280.4068750701845,
+      "families": 515,
+      "iteration": 1,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 80.61879174783826,
+      "families": 17,
+      "iteration": 1,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 71.42158318310976,
+      "families": 16,
+      "iteration": 1,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 613.8933752663434,
+      "families": 51,
+      "iteration": 1,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.81587493419647,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 243.24649991467595,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 297.04758431762457,
+      "families": 84,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1190.0294171646237,
+      "families": 267,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 106.74079181626439,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 550.3832502290606,
+      "families": 45,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 76.01787522435188,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 261.75733283162117,
+      "families": 64,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 803.5179590806365,
+      "families": 327,
+      "iteration": 1,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 137.70458288490772,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 88.15325004979968,
+      "families": 62,
+      "iteration": 1,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 72.74104095995426,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2017.3836667090654,
+      "families": 1068,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 537.9653330892324,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 163.64470915868878,
+      "families": 31,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 113.98541694507003,
+      "families": 4,
+      "iteration": 1,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 93.22162484750152,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 78.7540003657341,
+      "families": 113,
+      "iteration": 1,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 73.56191612780094,
+      "families": 17,
+      "iteration": 1,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 871.110875159502,
+      "families": 15,
+      "iteration": 1,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 905.4729999043047,
+      "families": 54,
+      "iteration": 1,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 344.24829203635454,
+      "families": 102,
+      "iteration": 1,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1240.5885001644492,
+      "families": 27,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2171.1051668971777,
+      "families": 879,
+      "iteration": 1,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 444.26970882341266,
+      "families": 44,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 79.67150025069714,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1507.5248749926686,
+      "families": 59,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 133.17837519571185,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 823.2227079570293,
+      "families": 52,
+      "iteration": 1,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 259.50224976986647,
+      "families": 168,
+      "iteration": 1,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 994.6996662765741,
+      "families": 151,
+      "iteration": 1,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 919.8005418293178,
+      "families": 66,
+      "iteration": 1,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 121.92449998110533,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 123.96154180169106,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 227.9907912015915,
+      "families": 428,
+      "iteration": 1,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 91.6327079758048,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 61.12333294004202,
+      "families": 37,
+      "iteration": 1,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2053.8808749988675,
+      "families": 148,
+      "iteration": 1,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 730.3122919984162,
+      "families": 30,
+      "iteration": 1,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 488.87633299455047,
+      "families": 34,
+      "iteration": 1,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 67.17033311724663,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 169.61600026115775,
+      "families": 81,
+      "iteration": 1,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 169.03533274307847,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 693.8289999961853,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 154.54912511631846,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 654.3333339504898,
+      "families": 104,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 317.0611667446792,
+      "families": 20,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1435.5505420826375,
+      "families": 618,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 248.01516719162464,
+      "families": 33,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 629.0400419384241,
+      "families": 426,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 282.72945806384087,
+      "families": 134,
+      "iteration": 1,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 138.09716701507568,
+      "families": 12,
+      "iteration": 1,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 152.68149971961975,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 108.18041628226638,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 89.00099992752075,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1528.4537500701845,
+      "families": 391,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1155.0960410386324,
+      "families": 112,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 66.18775008246303,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 86.44958399236202,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 405.96550004556775,
+      "families": 51,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 278.5465409979224,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 48.32512466236949,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 43.03362499922514,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 640.5457500368357,
+      "families": 52,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 42.65087516978383,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 292.90799982845783,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 135.06695767864585,
+      "families": 49,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3080.674833152443,
+      "families": 645,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 70.86458383128047,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 212.1587498113513,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 33.929041121155024,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 497.09145817905664,
+      "families": 37,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 365.3010409325361,
+      "families": 64,
+      "iteration": 1,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 57.283875066787004,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 111.6407080553472,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1183.8293331675231,
+      "families": 39,
+      "iteration": 1,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 36.87099972739816,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 65.59504196047783,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 348.8912498578429,
+      "families": 21,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 319.51587507501245,
+      "families": 39,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 77.35183322802186,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 248.67816688492894,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1762.7668748609722,
+      "families": 3488,
+      "iteration": 2,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 589.7665829397738,
+      "families": 197,
+      "iteration": 2,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 144.43658338859677,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 157.05458261072636,
+      "families": 148,
+      "iteration": 2,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 288.95795810967684,
+      "families": 18,
+      "iteration": 2,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 111.20170820504427,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 297.7979159913957,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 407.73145807906985,
+      "families": 19,
+      "iteration": 2,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 97.60120790451765,
+      "families": 41,
+      "iteration": 2,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 52.7883330360055,
+      "families": 4,
+      "iteration": 2,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 304.25345804542303,
+      "families": 11,
+      "iteration": 2,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 110.27883319184184,
+      "families": 34,
+      "iteration": 2,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 89.26229225471616,
+      "families": 10,
+      "iteration": 2,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 66.20745779946446,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 583.0187499523163,
+      "families": 156,
+      "iteration": 2,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 686.5246668457985,
+      "families": 115,
+      "iteration": 2,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 380.2434587851167,
+      "families": 27,
+      "iteration": 2,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 428.7262917496264,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 78.34295881912112,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1052.9127498157322,
+      "families": 63,
+      "iteration": 2,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1740.5144162476063,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 501.7045000568032,
+      "families": 32,
+      "iteration": 2,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 140.2430422604084,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 88.45008397474885,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 852.8720829635859,
+      "families": 28,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 38.474499713629484,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 84.57404235377908,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 377.67458287999034,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 93.83708285167813,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 1004.1259997524321,
+      "families": 111,
+      "iteration": 2,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 144.93483398109674,
+      "families": 13,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 770.4632496461272,
+      "families": 245,
+      "iteration": 2,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 244.44262497127056,
+      "families": 79,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2786.168542224914,
+      "families": 1796,
+      "iteration": 2,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1248.3783750794828,
+      "families": 515,
+      "iteration": 2,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 72.79941719025373,
+      "families": 17,
+      "iteration": 2,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 68.30737506970763,
+      "families": 16,
+      "iteration": 2,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 689.9502919986844,
+      "families": 51,
+      "iteration": 2,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.673541370779276,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 210.2984576486051,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 315.3518750332296,
+      "families": 84,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1310.2363338693976,
+      "families": 267,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 99.77629082277417,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 486.45170871168375,
+      "families": 45,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 109.47124985978007,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 223.14662486314774,
+      "families": 64,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 834.4355411827564,
+      "families": 327,
+      "iteration": 2,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 130.5759591050446,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 92.19995886087418,
+      "families": 62,
+      "iteration": 2,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 65.05479197949171,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 1990.4733751900494,
+      "families": 1068,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 493.69149981066585,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 219.73583288490772,
+      "families": 31,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 84.90195777267218,
+      "families": 4,
+      "iteration": 2,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 105.3121667355299,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 82.52775017172098,
+      "families": 113,
+      "iteration": 2,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 83.21187505498528,
+      "families": 17,
+      "iteration": 2,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 828.7220830097795,
+      "families": 15,
+      "iteration": 2,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 895.4282910563052,
+      "families": 54,
+      "iteration": 2,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 370.79912470653653,
+      "families": 102,
+      "iteration": 2,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1218.0810421705246,
+      "families": 27,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2204.9674168229103,
+      "families": 879,
+      "iteration": 2,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 436.86591694131494,
+      "families": 44,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 73.43737501651049,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1477.1794159896672,
+      "families": 59,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 118.14899975433946,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 797.1986248157918,
+      "families": 52,
+      "iteration": 2,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 281.50087501853704,
+      "families": 168,
+      "iteration": 2,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 962.8381659276783,
+      "families": 151,
+      "iteration": 2,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 840.867833700031,
+      "families": 66,
+      "iteration": 2,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 124.73970791324973,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 124.67733304947615,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 231.66987486183643,
+      "families": 428,
+      "iteration": 2,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 97.27966692298651,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 58.71099978685379,
+      "families": 37,
+      "iteration": 2,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2125.7501668296754,
+      "families": 148,
+      "iteration": 2,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 748.749874997884,
+      "families": 30,
+      "iteration": 2,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 490.7718342728913,
+      "families": 34,
+      "iteration": 2,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 65.41799986734986,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 155.99620807915926,
+      "families": 81,
+      "iteration": 2,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 175.23416690528393,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 676.9882496446371,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 155.29725002124906,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 675.7616670802236,
+      "families": 104,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 307.31862457469106,
+      "families": 20,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1424.4829169474542,
+      "families": 618,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 279.7079589217901,
+      "families": 33,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 672.9361247271299,
+      "families": 426,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 266.7928747832775,
+      "families": 134,
+      "iteration": 2,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 158.73087476938963,
+      "families": 12,
+      "iteration": 2,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 100.06745904684067,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 103.71495876461267,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 87.42150012403727,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1414.0387498773634,
+      "families": 391,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1151.0189999826252,
+      "families": 112,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 56.50220811367035,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 107.46758291497827,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 404.5661659911275,
+      "families": 51,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 275.95866611227393,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 43.29441720619798,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 44.062166940420866,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 625.5341251380742,
+      "families": 52,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 41.13116720691323,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 265.9518327564001,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 135.58500027284026,
+      "families": 49,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3089.7845001891255,
+      "families": 645,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 59.27112512290478,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 226.81562509387732,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 39.66983314603567,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 486.96791706606746,
+      "families": 37,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 362.89433389902115,
+      "families": 64,
+      "iteration": 2,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 63.58720827847719,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 125.25866739451885,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1182.128167245537,
+      "families": 39,
+      "iteration": 2,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 42.812082916498184,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 79.42712493240833,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 375.46154111623764,
+      "families": 21,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 307.7034172601998,
+      "families": 39,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 76.74912502989173,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 277.4449158459902,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1722.5445411168039,
+      "families": 3488,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 547.6774172857404,
+      "families": 197,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 155.23004112765193,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 179.21441607177258,
+      "families": 148,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 268.6277092434466,
+      "families": 18,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 99.8991671949625,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 286.12637473270297,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 403.8763749413192,
+      "families": 19,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 86.9579166173935,
+      "families": 41,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 45.77925009652972,
+      "families": 4,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 226.434042211622,
+      "families": 11,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 133.45699990168214,
+      "families": 34,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 91.18041675537825,
+      "families": 10,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 65.12020900845528,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 581.4971248619258,
+      "families": 156,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 613.6856251396239,
+      "families": 115,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 388.690875377506,
+      "families": 27,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 461.4707906730473,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 83.77037523314357,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1021.7865840531886,
+      "families": 63,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1997.8799168020487,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 452.38454081118107,
+      "families": 32,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 156.23850002884865,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 53.314334247261286,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 824.2459171451628,
+      "families": 28,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 40.773124899715185,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 83.86404206976295,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 369.7055000811815,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 91.1943749524653,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 930.5080831982195,
+      "families": 111,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 149.319542106241,
+      "families": 13,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 771.5869168750942,
+      "families": 245,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 216.67116740718484,
+      "families": 79,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2750.825791154057,
+      "families": 1796,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1283.0189997330308,
+      "families": 515,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 86.31529193371534,
+      "families": 17,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 69.82570793479681,
+      "families": 16,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 676.1813750490546,
+      "families": 51,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.25733284652233,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 229.17075036093593,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 299.8744170181453,
+      "families": 84,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1220.445292070508,
+      "families": 267,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 95.53141705691814,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 518.043250311166,
+      "families": 45,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 81.9708751514554,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 259.46137495338917,
+      "families": 64,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 834.0666247531772,
+      "families": 327,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 125.3987499512732,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 97.05779189243913,
+      "families": 62,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 72.12966587394476,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 1970.6973331049085,
+      "families": 1068,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 509.4147501513362,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 190.80445868894458,
+      "families": 31,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 73.35949968546629,
+      "families": 4,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 84.30604217574,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 85.85920790210366,
+      "families": 113,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 75.98404213786125,
+      "families": 17,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 863.898292183876,
+      "families": 15,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 853.3149589784443,
+      "families": 54,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 347.5652923807502,
+      "families": 102,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1244.85870776698,
+      "families": 27,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2226.433000061661,
+      "families": 879,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 446.5175000950694,
+      "families": 44,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 83.27591698616743,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1516.926750075072,
+      "families": 59,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 126.16266682744026,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 825.5543340928853,
+      "families": 52,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 291.32087528705597,
+      "families": 168,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1024.6091671288013,
+      "families": 151,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 881.4727086573839,
+      "families": 66,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 117.15412512421608,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 119.5569159463048,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 230.41449999436736,
+      "families": 428,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 87.15537516400218,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 54.57291612401605,
+      "families": 37,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2071.639749687165,
+      "families": 148,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 731.5161656588316,
+      "families": 30,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 463.25779194012284,
+      "families": 34,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 76.26166706904769,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 145.90983325615525,
+      "families": 81,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 180.2267082966864,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 681.1394160613418,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 146.49050030857325,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 663.7450000271201,
+      "families": 104,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 345.75970796868205,
+      "families": 20,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1433.7583747692406,
+      "families": 618,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 244.2983747459948,
+      "families": 33,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 621.8782500363886,
+      "families": 426,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 276.32304187864065,
+      "families": 134,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 126.68679188936949,
+      "families": 12,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 129.74687479436398,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 88.88695808127522,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 82.67008326947689,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1402.6597924530506,
+      "families": 391,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1152.9997079633176,
+      "families": 112,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 60.450208839029074,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 93.38166704401374,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 446.6878748498857,
+      "families": 51,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 303.1089170835912,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 44.873000122606754,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 44.85937487334013,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 597.1050001680851,
+      "families": 52,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 41.38329206034541,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 289.06358359381557,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 113.14333276823163,
+      "families": 49,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3054.164041765034,
+      "families": 645,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 89.34270916506648,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 237.01162496581674,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 35.63591605052352,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 479.29404210299253,
+      "families": 37,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 362.0402500964701,
+      "families": 64,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 67.54487520083785,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 120.71050005033612,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1189.1232091002166,
+      "families": 39,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 40.37716705352068,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 61.101834289729595,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 332.00412476435304,
+      "families": 21,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 368.94216714426875,
+      "families": 39,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 74.53454099595547,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 232.1126670576632,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1780.466000083834,
+      "families": 3488,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 583.7552077136934,
+      "families": 197,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 146.332582924515,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 149.7729169204831,
+      "families": 148,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 299.56495808437467,
+      "families": 18,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 112.59674979373813,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 269.92104202508926,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 414.93875021114945,
+      "families": 19,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 102.73358272388577,
+      "families": 41,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 54.57929102703929,
+      "families": 4,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 270.821874961257,
+      "families": 11,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 138.36474996060133,
+      "families": 34,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 79.01625009253621,
+      "families": 10,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 66.93016598001122,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 576.0190421715379,
+      "families": 156,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 646.6932920739055,
+      "families": 115,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 370.6465410068631,
+      "families": 27,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 455.67987486720085,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 74.14012495428324,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1052.1926661022007,
+      "families": 63,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1770.3281249850988,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 517.6718751899898,
+      "families": 32,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 137.1324579231441,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 47.89341567084193,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 729.7932081855834,
+      "families": 28,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 49.52166695147753,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 89.11816729232669,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 361.9862082414329,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 86.4658746868372,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 955.6309161707759,
+      "families": 111,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 139.52350011095405,
+      "families": 13,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 838.8182502239943,
+      "families": 245,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 222.79483266174793,
+      "families": 79,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2839.4073341041803,
+      "families": 1796,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1319.0367915667593,
+      "families": 515,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 77.17204233631492,
+      "families": 17,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 78.9376669563353,
+      "families": 16,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 666.9950420036912,
+      "families": 51,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 38.18891663104296,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 214.2889159731567,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 279.7483750618994,
+      "families": 84,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1281.7109585739672,
+      "families": 267,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 111.92262498661876,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 525.5662919953465,
+      "families": 45,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 81.91641699522734,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 243.5717498883605,
+      "families": 64,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 902.3816669359803,
+      "families": 327,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 123.37712524458766,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 100.68112472072244,
+      "families": 62,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 69.41095786169171,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 1963.4875827468932,
+      "families": 1068,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 545.4961252398789,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 203.97933293133974,
+      "families": 31,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 79.82116704806685,
+      "families": 4,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 102.06616623327136,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 82.31549989432096,
+      "families": 113,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 84.42449988797307,
+      "families": 17,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 905.4945418611169,
+      "families": 15,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 910.7950003817677,
+      "families": 54,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 334.4973330385983,
+      "families": 102,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1267.504250165075,
+      "families": 27,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2208.9293329045177,
+      "families": 879,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 458.64141592755914,
+      "families": 44,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 86.46133309230208,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1542.435958981514,
+      "families": 59,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 125.40704105049372,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 778.5547086969018,
+      "families": 52,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 283.6591247469187,
+      "families": 168,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1029.6600838191807,
+      "families": 151,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 833.710000384599,
+      "families": 66,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 133.17970791831613,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 135.2944578975439,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 235.3941248729825,
+      "families": 428,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 80.54266683757305,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 54.155416786670685,
+      "families": 37,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2298.452000133693,
+      "families": 148,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 754.4477079063654,
+      "families": 30,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 509.46616707369685,
+      "families": 34,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 78.95916607230902,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 156.8015841767192,
+      "families": 81,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 182.0030827075243,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 731.1801658943295,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 119.76562533527613,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 664.3213341012597,
+      "families": 104,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 315.43062534183264,
+      "families": 20,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1534.0633327141404,
+      "families": 618,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 306.38929223641753,
+      "families": 33,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 615.8266249112785,
+      "families": 426,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 286.00354213267565,
+      "families": 134,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 148.69829220697284,
+      "families": 12,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 99.03320809826255,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 102.50079212710261,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 69.53779142349958,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1453.8700003176928,
+      "families": 391,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1163.1937501952052,
+      "families": 112,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 56.206374894827604,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 92.16475021094084,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 430.6744998320937,
+      "families": 51,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 299.9050416983664,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 46.882042195647955,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 42.931375093758106,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 644.0869579091668,
+      "families": 52,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 40.801249910146,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 256.77016703411937,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 115.47004198655486,
+      "families": 49,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3187.839665915817,
+      "families": 645,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 66.20579119771719,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 231.23983340337873,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 39.84862519428134,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 478.6533326841891,
+      "families": 37,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 331.17824979126453,
+      "families": 64,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 63.20120906457305,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 152.1357921883464,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1187.6090420410037,
+      "families": 39,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 41.520209051668644,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 85.79066675156355,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 323.21833400055766,
+      "families": 21,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 356.25320905819535,
+      "families": 39,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 75.30929241329432,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 270.04412468522787,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1775.6345830857754,
+      "families": 3488,
+      "iteration": 3,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 531.3978330232203,
+      "families": 197,
+      "iteration": 3,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 168.9278748817742,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 163.27904118224978,
+      "families": 148,
+      "iteration": 3,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 297.62949980795383,
+      "families": 18,
+      "iteration": 3,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 126.30862463265657,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 273.60683400183916,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 405.4927919059992,
+      "families": 19,
+      "iteration": 3,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 107.63350035995245,
+      "families": 41,
+      "iteration": 3,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 55.20645808428526,
+      "families": 4,
+      "iteration": 3,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 284.4577906653285,
+      "families": 11,
+      "iteration": 3,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 97.74074982851744,
+      "families": 34,
+      "iteration": 3,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 78.02700018510222,
+      "families": 10,
+      "iteration": 3,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 77.89912493899465,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 565.3153746388853,
+      "families": 156,
+      "iteration": 3,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 632.5872503221035,
+      "families": 115,
+      "iteration": 3,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 387.0179997757077,
+      "families": 27,
+      "iteration": 3,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 433.3274173550308,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 72.88641622290015,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1094.9348332360387,
+      "families": 63,
+      "iteration": 3,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1889.8553750477731,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 521.3004588149488,
+      "families": 32,
+      "iteration": 3,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 155.13262525200844,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 47.11133427917957,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 857.8979168087244,
+      "families": 28,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 49.366125371307135,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 72.92733388021588,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 376.1231671087444,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 92.50416606664658,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 971.4578329585493,
+      "families": 111,
+      "iteration": 3,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 154.52262526378036,
+      "families": 13,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 742.281457874924,
+      "families": 245,
+      "iteration": 3,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 225.0863746739924,
+      "families": 79,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2852.9972503893077,
+      "families": 1796,
+      "iteration": 3,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1279.4624590314925,
+      "families": 515,
+      "iteration": 3,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 85.45025018975139,
+      "families": 17,
+      "iteration": 3,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 75.74862521141768,
+      "families": 16,
+      "iteration": 3,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 652.81733404845,
+      "families": 51,
+      "iteration": 3,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 38.205125369131565,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 223.5779999755323,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 292.1550418250263,
+      "families": 84,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1251.1075418442488,
+      "families": 267,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 103.80916623398662,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 523.8751657307148,
+      "families": 45,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 87.84629078581929,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 245.08916679769754,
+      "families": 64,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 824.6366251260042,
+      "families": 327,
+      "iteration": 3,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 130.93991670757532,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 88.77974981442094,
+      "families": 62,
+      "iteration": 3,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 69.20237513259053,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 1978.6692499183118,
+      "families": 1068,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 552.2724590264261,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 169.66120805591345,
+      "families": 31,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 87.3865419998765,
+      "families": 4,
+      "iteration": 3,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 110.5439169332385,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 85.37533273920417,
+      "families": 113,
+      "iteration": 3,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 84.7389162518084,
+      "families": 17,
+      "iteration": 3,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 881.3209575600922,
+      "families": 15,
+      "iteration": 3,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 871.1840002797544,
+      "families": 54,
+      "iteration": 3,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 386.5012498572469,
+      "families": 102,
+      "iteration": 3,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1266.619332600385,
+      "families": 27,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2405.435875058174,
+      "families": 879,
+      "iteration": 3,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 474.6161657385528,
+      "families": 44,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 81.06408407911658,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1562.0531248860061,
+      "families": 59,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 125.60887495055795,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 749.0415000356734,
+      "families": 52,
+      "iteration": 3,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 253.13441595062613,
+      "families": 168,
+      "iteration": 3,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1056.5200839191675,
+      "families": 151,
+      "iteration": 3,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 876.4300411567092,
+      "families": 66,
+      "iteration": 3,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 107.62058384716511,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 120.55637501180172,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 214.58412474021316,
+      "families": 428,
+      "iteration": 3,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 81.93970797583461,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 56.251208297908306,
+      "families": 37,
+      "iteration": 3,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2139.2991254106164,
+      "families": 148,
+      "iteration": 3,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 801.812666002661,
+      "families": 30,
+      "iteration": 3,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 497.980666346848,
+      "families": 34,
+      "iteration": 3,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 74.33891715481877,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 163.2090420462191,
+      "families": 81,
+      "iteration": 3,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 166.30154196172953,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 723.4634580090642,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 143.26279191300273,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 631.237625144422,
+      "families": 104,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 327.35312497243285,
+      "families": 20,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1455.0405000336468,
+      "families": 618,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 284.4002079218626,
+      "families": 33,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 579.6019174158573,
+      "families": 426,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 272.21595915034413,
+      "families": 134,
+      "iteration": 3,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 166.25870810821652,
+      "families": 12,
+      "iteration": 3,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 110.09445833042264,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 116.58074986189604,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 85.7634162530303,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1478.6349586211145,
+      "families": 391,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1161.112291738391,
+      "families": 112,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 50.48062512651086,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 92.94987516477704,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 414.45945762097836,
+      "families": 51,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 309.9871249869466,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 45.11841665953398,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 43.287125416100025,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 620.9305832162499,
+      "families": 52,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 41.560708079487085,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 289.0103328973055,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 114.40991703420877,
+      "families": 49,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3097.103707958013,
+      "families": 645,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 55.28066726401448,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 207.90166687220335,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 37.5561248511076,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 497.8837501257658,
+      "families": 37,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 354.8612077720463,
+      "families": 64,
+      "iteration": 3,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 74.26445791497827,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 136.4644579589367,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1286.8302091956139,
+      "families": 39,
+      "iteration": 3,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 40.905707981437445,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 86.4894581027329,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 355.2070828154683,
+      "families": 21,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 315.787167288363,
+      "families": 39,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 107.67004219815135,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 56301.32029252127,
+    "aggregate_current_median_ms": 56835.43049916625,
+    "aggregate_delta_pct": 0.9486637326974553,
+    "by_repo": {
+      "alacritty": {
+        "baseline": {
+          "bytes": [
+            30552
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+          ],
+          "median_ms": 244.99454209581017
+        },
+        "current": {
+          "bytes": [
+            30552
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+          ],
+          "median_ms": 270.04412468522787
+        }
+      },
+      "alamofire": {
+        "baseline": {
+          "bytes": [
+            21155006
+          ],
+          "families": [
+            3488
+          ],
+          "hashes": [
+            "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+          ],
+          "median_ms": 1722.5445411168039
+        },
+        "current": {
+          "bytes": [
+            21155006
+          ],
+          "families": [
+            3488
+          ],
+          "hashes": [
+            "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+          ],
+          "median_ms": 1762.7668748609722
+        }
+      },
+      "antlr4": {
+        "baseline": {
+          "bytes": [
+            279862
+          ],
+          "families": [
+            197
+          ],
+          "hashes": [
+            "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+          ],
+          "median_ms": 547.6774172857404
+        },
+        "current": {
+          "bytes": [
+            279862
+          ],
+          "families": [
+            197
+          ],
+          "hashes": [
+            "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+          ],
+          "median_ms": 532.3021248914301
+        }
+      },
+      "arrow": {
+        "baseline": {
+          "bytes": [
+            27867
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+          ],
+          "median_ms": 146.332582924515
+        },
+        "current": {
+          "bytes": [
+            27867
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+          ],
+          "median_ms": 162.9550000652671
+        }
+      },
+      "asciidoctor": {
+        "baseline": {
+          "bytes": [
+            234578
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+          ],
+          "median_ms": 168.41450007632375
+        },
+        "current": {
+          "bytes": [
+            234578
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+          ],
+          "median_ms": 157.05458261072636
+        }
+      },
+      "axios": {
+        "baseline": {
+          "bytes": [
+            44590
+          ],
+          "families": [
+            18
+          ],
+          "hashes": [
+            "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+          ],
+          "median_ms": 299.56495808437467
+        },
+        "current": {
+          "bytes": [
+            44590
+          ],
+          "families": [
+            18
+          ],
+          "hashes": [
+            "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+          ],
+          "median_ms": 288.95795810967684
+        }
+      },
+      "badger": {
+        "baseline": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+          ],
+          "median_ms": 112.59674979373813
+        },
+        "current": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+          ],
+          "median_ms": 118.03104216232896
+        }
+      },
+      "bat": {
+        "baseline": {
+          "bytes": [
+            31779
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+          ],
+          "median_ms": 269.92104202508926
+        },
+        "current": {
+          "bytes": [
+            31779
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+          ],
+          "median_ms": 282.66337467357516
+        }
+      },
+      "black": {
+        "baseline": {
+          "bytes": [
+            57327
+          ],
+          "families": [
+            19
+          ],
+          "hashes": [
+            "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+          ],
+          "median_ms": 403.8763749413192
+        },
+        "current": {
+          "bytes": [
+            57327
+          ],
+          "families": [
+            19
+          ],
+          "hashes": [
+            "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+          ],
+          "median_ms": 405.4927919059992
+        }
+      },
+      "boltons": {
+        "baseline": {
+          "bytes": [
+            70069
+          ],
+          "families": [
+            41
+          ],
+          "hashes": [
+            "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+          ],
+          "median_ms": 102.73358272388577
+        },
+        "current": {
+          "bytes": [
+            70069
+          ],
+          "families": [
+            41
+          ],
+          "hashes": [
+            "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+          ],
+          "median_ms": 97.60120790451765
+        }
+      },
+      "chi": {
+        "baseline": {
+          "bytes": [
+            29758
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+          ],
+          "median_ms": 54.53937500715256
+        },
+        "current": {
+          "bytes": [
+            29758
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+          ],
+          "median_ms": 55.20645808428526
+        }
+      },
+      "clap": {
+        "baseline": {
+          "bytes": [
+            42192
+          ],
+          "families": [
+            11
+          ],
+          "hashes": [
+            "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+          ],
+          "median_ms": 270.821874961257
+        },
+        "current": {
+          "bytes": [
+            42192
+          ],
+          "families": [
+            11
+          ],
+          "hashes": [
+            "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+          ],
+          "median_ms": 304.25345804542303
+        }
+      },
+      "click": {
+        "baseline": {
+          "bytes": [
+            60344
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+          ],
+          "median_ms": 133.45699990168214
+        },
+        "current": {
+          "bytes": [
+            60344
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+          ],
+          "median_ms": 107.37220803275704
+        }
+      },
+      "cmark": {
+        "baseline": {
+          "bytes": [
+            37347
+          ],
+          "families": [
+            10
+          ],
+          "hashes": [
+            "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+          ],
+          "median_ms": 79.01625009253621
+        },
+        "current": {
+          "bytes": [
+            37347
+          ],
+          "families": [
+            10
+          ],
+          "hashes": [
+            "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+          ],
+          "median_ms": 84.29662510752678
+        }
+      },
+      "cobra": {
+        "baseline": {
+          "bytes": [
+            32106
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+          ],
+          "median_ms": 65.12020900845528
+        },
+        "current": {
+          "bytes": [
+            32106
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+          ],
+          "median_ms": 68.44499986618757
+        }
+      },
+      "commons-lang": {
+        "baseline": {
+          "bytes": [
+            255227
+          ],
+          "families": [
+            156
+          ],
+          "hashes": [
+            "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+          ],
+          "median_ms": 576.0190421715379
+        },
+        "current": {
+          "bytes": [
+            255227
+          ],
+          "families": [
+            156
+          ],
+          "hashes": [
+            "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+          ],
+          "median_ms": 575.2576249651611
+        }
+      },
+      "curl": {
+        "baseline": {
+          "bytes": [
+            173509
+          ],
+          "families": [
+            115
+          ],
+          "hashes": [
+            "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+          ],
+          "median_ms": 638.5052497498691
+        },
+        "current": {
+          "bytes": [
+            173509
+          ],
+          "families": [
+            115
+          ],
+          "hashes": [
+            "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+          ],
+          "median_ms": 632.5872503221035
+        }
+      },
+      "date-fns": {
+        "baseline": {
+          "bytes": [
+            64050
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+          ],
+          "median_ms": 370.6465410068631
+        },
+        "current": {
+          "bytes": [
+            64050
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+          ],
+          "median_ms": 380.2434587851167
+        }
+      },
+      "delve": {
+        "baseline": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+          ],
+          "median_ms": 455.67987486720085
+        },
+        "current": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+          ],
+          "median_ms": 433.3274173550308
+        }
+      },
+      "devise": {
+        "baseline": {
+          "bytes": [
+            31155
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+          ],
+          "median_ms": 74.14012495428324
+        },
+        "current": {
+          "bytes": [
+            31155
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+          ],
+          "median_ms": 72.88641622290015
+        }
+      },
+      "drizzle-orm": {
+        "baseline": {
+          "bytes": [
+            116840
+          ],
+          "families": [
+            63
+          ],
+          "hashes": [
+            "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+          ],
+          "median_ms": 1042.580250184983
+        },
+        "current": {
+          "bytes": [
+            116840
+          ],
+          "families": [
+            63
+          ],
+          "hashes": [
+            "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+          ],
+          "median_ms": 1052.9127498157322
+        }
+      },
+      "esbuild": {
+        "baseline": {
+          "bytes": [
+            54599
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+          ],
+          "median_ms": 1789.8662080988288
+        },
+        "current": {
+          "bytes": [
+            54599
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+          ],
+          "median_ms": 1808.9924580417573
+        }
+      },
+      "etcd": {
+        "baseline": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+          ],
+          "median_ms": 460.3649158962071
+        },
+        "current": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+          ],
+          "median_ms": 501.7045000568032
+        }
+      },
+      "execa": {
+        "baseline": {
+          "bytes": [
+            33322
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+          ],
+          "median_ms": 156.23850002884865
+        },
+        "current": {
+          "bytes": [
+            33322
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+          ],
+          "median_ms": 140.2430422604084
+        }
+      },
+      "faraday": {
+        "baseline": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+          ],
+          "median_ms": 51.59137537702918
+        },
+        "current": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+          ],
+          "median_ms": 85.77762497588992
+        }
+      },
+      "fastlane": {
+        "baseline": {
+          "bytes": [
+            71641
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+          ],
+          "median_ms": 729.7932081855834
+        },
+        "current": {
+          "bytes": [
+            71641
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+          ],
+          "median_ms": 852.8720829635859
+        }
+      },
+      "fd": {
+        "baseline": {
+          "bytes": [
+            25951
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+          ],
+          "median_ms": 49.52166695147753
+        },
+        "current": {
+          "bytes": [
+            25951
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+          ],
+          "median_ms": 45.804624911397696
+        }
+      },
+      "flask": {
+        "baseline": {
+          "bytes": [
+            48054
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+          ],
+          "median_ms": 83.86404206976295
+        },
+        "current": {
+          "bytes": [
+            48054
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+          ],
+          "median_ms": 84.57404235377908
+        }
+      },
+      "fzf": {
+        "baseline": {
+          "bytes": [
+            30077
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+          ],
+          "median_ms": 369.7055000811815
+        },
+        "current": {
+          "bytes": [
+            30077
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+          ],
+          "median_ms": 376.1231671087444
+        }
+      },
+      "gin": {
+        "baseline": {
+          "bytes": [
+            28981
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+          ],
+          "median_ms": 86.4658746868372
+        },
+        "current": {
+          "bytes": [
+            28981
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+          ],
+          "median_ms": 92.50416606664658
+        }
+      },
+      "git": {
+        "baseline": {
+          "bytes": [
+            147615
+          ],
+          "families": [
+            111
+          ],
+          "hashes": [
+            "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+          ],
+          "median_ms": 930.5080831982195
+        },
+        "current": {
+          "bytes": [
+            147615
+          ],
+          "families": [
+            111
+          ],
+          "hashes": [
+            "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+          ],
+          "median_ms": 971.4578329585493
+        }
+      },
+      "gorm": {
+        "baseline": {
+          "bytes": [
+            36406
+          ],
+          "families": [
+            13
+          ],
+          "hashes": [
+            "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+          ],
+          "median_ms": 139.52350011095405
+        },
+        "current": {
+          "bytes": [
+            36406
+          ],
+          "families": [
+            13
+          ],
+          "hashes": [
+            "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+          ],
+          "median_ms": 144.93483398109674
+        }
+      },
+      "graphhopper": {
+        "baseline": {
+          "bytes": [
+            307191
+          ],
+          "families": [
+            245
+          ],
+          "hashes": [
+            "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+          ],
+          "median_ms": 771.5869168750942
+        },
+        "current": {
+          "bytes": [
+            307191
+          ],
+          "families": [
+            245
+          ],
+          "hashes": [
+            "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+          ],
+          "median_ms": 742.281457874924
+        }
+      },
+      "gson": {
+        "baseline": {
+          "bytes": [
+            115379
+          ],
+          "families": [
+            79
+          ],
+          "hashes": [
+            "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+          ],
+          "median_ms": 216.67116740718484
+        },
+        "current": {
+          "bytes": [
+            115379
+          ],
+          "families": [
+            79
+          ],
+          "hashes": [
+            "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+          ],
+          "median_ms": 225.0863746739924
+        }
+      },
+      "guava": {
+        "baseline": {
+          "bytes": [
+            2574446
+          ],
+          "families": [
+            1796
+          ],
+          "hashes": [
+            "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+          ],
+          "median_ms": 2785.0131671875715
+        },
+        "current": {
+          "bytes": [
+            2574446
+          ],
+          "families": [
+            1796
+          ],
+          "hashes": [
+            "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+          ],
+          "median_ms": 2786.168542224914
+        }
+      },
+      "h2database": {
+        "baseline": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+          ],
+          "median_ms": 1283.0189997330308
+        },
+        "current": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+          ],
+          "median_ms": 1279.4624590314925
+        }
+      },
+      "httpie": {
+        "baseline": {
+          "bytes": [
+            42215
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+          ],
+          "median_ms": 77.9058332554996
+        },
+        "current": {
+          "bytes": [
+            42215
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+          ],
+          "median_ms": 80.61879174783826
+        }
+      },
+      "httpx": {
+        "baseline": {
+          "bytes": [
+            41185
+          ],
+          "families": [
+            16
+          ],
+          "hashes": [
+            "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+          ],
+          "median_ms": 69.82570793479681
+        },
+        "current": {
+          "bytes": [
+            41185
+          ],
+          "families": [
+            16
+          ],
+          "hashes": [
+            "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+          ],
+          "median_ms": 71.42158318310976
+        }
+      },
+      "hugo": {
+        "baseline": {
+          "bytes": [
+            220447
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+          ],
+          "median_ms": 666.9950420036912
+        },
+        "current": {
+          "bytes": [
+            220447
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+          ],
+          "median_ms": 652.81733404845
+        }
+      },
+      "hyperfine": {
+        "baseline": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+          ],
+          "median_ms": 38.18891663104296
+        },
+        "current": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+          ],
+          "median_ms": 40.673541370779276
+        }
+      },
+      "image": {
+        "baseline": {
+          "bytes": [
+            33344
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+          ],
+          "median_ms": 221.41091711819172
+        },
+        "current": {
+          "bytes": [
+            33344
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+          ],
+          "median_ms": 223.5779999755323
+        }
+      },
+      "jackson-core": {
+        "baseline": {
+          "bytes": [
+            136865
+          ],
+          "families": [
+            84
+          ],
+          "hashes": [
+            "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+          ],
+          "median_ms": 293.77508303150535
+        },
+        "current": {
+          "bytes": [
+            136865
+          ],
+          "families": [
+            84
+          ],
+          "hashes": [
+            "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+          ],
+          "median_ms": 297.04758431762457
+        }
+      },
+      "jedis": {
+        "baseline": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+          ],
+          "median_ms": 1246.1971659213305
+        },
+        "current": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+          ],
+          "median_ms": 1251.1075418442488
+        }
+      },
+      "jekyll": {
+        "baseline": {
+          "bytes": [
+            35027
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+          ],
+          "median_ms": 99.69004103913903
+        },
+        "current": {
+          "bytes": [
+            35027
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+          ],
+          "median_ms": 103.80916623398662
+        }
+      },
+      "jest": {
+        "baseline": {
+          "bytes": [
+            74900
+          ],
+          "families": [
+            45
+          ],
+          "hashes": [
+            "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+          ],
+          "median_ms": 518.043250311166
+        },
+        "current": {
+          "bytes": [
+            74900
+          ],
+          "families": [
+            45
+          ],
+          "hashes": [
+            "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+          ],
+          "median_ms": 523.8751657307148
+        }
+      },
+      "jq": {
+        "baseline": {
+          "bytes": [
+            26681
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+          ],
+          "median_ms": 81.91641699522734
+        },
+        "current": {
+          "bytes": [
+            26681
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+          ],
+          "median_ms": 87.84629078581929
+        }
+      },
+      "jsoup": {
+        "baseline": {
+          "bytes": [
+            113185
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+          ],
+          "median_ms": 250.50095794722438
+        },
+        "current": {
+          "bytes": [
+            113185
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+          ],
+          "median_ms": 245.08916679769754
+        }
+      },
+      "junit5": {
+        "baseline": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+          ],
+          "median_ms": 849.6275409124792
+        },
+        "current": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+          ],
+          "median_ms": 824.6366251260042
+        }
+      },
+      "kingfisher": {
+        "baseline": {
+          "bytes": [
+            31195
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+          ],
+          "median_ms": 123.37712524458766
+        },
+        "current": {
+          "bytes": [
+            31195
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+          ],
+          "median_ms": 130.93991670757532
+        }
+      },
+      "kramdown": {
+        "baseline": {
+          "bytes": [
+            114711
+          ],
+          "families": [
+            62
+          ],
+          "hashes": [
+            "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+          ],
+          "median_ms": 97.05779189243913
+        },
+        "current": {
+          "bytes": [
+            114711
+          ],
+          "families": [
+            62
+          ],
+          "hashes": [
+            "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+          ],
+          "median_ms": 88.77974981442094
+        }
+      },
+      "ky": {
+        "baseline": {
+          "bytes": [
+            27472
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+          ],
+          "median_ms": 70.09924994781613
+        },
+        "current": {
+          "bytes": [
+            27472
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+          ],
+          "median_ms": 69.20237513259053
+        }
+      },
+      "libgdx": {
+        "baseline": {
+          "bytes": [
+            2126164
+          ],
+          "families": [
+            1068
+          ],
+          "hashes": [
+            "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+          ],
+          "median_ms": 1970.6973331049085
+        },
+        "current": {
+          "bytes": [
+            2126164
+          ],
+          "families": [
+            1068
+          ],
+          "hashes": [
+            "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+          ],
+          "median_ms": 1990.4733751900494
+        }
+      },
+      "libsodium": {
+        "baseline": {
+          "bytes": [
+            52625
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+          ],
+          "median_ms": 509.4147501513362
+        },
+        "current": {
+          "bytes": [
+            52625
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+          ],
+          "median_ms": 537.9653330892324
+        }
+      },
+      "libuv": {
+        "baseline": {
+          "bytes": [
+            55324
+          ],
+          "families": [
+            31
+          ],
+          "hashes": [
+            "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+          ],
+          "median_ms": 190.80445868894458
+        },
+        "current": {
+          "bytes": [
+            55324
+          ],
+          "families": [
+            31
+          ],
+          "hashes": [
+            "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+          ],
+          "median_ms": 169.66120805591345
+        }
+      },
+      "liquid": {
+        "baseline": {
+          "bytes": [
+            29342
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+          ],
+          "median_ms": 73.35949968546629
+        },
+        "current": {
+          "bytes": [
+            29342
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+          ],
+          "median_ms": 87.3865419998765
+        }
+      },
+      "lua": {
+        "baseline": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+          ],
+          "median_ms": 102.06616623327136
+        },
+        "current": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+          ],
+          "median_ms": 105.3121667355299
+        }
+      },
+      "marked": {
+        "baseline": {
+          "bytes": [
+            192560
+          ],
+          "families": [
+            113
+          ],
+          "hashes": [
+            "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+          ],
+          "median_ms": 82.31549989432096
+        },
+        "current": {
+          "bytes": [
+            192560
+          ],
+          "families": [
+            113
+          ],
+          "hashes": [
+            "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+          ],
+          "median_ms": 82.52775017172098
+        }
+      },
+      "marshmallow": {
+        "baseline": {
+          "bytes": [
+            44437
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+          ],
+          "median_ms": 75.98404213786125
+        },
+        "current": {
+          "bytes": [
+            44437
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+          ],
+          "median_ms": 83.21187505498528
+        }
+      },
+      "meilisearch": {
+        "baseline": {
+          "bytes": [
+            52737
+          ],
+          "families": [
+            15
+          ],
+          "hashes": [
+            "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+          ],
+          "median_ms": 863.898292183876
+        },
+        "current": {
+          "bytes": [
+            52737
+          ],
+          "families": [
+            15
+          ],
+          "hashes": [
+            "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+          ],
+          "median_ms": 871.110875159502
+        }
+      },
+      "minio": {
+        "baseline": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+          ],
+          "median_ms": 881.9726668298244
+        },
+        "current": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+          ],
+          "median_ms": 895.4282910563052
+        }
+      },
+      "mockito": {
+        "baseline": {
+          "bytes": [
+            148904
+          ],
+          "families": [
+            102
+          ],
+          "hashes": [
+            "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+          ],
+          "median_ms": 334.4973330385983
+        },
+        "current": {
+          "bytes": [
+            148904
+          ],
+          "families": [
+            102
+          ],
+          "hashes": [
+            "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+          ],
+          "median_ms": 370.79912470653653
+        }
+      },
+      "nats-server": {
+        "baseline": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+          ],
+          "median_ms": 1244.85870776698
+        },
+        "current": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+          ],
+          "median_ms": 1240.5885001644492
+        }
+      },
+      "netty": {
+        "baseline": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+          ],
+          "median_ms": 2208.9293329045177
+        },
+        "current": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+          ],
+          "median_ms": 2204.9674168229103
+        }
+      },
+      "nginx": {
+        "baseline": {
+          "bytes": [
+            65918
+          ],
+          "families": [
+            44
+          ],
+          "hashes": [
+            "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+          ],
+          "median_ms": 446.5175000950694
+        },
+        "current": {
+          "bytes": [
+            65918
+          ],
+          "families": [
+            44
+          ],
+          "hashes": [
+            "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+          ],
+          "median_ms": 444.26970882341266
+        }
+      },
+      "nimble": {
+        "baseline": {
+          "bytes": [
+            28485
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+          ],
+          "median_ms": 83.60495837405324
+        },
+        "current": {
+          "bytes": [
+            28485
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+          ],
+          "median_ms": 79.67150025069714
+        }
+      },
+      "nushell": {
+        "baseline": {
+          "bytes": [
+            116070
+          ],
+          "families": [
+            59
+          ],
+          "hashes": [
+            "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+          ],
+          "median_ms": 1516.926750075072
+        },
+        "current": {
+          "bytes": [
+            116070
+          ],
+          "families": [
+            59
+          ],
+          "hashes": [
+            "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+          ],
+          "median_ms": 1507.5248749926686
+        }
+      },
+      "packaging": {
+        "baseline": {
+          "bytes": [
+            51585
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+          ],
+          "median_ms": 125.40704105049372
+        },
+        "current": {
+          "bytes": [
+            51585
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+          ],
+          "median_ms": 125.60887495055795
+        }
+      },
+      "pixijs": {
+        "baseline": {
+          "bytes": [
+            83612
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+          ],
+          "median_ms": 797.0126247964799
+        },
+        "current": {
+          "bytes": [
+            83612
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+          ],
+          "median_ms": 797.1986248157918
+        }
+      },
+      "poetry": {
+        "baseline": {
+          "bytes": [
+            198324
+          ],
+          "families": [
+            168
+          ],
+          "hashes": [
+            "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+          ],
+          "median_ms": 283.6591247469187
+        },
+        "current": {
+          "bytes": [
+            198324
+          ],
+          "families": [
+            168
+          ],
+          "hashes": [
+            "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+          ],
+          "median_ms": 259.50224976986647
+        }
+      },
+      "prettier": {
+        "baseline": {
+          "bytes": [
+            241230
+          ],
+          "families": [
+            151
+          ],
+          "hashes": [
+            "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+          ],
+          "median_ms": 1029.6600838191807
+        },
+        "current": {
+          "bytes": [
+            241230
+          ],
+          "families": [
+            151
+          ],
+          "hashes": [
+            "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+          ],
+          "median_ms": 994.6996662765741
+        }
+      },
+      "prometheus": {
+        "baseline": {
+          "bytes": [
+            148141
+          ],
+          "families": [
+            66
+          ],
+          "hashes": [
+            "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+          ],
+          "median_ms": 847.5188328884542
+        },
+        "current": {
+          "bytes": [
+            148141
+          ],
+          "families": [
+            66
+          ],
+          "hashes": [
+            "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+          ],
+          "median_ms": 876.4300411567092
+        }
+      },
+      "pry": {
+        "baseline": {
+          "bytes": [
+            31685
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+          ],
+          "median_ms": 117.15412512421608
+        },
+        "current": {
+          "bytes": [
+            31685
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+          ],
+          "median_ms": 121.92449998110533
+        }
+      },
+      "puma": {
+        "baseline": {
+          "bytes": [
+            34593
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+          ],
+          "median_ms": 119.5569159463048
+        },
+        "current": {
+          "bytes": [
+            34593
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+          ],
+          "median_ms": 123.96154180169106
+        }
+      },
+      "quick": {
+        "baseline": {
+          "bytes": [
+            1355479
+          ],
+          "families": [
+            428
+          ],
+          "hashes": [
+            "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+          ],
+          "median_ms": 235.3941248729825
+        },
+        "current": {
+          "bytes": [
+            1355479
+          ],
+          "families": [
+            428
+          ],
+          "hashes": [
+            "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+          ],
+          "median_ms": 227.9907912015915
+        }
+      },
+      "rack": {
+        "baseline": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+          ],
+          "median_ms": 86.48674981668591
+        },
+        "current": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+          ],
+          "median_ms": 91.6327079758048
+        }
+      },
+      "radash": {
+        "baseline": {
+          "bytes": [
+            60570
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+          ],
+          "median_ms": 54.57291612401605
+        },
+        "current": {
+          "bytes": [
+            60570
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+          ],
+          "median_ms": 58.71099978685379
+        }
+      },
+      "raylib": {
+        "baseline": {
+          "bytes": [
+            244815
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+          ],
+          "median_ms": 2081.1580000445247
+        },
+        "current": {
+          "bytes": [
+            244815
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+          ],
+          "median_ms": 2125.7501668296754
+        }
+      },
+      "redis": {
+        "baseline": {
+          "bytes": [
+            59103
+          ],
+          "families": [
+            30
+          ],
+          "hashes": [
+            "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+          ],
+          "median_ms": 731.5161656588316
+        },
+        "current": {
+          "bytes": [
+            59103
+          ],
+          "families": [
+            30
+          ],
+          "hashes": [
+            "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+          ],
+          "median_ms": 748.749874997884
+        }
+      },
+      "regex": {
+        "baseline": {
+          "bytes": [
+            70161
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+          ],
+          "median_ms": 509.46616707369685
+        },
+        "current": {
+          "bytes": [
+            70161
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+          ],
+          "median_ms": 490.7718342728913
+        }
+      },
+      "requests": {
+        "baseline": {
+          "bytes": [
+            34891
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+          ],
+          "median_ms": 76.7059582285583
+        },
+        "current": {
+          "bytes": [
+            34891
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+          ],
+          "median_ms": 67.17033311724663
+        }
+      },
+      "retrofit": {
+        "baseline": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+          ],
+          "median_ms": 150.4314998164773
+        },
+        "current": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+          ],
+          "median_ms": 163.2090420462191
+        }
+      },
+      "rich": {
+        "baseline": {
+          "bytes": [
+            50546
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+          ],
+          "median_ms": 180.2267082966864
+        },
+        "current": {
+          "bytes": [
+            50546
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+          ],
+          "median_ms": 169.03533274307847
+        }
+      },
+      "ripgrep": {
+        "baseline": {
+          "bytes": [
+            33574
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+          ],
+          "median_ms": 723.060917109251
+        },
+        "current": {
+          "bytes": [
+            33574
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+          ],
+          "median_ms": 693.8289999961853
+        }
+      },
+      "rspec-core": {
+        "baseline": {
+          "bytes": [
+            35566
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+          ],
+          "median_ms": 141.06795890256763
+        },
+        "current": {
+          "bytes": [
+            35566
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+          ],
+          "median_ms": 154.54912511631846
+        }
+      },
+      "rubocop": {
+        "baseline": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+          ],
+          "median_ms": 664.3213341012597
+        },
+        "current": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+          ],
+          "median_ms": 654.3333339504898
+        }
+      },
+      "rustls": {
+        "baseline": {
+          "bytes": [
+            51848
+          ],
+          "families": [
+            20
+          ],
+          "hashes": [
+            "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+          ],
+          "median_ms": 315.43062534183264
+        },
+        "current": {
+          "bytes": [
+            51848
+          ],
+          "families": [
+            20
+          ],
+          "hashes": [
+            "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+          ],
+          "median_ms": 317.0611667446792
+        }
+      },
+      "rxjava": {
+        "baseline": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+          ],
+          "median_ms": 1433.7583747692406
+        },
+        "current": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+          ],
+          "median_ms": 1435.5505420826375
+        }
+      },
+      "rxjs": {
+        "baseline": {
+          "bytes": [
+            71630
+          ],
+          "families": [
+            33
+          ],
+          "hashes": [
+            "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+          ],
+          "median_ms": 294.05345814302564
+        },
+        "current": {
+          "bytes": [
+            71630
+          ],
+          "families": [
+            33
+          ],
+          "hashes": [
+            "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+          ],
+          "median_ms": 279.7079589217901
+        }
+      },
+      "rxswift": {
+        "baseline": {
+          "bytes": [
+            1588850
+          ],
+          "families": [
+            426
+          ],
+          "hashes": [
+            "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+          ],
+          "median_ms": 615.8266249112785
+        },
+        "current": {
+          "bytes": [
+            1588850
+          ],
+          "families": [
+            426
+          ],
+          "hashes": [
+            "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+          ],
+          "median_ms": 629.0400419384241
+        }
+      },
+      "scrapy": {
+        "baseline": {
+          "bytes": [
+            169140
+          ],
+          "families": [
+            134
+          ],
+          "hashes": [
+            "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+          ],
+          "median_ms": 276.32304187864065
+        },
+        "current": {
+          "bytes": [
+            169140
+          ],
+          "families": [
+            134
+          ],
+          "hashes": [
+            "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+          ],
+          "median_ms": 272.21595915034413
+        }
+      },
+      "serde_json": {
+        "baseline": {
+          "bytes": [
+            39884
+          ],
+          "families": [
+            12
+          ],
+          "hashes": [
+            "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+          ],
+          "median_ms": 148.69829220697284
+        },
+        "current": {
+          "bytes": [
+            39884
+          ],
+          "families": [
+            12
+          ],
+          "hashes": [
+            "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+          ],
+          "median_ms": 158.73087476938963
+        }
+      },
+      "sidekiq": {
+        "baseline": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+          ],
+          "median_ms": 99.03320809826255
+        },
+        "current": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+          ],
+          "median_ms": 110.09445833042264
+        }
+      },
+      "sinatra": {
+        "baseline": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+          ],
+          "median_ms": 88.88695808127522
+        },
+        "current": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+          ],
+          "median_ms": 108.18041628226638
+        }
+      },
+      "sled": {
+        "baseline": {
+          "bytes": [
+            26733
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+          ],
+          "median_ms": 76.01058389991522
+        },
+        "current": {
+          "bytes": [
+            26733
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+          ],
+          "median_ms": 87.42150012403727
+        }
+      },
+      "sqlalchemy": {
+        "baseline": {
+          "bytes": [
+            517222
+          ],
+          "families": [
+            391
+          ],
+          "hashes": [
+            "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+          ],
+          "median_ms": 1412.8247080370784
+        },
+        "current": {
+          "bytes": [
+            517222
+          ],
+          "families": [
+            391
+          ],
+          "hashes": [
+            "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+          ],
+          "median_ms": 1478.6349586211145
+        }
+      },
+      "sqlite": {
+        "baseline": {
+          "bytes": [
+            159393
+          ],
+          "families": [
+            112
+          ],
+          "hashes": [
+            "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+          ],
+          "median_ms": 1152.9997079633176
+        },
+        "current": {
+          "bytes": [
+            159393
+          ],
+          "families": [
+            112
+          ],
+          "hashes": [
+            "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+          ],
+          "median_ms": 1155.0960410386324
+        }
+      },
+      "swift-algorithms": {
+        "baseline": {
+          "bytes": [
+            37862
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+          ],
+          "median_ms": 56.206374894827604
+        },
+        "current": {
+          "bytes": [
+            37862
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+          ],
+          "median_ms": 56.50220811367035
+        }
+      },
+      "swift-argument-parser": {
+        "baseline": {
+          "bytes": [
+            28093
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+          ],
+          "median_ms": 93.38166704401374
+        },
+        "current": {
+          "bytes": [
+            28093
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+          ],
+          "median_ms": 92.94987516477704
+        }
+      },
+      "swift-collections": {
+        "baseline": {
+          "bytes": [
+            105222
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+          ],
+          "median_ms": 430.6744998320937
+        },
+        "current": {
+          "bytes": [
+            105222
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+          ],
+          "median_ms": 405.96550004556775
+        }
+      },
+      "swift-composable-architecture": {
+        "baseline": {
+          "bytes": [
+            32913
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+          ],
+          "median_ms": 299.9050416983664
+        },
+        "current": {
+          "bytes": [
+            32913
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+          ],
+          "median_ms": 278.5465409979224
+        }
+      },
+      "swift-log": {
+        "baseline": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+          ],
+          "median_ms": 44.873000122606754
+        },
+        "current": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+          ],
+          "median_ms": 45.11841665953398
+        }
+      },
+      "swift-metrics": {
+        "baseline": {
+          "bytes": [
+            32765
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+          ],
+          "median_ms": 43.827875051647425
+        },
+        "current": {
+          "bytes": [
+            32765
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+          ],
+          "median_ms": 43.287125416100025
+        }
+      },
+      "swift-nio": {
+        "baseline": {
+          "bytes": [
+            111694
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+          ],
+          "median_ms": 597.1050001680851
+        },
+        "current": {
+          "bytes": [
+            111694
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+          ],
+          "median_ms": 625.5341251380742
+        }
+      },
+      "swift-service-lifecycle": {
+        "baseline": {
+          "bytes": [
+            27152
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+          ],
+          "median_ms": 41.38329206034541
+        },
+        "current": {
+          "bytes": [
+            27152
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+          ],
+          "median_ms": 41.560708079487085
+        }
+      },
+      "swiftlint": {
+        "baseline": {
+          "bytes": [
+            34954
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+          ],
+          "median_ms": 266.0819999873638
+        },
+        "current": {
+          "bytes": [
+            34954
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+          ],
+          "median_ms": 289.0103328973055
+        }
+      },
+      "swr": {
+        "baseline": {
+          "bytes": [
+            119283
+          ],
+          "families": [
+            49
+          ],
+          "hashes": [
+            "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+          ],
+          "median_ms": 113.14333276823163
+        },
+        "current": {
+          "bytes": [
+            119283
+          ],
+          "families": [
+            49
+          ],
+          "hashes": [
+            "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+          ],
+          "median_ms": 135.06695767864585
+        }
+      },
+      "sympy": {
+        "baseline": {
+          "bytes": [
+            853198
+          ],
+          "families": [
+            645
+          ],
+          "hashes": [
+            "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+          ],
+          "median_ms": 3086.6631250828505
+        },
+        "current": {
+          "bytes": [
+            853198
+          ],
+          "families": [
+            645
+          ],
+          "hashes": [
+            "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+          ],
+          "median_ms": 3089.7845001891255
+        }
+      },
+      "thor": {
+        "baseline": {
+          "bytes": [
+            28324
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+          ],
+          "median_ms": 68.8671669922769
+        },
+        "current": {
+          "bytes": [
+            28324
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+          ],
+          "median_ms": 59.27112512290478
+        }
+      },
+      "tmux": {
+        "baseline": {
+          "bytes": [
+            51015
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+          ],
+          "median_ms": 231.23983340337873
+        },
+        "current": {
+          "bytes": [
+            51015
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+          ],
+          "median_ms": 212.1587498113513
+        }
+      },
+      "tokei": {
+        "baseline": {
+          "bytes": [
+            25960
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+          ],
+          "median_ms": 36.23162489384413
+        },
+        "current": {
+          "bytes": [
+            25960
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+          ],
+          "median_ms": 37.5561248511076
+        }
+      },
+      "tokio": {
+        "baseline": {
+          "bytes": [
+            75904
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+          ],
+          "median_ms": 479.29404210299253
+        },
+        "current": {
+          "bytes": [
+            75904
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+          ],
+          "median_ms": 497.09145817905664
+        }
+      },
+      "trpc": {
+        "baseline": {
+          "bytes": [
+            128760
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+          ],
+          "median_ms": 331.17824979126453
+        },
+        "current": {
+          "bytes": [
+            128760
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+          ],
+          "median_ms": 362.89433389902115
+        }
+      },
+      "urfave-cli": {
+        "baseline": {
+          "bytes": [
+            25975
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+          ],
+          "median_ms": 63.20120906457305
+        },
+        "current": {
+          "bytes": [
+            25975
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+          ],
+          "median_ms": 63.58720827847719
+        }
+      },
+      "vapor": {
+        "baseline": {
+          "bytes": [
+            27156
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+          ],
+          "median_ms": 126.31708290427923
+        },
+        "current": {
+          "bytes": [
+            27156
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+          ],
+          "median_ms": 125.25866739451885
+        }
+      },
+      "vim": {
+        "baseline": {
+          "bytes": [
+            72267
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+          ],
+          "median_ms": 1189.1232091002166
+        },
+        "current": {
+          "bytes": [
+            72267
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+          ],
+          "median_ms": 1183.8293331675231
+        }
+      },
+      "wrk": {
+        "baseline": {
+          "bytes": [
+            26686
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+          ],
+          "median_ms": 40.37716705352068
+        },
+        "current": {
+          "bytes": [
+            26686
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+          ],
+          "median_ms": 40.905707981437445
+        }
+      },
+      "zap": {
+        "baseline": {
+          "bytes": [
+            32782
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+          ],
+          "median_ms": 66.63566688075662
+        },
+        "current": {
+          "bytes": [
+            32782
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+          ],
+          "median_ms": 79.42712493240833
+        }
+      },
+      "zod": {
+        "baseline": {
+          "bytes": [
+            49195
+          ],
+          "families": [
+            21
+          ],
+          "hashes": [
+            "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+          ],
+          "median_ms": 323.21833400055766
+        },
+        "current": {
+          "bytes": [
+            49195
+          ],
+          "families": [
+            21
+          ],
+          "hashes": [
+            "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+          ],
+          "median_ms": 355.2070828154683
+        }
+      },
+      "zstd": {
+        "baseline": {
+          "bytes": [
+            76464
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+          ],
+          "median_ms": 356.25320905819535
+        },
+        "current": {
+          "bytes": [
+            76464
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+          ],
+          "median_ms": 315.787167288363
+        }
+      },
+      "zustand": {
+        "baseline": {
+          "bytes": [
+            41646
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+          ],
+          "median_ms": 74.54191660508513
+        },
+        "current": {
+          "bytes": [
+            41646
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+          ],
+          "median_ms": 77.35183322802186
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "alacritty": true,
+      "alamofire": true,
+      "antlr4": true,
+      "arrow": true,
+      "asciidoctor": true,
+      "axios": true,
+      "badger": true,
+      "bat": true,
+      "black": true,
+      "boltons": true,
+      "chi": true,
+      "clap": true,
+      "click": true,
+      "cmark": true,
+      "cobra": true,
+      "commons-lang": true,
+      "curl": true,
+      "date-fns": true,
+      "delve": true,
+      "devise": true,
+      "drizzle-orm": true,
+      "esbuild": true,
+      "etcd": true,
+      "execa": true,
+      "faraday": true,
+      "fastlane": true,
+      "fd": true,
+      "flask": true,
+      "fzf": true,
+      "gin": true,
+      "git": true,
+      "gorm": true,
+      "graphhopper": true,
+      "gson": true,
+      "guava": true,
+      "h2database": true,
+      "httpie": true,
+      "httpx": true,
+      "hugo": true,
+      "hyperfine": true,
+      "image": true,
+      "jackson-core": true,
+      "jedis": true,
+      "jekyll": true,
+      "jest": true,
+      "jq": true,
+      "jsoup": true,
+      "junit5": true,
+      "kingfisher": true,
+      "kramdown": true,
+      "ky": true,
+      "libgdx": true,
+      "libsodium": true,
+      "libuv": true,
+      "liquid": true,
+      "lua": true,
+      "marked": true,
+      "marshmallow": true,
+      "meilisearch": true,
+      "minio": true,
+      "mockito": true,
+      "nats-server": true,
+      "netty": true,
+      "nginx": true,
+      "nimble": true,
+      "nushell": true,
+      "packaging": true,
+      "pixijs": true,
+      "poetry": true,
+      "prettier": true,
+      "prometheus": true,
+      "pry": true,
+      "puma": true,
+      "quick": true,
+      "rack": true,
+      "radash": true,
+      "raylib": true,
+      "redis": true,
+      "regex": true,
+      "requests": true,
+      "retrofit": true,
+      "rich": true,
+      "ripgrep": true,
+      "rspec-core": true,
+      "rubocop": true,
+      "rustls": true,
+      "rxjava": true,
+      "rxjs": true,
+      "rxswift": true,
+      "scrapy": true,
+      "serde_json": true,
+      "sidekiq": true,
+      "sinatra": true,
+      "sled": true,
+      "sqlalchemy": true,
+      "sqlite": true,
+      "swift-algorithms": true,
+      "swift-argument-parser": true,
+      "swift-collections": true,
+      "swift-composable-architecture": true,
+      "swift-log": true,
+      "swift-metrics": true,
+      "swift-nio": true,
+      "swift-service-lifecycle": true,
+      "swiftlint": true,
+      "swr": true,
+      "sympy": true,
+      "thor": true,
+      "tmux": true,
+      "tokei": true,
+      "tokio": true,
+      "trpc": true,
+      "urfave-cli": true,
+      "vapor": true,
+      "vim": true,
+      "wrk": true,
+      "zap": true,
+      "zod": true,
+      "zstd": true,
+      "zustand": true
+    }
+  }
+}

--- a/bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json
@@ -1,0 +1,409 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-688/nose-551758d5",
+    "baseline_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+    "baseline_source_ref": "551758d5",
+    "baseline_source_sha": "551758d5139372a58645f411ac3b887d679c755a",
+    "current_binary": "/private/tmp/nose-688/nose-08052e90",
+    "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "current_source_ref": "08052e90",
+    "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --repos-root . --repo crates/nose-cli/src --repo crates/nose-cli/tests/cli --iterations 9 --warmups 1 --output bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json",
+    "working_tree_status_before_measurement": "?? bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json\n?? bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json"
+  },
+  "repos": [
+    "crates/nose-cli/src",
+    "crates/nose-cli/tests/cli"
+  ],
+  "runs": [
+    {
+      "bytes": 27838,
+      "elapsed_ms": 80.94512484967709,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 43.26308285817504,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 83.47820909693837,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 43.75070845708251,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 81.87095820903778,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 45.7503329962492,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 71.61733321845531,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 33.731999807059765,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 67.2470424324274,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 36.145334132015705,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 67.13137496262789,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 36.04479227215052,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 67.12929205968976,
+      "families": 2,
+      "iteration": 4,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 37.10737498477101,
+      "families": 0,
+      "iteration": 4,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 108.46983408555388,
+      "families": 2,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 47.12162492796779,
+      "families": 0,
+      "iteration": 4,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 76.48966694250703,
+      "families": 2,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 49.59387518465519,
+      "families": 0,
+      "iteration": 5,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 80.97400004044175,
+      "families": 2,
+      "iteration": 5,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 44.40041584894061,
+      "families": 0,
+      "iteration": 5,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 87.86220801994205,
+      "families": 2,
+      "iteration": 6,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 47.94537462294102,
+      "families": 0,
+      "iteration": 6,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 94.21599982306361,
+      "families": 2,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 38.81479101255536,
+      "families": 0,
+      "iteration": 6,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 71.14608306437731,
+      "families": 2,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 37.1378343552351,
+      "families": 0,
+      "iteration": 7,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 74.06475022435188,
+      "families": 2,
+      "iteration": 7,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 39.59533292800188,
+      "families": 0,
+      "iteration": 7,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 72.1200411207974,
+      "families": 2,
+      "iteration": 8,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 78.01704201847315,
+      "families": 0,
+      "iteration": 8,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 87.56291680037975,
+      "families": 2,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 51.41004081815481,
+      "families": 0,
+      "iteration": 8,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 95.34800006076694,
+      "families": 2,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 44.523708056658506,
+      "families": 0,
+      "iteration": 9,
+      "label": "baseline",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    },
+    {
+      "bytes": 27838,
+      "elapsed_ms": 92.11387485265732,
+      "families": 2,
+      "iteration": 9,
+      "label": "current",
+      "repo": "crates/nose-cli/src",
+      "sha256": "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+    },
+    {
+      "bytes": 25984,
+      "elapsed_ms": 46.814917121082544,
+      "families": 0,
+      "iteration": 9,
+      "label": "current",
+      "repo": "crates/nose-cli/tests/cli",
+      "sha256": "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 124.20820770785213,
+    "aggregate_current_median_ms": 125.37441588938236,
+    "aggregate_delta_pct": 0.9389139438138053,
+    "by_repo": {
+      "crates/nose-cli/src": {
+        "baseline": {
+          "bytes": [
+            27838
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+          ],
+          "median_ms": 80.94512484967709
+        },
+        "current": {
+          "bytes": [
+            27838
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "ed629c4cf604772a671356343eb459a41f4ced1d040378ee51b82e339911f843"
+          ],
+          "median_ms": 80.97400004044175
+        }
+      },
+      "crates/nose-cli/tests/cli": {
+        "baseline": {
+          "bytes": [
+            25984
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+          ],
+          "median_ms": 43.26308285817504
+        },
+        "current": {
+          "bytes": [
+            25984
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "a012645aac2b3a4bbcdc81a8d7028bfe84a29e9fb121bb6ebf12c3c84e0d6782"
+          ],
+          "median_ms": 44.40041584894061
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "crates/nose-cli/src": true,
+      "crates/nose-cli/tests/cli": true
+    }
+  }
+}

--- a/bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json
@@ -1,0 +1,9869 @@
+{
+  "command": "nose query <repo> all top=0 --mode semantic --format json",
+  "provenance": {
+    "baseline_binary": "/private/tmp/nose-688/nose-08052e90",
+    "baseline_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "baseline_source_ref": "08052e90",
+    "baseline_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "current_binary": "/private/tmp/nose-688/nose-08052e90",
+    "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "current_source_ref": "08052e90",
+    "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "harness": "scripts/query-regression-harness.py",
+    "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-08052e90 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 08052e90 --baseline-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json",
+    "working_tree_status_before_measurement": "?? bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json"
+  },
+  "repos": [
+    "alacritty",
+    "alamofire",
+    "antlr4",
+    "arrow",
+    "asciidoctor",
+    "axios",
+    "badger",
+    "bat",
+    "black",
+    "boltons",
+    "chi",
+    "clap",
+    "click",
+    "cmark",
+    "cobra",
+    "commons-lang",
+    "curl",
+    "date-fns",
+    "delve",
+    "devise",
+    "drizzle-orm",
+    "esbuild",
+    "etcd",
+    "execa",
+    "faraday",
+    "fastlane",
+    "fd",
+    "flask",
+    "fzf",
+    "gin",
+    "git",
+    "gorm",
+    "graphhopper",
+    "gson",
+    "guava",
+    "h2database",
+    "httpie",
+    "httpx",
+    "hugo",
+    "hyperfine",
+    "image",
+    "jackson-core",
+    "jedis",
+    "jekyll",
+    "jest",
+    "jq",
+    "jsoup",
+    "junit5",
+    "kingfisher",
+    "kramdown",
+    "ky",
+    "libgdx",
+    "libsodium",
+    "libuv",
+    "liquid",
+    "lua",
+    "marked",
+    "marshmallow",
+    "meilisearch",
+    "minio",
+    "mockito",
+    "nats-server",
+    "netty",
+    "nginx",
+    "nimble",
+    "nushell",
+    "packaging",
+    "pixijs",
+    "poetry",
+    "prettier",
+    "prometheus",
+    "pry",
+    "puma",
+    "quick",
+    "rack",
+    "radash",
+    "raylib",
+    "redis",
+    "regex",
+    "requests",
+    "retrofit",
+    "rich",
+    "ripgrep",
+    "rspec-core",
+    "rubocop",
+    "rustls",
+    "rxjava",
+    "rxjs",
+    "rxswift",
+    "scrapy",
+    "serde_json",
+    "sidekiq",
+    "sinatra",
+    "sled",
+    "sqlalchemy",
+    "sqlite",
+    "swift-algorithms",
+    "swift-argument-parser",
+    "swift-collections",
+    "swift-composable-architecture",
+    "swift-log",
+    "swift-metrics",
+    "swift-nio",
+    "swift-service-lifecycle",
+    "swiftlint",
+    "swr",
+    "sympy",
+    "thor",
+    "tmux",
+    "tokei",
+    "tokio",
+    "trpc",
+    "urfave-cli",
+    "vapor",
+    "vim",
+    "wrk",
+    "zap",
+    "zod",
+    "zstd",
+    "zustand"
+  ],
+  "runs": [
+    {
+      "bytes": 30552,
+      "elapsed_ms": 266.40833308920264,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1773.3995411545038,
+      "families": 3488,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 500.47387508675456,
+      "families": 197,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 163.51666674017906,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 192.5459997728467,
+      "families": 148,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 303.05670807138085,
+      "families": 18,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 90.73866670951247,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 328.48854130133986,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 410.6438751332462,
+      "families": 19,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 84.72137479111552,
+      "families": 41,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 46.72937514260411,
+      "families": 4,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 281.1939581297338,
+      "families": 11,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 110.00100011005998,
+      "families": 34,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 89.24799971282482,
+      "families": 10,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 72.97791726887226,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 607.2515416890383,
+      "families": 156,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 589.5964587107301,
+      "families": 115,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 357.1736658923328,
+      "families": 27,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 434.1044998727739,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 75.75941737741232,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1002.8439173474908,
+      "families": 63,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1981.7035840824246,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 512.3586249537766,
+      "families": 32,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 240.71979196742177,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 62.5043329782784,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 2869.935624767095,
+      "families": 28,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 192.67891719937325,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 211.409917101264,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 1085.4637078009546,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 158.13616709783673,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 2430.099042132497,
+      "families": 111,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 286.27254208549857,
+      "families": 13,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 1727.1322500891984,
+      "families": 245,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 505.43041713535786,
+      "families": 79,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 7527.659125160426,
+      "families": 1796,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 3398.949457798153,
+      "families": 515,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 131.22608326375484,
+      "families": 17,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 164.7426667623222,
+      "families": 16,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 1244.727207813412,
+      "families": 51,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 99.62812531739473,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 453.44695821404457,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 590.7111661508679,
+      "families": 84,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 2985.4939999058843,
+      "families": 267,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 163.0902080796659,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 1068.0256658233702,
+      "families": 45,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 191.55533332377672,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 398.4362920746207,
+      "families": 64,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 1630.4002907127142,
+      "families": 327,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 237.22050013020635,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 146.26304199919105,
+      "families": 62,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 93.67637522518635,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 4232.955750077963,
+      "families": 1068,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 1337.0135412551463,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 400.86395805701613,
+      "families": 31,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 131.09541684389114,
+      "families": 4,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 160.66562524065375,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 186.83758284896612,
+      "families": 113,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 171.49950005114079,
+      "families": 17,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 1895.4268340021372,
+      "families": 15,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 1934.2222921550274,
+      "families": 54,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 789.9533342570066,
+      "families": 102,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 2756.7792083136737,
+      "families": 27,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 4877.93833296746,
+      "families": 879,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 1079.29554162547,
+      "families": 44,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 204.72624991089106,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 3797.3204161971807,
+      "families": 59,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 156.4820408821106,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 1210.0093751214445,
+      "families": 52,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 342.9104997776449,
+      "families": 168,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1410.0989592261612,
+      "families": 151,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 1132.652583066374,
+      "families": 66,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 113.37970895692706,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 147.55450002849102,
+      "families": 7,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 293.26654179021716,
+      "families": 428,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 135.87679201737046,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 78.26333260163665,
+      "families": 37,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2608.0523752607405,
+      "families": 148,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 980.0827908329666,
+      "families": 30,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 629.1458331979811,
+      "families": 34,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 83.90524983406067,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 171.23141698539257,
+      "families": 81,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 211.4389161579311,
+      "families": 22,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 875.5433331243694,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 256.8544582463801,
+      "families": 8,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 977.553874719888,
+      "families": 104,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 386.3218752667308,
+      "families": 20,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1673.4882919117808,
+      "families": 618,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 305.3643750026822,
+      "families": 33,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 756.280249916017,
+      "families": 426,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 300.77474983409047,
+      "families": 134,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 163.90149993821979,
+      "families": 12,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 109.9405842833221,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 156.38162521645427,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 115.2263330295682,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1654.6141249127686,
+      "families": 391,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1310.2299170568585,
+      "families": 112,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 71.76766591146588,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 120.51895819604397,
+      "families": 2,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 457.3960001580417,
+      "families": 51,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 358.80604200065136,
+      "families": 6,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 46.56945914030075,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 47.07170883193612,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 695.2327080070972,
+      "families": 52,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 52.24424973130226,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 326.05633279308677,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 113.42904204502702,
+      "families": 49,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3569.5310421288013,
+      "families": 645,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 68.165916018188,
+      "families": 3,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 308.445833157748,
+      "families": 29,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 41.34712461382151,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 545.4482082277536,
+      "families": 37,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 400.64979111775756,
+      "families": 64,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 69.88366693258286,
+      "families": 0,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 157.50304190441966,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1316.7449170723557,
+      "families": 39,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 44.22120796516538,
+      "families": 1,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 104.03204197064042,
+      "families": 5,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 433.334625326097,
+      "families": 21,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 362.4843331053853,
+      "families": 39,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 88.89150014147162,
+      "families": 9,
+      "iteration": 1,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 328.3822499215603,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 2072.6047502830625,
+      "families": 3488,
+      "iteration": 1,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 636.9021250866354,
+      "families": 197,
+      "iteration": 1,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 180.81537494435906,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 212.26616576313972,
+      "families": 148,
+      "iteration": 1,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 344.9420421384275,
+      "families": 18,
+      "iteration": 1,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 155.71966720744967,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 364.41812524572015,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 577.324875164777,
+      "families": 19,
+      "iteration": 1,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 146.39104111120105,
+      "families": 41,
+      "iteration": 1,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 67.03683268278837,
+      "families": 4,
+      "iteration": 1,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 383.69400007650256,
+      "families": 11,
+      "iteration": 1,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 143.12366675585508,
+      "families": 34,
+      "iteration": 1,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 100.79170856624842,
+      "families": 10,
+      "iteration": 1,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 85.5927080847323,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 830.801541917026,
+      "families": 156,
+      "iteration": 1,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 858.7736668996513,
+      "families": 115,
+      "iteration": 1,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 555.4946670308709,
+      "families": 27,
+      "iteration": 1,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 646.8751248903573,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 79.90983314812183,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1434.5572083257139,
+      "families": 63,
+      "iteration": 1,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 2727.154833264649,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 562.6221662387252,
+      "families": 32,
+      "iteration": 1,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 184.23820799216628,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 53.0500840395689,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 924.8439157381654,
+      "families": 28,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 49.69712486490607,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 87.1294173412025,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 407.5718750245869,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 90.61979176476598,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 1023.4045833349228,
+      "families": 111,
+      "iteration": 1,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 144.41616600379348,
+      "families": 13,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 836.3763750530779,
+      "families": 245,
+      "iteration": 1,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 222.14012499898672,
+      "families": 79,
+      "iteration": 1,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2988.7349577620625,
+      "families": 1796,
+      "iteration": 1,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1409.5618333667517,
+      "families": 515,
+      "iteration": 1,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 84.67225031927228,
+      "families": 17,
+      "iteration": 1,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 76.49370795115829,
+      "families": 16,
+      "iteration": 1,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 681.1806252226233,
+      "families": 51,
+      "iteration": 1,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.02691712230444,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 242.55408300086856,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 319.91274980828166,
+      "families": 84,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1348.9778749644756,
+      "families": 267,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 114.5855002105236,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 551.745958160609,
+      "families": 45,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 99.18654197826982,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 237.81437519937754,
+      "families": 64,
+      "iteration": 1,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 930.6334997527301,
+      "families": 327,
+      "iteration": 1,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 129.14495775476098,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 118.37962502613664,
+      "families": 62,
+      "iteration": 1,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 68.14212491735816,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2161.3071248866618,
+      "families": 1068,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 595.4465419054031,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 239.3208327703178,
+      "families": 31,
+      "iteration": 1,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 87.5405422411859,
+      "families": 4,
+      "iteration": 1,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 115.86691625416279,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 95.82683304324746,
+      "families": 113,
+      "iteration": 1,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 92.68274996429682,
+      "families": 17,
+      "iteration": 1,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 1021.9587078318,
+      "families": 15,
+      "iteration": 1,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 899.0712915547192,
+      "families": 54,
+      "iteration": 1,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 392.5164584070444,
+      "families": 102,
+      "iteration": 1,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1316.3284580223262,
+      "families": 27,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2231.6222079098225,
+      "families": 879,
+      "iteration": 1,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 472.889041993767,
+      "families": 44,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 76.51116698980331,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1563.8668327592313,
+      "families": 59,
+      "iteration": 1,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 140.04729082807899,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 825.9831666946411,
+      "families": 52,
+      "iteration": 1,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 278.8745420984924,
+      "families": 168,
+      "iteration": 1,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1154.2529170401394,
+      "families": 151,
+      "iteration": 1,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 946.1572919972241,
+      "families": 66,
+      "iteration": 1,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 107.88850020617247,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 123.55854222550988,
+      "families": 7,
+      "iteration": 1,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 225.27208318933845,
+      "families": 428,
+      "iteration": 1,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 94.05708312988281,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 62.14454211294651,
+      "families": 37,
+      "iteration": 1,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2265.952416229993,
+      "families": 148,
+      "iteration": 1,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 775.8065001107752,
+      "families": 30,
+      "iteration": 1,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 454.7942909412086,
+      "families": 34,
+      "iteration": 1,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 70.53666701540351,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 162.93037496507168,
+      "families": 81,
+      "iteration": 1,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 171.73670791089535,
+      "families": 22,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 713.9604170806706,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 144.58479173481464,
+      "families": 8,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 671.4384593069553,
+      "families": 104,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 352.2669170051813,
+      "families": 20,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1455.05395764485,
+      "families": 618,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 279.70620803534985,
+      "families": 33,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 602.832708042115,
+      "families": 426,
+      "iteration": 1,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 290.84262531250715,
+      "families": 134,
+      "iteration": 1,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 151.7172921448946,
+      "families": 12,
+      "iteration": 1,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 104.34045782312751,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 108.31125034019351,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 92.04041725024581,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1438.107166904956,
+      "families": 391,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1157.8282499685884,
+      "families": 112,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 62.84020794555545,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 91.46333299577236,
+      "families": 2,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 420.28237506747246,
+      "families": 51,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 290.92891700565815,
+      "families": 6,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 49.35770807787776,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 44.55620888620615,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 633.2348329015076,
+      "families": 52,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 44.106250163167715,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 291.46954137831926,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 106.4154589548707,
+      "families": 49,
+      "iteration": 1,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3190.458041150123,
+      "families": 645,
+      "iteration": 1,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 55.3788747638464,
+      "families": 3,
+      "iteration": 1,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 213.5928333736956,
+      "families": 29,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 39.26412481814623,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 541.358333081007,
+      "families": 37,
+      "iteration": 1,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 335.5667917057872,
+      "families": 64,
+      "iteration": 1,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 68.57729190960526,
+      "families": 0,
+      "iteration": 1,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 136.64183299988508,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1237.350458279252,
+      "families": 39,
+      "iteration": 1,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 42.73116681724787,
+      "families": 1,
+      "iteration": 1,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 82.08062499761581,
+      "families": 5,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 356.495666783303,
+      "families": 21,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 301.78304109722376,
+      "families": 39,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 75.10754186660051,
+      "families": 9,
+      "iteration": 1,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 307.2988330386579,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1761.8860830552876,
+      "families": 3488,
+      "iteration": 2,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 579.0965422056615,
+      "families": 197,
+      "iteration": 2,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 168.44829125329852,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 172.68949979916215,
+      "families": 148,
+      "iteration": 2,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 296.9917501322925,
+      "families": 18,
+      "iteration": 2,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 113.17491624504328,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 302.6877921074629,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 373.87175019830465,
+      "families": 19,
+      "iteration": 2,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 117.1080837957561,
+      "families": 41,
+      "iteration": 2,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 52.2815827280283,
+      "families": 4,
+      "iteration": 2,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 280.9852911159396,
+      "families": 11,
+      "iteration": 2,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 118.57704212889075,
+      "families": 34,
+      "iteration": 2,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 87.27124985307455,
+      "families": 10,
+      "iteration": 2,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 68.4937504120171,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 562.5402498990297,
+      "families": 156,
+      "iteration": 2,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 632.5325001962483,
+      "families": 115,
+      "iteration": 2,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 393.9592079259455,
+      "families": 27,
+      "iteration": 2,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 437.5551249831915,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 74.39545821398497,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1029.8527907580137,
+      "families": 63,
+      "iteration": 2,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1824.232832994312,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 502.45074974372983,
+      "families": 32,
+      "iteration": 2,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 164.42920826375484,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 51.99566716328263,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 792.2327080741525,
+      "families": 28,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 50.54266704246402,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 82.22000021487474,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 413.1532497704029,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 77.93975016102195,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 972.1992909908295,
+      "families": 111,
+      "iteration": 2,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 142.9030830040574,
+      "families": 13,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 767.6433748565614,
+      "families": 245,
+      "iteration": 2,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 220.85699997842312,
+      "families": 79,
+      "iteration": 2,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2836.4890832453966,
+      "families": 1796,
+      "iteration": 2,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1334.637583233416,
+      "families": 515,
+      "iteration": 2,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 76.61204226315022,
+      "families": 17,
+      "iteration": 2,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 64.43645805120468,
+      "families": 16,
+      "iteration": 2,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 643.3310844004154,
+      "families": 51,
+      "iteration": 2,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.81649985164404,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 232.47816739603877,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 309.30725019425154,
+      "families": 84,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1225.8617500774562,
+      "families": 267,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 103.6317921243608,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 539.8250417783856,
+      "families": 45,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 83.9118342846632,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 235.59637507423759,
+      "families": 64,
+      "iteration": 2,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 855.5888747796416,
+      "families": 327,
+      "iteration": 2,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 126.75745924934745,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 99.04087474569678,
+      "families": 62,
+      "iteration": 2,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 62.67695827409625,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2033.3029166795313,
+      "families": 1068,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 549.6381251141429,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 209.27845826372504,
+      "families": 31,
+      "iteration": 2,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 71.59279193729162,
+      "families": 4,
+      "iteration": 2,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 84.20187514275312,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 72.3913749679923,
+      "families": 113,
+      "iteration": 2,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 72.88095774129033,
+      "families": 17,
+      "iteration": 2,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 910.5880842544138,
+      "families": 15,
+      "iteration": 2,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 945.6997909583151,
+      "families": 54,
+      "iteration": 2,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 358.05029096081853,
+      "families": 102,
+      "iteration": 2,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1312.4578748829663,
+      "families": 27,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2274.586458224803,
+      "families": 879,
+      "iteration": 2,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 419.3213749676943,
+      "families": 44,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 90.21479217335582,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1567.0483750291169,
+      "families": 59,
+      "iteration": 2,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 104.88450014963746,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 820.0570833869278,
+      "families": 52,
+      "iteration": 2,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 231.80508380755782,
+      "families": 168,
+      "iteration": 2,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1102.4120831862092,
+      "families": 151,
+      "iteration": 2,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 833.4650844335556,
+      "families": 66,
+      "iteration": 2,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 104.56883395090699,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 116.58020783215761,
+      "families": 7,
+      "iteration": 2,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 227.3397920653224,
+      "families": 428,
+      "iteration": 2,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 98.60466700047255,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 67.17329239472747,
+      "families": 37,
+      "iteration": 2,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2206.1881250701845,
+      "families": 148,
+      "iteration": 2,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 781.552332919091,
+      "families": 30,
+      "iteration": 2,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 471.1164999753237,
+      "families": 34,
+      "iteration": 2,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 80.3438751026988,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 159.083791077137,
+      "families": 81,
+      "iteration": 2,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 177.37304186448455,
+      "families": 22,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 674.1084577515721,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 144.87595902755857,
+      "families": 8,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 649.6637919917703,
+      "families": 104,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 312.4823747202754,
+      "families": 20,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1390.8721669577062,
+      "families": 618,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 277.2881658747792,
+      "families": 33,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 617.4141671508551,
+      "families": 426,
+      "iteration": 2,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 278.86816672980785,
+      "families": 134,
+      "iteration": 2,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 145.99604113027453,
+      "families": 12,
+      "iteration": 2,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 126.25537533313036,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 95.87166737765074,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 72.82366696745157,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1548.8551668822765,
+      "families": 391,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1143.2865001261234,
+      "families": 112,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 65.78395888209343,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 125.93875033780932,
+      "families": 2,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 374.67183405533433,
+      "families": 51,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 285.3511250577867,
+      "families": 6,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 43.1540422141552,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 46.05362517759204,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 631.6828331910074,
+      "families": 52,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 40.82012502476573,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 259.961917065084,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 107.68820811063051,
+      "families": 49,
+      "iteration": 2,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3111.5776249207556,
+      "families": 645,
+      "iteration": 2,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 65.90345874428749,
+      "families": 3,
+      "iteration": 2,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 236.47429142147303,
+      "families": 29,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 36.99300019070506,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 466.6846669279039,
+      "families": 37,
+      "iteration": 2,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 367.8760421462357,
+      "families": 64,
+      "iteration": 2,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 68.61158413812518,
+      "families": 0,
+      "iteration": 2,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 129.28966619074345,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1253.483375068754,
+      "families": 39,
+      "iteration": 2,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 40.653917007148266,
+      "families": 1,
+      "iteration": 2,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 66.513542085886,
+      "families": 5,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 322.8092500939965,
+      "families": 21,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 321.2080420926213,
+      "families": 39,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 76.56470825895667,
+      "families": 9,
+      "iteration": 2,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 268.2347916997969,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1798.1368340551853,
+      "families": 3488,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 551.7685827799141,
+      "families": 197,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 162.79824962839484,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 170.4774578101933,
+      "families": 148,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 269.4857497699559,
+      "families": 18,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 99.45808304473758,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 313.165542203933,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 411.65066603571177,
+      "families": 19,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 89.28554179146886,
+      "families": 41,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 43.18095790222287,
+      "families": 4,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 284.8289171233773,
+      "families": 11,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 107.90687520056963,
+      "families": 34,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 87.2382503002882,
+      "families": 10,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 70.65937481820583,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 562.4769581481814,
+      "families": 156,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 669.8980000801384,
+      "families": 115,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 369.4931250065565,
+      "families": 27,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 450.36470890045166,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 81.99725020676851,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1075.1447081565857,
+      "families": 63,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1844.0922913141549,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 460.1932503283024,
+      "families": 32,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 149.2770412005484,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 61.703292187303305,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 815.7200003042817,
+      "families": 28,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 39.58362527191639,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 98.71016582474113,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 366.3023333065212,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 90.1821251027286,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 944.8909577913582,
+      "families": 111,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 133.86820815503597,
+      "families": 13,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 722.5064588710666,
+      "families": 245,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 242.78720933943987,
+      "families": 79,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2770.1246249489486,
+      "families": 1796,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1290.7993327826262,
+      "families": 515,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 83.14133295789361,
+      "families": 17,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 67.07150023430586,
+      "families": 16,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 679.629834368825,
+      "families": 51,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 41.64666682481766,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 237.04987484961748,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 322.8679997846484,
+      "families": 84,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1243.267874699086,
+      "families": 267,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 107.62662487104535,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 527.2575407288969,
+      "families": 45,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 113.5081248357892,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 221.56312502920628,
+      "families": 64,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 814.2999578267336,
+      "families": 327,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 121.30225030705333,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 106.11479170620441,
+      "families": 62,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 73.54587502777576,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2075.5906249396503,
+      "families": 1068,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 587.5389999710023,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 241.52629217132926,
+      "families": 31,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 85.56474978104234,
+      "families": 4,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 105.31000001356006,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 85.93658404424787,
+      "families": 113,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 74.74899990484118,
+      "families": 17,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 848.239874932915,
+      "families": 15,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 867.0298340730369,
+      "families": 54,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 376.9250828772783,
+      "families": 102,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1238.4748752228916,
+      "families": 27,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2162.7632919698954,
+      "families": 879,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 449.4067500345409,
+      "families": 44,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 90.91149969026446,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1516.018541995436,
+      "families": 59,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 136.43529219552875,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 781.9649167358875,
+      "families": 52,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 282.66804199665785,
+      "families": 168,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1007.5248749926686,
+      "families": 151,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 876.9704578444362,
+      "families": 66,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 123.21195797994733,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 121.02845823392272,
+      "families": 7,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 219.30437488481402,
+      "families": 428,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 71.31800008937716,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 53.25224995613098,
+      "families": 37,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2301.075333263725,
+      "families": 148,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 732.8936252743006,
+      "families": 30,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 569.6597923524678,
+      "families": 34,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 77.19766674563289,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 164.32083398103714,
+      "families": 81,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 139.8920831270516,
+      "families": 22,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 744.7038749232888,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 117.91645875200629,
+      "families": 8,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 695.4577919095755,
+      "families": 104,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 306.32216623052955,
+      "families": 20,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1431.193333119154,
+      "families": 618,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 296.8797502107918,
+      "families": 33,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 622.3486671224236,
+      "families": 426,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 289.0240834094584,
+      "families": 134,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 139.41020797938108,
+      "families": 12,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 105.62841687351465,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 96.0646253079176,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 76.19749987497926,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1419.126084074378,
+      "families": 391,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1115.477459039539,
+      "families": 112,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 53.022250067442656,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 92.80562493950129,
+      "families": 2,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 389.91779182106256,
+      "families": 51,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 317.0749582350254,
+      "families": 6,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 42.52683278173208,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 41.91291658207774,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 634.7539159469306,
+      "families": 52,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 48.331249970942736,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 247.7732920087874,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 110.49454193562269,
+      "families": 49,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3100.757417269051,
+      "families": 645,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 57.54104070365429,
+      "families": 3,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 228.33737498149276,
+      "families": 29,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 38.59050013124943,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 514.4740422256291,
+      "families": 37,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 353.15524972975254,
+      "families": 64,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 63.311916310340166,
+      "families": 0,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 130.76570816338062,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1254.3913340196013,
+      "families": 39,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 41.89454158768058,
+      "families": 1,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 81.60150004550815,
+      "families": 5,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 306.18491722270846,
+      "families": 21,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 339.953999966383,
+      "families": 39,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 101.02812480181456,
+      "families": 9,
+      "iteration": 2,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 274.3131252937019,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1741.6043751873076,
+      "families": 3488,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 570.3227501362562,
+      "families": 197,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 142.12891599163413,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 169.73362490534782,
+      "families": 148,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 288.21441624313593,
+      "families": 18,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 131.35916693136096,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 284.02625024318695,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 376.81670766323805,
+      "families": 19,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 105.8038747869432,
+      "families": 41,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 56.41441699117422,
+      "families": 4,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 279.5834173448384,
+      "families": 11,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 106.5462501719594,
+      "families": 34,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 88.33158295601606,
+      "families": 10,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 61.883417423814535,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 630.8466247282922,
+      "families": 156,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 604.0702918544412,
+      "families": 115,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 404.43691704422235,
+      "families": 27,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 426.7932497896254,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 65.39799971506,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1060.0219168700278,
+      "families": 63,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1815.9947087988257,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 520.0772089883685,
+      "families": 32,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 155.92195792123675,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 57.0209170691669,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 816.8159169144928,
+      "families": 28,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 51.83858284726739,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 88.21104234084487,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 340.8600832335651,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 68.7502920627594,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 988.0354581400752,
+      "families": 111,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 143.65591714158654,
+      "families": 13,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 720.3428749926388,
+      "families": 245,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 240.89058302342892,
+      "families": 79,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2764.5240831188858,
+      "families": 1796,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1312.9342920146883,
+      "families": 515,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 74.89104196429253,
+      "families": 17,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 73.84887477383018,
+      "families": 16,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 635.5762500315905,
+      "families": 51,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 40.73908319696784,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 255.28695806860924,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 308.4701248444617,
+      "families": 84,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1225.497332867235,
+      "families": 267,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 106.14595795050263,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 570.5839172005653,
+      "families": 45,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 80.12312464416027,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 236.81137524545193,
+      "families": 64,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 838.9803329482675,
+      "families": 327,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 121.34416680783033,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 110.26695789769292,
+      "families": 62,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 70.83066599443555,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2132.494874764234,
+      "families": 1068,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 577.1151669323444,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 182.1511248126626,
+      "families": 31,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 65.29854191467166,
+      "families": 4,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 82.03062508255243,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 96.89841698855162,
+      "families": 113,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 77.6014169678092,
+      "families": 17,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 868.3159579522908,
+      "families": 15,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 892.9164581932127,
+      "families": 54,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 374.35116712003946,
+      "families": 102,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1197.4309999495745,
+      "families": 27,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2240.1350419968367,
+      "families": 879,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 424.5716668665409,
+      "families": 44,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 74.41304111853242,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1514.3781658262014,
+      "families": 59,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 130.30749978497624,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 857.4942499399185,
+      "families": 52,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 260.4649579152465,
+      "families": 168,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1090.810667257756,
+      "families": 151,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 848.3379171229899,
+      "families": 66,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 120.89591706171632,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 120.9367080591619,
+      "families": 7,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 215.4985419474542,
+      "families": 428,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 103.1313338316977,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 58.00245841965079,
+      "families": 37,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2150.6994999945164,
+      "families": 148,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 739.6383327431977,
+      "families": 30,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 484.2855832539499,
+      "families": 34,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 85.84545878693461,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 153.39887514710426,
+      "families": 81,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 176.12383281812072,
+      "families": 22,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 684.5019171014428,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 149.25029082223773,
+      "families": 8,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 660.2199580520391,
+      "families": 104,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 352.13870787993073,
+      "families": 20,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1397.6421672850847,
+      "families": 618,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 273.7380410544574,
+      "families": 33,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 651.2210420332849,
+      "families": 426,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 279.49145808815956,
+      "families": 134,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 133.6331251077354,
+      "families": 12,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 115.48304185271263,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 110.706124920398,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 79.18254099786282,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1425.2870827913284,
+      "families": 391,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1104.8681661486626,
+      "families": 112,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 53.13929216936231,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 97.71270817145705,
+      "families": 2,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 424.33141684159636,
+      "families": 51,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 265.36850025877357,
+      "families": 6,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 45.04337487742305,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 49.103999976068735,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 641.0419158637524,
+      "families": 52,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 51.222541369497776,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 266.1132086068392,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 106.77362512797117,
+      "families": 49,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3075.1699581742287,
+      "families": 645,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 66.90854206681252,
+      "families": 3,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 236.8998327292502,
+      "families": 29,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 36.75058297812939,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 483.690083026886,
+      "families": 37,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 399.0555419586599,
+      "families": 64,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 60.18775003030896,
+      "families": 0,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 118.82145795971155,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1208.0707498826087,
+      "families": 39,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 41.17312515154481,
+      "families": 1,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 77.98841595649719,
+      "families": 5,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 380.9790420345962,
+      "families": 21,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 304.18720794841647,
+      "families": 39,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 69.76700015366077,
+      "families": 9,
+      "iteration": 3,
+      "label": "baseline",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    },
+    {
+      "bytes": 30552,
+      "elapsed_ms": 271.4376673102379,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "alacritty",
+      "sha256": "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+    },
+    {
+      "bytes": 21155006,
+      "elapsed_ms": 1727.5403328239918,
+      "families": 3488,
+      "iteration": 3,
+      "label": "current",
+      "repo": "alamofire",
+      "sha256": "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+    },
+    {
+      "bytes": 279862,
+      "elapsed_ms": 530.8979167602956,
+      "families": 197,
+      "iteration": 3,
+      "label": "current",
+      "repo": "antlr4",
+      "sha256": "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+    },
+    {
+      "bytes": 27867,
+      "elapsed_ms": 154.95212515816092,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "arrow",
+      "sha256": "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+    },
+    {
+      "bytes": 234578,
+      "elapsed_ms": 162.24420769140124,
+      "families": 148,
+      "iteration": 3,
+      "label": "current",
+      "repo": "asciidoctor",
+      "sha256": "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+    },
+    {
+      "bytes": 44590,
+      "elapsed_ms": 304.8889171332121,
+      "families": 18,
+      "iteration": 3,
+      "label": "current",
+      "repo": "axios",
+      "sha256": "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+    },
+    {
+      "bytes": 32276,
+      "elapsed_ms": 99.35070807114244,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "badger",
+      "sha256": "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+    },
+    {
+      "bytes": 31779,
+      "elapsed_ms": 271.8831659294665,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "bat",
+      "sha256": "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+    },
+    {
+      "bytes": 57327,
+      "elapsed_ms": 421.11212480813265,
+      "families": 19,
+      "iteration": 3,
+      "label": "current",
+      "repo": "black",
+      "sha256": "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+    },
+    {
+      "bytes": 70069,
+      "elapsed_ms": 106.55225021764636,
+      "families": 41,
+      "iteration": 3,
+      "label": "current",
+      "repo": "boltons",
+      "sha256": "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+    },
+    {
+      "bytes": 29758,
+      "elapsed_ms": 49.85787533223629,
+      "families": 4,
+      "iteration": 3,
+      "label": "current",
+      "repo": "chi",
+      "sha256": "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+    },
+    {
+      "bytes": 42192,
+      "elapsed_ms": 217.73374965414405,
+      "families": 11,
+      "iteration": 3,
+      "label": "current",
+      "repo": "clap",
+      "sha256": "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+    },
+    {
+      "bytes": 60344,
+      "elapsed_ms": 93.32383284345269,
+      "families": 34,
+      "iteration": 3,
+      "label": "current",
+      "repo": "click",
+      "sha256": "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+    },
+    {
+      "bytes": 37347,
+      "elapsed_ms": 105.87204108014703,
+      "families": 10,
+      "iteration": 3,
+      "label": "current",
+      "repo": "cmark",
+      "sha256": "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+    },
+    {
+      "bytes": 32106,
+      "elapsed_ms": 59.966042172163725,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "cobra",
+      "sha256": "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+    },
+    {
+      "bytes": 255227,
+      "elapsed_ms": 548.9225001074374,
+      "families": 156,
+      "iteration": 3,
+      "label": "current",
+      "repo": "commons-lang",
+      "sha256": "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+    },
+    {
+      "bytes": 173509,
+      "elapsed_ms": 613.1016248837113,
+      "families": 115,
+      "iteration": 3,
+      "label": "current",
+      "repo": "curl",
+      "sha256": "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+    },
+    {
+      "bytes": 64050,
+      "elapsed_ms": 359.03583327308297,
+      "families": 27,
+      "iteration": 3,
+      "label": "current",
+      "repo": "date-fns",
+      "sha256": "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+    },
+    {
+      "bytes": 65064,
+      "elapsed_ms": 410.8833749778569,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "delve",
+      "sha256": "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+    },
+    {
+      "bytes": 31155,
+      "elapsed_ms": 72.20758311450481,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "devise",
+      "sha256": "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+    },
+    {
+      "bytes": 116840,
+      "elapsed_ms": 1012.9175838083029,
+      "families": 63,
+      "iteration": 3,
+      "label": "current",
+      "repo": "drizzle-orm",
+      "sha256": "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+    },
+    {
+      "bytes": 54599,
+      "elapsed_ms": 1837.0385407470167,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "esbuild",
+      "sha256": "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+    },
+    {
+      "bytes": 63385,
+      "elapsed_ms": 501.3028336688876,
+      "families": 32,
+      "iteration": 3,
+      "label": "current",
+      "repo": "etcd",
+      "sha256": "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+    },
+    {
+      "bytes": 33322,
+      "elapsed_ms": 154.78866593912244,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "execa",
+      "sha256": "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 56.621167343109846,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "faraday",
+      "sha256": "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+    },
+    {
+      "bytes": 71641,
+      "elapsed_ms": 814.8212912492454,
+      "families": 28,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fastlane",
+      "sha256": "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+    },
+    {
+      "bytes": 25951,
+      "elapsed_ms": 52.948625292629,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fd",
+      "sha256": "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+    },
+    {
+      "bytes": 48054,
+      "elapsed_ms": 75.85416687652469,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "flask",
+      "sha256": "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+    },
+    {
+      "bytes": 30077,
+      "elapsed_ms": 335.62695793807507,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "fzf",
+      "sha256": "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+    },
+    {
+      "bytes": 28981,
+      "elapsed_ms": 97.07229072228074,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gin",
+      "sha256": "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+    },
+    {
+      "bytes": 147615,
+      "elapsed_ms": 986.0233748331666,
+      "families": 111,
+      "iteration": 3,
+      "label": "current",
+      "repo": "git",
+      "sha256": "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+    },
+    {
+      "bytes": 36406,
+      "elapsed_ms": 123.71183373034,
+      "families": 13,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gorm",
+      "sha256": "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+    },
+    {
+      "bytes": 307191,
+      "elapsed_ms": 735.5033750645816,
+      "families": 245,
+      "iteration": 3,
+      "label": "current",
+      "repo": "graphhopper",
+      "sha256": "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+    },
+    {
+      "bytes": 115379,
+      "elapsed_ms": 212.38799998536706,
+      "families": 79,
+      "iteration": 3,
+      "label": "current",
+      "repo": "gson",
+      "sha256": "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+    },
+    {
+      "bytes": 2574446,
+      "elapsed_ms": 2864.3864998593926,
+      "families": 1796,
+      "iteration": 3,
+      "label": "current",
+      "repo": "guava",
+      "sha256": "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+    },
+    {
+      "bytes": 650060,
+      "elapsed_ms": 1295.6682918593287,
+      "families": 515,
+      "iteration": 3,
+      "label": "current",
+      "repo": "h2database",
+      "sha256": "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+    },
+    {
+      "bytes": 42215,
+      "elapsed_ms": 79.39124992117286,
+      "families": 17,
+      "iteration": 3,
+      "label": "current",
+      "repo": "httpie",
+      "sha256": "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+    },
+    {
+      "bytes": 41185,
+      "elapsed_ms": 80.87283279746771,
+      "families": 16,
+      "iteration": 3,
+      "label": "current",
+      "repo": "httpx",
+      "sha256": "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+    },
+    {
+      "bytes": 220447,
+      "elapsed_ms": 686.677458230406,
+      "families": 51,
+      "iteration": 3,
+      "label": "current",
+      "repo": "hugo",
+      "sha256": "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 34.51995924115181,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "hyperfine",
+      "sha256": "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+    },
+    {
+      "bytes": 33344,
+      "elapsed_ms": 252.88520799949765,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "image",
+      "sha256": "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+    },
+    {
+      "bytes": 136865,
+      "elapsed_ms": 307.4466250836849,
+      "families": 84,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jackson-core",
+      "sha256": "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+    },
+    {
+      "bytes": 329711,
+      "elapsed_ms": 1246.110583189875,
+      "families": 267,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jedis",
+      "sha256": "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+    },
+    {
+      "bytes": 35027,
+      "elapsed_ms": 101.67141584679484,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jekyll",
+      "sha256": "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+    },
+    {
+      "bytes": 74900,
+      "elapsed_ms": 519.4817502051592,
+      "families": 45,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jest",
+      "sha256": "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+    },
+    {
+      "bytes": 26681,
+      "elapsed_ms": 93.58908282592893,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jq",
+      "sha256": "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+    },
+    {
+      "bytes": 113185,
+      "elapsed_ms": 225.91650020331144,
+      "families": 64,
+      "iteration": 3,
+      "label": "current",
+      "repo": "jsoup",
+      "sha256": "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+    },
+    {
+      "bytes": 514636,
+      "elapsed_ms": 887.2179999016225,
+      "families": 327,
+      "iteration": 3,
+      "label": "current",
+      "repo": "junit5",
+      "sha256": "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+    },
+    {
+      "bytes": 31195,
+      "elapsed_ms": 112.39099968224764,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "kingfisher",
+      "sha256": "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+    },
+    {
+      "bytes": 114711,
+      "elapsed_ms": 118.5321668162942,
+      "families": 62,
+      "iteration": 3,
+      "label": "current",
+      "repo": "kramdown",
+      "sha256": "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+    },
+    {
+      "bytes": 27472,
+      "elapsed_ms": 74.69941582530737,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "ky",
+      "sha256": "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+    },
+    {
+      "bytes": 2126164,
+      "elapsed_ms": 2033.422291278839,
+      "families": 1068,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libgdx",
+      "sha256": "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+    },
+    {
+      "bytes": 52625,
+      "elapsed_ms": 542.578459251672,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libsodium",
+      "sha256": "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+    },
+    {
+      "bytes": 55324,
+      "elapsed_ms": 168.70299959555268,
+      "families": 31,
+      "iteration": 3,
+      "label": "current",
+      "repo": "libuv",
+      "sha256": "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+    },
+    {
+      "bytes": 29342,
+      "elapsed_ms": 64.40741615369916,
+      "families": 4,
+      "iteration": 3,
+      "label": "current",
+      "repo": "liquid",
+      "sha256": "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+    },
+    {
+      "bytes": 27093,
+      "elapsed_ms": 117.61491699144244,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "lua",
+      "sha256": "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+    },
+    {
+      "bytes": 192560,
+      "elapsed_ms": 71.83337491005659,
+      "families": 113,
+      "iteration": 3,
+      "label": "current",
+      "repo": "marked",
+      "sha256": "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+    },
+    {
+      "bytes": 44437,
+      "elapsed_ms": 77.73900032043457,
+      "families": 17,
+      "iteration": 3,
+      "label": "current",
+      "repo": "marshmallow",
+      "sha256": "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+    },
+    {
+      "bytes": 52737,
+      "elapsed_ms": 859.5580421388149,
+      "families": 15,
+      "iteration": 3,
+      "label": "current",
+      "repo": "meilisearch",
+      "sha256": "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+    },
+    {
+      "bytes": 84761,
+      "elapsed_ms": 916.9398751109838,
+      "families": 54,
+      "iteration": 3,
+      "label": "current",
+      "repo": "minio",
+      "sha256": "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+    },
+    {
+      "bytes": 148904,
+      "elapsed_ms": 368.40016720816493,
+      "families": 102,
+      "iteration": 3,
+      "label": "current",
+      "repo": "mockito",
+      "sha256": "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+    },
+    {
+      "bytes": 64019,
+      "elapsed_ms": 1289.5432910881937,
+      "families": 27,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nats-server",
+      "sha256": "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+    },
+    {
+      "bytes": 1321539,
+      "elapsed_ms": 2210.818958003074,
+      "families": 879,
+      "iteration": 3,
+      "label": "current",
+      "repo": "netty",
+      "sha256": "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+    },
+    {
+      "bytes": 65918,
+      "elapsed_ms": 455.2865829318762,
+      "families": 44,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nginx",
+      "sha256": "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+    },
+    {
+      "bytes": 28485,
+      "elapsed_ms": 78.26525019481778,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nimble",
+      "sha256": "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+    },
+    {
+      "bytes": 116070,
+      "elapsed_ms": 1461.064666043967,
+      "families": 59,
+      "iteration": 3,
+      "label": "current",
+      "repo": "nushell",
+      "sha256": "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+    },
+    {
+      "bytes": 51585,
+      "elapsed_ms": 128.87550005689263,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "packaging",
+      "sha256": "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+    },
+    {
+      "bytes": 83612,
+      "elapsed_ms": 815.8275838941336,
+      "families": 52,
+      "iteration": 3,
+      "label": "current",
+      "repo": "pixijs",
+      "sha256": "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+    },
+    {
+      "bytes": 198324,
+      "elapsed_ms": 281.5518327988684,
+      "families": 168,
+      "iteration": 3,
+      "label": "current",
+      "repo": "poetry",
+      "sha256": "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+    },
+    {
+      "bytes": 241230,
+      "elapsed_ms": 1048.5149999149144,
+      "families": 151,
+      "iteration": 3,
+      "label": "current",
+      "repo": "prettier",
+      "sha256": "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+    },
+    {
+      "bytes": 148141,
+      "elapsed_ms": 836.3070422783494,
+      "families": 66,
+      "iteration": 3,
+      "label": "current",
+      "repo": "prometheus",
+      "sha256": "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+    },
+    {
+      "bytes": 31685,
+      "elapsed_ms": 129.43966640159488,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "pry",
+      "sha256": "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+    },
+    {
+      "bytes": 34593,
+      "elapsed_ms": 115.99945835769176,
+      "families": 7,
+      "iteration": 3,
+      "label": "current",
+      "repo": "puma",
+      "sha256": "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+    },
+    {
+      "bytes": 1355479,
+      "elapsed_ms": 218.3957090601325,
+      "families": 428,
+      "iteration": 3,
+      "label": "current",
+      "repo": "quick",
+      "sha256": "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+    },
+    {
+      "bytes": 28232,
+      "elapsed_ms": 89.09899974241853,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rack",
+      "sha256": "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+    },
+    {
+      "bytes": 60570,
+      "elapsed_ms": 70.6205409951508,
+      "families": 37,
+      "iteration": 3,
+      "label": "current",
+      "repo": "radash",
+      "sha256": "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+    },
+    {
+      "bytes": 244815,
+      "elapsed_ms": 2143.559250049293,
+      "families": 148,
+      "iteration": 3,
+      "label": "current",
+      "repo": "raylib",
+      "sha256": "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+    },
+    {
+      "bytes": 59103,
+      "elapsed_ms": 775.7147080264986,
+      "families": 30,
+      "iteration": 3,
+      "label": "current",
+      "repo": "redis",
+      "sha256": "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+    },
+    {
+      "bytes": 70161,
+      "elapsed_ms": 474.7288338840008,
+      "families": 34,
+      "iteration": 3,
+      "label": "current",
+      "repo": "regex",
+      "sha256": "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+    },
+    {
+      "bytes": 34891,
+      "elapsed_ms": 71.74879172816873,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "requests",
+      "sha256": "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+    },
+    {
+      "bytes": 124169,
+      "elapsed_ms": 154.5959166251123,
+      "families": 81,
+      "iteration": 3,
+      "label": "current",
+      "repo": "retrofit",
+      "sha256": "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+    },
+    {
+      "bytes": 50546,
+      "elapsed_ms": 165.33095808699727,
+      "families": 22,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rich",
+      "sha256": "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+    },
+    {
+      "bytes": 33574,
+      "elapsed_ms": 672.3632076755166,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "ripgrep",
+      "sha256": "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+    },
+    {
+      "bytes": 35566,
+      "elapsed_ms": 145.17620764672756,
+      "families": 8,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rspec-core",
+      "sha256": "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+    },
+    {
+      "bytes": 138988,
+      "elapsed_ms": 661.5623747929931,
+      "families": 104,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rubocop",
+      "sha256": "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+    },
+    {
+      "bytes": 51848,
+      "elapsed_ms": 356.5097921527922,
+      "families": 20,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rustls",
+      "sha256": "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+    },
+    {
+      "bytes": 1169728,
+      "elapsed_ms": 1440.5007502064109,
+      "families": 618,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxjava",
+      "sha256": "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+    },
+    {
+      "bytes": 71630,
+      "elapsed_ms": 254.4760829769075,
+      "families": 33,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxjs",
+      "sha256": "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+    },
+    {
+      "bytes": 1588850,
+      "elapsed_ms": 604.3542502447963,
+      "families": 426,
+      "iteration": 3,
+      "label": "current",
+      "repo": "rxswift",
+      "sha256": "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+    },
+    {
+      "bytes": 169140,
+      "elapsed_ms": 284.0998340398073,
+      "families": 134,
+      "iteration": 3,
+      "label": "current",
+      "repo": "scrapy",
+      "sha256": "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+    },
+    {
+      "bytes": 39884,
+      "elapsed_ms": 153.8809579797089,
+      "families": 12,
+      "iteration": 3,
+      "label": "current",
+      "repo": "serde_json",
+      "sha256": "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+    },
+    {
+      "bytes": 32237,
+      "elapsed_ms": 94.58199981600046,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sidekiq",
+      "sha256": "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+    },
+    {
+      "bytes": 27177,
+      "elapsed_ms": 102.70849987864494,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sinatra",
+      "sha256": "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+    },
+    {
+      "bytes": 26733,
+      "elapsed_ms": 86.53637487441301,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sled",
+      "sha256": "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+    },
+    {
+      "bytes": 517222,
+      "elapsed_ms": 1630.1334584131837,
+      "families": 391,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sqlalchemy",
+      "sha256": "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+    },
+    {
+      "bytes": 159393,
+      "elapsed_ms": 1192.9667498916388,
+      "families": 112,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sqlite",
+      "sha256": "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+    },
+    {
+      "bytes": 37862,
+      "elapsed_ms": 53.29049983993173,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-algorithms",
+      "sha256": "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+    },
+    {
+      "bytes": 28093,
+      "elapsed_ms": 94.78179179131985,
+      "families": 2,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-argument-parser",
+      "sha256": "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+    },
+    {
+      "bytes": 105222,
+      "elapsed_ms": 391.96095801889896,
+      "families": 51,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-collections",
+      "sha256": "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+    },
+    {
+      "bytes": 32913,
+      "elapsed_ms": 317.2169579192996,
+      "families": 6,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-composable-architecture",
+      "sha256": "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+    },
+    {
+      "bytes": 25972,
+      "elapsed_ms": 43.49787486717105,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-log",
+      "sha256": "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+    },
+    {
+      "bytes": 32765,
+      "elapsed_ms": 42.15937480330467,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-metrics",
+      "sha256": "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+    },
+    {
+      "bytes": 111694,
+      "elapsed_ms": 591.341083869338,
+      "families": 52,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-nio",
+      "sha256": "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+    },
+    {
+      "bytes": 27152,
+      "elapsed_ms": 44.16608391329646,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swift-service-lifecycle",
+      "sha256": "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+    },
+    {
+      "bytes": 34954,
+      "elapsed_ms": 295.79708399251103,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swiftlint",
+      "sha256": "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+    },
+    {
+      "bytes": 119283,
+      "elapsed_ms": 119.71979169175029,
+      "families": 49,
+      "iteration": 3,
+      "label": "current",
+      "repo": "swr",
+      "sha256": "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+    },
+    {
+      "bytes": 853198,
+      "elapsed_ms": 3095.797165762633,
+      "families": 645,
+      "iteration": 3,
+      "label": "current",
+      "repo": "sympy",
+      "sha256": "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+    },
+    {
+      "bytes": 28324,
+      "elapsed_ms": 69.88045759499073,
+      "families": 3,
+      "iteration": 3,
+      "label": "current",
+      "repo": "thor",
+      "sha256": "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+    },
+    {
+      "bytes": 51015,
+      "elapsed_ms": 220.29629116877913,
+      "families": 29,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tmux",
+      "sha256": "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+    },
+    {
+      "bytes": 25960,
+      "elapsed_ms": 36.317791789770126,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tokei",
+      "sha256": "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+    },
+    {
+      "bytes": 75904,
+      "elapsed_ms": 557.8967500478029,
+      "families": 37,
+      "iteration": 3,
+      "label": "current",
+      "repo": "tokio",
+      "sha256": "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+    },
+    {
+      "bytes": 128760,
+      "elapsed_ms": 343.450749758631,
+      "families": 64,
+      "iteration": 3,
+      "label": "current",
+      "repo": "trpc",
+      "sha256": "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+    },
+    {
+      "bytes": 25975,
+      "elapsed_ms": 58.35149995982647,
+      "families": 0,
+      "iteration": 3,
+      "label": "current",
+      "repo": "urfave-cli",
+      "sha256": "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+    },
+    {
+      "bytes": 27156,
+      "elapsed_ms": 116.46537482738495,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "vapor",
+      "sha256": "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+    },
+    {
+      "bytes": 72267,
+      "elapsed_ms": 1192.4062077887356,
+      "families": 39,
+      "iteration": 3,
+      "label": "current",
+      "repo": "vim",
+      "sha256": "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+    },
+    {
+      "bytes": 26686,
+      "elapsed_ms": 37.54229098558426,
+      "families": 1,
+      "iteration": 3,
+      "label": "current",
+      "repo": "wrk",
+      "sha256": "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+    },
+    {
+      "bytes": 32782,
+      "elapsed_ms": 83.0858750268817,
+      "families": 5,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zap",
+      "sha256": "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+    },
+    {
+      "bytes": 49195,
+      "elapsed_ms": 373.3312920667231,
+      "families": 21,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zod",
+      "sha256": "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+    },
+    {
+      "bytes": 76464,
+      "elapsed_ms": 299.75808318704367,
+      "families": 39,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zstd",
+      "sha256": "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+    },
+    {
+      "bytes": 41646,
+      "elapsed_ms": 72.06529192626476,
+      "families": 9,
+      "iteration": 3,
+      "label": "current",
+      "repo": "zustand",
+      "sha256": "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+    }
+  ],
+  "summary": {
+    "aggregate_baseline_median_ms": 58206.39175269753,
+    "aggregate_current_median_ms": 57973.761706613004,
+    "aggregate_delta_pct": -0.3996640902822191,
+    "by_repo": {
+      "alacritty": {
+        "baseline": {
+          "bytes": [
+            30552
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+          ],
+          "median_ms": 268.2347916997969
+        },
+        "current": {
+          "bytes": [
+            30552
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "c03b225ff28958338545ef064336202a9ee4998214b65060ac8aa71108ecc5de"
+          ],
+          "median_ms": 307.2988330386579
+        }
+      },
+      "alamofire": {
+        "baseline": {
+          "bytes": [
+            21155006
+          ],
+          "families": [
+            3488
+          ],
+          "hashes": [
+            "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+          ],
+          "median_ms": 1773.3995411545038
+        },
+        "current": {
+          "bytes": [
+            21155006
+          ],
+          "families": [
+            3488
+          ],
+          "hashes": [
+            "4a856bb83a880777d10aeebebbbcec5b51875febeddc3870cdf125d18350e79a"
+          ],
+          "median_ms": 1761.8860830552876
+        }
+      },
+      "antlr4": {
+        "baseline": {
+          "bytes": [
+            279862
+          ],
+          "families": [
+            197
+          ],
+          "hashes": [
+            "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+          ],
+          "median_ms": 551.7685827799141
+        },
+        "current": {
+          "bytes": [
+            279862
+          ],
+          "families": [
+            197
+          ],
+          "hashes": [
+            "87295ea4a74c1ec18c318bde1be454bf954bd50af147384f70573c9ae5d57eda"
+          ],
+          "median_ms": 579.0965422056615
+        }
+      },
+      "arrow": {
+        "baseline": {
+          "bytes": [
+            27867
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+          ],
+          "median_ms": 162.79824962839484
+        },
+        "current": {
+          "bytes": [
+            27867
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "18bb193ad6adf43102adcc51824ebf9f3cf6c2a4da3a8462695a5f55091f4f2e"
+          ],
+          "median_ms": 168.44829125329852
+        }
+      },
+      "asciidoctor": {
+        "baseline": {
+          "bytes": [
+            234578
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+          ],
+          "median_ms": 170.4774578101933
+        },
+        "current": {
+          "bytes": [
+            234578
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "fa09e4303d24bea6a882b25ee9cef5355990223a0373ca7aab35cebfc6e0845c"
+          ],
+          "median_ms": 172.68949979916215
+        }
+      },
+      "axios": {
+        "baseline": {
+          "bytes": [
+            44590
+          ],
+          "families": [
+            18
+          ],
+          "hashes": [
+            "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+          ],
+          "median_ms": 288.21441624313593
+        },
+        "current": {
+          "bytes": [
+            44590
+          ],
+          "families": [
+            18
+          ],
+          "hashes": [
+            "556e53535236005f3e452aaf5ae3bf9545bc1451d8a53d10109f5e2539a06e1b"
+          ],
+          "median_ms": 304.8889171332121
+        }
+      },
+      "badger": {
+        "baseline": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+          ],
+          "median_ms": 99.45808304473758
+        },
+        "current": {
+          "bytes": [
+            32276
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0d8c7144c3525ecdafefbea59b94aef9d3ac7987028305ae30f2e0803f428a9b"
+          ],
+          "median_ms": 113.17491624504328
+        }
+      },
+      "bat": {
+        "baseline": {
+          "bytes": [
+            31779
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+          ],
+          "median_ms": 313.165542203933
+        },
+        "current": {
+          "bytes": [
+            31779
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "58d07d2bc38023909236a3aa0544b87815cf977b5b10056bb5120d906ccda295"
+          ],
+          "median_ms": 302.6877921074629
+        }
+      },
+      "black": {
+        "baseline": {
+          "bytes": [
+            57327
+          ],
+          "families": [
+            19
+          ],
+          "hashes": [
+            "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+          ],
+          "median_ms": 410.6438751332462
+        },
+        "current": {
+          "bytes": [
+            57327
+          ],
+          "families": [
+            19
+          ],
+          "hashes": [
+            "f56f7a68b0fea7f69b8aa1aa9bae41dc9134298cba88ae3c54dba5b5936ac027"
+          ],
+          "median_ms": 421.11212480813265
+        }
+      },
+      "boltons": {
+        "baseline": {
+          "bytes": [
+            70069
+          ],
+          "families": [
+            41
+          ],
+          "hashes": [
+            "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+          ],
+          "median_ms": 89.28554179146886
+        },
+        "current": {
+          "bytes": [
+            70069
+          ],
+          "families": [
+            41
+          ],
+          "hashes": [
+            "cc43218a248301de8c637e8e875e1359e6d2537ca54b8b4f13a460d53c20be4e"
+          ],
+          "median_ms": 117.1080837957561
+        }
+      },
+      "chi": {
+        "baseline": {
+          "bytes": [
+            29758
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+          ],
+          "median_ms": 46.72937514260411
+        },
+        "current": {
+          "bytes": [
+            29758
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "cbe556b84bb485f59a44d0b7b89cb8b08b02c35ac15ab4330279784c5cb50360"
+          ],
+          "median_ms": 52.2815827280283
+        }
+      },
+      "clap": {
+        "baseline": {
+          "bytes": [
+            42192
+          ],
+          "families": [
+            11
+          ],
+          "hashes": [
+            "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+          ],
+          "median_ms": 281.1939581297338
+        },
+        "current": {
+          "bytes": [
+            42192
+          ],
+          "families": [
+            11
+          ],
+          "hashes": [
+            "75339f5eb197adaa14425869f1ff35e474e98ecb5106c5db79707c8e42d3dcb2"
+          ],
+          "median_ms": 280.9852911159396
+        }
+      },
+      "click": {
+        "baseline": {
+          "bytes": [
+            60344
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+          ],
+          "median_ms": 107.90687520056963
+        },
+        "current": {
+          "bytes": [
+            60344
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "9c54adaf70c586fd66fed31aa0d19b1a7ea1172d86fc6e3571f336c364050ac7"
+          ],
+          "median_ms": 118.57704212889075
+        }
+      },
+      "cmark": {
+        "baseline": {
+          "bytes": [
+            37347
+          ],
+          "families": [
+            10
+          ],
+          "hashes": [
+            "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+          ],
+          "median_ms": 88.33158295601606
+        },
+        "current": {
+          "bytes": [
+            37347
+          ],
+          "families": [
+            10
+          ],
+          "hashes": [
+            "2dc0a45e5ab08898551f7d638ca4b28e3a14d68080e370838ce2883e30e5e6ca"
+          ],
+          "median_ms": 100.79170856624842
+        }
+      },
+      "cobra": {
+        "baseline": {
+          "bytes": [
+            32106
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+          ],
+          "median_ms": 70.65937481820583
+        },
+        "current": {
+          "bytes": [
+            32106
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "45172053705c691a52c4a823cdb3f4590ed6d99d84ba7b5c4e1c7674eb3b0c10"
+          ],
+          "median_ms": 68.4937504120171
+        }
+      },
+      "commons-lang": {
+        "baseline": {
+          "bytes": [
+            255227
+          ],
+          "families": [
+            156
+          ],
+          "hashes": [
+            "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+          ],
+          "median_ms": 607.2515416890383
+        },
+        "current": {
+          "bytes": [
+            255227
+          ],
+          "families": [
+            156
+          ],
+          "hashes": [
+            "8ced935f794798fa52a8c9105019b8e1846cdef4c90ea440a61fe32a99e16901"
+          ],
+          "median_ms": 562.5402498990297
+        }
+      },
+      "curl": {
+        "baseline": {
+          "bytes": [
+            173509
+          ],
+          "families": [
+            115
+          ],
+          "hashes": [
+            "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+          ],
+          "median_ms": 604.0702918544412
+        },
+        "current": {
+          "bytes": [
+            173509
+          ],
+          "families": [
+            115
+          ],
+          "hashes": [
+            "d307f6189dc1773c97208fd7ec4cb8391a1824c683df3c61fde45d136a473c06"
+          ],
+          "median_ms": 632.5325001962483
+        }
+      },
+      "date-fns": {
+        "baseline": {
+          "bytes": [
+            64050
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+          ],
+          "median_ms": 369.4931250065565
+        },
+        "current": {
+          "bytes": [
+            64050
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "45bc667de7be6a197279e4c9158fbc294d25af50d085a3fed4c25a033954de90"
+          ],
+          "median_ms": 393.9592079259455
+        }
+      },
+      "delve": {
+        "baseline": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+          ],
+          "median_ms": 434.1044998727739
+        },
+        "current": {
+          "bytes": [
+            65064
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "9a85f816dad92cee240afd8cc2229f73a8286ee594e614d0755dc5921753a027"
+          ],
+          "median_ms": 437.5551249831915
+        }
+      },
+      "devise": {
+        "baseline": {
+          "bytes": [
+            31155
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+          ],
+          "median_ms": 75.75941737741232
+        },
+        "current": {
+          "bytes": [
+            31155
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "1a6f734027a7c1084e5df0d51b07f22f23c29e0b0bea22030df4ac4987730e31"
+          ],
+          "median_ms": 74.39545821398497
+        }
+      },
+      "drizzle-orm": {
+        "baseline": {
+          "bytes": [
+            116840
+          ],
+          "families": [
+            63
+          ],
+          "hashes": [
+            "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+          ],
+          "median_ms": 1060.0219168700278
+        },
+        "current": {
+          "bytes": [
+            116840
+          ],
+          "families": [
+            63
+          ],
+          "hashes": [
+            "0a4db053785146b849a3d2fcaf19254f3e5252c004ff34c0767926e7eaccec2c"
+          ],
+          "median_ms": 1029.8527907580137
+        }
+      },
+      "esbuild": {
+        "baseline": {
+          "bytes": [
+            54599
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+          ],
+          "median_ms": 1844.0922913141549
+        },
+        "current": {
+          "bytes": [
+            54599
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "8393f5df9120d9d9216187adccc1121c54e76f73c0daa3332a095b943c443812"
+          ],
+          "median_ms": 1837.0385407470167
+        }
+      },
+      "etcd": {
+        "baseline": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+          ],
+          "median_ms": 512.3586249537766
+        },
+        "current": {
+          "bytes": [
+            63385
+          ],
+          "families": [
+            32
+          ],
+          "hashes": [
+            "37d12fcecd5157394826496ebddae3e53ce9a7b2f1633a91a94c4ab44d5785cb"
+          ],
+          "median_ms": 502.45074974372983
+        }
+      },
+      "execa": {
+        "baseline": {
+          "bytes": [
+            33322
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+          ],
+          "median_ms": 155.92195792123675
+        },
+        "current": {
+          "bytes": [
+            33322
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "7c99a11f89a77a4772b9874a5a30f03b30cbb0a2d7cfce18ccc32bd34e905796"
+          ],
+          "median_ms": 164.42920826375484
+        }
+      },
+      "faraday": {
+        "baseline": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+          ],
+          "median_ms": 61.703292187303305
+        },
+        "current": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "a260077c5355031006a6874318d962b32c1b9309687391d37131cc697eda26fe"
+          ],
+          "median_ms": 53.0500840395689
+        }
+      },
+      "fastlane": {
+        "baseline": {
+          "bytes": [
+            71641
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+          ],
+          "median_ms": 816.8159169144928
+        },
+        "current": {
+          "bytes": [
+            71641
+          ],
+          "families": [
+            28
+          ],
+          "hashes": [
+            "b687561fba80922749137e44cd5c305ec883f200d30e64edf58cfb4a7312cb80"
+          ],
+          "median_ms": 814.8212912492454
+        }
+      },
+      "fd": {
+        "baseline": {
+          "bytes": [
+            25951
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+          ],
+          "median_ms": 51.83858284726739
+        },
+        "current": {
+          "bytes": [
+            25951
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "495c2ef532951b8ba5957d04c93657f432b8565c7ed152637fac194be81749a5"
+          ],
+          "median_ms": 50.54266704246402
+        }
+      },
+      "flask": {
+        "baseline": {
+          "bytes": [
+            48054
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+          ],
+          "median_ms": 98.71016582474113
+        },
+        "current": {
+          "bytes": [
+            48054
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c46b9b3b5f393d61b23077a267d958a649445e4843279a50c88fdb373421187e"
+          ],
+          "median_ms": 82.22000021487474
+        }
+      },
+      "fzf": {
+        "baseline": {
+          "bytes": [
+            30077
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+          ],
+          "median_ms": 366.3023333065212
+        },
+        "current": {
+          "bytes": [
+            30077
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "763d7c648e69b2b08a378aac6f12e36a2d781a266b925b7e8e055ef7e678687e"
+          ],
+          "median_ms": 407.5718750245869
+        }
+      },
+      "gin": {
+        "baseline": {
+          "bytes": [
+            28981
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+          ],
+          "median_ms": 90.1821251027286
+        },
+        "current": {
+          "bytes": [
+            28981
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "544d965bb3ef986a6d60d1fab95dadfff4d4967d6cc50fcb0f9c34b9385070c4"
+          ],
+          "median_ms": 90.61979176476598
+        }
+      },
+      "git": {
+        "baseline": {
+          "bytes": [
+            147615
+          ],
+          "families": [
+            111
+          ],
+          "hashes": [
+            "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+          ],
+          "median_ms": 988.0354581400752
+        },
+        "current": {
+          "bytes": [
+            147615
+          ],
+          "families": [
+            111
+          ],
+          "hashes": [
+            "6523e2d57bd8e5fcf036cf2552bdf95626ae73ceb3df8b130ad29ebcb789258f"
+          ],
+          "median_ms": 986.0233748331666
+        }
+      },
+      "gorm": {
+        "baseline": {
+          "bytes": [
+            36406
+          ],
+          "families": [
+            13
+          ],
+          "hashes": [
+            "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+          ],
+          "median_ms": 143.65591714158654
+        },
+        "current": {
+          "bytes": [
+            36406
+          ],
+          "families": [
+            13
+          ],
+          "hashes": [
+            "1bbbbf19af555b79c2b6c6e87f9dadaeadb71a321ceda4ad44362d101793ef2f"
+          ],
+          "median_ms": 142.9030830040574
+        }
+      },
+      "graphhopper": {
+        "baseline": {
+          "bytes": [
+            307191
+          ],
+          "families": [
+            245
+          ],
+          "hashes": [
+            "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+          ],
+          "median_ms": 722.5064588710666
+        },
+        "current": {
+          "bytes": [
+            307191
+          ],
+          "families": [
+            245
+          ],
+          "hashes": [
+            "9b42be73ee350d648f015e937fb37efe8ccb546cacde36e77cf7a8aaa0e0b253"
+          ],
+          "median_ms": 767.6433748565614
+        }
+      },
+      "gson": {
+        "baseline": {
+          "bytes": [
+            115379
+          ],
+          "families": [
+            79
+          ],
+          "hashes": [
+            "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+          ],
+          "median_ms": 242.78720933943987
+        },
+        "current": {
+          "bytes": [
+            115379
+          ],
+          "families": [
+            79
+          ],
+          "hashes": [
+            "4df0054091e04723486f2cd9d52e57216dc80a6559a25a34a20dc372b0ae3920"
+          ],
+          "median_ms": 220.85699997842312
+        }
+      },
+      "guava": {
+        "baseline": {
+          "bytes": [
+            2574446
+          ],
+          "families": [
+            1796
+          ],
+          "hashes": [
+            "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+          ],
+          "median_ms": 2770.1246249489486
+        },
+        "current": {
+          "bytes": [
+            2574446
+          ],
+          "families": [
+            1796
+          ],
+          "hashes": [
+            "b61e976f8d3d019a977ed89c2df620771aabe2711e3d25a98639630e00c6e59a"
+          ],
+          "median_ms": 2864.3864998593926
+        }
+      },
+      "h2database": {
+        "baseline": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+          ],
+          "median_ms": 1312.9342920146883
+        },
+        "current": {
+          "bytes": [
+            650060
+          ],
+          "families": [
+            515
+          ],
+          "hashes": [
+            "942fa92402a7c5bb0161d52097d51fb0fe72fa7bc9c017a6eda9e9e7af40c494"
+          ],
+          "median_ms": 1334.637583233416
+        }
+      },
+      "httpie": {
+        "baseline": {
+          "bytes": [
+            42215
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+          ],
+          "median_ms": 83.14133295789361
+        },
+        "current": {
+          "bytes": [
+            42215
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "0fcce361cfac807470a848538e9322df1b5d5b13c4e6f2b3ab66f5b42d594986"
+          ],
+          "median_ms": 79.39124992117286
+        }
+      },
+      "httpx": {
+        "baseline": {
+          "bytes": [
+            41185
+          ],
+          "families": [
+            16
+          ],
+          "hashes": [
+            "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+          ],
+          "median_ms": 73.84887477383018
+        },
+        "current": {
+          "bytes": [
+            41185
+          ],
+          "families": [
+            16
+          ],
+          "hashes": [
+            "7cb49d647ccecb957ed1f1b3d4dabcba8edd315a6442e5671f177835b615660c"
+          ],
+          "median_ms": 76.49370795115829
+        }
+      },
+      "hugo": {
+        "baseline": {
+          "bytes": [
+            220447
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+          ],
+          "median_ms": 679.629834368825
+        },
+        "current": {
+          "bytes": [
+            220447
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "aa371e43fdb86210eef897a288261150ffc14aa304d96dd12c179e8c1494858e"
+          ],
+          "median_ms": 681.1806252226233
+        }
+      },
+      "hyperfine": {
+        "baseline": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+          ],
+          "median_ms": 41.64666682481766
+        },
+        "current": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "be754cccc0f51a48abff190744366d704a6ff1c56df1f697b9f46f3276bd9185"
+          ],
+          "median_ms": 40.02691712230444
+        }
+      },
+      "image": {
+        "baseline": {
+          "bytes": [
+            33344
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+          ],
+          "median_ms": 255.28695806860924
+        },
+        "current": {
+          "bytes": [
+            33344
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "a5e8a656049fe453d86c68d7ee491f1b90440da4d222af8d6f8c0bd1d06d4455"
+          ],
+          "median_ms": 242.55408300086856
+        }
+      },
+      "jackson-core": {
+        "baseline": {
+          "bytes": [
+            136865
+          ],
+          "families": [
+            84
+          ],
+          "hashes": [
+            "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+          ],
+          "median_ms": 322.8679997846484
+        },
+        "current": {
+          "bytes": [
+            136865
+          ],
+          "families": [
+            84
+          ],
+          "hashes": [
+            "24079bd1487945b078ef0c8480f4632ba2887e69050511ce935af3b9b012b000"
+          ],
+          "median_ms": 309.30725019425154
+        }
+      },
+      "jedis": {
+        "baseline": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+          ],
+          "median_ms": 1243.267874699086
+        },
+        "current": {
+          "bytes": [
+            329711
+          ],
+          "families": [
+            267
+          ],
+          "hashes": [
+            "c4c5b898988e5dbaa7c1f9f3c5bfc15eb32e514bc200d026821880608a7b28a8"
+          ],
+          "median_ms": 1246.110583189875
+        }
+      },
+      "jekyll": {
+        "baseline": {
+          "bytes": [
+            35027
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+          ],
+          "median_ms": 107.62662487104535
+        },
+        "current": {
+          "bytes": [
+            35027
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "fc2719be0d6bd916760c91173239807e6fe6bdd13d2e6daf82bd023e9652fb77"
+          ],
+          "median_ms": 103.6317921243608
+        }
+      },
+      "jest": {
+        "baseline": {
+          "bytes": [
+            74900
+          ],
+          "families": [
+            45
+          ],
+          "hashes": [
+            "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+          ],
+          "median_ms": 570.5839172005653
+        },
+        "current": {
+          "bytes": [
+            74900
+          ],
+          "families": [
+            45
+          ],
+          "hashes": [
+            "39db78fa37df51c3c582796183078975fa12eb533d6363df14bc1b9f9e76df0c"
+          ],
+          "median_ms": 539.8250417783856
+        }
+      },
+      "jq": {
+        "baseline": {
+          "bytes": [
+            26681
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+          ],
+          "median_ms": 113.5081248357892
+        },
+        "current": {
+          "bytes": [
+            26681
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "0ec339c8df465deda2b6301e357f459a491324d7742a8527d935e3f0ae7776a4"
+          ],
+          "median_ms": 93.58908282592893
+        }
+      },
+      "jsoup": {
+        "baseline": {
+          "bytes": [
+            113185
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+          ],
+          "median_ms": 236.81137524545193
+        },
+        "current": {
+          "bytes": [
+            113185
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "e3f048ae7214e6fa6260b481aa9a6b1b01a7806e4a2f353767905330b17c4539"
+          ],
+          "median_ms": 235.59637507423759
+        }
+      },
+      "junit5": {
+        "baseline": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+          ],
+          "median_ms": 838.9803329482675
+        },
+        "current": {
+          "bytes": [
+            514636
+          ],
+          "families": [
+            327
+          ],
+          "hashes": [
+            "eb98dae9bd51a67c43d98d70309c344e96c666fc96c04d33ce82ac376e6f482a"
+          ],
+          "median_ms": 887.2179999016225
+        }
+      },
+      "kingfisher": {
+        "baseline": {
+          "bytes": [
+            31195
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+          ],
+          "median_ms": 121.34416680783033
+        },
+        "current": {
+          "bytes": [
+            31195
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "585a56a6912c1c76db9c633380a1c851541bfa6002f0b051027b6f215826bb17"
+          ],
+          "median_ms": 126.75745924934745
+        }
+      },
+      "kramdown": {
+        "baseline": {
+          "bytes": [
+            114711
+          ],
+          "families": [
+            62
+          ],
+          "hashes": [
+            "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+          ],
+          "median_ms": 110.26695789769292
+        },
+        "current": {
+          "bytes": [
+            114711
+          ],
+          "families": [
+            62
+          ],
+          "hashes": [
+            "8f3a491d04030e174f7a7cfe285babbfaf9646d3a18655d3fbeb89acb130358c"
+          ],
+          "median_ms": 118.37962502613664
+        }
+      },
+      "ky": {
+        "baseline": {
+          "bytes": [
+            27472
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+          ],
+          "median_ms": 73.54587502777576
+        },
+        "current": {
+          "bytes": [
+            27472
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "97f926309852dd82becf05af12553dab4d36f0ff28120710fd987c991dd51c41"
+          ],
+          "median_ms": 68.14212491735816
+        }
+      },
+      "libgdx": {
+        "baseline": {
+          "bytes": [
+            2126164
+          ],
+          "families": [
+            1068
+          ],
+          "hashes": [
+            "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+          ],
+          "median_ms": 2132.494874764234
+        },
+        "current": {
+          "bytes": [
+            2126164
+          ],
+          "families": [
+            1068
+          ],
+          "hashes": [
+            "dc73ad80aa9c5c46325a18ec0a522076e459eb0b099b41a9e1ce4e129ed05b39"
+          ],
+          "median_ms": 2033.422291278839
+        }
+      },
+      "libsodium": {
+        "baseline": {
+          "bytes": [
+            52625
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+          ],
+          "median_ms": 587.5389999710023
+        },
+        "current": {
+          "bytes": [
+            52625
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "c3949da1360deed0b3d65b4a83f67bf3e69ff8aad7797431b12308c291202bfb"
+          ],
+          "median_ms": 549.6381251141429
+        }
+      },
+      "libuv": {
+        "baseline": {
+          "bytes": [
+            55324
+          ],
+          "families": [
+            31
+          ],
+          "hashes": [
+            "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+          ],
+          "median_ms": 241.52629217132926
+        },
+        "current": {
+          "bytes": [
+            55324
+          ],
+          "families": [
+            31
+          ],
+          "hashes": [
+            "9fad712317882c5c79547121314f872f4fa6277e4e92046911252be642344752"
+          ],
+          "median_ms": 209.27845826372504
+        }
+      },
+      "liquid": {
+        "baseline": {
+          "bytes": [
+            29342
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+          ],
+          "median_ms": 85.56474978104234
+        },
+        "current": {
+          "bytes": [
+            29342
+          ],
+          "families": [
+            4
+          ],
+          "hashes": [
+            "b2df63fbe3ef8e1a862bba56985e0930faaba984e5bf3cc076eea13e9efb62e1"
+          ],
+          "median_ms": 71.59279193729162
+        }
+      },
+      "lua": {
+        "baseline": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+          ],
+          "median_ms": 105.31000001356006
+        },
+        "current": {
+          "bytes": [
+            27093
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "51c3c7162a69f2193b36f3f70ebc23198411346e53002079a9afacebc12e394c"
+          ],
+          "median_ms": 115.86691625416279
+        }
+      },
+      "marked": {
+        "baseline": {
+          "bytes": [
+            192560
+          ],
+          "families": [
+            113
+          ],
+          "hashes": [
+            "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+          ],
+          "median_ms": 96.89841698855162
+        },
+        "current": {
+          "bytes": [
+            192560
+          ],
+          "families": [
+            113
+          ],
+          "hashes": [
+            "c4fec9214b74e5c324b330d0a6e7b9bec3885442d2d8d4b68ecf87e2bd5b0ac8"
+          ],
+          "median_ms": 72.3913749679923
+        }
+      },
+      "marshmallow": {
+        "baseline": {
+          "bytes": [
+            44437
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+          ],
+          "median_ms": 77.6014169678092
+        },
+        "current": {
+          "bytes": [
+            44437
+          ],
+          "families": [
+            17
+          ],
+          "hashes": [
+            "bebec113e27d1514ff61c841cc88cc712f5b5edff48b952052ec55639f4c3b9d"
+          ],
+          "median_ms": 77.73900032043457
+        }
+      },
+      "meilisearch": {
+        "baseline": {
+          "bytes": [
+            52737
+          ],
+          "families": [
+            15
+          ],
+          "hashes": [
+            "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+          ],
+          "median_ms": 868.3159579522908
+        },
+        "current": {
+          "bytes": [
+            52737
+          ],
+          "families": [
+            15
+          ],
+          "hashes": [
+            "03a25272f24f664acb37957b79a2eb6a87aa33be1e39e56e41664035ca7cd96f"
+          ],
+          "median_ms": 910.5880842544138
+        }
+      },
+      "minio": {
+        "baseline": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+          ],
+          "median_ms": 892.9164581932127
+        },
+        "current": {
+          "bytes": [
+            84761
+          ],
+          "families": [
+            54
+          ],
+          "hashes": [
+            "bb0bc714b117478f76c51040350cd20725ac12c577019b1f0cab0e06e3489940"
+          ],
+          "median_ms": 916.9398751109838
+        }
+      },
+      "mockito": {
+        "baseline": {
+          "bytes": [
+            148904
+          ],
+          "families": [
+            102
+          ],
+          "hashes": [
+            "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+          ],
+          "median_ms": 376.9250828772783
+        },
+        "current": {
+          "bytes": [
+            148904
+          ],
+          "families": [
+            102
+          ],
+          "hashes": [
+            "974b9c890d223f6fc379547616003abfb33b3885f456ed29fdff960a9f353743"
+          ],
+          "median_ms": 368.40016720816493
+        }
+      },
+      "nats-server": {
+        "baseline": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+          ],
+          "median_ms": 1238.4748752228916
+        },
+        "current": {
+          "bytes": [
+            64019
+          ],
+          "families": [
+            27
+          ],
+          "hashes": [
+            "ed05afaef4c194c9ec11886c5d7a0794ae346cf0bada59c9083f408e488e83b4"
+          ],
+          "median_ms": 1312.4578748829663
+        }
+      },
+      "netty": {
+        "baseline": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+          ],
+          "median_ms": 2240.1350419968367
+        },
+        "current": {
+          "bytes": [
+            1321539
+          ],
+          "families": [
+            879
+          ],
+          "hashes": [
+            "8f820fd935e6a41d6dcbb8d411caf7a0a73251d44810c1b1201fa260b6c59417"
+          ],
+          "median_ms": 2231.6222079098225
+        }
+      },
+      "nginx": {
+        "baseline": {
+          "bytes": [
+            65918
+          ],
+          "families": [
+            44
+          ],
+          "hashes": [
+            "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+          ],
+          "median_ms": 449.4067500345409
+        },
+        "current": {
+          "bytes": [
+            65918
+          ],
+          "families": [
+            44
+          ],
+          "hashes": [
+            "732f64888e477b0e5a56649406dafe8d73746600149abe85365fd4d691b0ed8f"
+          ],
+          "median_ms": 455.2865829318762
+        }
+      },
+      "nimble": {
+        "baseline": {
+          "bytes": [
+            28485
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+          ],
+          "median_ms": 90.91149969026446
+        },
+        "current": {
+          "bytes": [
+            28485
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "2ea02bd1214f3bc21c6b0d90315c79bb80f001e9a7174492f17a58dec2b1b68b"
+          ],
+          "median_ms": 78.26525019481778
+        }
+      },
+      "nushell": {
+        "baseline": {
+          "bytes": [
+            116070
+          ],
+          "families": [
+            59
+          ],
+          "hashes": [
+            "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+          ],
+          "median_ms": 1516.018541995436
+        },
+        "current": {
+          "bytes": [
+            116070
+          ],
+          "families": [
+            59
+          ],
+          "hashes": [
+            "7a025a6c624e8bef57cf305f12a31d632ef90b8969d20466db41a8c615c65f84"
+          ],
+          "median_ms": 1563.8668327592313
+        }
+      },
+      "packaging": {
+        "baseline": {
+          "bytes": [
+            51585
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+          ],
+          "median_ms": 136.43529219552875
+        },
+        "current": {
+          "bytes": [
+            51585
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "13f8b2c024ee8b5fafc839bba0985abeb73a868e799e094ac3b330e5d7871a61"
+          ],
+          "median_ms": 128.87550005689263
+        }
+      },
+      "pixijs": {
+        "baseline": {
+          "bytes": [
+            83612
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+          ],
+          "median_ms": 857.4942499399185
+        },
+        "current": {
+          "bytes": [
+            83612
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "638da8897dde3f0a1f9dcdb6f3e39cce6088a97d4bb62ccb933c54c0ce91da17"
+          ],
+          "median_ms": 820.0570833869278
+        }
+      },
+      "poetry": {
+        "baseline": {
+          "bytes": [
+            198324
+          ],
+          "families": [
+            168
+          ],
+          "hashes": [
+            "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+          ],
+          "median_ms": 282.66804199665785
+        },
+        "current": {
+          "bytes": [
+            198324
+          ],
+          "families": [
+            168
+          ],
+          "hashes": [
+            "da9f290dd4f4b50be594cf6abd2195418bb1853f78ae59ea3ec453448df0b79b"
+          ],
+          "median_ms": 278.8745420984924
+        }
+      },
+      "prettier": {
+        "baseline": {
+          "bytes": [
+            241230
+          ],
+          "families": [
+            151
+          ],
+          "hashes": [
+            "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+          ],
+          "median_ms": 1090.810667257756
+        },
+        "current": {
+          "bytes": [
+            241230
+          ],
+          "families": [
+            151
+          ],
+          "hashes": [
+            "ca2f0de5539b9feedb67ea8b890c3098a3582bf49c0adc429b526cc803c6a764"
+          ],
+          "median_ms": 1102.4120831862092
+        }
+      },
+      "prometheus": {
+        "baseline": {
+          "bytes": [
+            148141
+          ],
+          "families": [
+            66
+          ],
+          "hashes": [
+            "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+          ],
+          "median_ms": 876.9704578444362
+        },
+        "current": {
+          "bytes": [
+            148141
+          ],
+          "families": [
+            66
+          ],
+          "hashes": [
+            "16c29ae07213aaa972a90ccc54ba1772adecb3bdb8c74c0af498037933e65bb3"
+          ],
+          "median_ms": 836.3070422783494
+        }
+      },
+      "pry": {
+        "baseline": {
+          "bytes": [
+            31685
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+          ],
+          "median_ms": 120.89591706171632
+        },
+        "current": {
+          "bytes": [
+            31685
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "42b68a1e20c4c89f43c092293b936cfd0a0f3c10b9c5523dcffb0130e86e7166"
+          ],
+          "median_ms": 107.88850020617247
+        }
+      },
+      "puma": {
+        "baseline": {
+          "bytes": [
+            34593
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+          ],
+          "median_ms": 121.02845823392272
+        },
+        "current": {
+          "bytes": [
+            34593
+          ],
+          "families": [
+            7
+          ],
+          "hashes": [
+            "beb9ec5fdea64a0c6aab0a985bf2756a3cb4f2c2ec6328bb7c4fa3cc1b906629"
+          ],
+          "median_ms": 116.58020783215761
+        }
+      },
+      "quick": {
+        "baseline": {
+          "bytes": [
+            1355479
+          ],
+          "families": [
+            428
+          ],
+          "hashes": [
+            "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+          ],
+          "median_ms": 219.30437488481402
+        },
+        "current": {
+          "bytes": [
+            1355479
+          ],
+          "families": [
+            428
+          ],
+          "hashes": [
+            "80e14c9073ebb4dac56c47ae993352113fcd7e794430dc6b4c5202eb43e92761"
+          ],
+          "median_ms": 225.27208318933845
+        }
+      },
+      "rack": {
+        "baseline": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+          ],
+          "median_ms": 103.1313338316977
+        },
+        "current": {
+          "bytes": [
+            28232
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "81c1f555a66350c2733f4afdf2b00590c1fd5d605e7c37680e2b9d5df71a242a"
+          ],
+          "median_ms": 94.05708312988281
+        }
+      },
+      "radash": {
+        "baseline": {
+          "bytes": [
+            60570
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+          ],
+          "median_ms": 58.00245841965079
+        },
+        "current": {
+          "bytes": [
+            60570
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "107aae84140aa651cc0ad2f021fbd13824db07fda275881a643b38fb39e8768a"
+          ],
+          "median_ms": 67.17329239472747
+        }
+      },
+      "raylib": {
+        "baseline": {
+          "bytes": [
+            244815
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+          ],
+          "median_ms": 2301.075333263725
+        },
+        "current": {
+          "bytes": [
+            244815
+          ],
+          "families": [
+            148
+          ],
+          "hashes": [
+            "4044d7b2afa0994f19d77a5e466ab0cfd87273b481ae39f0bdaac643729ff1cc"
+          ],
+          "median_ms": 2206.1881250701845
+        }
+      },
+      "redis": {
+        "baseline": {
+          "bytes": [
+            59103
+          ],
+          "families": [
+            30
+          ],
+          "hashes": [
+            "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+          ],
+          "median_ms": 739.6383327431977
+        },
+        "current": {
+          "bytes": [
+            59103
+          ],
+          "families": [
+            30
+          ],
+          "hashes": [
+            "d73d9a5a37b87ac1cd38e6605a680aa89774bbd4416070139c1a09cb67aef8b0"
+          ],
+          "median_ms": 775.8065001107752
+        }
+      },
+      "regex": {
+        "baseline": {
+          "bytes": [
+            70161
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+          ],
+          "median_ms": 569.6597923524678
+        },
+        "current": {
+          "bytes": [
+            70161
+          ],
+          "families": [
+            34
+          ],
+          "hashes": [
+            "15cc2582eb4ba7f9e28466b28002913ce308f4eac6b6f87e803393b50b938ee6"
+          ],
+          "median_ms": 471.1164999753237
+        }
+      },
+      "requests": {
+        "baseline": {
+          "bytes": [
+            34891
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+          ],
+          "median_ms": 83.90524983406067
+        },
+        "current": {
+          "bytes": [
+            34891
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "38eff4849b9afb3525397fc1f20bdc0a374342c048ab24ce4cd7bd75177b4242"
+          ],
+          "median_ms": 71.74879172816873
+        }
+      },
+      "retrofit": {
+        "baseline": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+          ],
+          "median_ms": 164.32083398103714
+        },
+        "current": {
+          "bytes": [
+            124169
+          ],
+          "families": [
+            81
+          ],
+          "hashes": [
+            "d287cc9a4d408670ed76e84217e4b60375d3f81f4ff7f80f433d3a7b154acd9e"
+          ],
+          "median_ms": 159.083791077137
+        }
+      },
+      "rich": {
+        "baseline": {
+          "bytes": [
+            50546
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+          ],
+          "median_ms": 176.12383281812072
+        },
+        "current": {
+          "bytes": [
+            50546
+          ],
+          "families": [
+            22
+          ],
+          "hashes": [
+            "730d84ed2f21b22b04cfa6175a3988189a0905a15ed6e7b7e003d3e9051f4985"
+          ],
+          "median_ms": 171.73670791089535
+        }
+      },
+      "ripgrep": {
+        "baseline": {
+          "bytes": [
+            33574
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+          ],
+          "median_ms": 744.7038749232888
+        },
+        "current": {
+          "bytes": [
+            33574
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "0ae8e4103067b7fd7d637fc5c597d64210c747f65549e5ba08018c521954c4f0"
+          ],
+          "median_ms": 674.1084577515721
+        }
+      },
+      "rspec-core": {
+        "baseline": {
+          "bytes": [
+            35566
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+          ],
+          "median_ms": 149.25029082223773
+        },
+        "current": {
+          "bytes": [
+            35566
+          ],
+          "families": [
+            8
+          ],
+          "hashes": [
+            "c34f5b2654b5c3dbefb477a993ca94cd73682f421459c5bf60cc59f701deb41d"
+          ],
+          "median_ms": 144.87595902755857
+        }
+      },
+      "rubocop": {
+        "baseline": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+          ],
+          "median_ms": 695.4577919095755
+        },
+        "current": {
+          "bytes": [
+            138988
+          ],
+          "families": [
+            104
+          ],
+          "hashes": [
+            "b88882f0996078b20ac6c37a013639c9e7748d2b66d4a54116a674d0aee77e8e"
+          ],
+          "median_ms": 661.5623747929931
+        }
+      },
+      "rustls": {
+        "baseline": {
+          "bytes": [
+            51848
+          ],
+          "families": [
+            20
+          ],
+          "hashes": [
+            "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+          ],
+          "median_ms": 352.13870787993073
+        },
+        "current": {
+          "bytes": [
+            51848
+          ],
+          "families": [
+            20
+          ],
+          "hashes": [
+            "15891213a0213e52aedffc28c4ed71fa8c4d3528d30753eab175aa475f22aaee"
+          ],
+          "median_ms": 352.2669170051813
+        }
+      },
+      "rxjava": {
+        "baseline": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+          ],
+          "median_ms": 1431.193333119154
+        },
+        "current": {
+          "bytes": [
+            1169728
+          ],
+          "families": [
+            618
+          ],
+          "hashes": [
+            "3c3718a88a5b8ecf2c4fe091def3bb255186d35efaa6fab8b002836ad3543bc1"
+          ],
+          "median_ms": 1440.5007502064109
+        }
+      },
+      "rxjs": {
+        "baseline": {
+          "bytes": [
+            71630
+          ],
+          "families": [
+            33
+          ],
+          "hashes": [
+            "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+          ],
+          "median_ms": 296.8797502107918
+        },
+        "current": {
+          "bytes": [
+            71630
+          ],
+          "families": [
+            33
+          ],
+          "hashes": [
+            "77933a6e84fed956330f129e014d96a203940432ffe0ae2ba76ec38f463186b3"
+          ],
+          "median_ms": 277.2881658747792
+        }
+      },
+      "rxswift": {
+        "baseline": {
+          "bytes": [
+            1588850
+          ],
+          "families": [
+            426
+          ],
+          "hashes": [
+            "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+          ],
+          "median_ms": 651.2210420332849
+        },
+        "current": {
+          "bytes": [
+            1588850
+          ],
+          "families": [
+            426
+          ],
+          "hashes": [
+            "1bb786d1774b858ec8d7a153b7db6fb63ec680bafa08fff79ba7387a1da0efbc"
+          ],
+          "median_ms": 604.3542502447963
+        }
+      },
+      "scrapy": {
+        "baseline": {
+          "bytes": [
+            169140
+          ],
+          "families": [
+            134
+          ],
+          "hashes": [
+            "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+          ],
+          "median_ms": 289.0240834094584
+        },
+        "current": {
+          "bytes": [
+            169140
+          ],
+          "families": [
+            134
+          ],
+          "hashes": [
+            "c554f68940dfeb6b3172d8616966a5c7b11cf690acff41e823a322b058b3214f"
+          ],
+          "median_ms": 284.0998340398073
+        }
+      },
+      "serde_json": {
+        "baseline": {
+          "bytes": [
+            39884
+          ],
+          "families": [
+            12
+          ],
+          "hashes": [
+            "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+          ],
+          "median_ms": 139.41020797938108
+        },
+        "current": {
+          "bytes": [
+            39884
+          ],
+          "families": [
+            12
+          ],
+          "hashes": [
+            "1e8ee12b2920d0cf8a7c468fc0831fa354028d93f7626ded5257565fcfd528c7"
+          ],
+          "median_ms": 151.7172921448946
+        }
+      },
+      "sidekiq": {
+        "baseline": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+          ],
+          "median_ms": 109.9405842833221
+        },
+        "current": {
+          "bytes": [
+            32237
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "76c45df994901a3de98f2c9baefc25ec26435d51e938a62c6a444193cae3525d"
+          ],
+          "median_ms": 104.34045782312751
+        }
+      },
+      "sinatra": {
+        "baseline": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+          ],
+          "median_ms": 110.706124920398
+        },
+        "current": {
+          "bytes": [
+            27177
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "cc781143fe8d6ef6aa1588b54a3f49fe372a68d161ad842bee3df762f6c14f8c"
+          ],
+          "median_ms": 102.70849987864494
+        }
+      },
+      "sled": {
+        "baseline": {
+          "bytes": [
+            26733
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+          ],
+          "median_ms": 79.18254099786282
+        },
+        "current": {
+          "bytes": [
+            26733
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "e578f073c30cdc6331bc37ad983c151dd1d21861325ec86a24d15c1324885574"
+          ],
+          "median_ms": 86.53637487441301
+        }
+      },
+      "sqlalchemy": {
+        "baseline": {
+          "bytes": [
+            517222
+          ],
+          "families": [
+            391
+          ],
+          "hashes": [
+            "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+          ],
+          "median_ms": 1425.2870827913284
+        },
+        "current": {
+          "bytes": [
+            517222
+          ],
+          "families": [
+            391
+          ],
+          "hashes": [
+            "82f05e6c84305f7a4d559d12f00a13b7b1da53ff5922a3f67247fb923926ebf4"
+          ],
+          "median_ms": 1548.8551668822765
+        }
+      },
+      "sqlite": {
+        "baseline": {
+          "bytes": [
+            159393
+          ],
+          "families": [
+            112
+          ],
+          "hashes": [
+            "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+          ],
+          "median_ms": 1115.477459039539
+        },
+        "current": {
+          "bytes": [
+            159393
+          ],
+          "families": [
+            112
+          ],
+          "hashes": [
+            "fdfd6f15c7d622b16873d9600df7e53da8fca86d35cf8069935a7d8eaea2ba88"
+          ],
+          "median_ms": 1157.8282499685884
+        }
+      },
+      "swift-algorithms": {
+        "baseline": {
+          "bytes": [
+            37862
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+          ],
+          "median_ms": 53.13929216936231
+        },
+        "current": {
+          "bytes": [
+            37862
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "f89da915dd5e30626bdfcf15202ce880153ebc657a243a33200fcbc0da8273b2"
+          ],
+          "median_ms": 62.84020794555545
+        }
+      },
+      "swift-argument-parser": {
+        "baseline": {
+          "bytes": [
+            28093
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+          ],
+          "median_ms": 97.71270817145705
+        },
+        "current": {
+          "bytes": [
+            28093
+          ],
+          "families": [
+            2
+          ],
+          "hashes": [
+            "95b1a92515e6f2c3f4358e018930b8d04a9f1b6917bc4521312db32c3ea780e9"
+          ],
+          "median_ms": 94.78179179131985
+        }
+      },
+      "swift-collections": {
+        "baseline": {
+          "bytes": [
+            105222
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+          ],
+          "median_ms": 424.33141684159636
+        },
+        "current": {
+          "bytes": [
+            105222
+          ],
+          "families": [
+            51
+          ],
+          "hashes": [
+            "4b55c148b26096415ab2c4f7d4c9878e2e4d641ea593c033196cde596715e97e"
+          ],
+          "median_ms": 391.96095801889896
+        }
+      },
+      "swift-composable-architecture": {
+        "baseline": {
+          "bytes": [
+            32913
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+          ],
+          "median_ms": 317.0749582350254
+        },
+        "current": {
+          "bytes": [
+            32913
+          ],
+          "families": [
+            6
+          ],
+          "hashes": [
+            "65a2ad871027a7da4d01158216071911853ca3fca45f370e47612e389de503c9"
+          ],
+          "median_ms": 290.92891700565815
+        }
+      },
+      "swift-log": {
+        "baseline": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+          ],
+          "median_ms": 45.04337487742305
+        },
+        "current": {
+          "bytes": [
+            25972
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "bb116e1741aea1b170898b7b60674405b72d91211a64e26b125cffa7fc801a30"
+          ],
+          "median_ms": 43.49787486717105
+        }
+      },
+      "swift-metrics": {
+        "baseline": {
+          "bytes": [
+            32765
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+          ],
+          "median_ms": 47.07170883193612
+        },
+        "current": {
+          "bytes": [
+            32765
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "16643c6c15014ce25e4a5869cc88a1f77fa17f7a17ad9365c79ded122e36c7b6"
+          ],
+          "median_ms": 44.55620888620615
+        }
+      },
+      "swift-nio": {
+        "baseline": {
+          "bytes": [
+            111694
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+          ],
+          "median_ms": 641.0419158637524
+        },
+        "current": {
+          "bytes": [
+            111694
+          ],
+          "families": [
+            52
+          ],
+          "hashes": [
+            "171bdd0e792c1d32ca5aa9bf1346138349b3b5f6fc6f8886b22ddcc1eb46c049"
+          ],
+          "median_ms": 631.6828331910074
+        }
+      },
+      "swift-service-lifecycle": {
+        "baseline": {
+          "bytes": [
+            27152
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+          ],
+          "median_ms": 51.222541369497776
+        },
+        "current": {
+          "bytes": [
+            27152
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "8d47995c9a4861d4a3e966cc65f25da784f51ac0d8ba6bc54285b9976b1638e8"
+          ],
+          "median_ms": 44.106250163167715
+        }
+      },
+      "swiftlint": {
+        "baseline": {
+          "bytes": [
+            34954
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+          ],
+          "median_ms": 266.1132086068392
+        },
+        "current": {
+          "bytes": [
+            34954
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "14203c0d06c87c1f61ee016ec77d8619854c2edef3b8f700e9c78d081a5f54b5"
+          ],
+          "median_ms": 291.46954137831926
+        }
+      },
+      "swr": {
+        "baseline": {
+          "bytes": [
+            119283
+          ],
+          "families": [
+            49
+          ],
+          "hashes": [
+            "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+          ],
+          "median_ms": 110.49454193562269
+        },
+        "current": {
+          "bytes": [
+            119283
+          ],
+          "families": [
+            49
+          ],
+          "hashes": [
+            "154bd22abf676a3853ae74b236f9be6b52807c351b238be4d27e67b802c9d617"
+          ],
+          "median_ms": 107.68820811063051
+        }
+      },
+      "sympy": {
+        "baseline": {
+          "bytes": [
+            853198
+          ],
+          "families": [
+            645
+          ],
+          "hashes": [
+            "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+          ],
+          "median_ms": 3100.757417269051
+        },
+        "current": {
+          "bytes": [
+            853198
+          ],
+          "families": [
+            645
+          ],
+          "hashes": [
+            "3cf21110c6f0f6f9dee1693554a335c4fdf8a214aec34638e64de8d39c898768"
+          ],
+          "median_ms": 3111.5776249207556
+        }
+      },
+      "thor": {
+        "baseline": {
+          "bytes": [
+            28324
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+          ],
+          "median_ms": 66.90854206681252
+        },
+        "current": {
+          "bytes": [
+            28324
+          ],
+          "families": [
+            3
+          ],
+          "hashes": [
+            "25b81c821c4ae5d185c65b4a488f4b7342815b84609a529aa4c4dc23f188b5ae"
+          ],
+          "median_ms": 65.90345874428749
+        }
+      },
+      "tmux": {
+        "baseline": {
+          "bytes": [
+            51015
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+          ],
+          "median_ms": 236.8998327292502
+        },
+        "current": {
+          "bytes": [
+            51015
+          ],
+          "families": [
+            29
+          ],
+          "hashes": [
+            "5abe949ae277410401390643a26c8fa0f23db0e068ad71894cf6c1f583da5fe8"
+          ],
+          "median_ms": 220.29629116877913
+        }
+      },
+      "tokei": {
+        "baseline": {
+          "bytes": [
+            25960
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+          ],
+          "median_ms": 38.59050013124943
+        },
+        "current": {
+          "bytes": [
+            25960
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "cbf2632ccb7b3ef44b674784d08e94e8a32f072f4bbf33edf1a6746b45ebffab"
+          ],
+          "median_ms": 36.99300019070506
+        }
+      },
+      "tokio": {
+        "baseline": {
+          "bytes": [
+            75904
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+          ],
+          "median_ms": 514.4740422256291
+        },
+        "current": {
+          "bytes": [
+            75904
+          ],
+          "families": [
+            37
+          ],
+          "hashes": [
+            "ff7c731270a4686a4a2c46ac725570f682566d9d98eb1e86afa5466f5dff3bf5"
+          ],
+          "median_ms": 541.358333081007
+        }
+      },
+      "trpc": {
+        "baseline": {
+          "bytes": [
+            128760
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+          ],
+          "median_ms": 399.0555419586599
+        },
+        "current": {
+          "bytes": [
+            128760
+          ],
+          "families": [
+            64
+          ],
+          "hashes": [
+            "b1a41e64faf0f2e67d67440d02c8ed0d9a3f10cdfd5f2711e05f6f63a9ca1af5"
+          ],
+          "median_ms": 343.450749758631
+        }
+      },
+      "urfave-cli": {
+        "baseline": {
+          "bytes": [
+            25975
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+          ],
+          "median_ms": 63.311916310340166
+        },
+        "current": {
+          "bytes": [
+            25975
+          ],
+          "families": [
+            0
+          ],
+          "hashes": [
+            "c9f679e957bb5d70c2ad001f922a611e067d6317ec351c5e3e96db504cb72748"
+          ],
+          "median_ms": 68.57729190960526
+        }
+      },
+      "vapor": {
+        "baseline": {
+          "bytes": [
+            27156
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+          ],
+          "median_ms": 130.76570816338062
+        },
+        "current": {
+          "bytes": [
+            27156
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "6f681b7d818989129b7493f064600408d253dbbc2cdb2a1c8605013da190f960"
+          ],
+          "median_ms": 129.28966619074345
+        }
+      },
+      "vim": {
+        "baseline": {
+          "bytes": [
+            72267
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+          ],
+          "median_ms": 1254.3913340196013
+        },
+        "current": {
+          "bytes": [
+            72267
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "e0ae05f1b4b544f9314a377395efb9b6ed3fc03e89ab05241e7c4392b68a0691"
+          ],
+          "median_ms": 1237.350458279252
+        }
+      },
+      "wrk": {
+        "baseline": {
+          "bytes": [
+            26686
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+          ],
+          "median_ms": 41.89454158768058
+        },
+        "current": {
+          "bytes": [
+            26686
+          ],
+          "families": [
+            1
+          ],
+          "hashes": [
+            "88f88fc12a64773f1257fd681655dbb205040040cf59ac98783ef70a35900583"
+          ],
+          "median_ms": 40.653917007148266
+        }
+      },
+      "zap": {
+        "baseline": {
+          "bytes": [
+            32782
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+          ],
+          "median_ms": 81.60150004550815
+        },
+        "current": {
+          "bytes": [
+            32782
+          ],
+          "families": [
+            5
+          ],
+          "hashes": [
+            "09edc7de64a652080dc0bf32e5a95c78f595cd6e194cf9c2a6ea8b2d4802f9b2"
+          ],
+          "median_ms": 82.08062499761581
+        }
+      },
+      "zod": {
+        "baseline": {
+          "bytes": [
+            49195
+          ],
+          "families": [
+            21
+          ],
+          "hashes": [
+            "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+          ],
+          "median_ms": 380.9790420345962
+        },
+        "current": {
+          "bytes": [
+            49195
+          ],
+          "families": [
+            21
+          ],
+          "hashes": [
+            "fcdc2f40d51360feb9cce9de4f74ae47ace217a8144ac7e865623bdc5ee22035"
+          ],
+          "median_ms": 356.495666783303
+        }
+      },
+      "zstd": {
+        "baseline": {
+          "bytes": [
+            76464
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+          ],
+          "median_ms": 339.953999966383
+        },
+        "current": {
+          "bytes": [
+            76464
+          ],
+          "families": [
+            39
+          ],
+          "hashes": [
+            "d5a8d2ccc093fd49d2e19032ae76d95875e1a69b57b43d41bfd6b3b444076646"
+          ],
+          "median_ms": 301.78304109722376
+        }
+      },
+      "zustand": {
+        "baseline": {
+          "bytes": [
+            41646
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+          ],
+          "median_ms": 88.89150014147162
+        },
+        "current": {
+          "bytes": [
+            41646
+          ],
+          "families": [
+            9
+          ],
+          "hashes": [
+            "1fa20f280e4db5a3fab6005c2fc10706d9fbfc7b60f52ce7b44c42958875aec8"
+          ],
+          "median_ms": 75.10754186660051
+        }
+      }
+    },
+    "hashes_identical_by_repo": {
+      "alacritty": true,
+      "alamofire": true,
+      "antlr4": true,
+      "arrow": true,
+      "asciidoctor": true,
+      "axios": true,
+      "badger": true,
+      "bat": true,
+      "black": true,
+      "boltons": true,
+      "chi": true,
+      "clap": true,
+      "click": true,
+      "cmark": true,
+      "cobra": true,
+      "commons-lang": true,
+      "curl": true,
+      "date-fns": true,
+      "delve": true,
+      "devise": true,
+      "drizzle-orm": true,
+      "esbuild": true,
+      "etcd": true,
+      "execa": true,
+      "faraday": true,
+      "fastlane": true,
+      "fd": true,
+      "flask": true,
+      "fzf": true,
+      "gin": true,
+      "git": true,
+      "gorm": true,
+      "graphhopper": true,
+      "gson": true,
+      "guava": true,
+      "h2database": true,
+      "httpie": true,
+      "httpx": true,
+      "hugo": true,
+      "hyperfine": true,
+      "image": true,
+      "jackson-core": true,
+      "jedis": true,
+      "jekyll": true,
+      "jest": true,
+      "jq": true,
+      "jsoup": true,
+      "junit5": true,
+      "kingfisher": true,
+      "kramdown": true,
+      "ky": true,
+      "libgdx": true,
+      "libsodium": true,
+      "libuv": true,
+      "liquid": true,
+      "lua": true,
+      "marked": true,
+      "marshmallow": true,
+      "meilisearch": true,
+      "minio": true,
+      "mockito": true,
+      "nats-server": true,
+      "netty": true,
+      "nginx": true,
+      "nimble": true,
+      "nushell": true,
+      "packaging": true,
+      "pixijs": true,
+      "poetry": true,
+      "prettier": true,
+      "prometheus": true,
+      "pry": true,
+      "puma": true,
+      "quick": true,
+      "rack": true,
+      "radash": true,
+      "raylib": true,
+      "redis": true,
+      "regex": true,
+      "requests": true,
+      "retrofit": true,
+      "rich": true,
+      "ripgrep": true,
+      "rspec-core": true,
+      "rubocop": true,
+      "rustls": true,
+      "rxjava": true,
+      "rxjs": true,
+      "rxswift": true,
+      "scrapy": true,
+      "serde_json": true,
+      "sidekiq": true,
+      "sinatra": true,
+      "sled": true,
+      "sqlalchemy": true,
+      "sqlite": true,
+      "swift-algorithms": true,
+      "swift-argument-parser": true,
+      "swift-collections": true,
+      "swift-composable-architecture": true,
+      "swift-log": true,
+      "swift-metrics": true,
+      "swift-nio": true,
+      "swift-service-lifecycle": true,
+      "swiftlint": true,
+      "swr": true,
+      "sympy": true,
+      "thor": true,
+      "tmux": true,
+      "tokei": true,
+      "tokio": true,
+      "trpc": true,
+      "urfave-cli": true,
+      "vapor": true,
+      "vim": true,
+      "wrk": true,
+      "zap": true,
+      "zod": true,
+      "zstd": true,
+      "zustand": true
+    }
+  }
+}

--- a/bench/divergent_history/issue-688-product-output-runtime-summary-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-product-output-runtime-summary-2026-07-06.v1.json
@@ -1,0 +1,620 @@
+{
+  "artifact_kind": "product-output-runtime-evidence",
+  "base_replay_runtime": {
+    "baseline": {
+      "metadata": {
+        "arms": {
+          "default": [],
+          "near": [
+            "--mode",
+            "syntax,semantic,near"
+          ]
+        },
+        "commands": {
+          "replay": "/tmp/nose-688-base-551758d5/eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl",
+          "summarize": "/tmp/nose-688-base-551758d5/eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos summarize --records /tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl --out /Users/ak/prjs/cc/nose/bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json"
+        },
+        "eligible_pool_cap": 200,
+        "jobs": 6,
+        "max_changed_src_lines": 600,
+        "min_changed_src_lines": 3,
+        "nose_binary": "target/release/nose",
+        "nose_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+        "nose_version": "nose 0.17.0",
+        "per_repo": 3,
+        "query_depth": 800,
+        "query_template": "nose query . base=<parent> top=0 --format json [arm args]",
+        "raw_records": {
+          "path": "/tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl",
+          "sha256": "956992876089eb8b83ce68191682319c9cfb798014c3e7ac8b59e562a85ffaa3"
+        },
+        "repos": [
+          "git",
+          "redis",
+          "hugo",
+          "minio",
+          "netty",
+          "rxjava",
+          "scrapy",
+          "sympy",
+          "rubocop",
+          "sidekiq",
+          "clap",
+          "tokio",
+          "jest",
+          "rxjs"
+        ],
+        "schema_version": 2,
+        "selection": "even sample over newest eligible first-parent commits",
+        "source_commit": "551758d5139372a58645f411ac3b887d679c755a",
+        "source_dirty": false,
+        "supported_exts": [
+          ".c",
+          ".cjs",
+          ".go",
+          ".h",
+          ".html",
+          ".java",
+          ".js",
+          ".jsx",
+          ".mjs",
+          ".py",
+          ".rb",
+          ".rs",
+          ".svelte",
+          ".ts",
+          ".tsx",
+          ".vue"
+        ],
+        "timeout_s": 240,
+        "timing_fields": [
+          "duration_s"
+        ]
+      },
+      "path": "bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json",
+      "per_arm": {
+        "default": {
+          "divergence_s_max": 10.38,
+          "divergence_s_p50": 3.79,
+          "divergence_s_p90": 8.91,
+          "errors": 0,
+          "findings_per_fire_max": 34,
+          "findings_per_fire_p50": 1,
+          "findings_per_fire_p90": 7,
+          "findings_per_replay_p50": 0,
+          "findings_per_replay_p90": 3,
+          "findings_total": 71,
+          "fire_rate": 0.4524,
+          "fired": 19,
+          "lane_counts": {
+            "base-divergence": 71
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 6,
+          "tier_counts": {
+            "report-only": 46,
+            "review": 13,
+            "strict": 12
+          }
+        },
+        "near": {
+          "divergence_s_max": 11.96,
+          "divergence_s_p50": 4.09,
+          "divergence_s_p90": 10.07,
+          "errors": 0,
+          "findings_per_fire_max": 42,
+          "findings_per_fire_p50": 2,
+          "findings_per_fire_p90": 8,
+          "findings_per_replay_p50": 0,
+          "findings_per_replay_p90": 3,
+          "findings_total": 88,
+          "fire_rate": 0.4762,
+          "fired": 20,
+          "lane_counts": {
+            "base-divergence": 88
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 9,
+          "tier_counts": {
+            "report-only": 58,
+            "review": 15,
+            "strict": 15
+          }
+        }
+      },
+      "sha256": "6b1bdc4b652f9d3f878ff659825df73dbb5ca46ac9dc9c8b88a2fd6e00b062a4"
+    },
+    "comparison": {
+      "default": {
+        "baseline": {
+          "divergence_s_max": 10.38,
+          "divergence_s_p50": 3.79,
+          "divergence_s_p90": 8.91,
+          "errors": 0,
+          "findings_total": 71,
+          "fired": 19,
+          "lane_counts": {
+            "base-divergence": 71
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 6,
+          "tier_counts": {
+            "report-only": 46,
+            "review": 13,
+            "strict": 12
+          }
+        },
+        "counts_identical": true,
+        "current": {
+          "divergence_s_max": 10.59,
+          "divergence_s_p50": 4.23,
+          "divergence_s_p90": 9.2,
+          "errors": 0,
+          "findings_total": 71,
+          "fired": 19,
+          "lane_counts": {
+            "base-divergence": 71
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 6,
+          "tier_counts": {
+            "report-only": 46,
+            "review": 13,
+            "strict": 12
+          }
+        },
+        "timing_delta_pct": {
+          "divergence_s_max": 2.023121387283228,
+          "divergence_s_p50": 11.609498680738795,
+          "divergence_s_p90": 3.254769921436578
+        }
+      },
+      "near": {
+        "baseline": {
+          "divergence_s_max": 11.96,
+          "divergence_s_p50": 4.09,
+          "divergence_s_p90": 10.07,
+          "errors": 0,
+          "findings_total": 88,
+          "fired": 20,
+          "lane_counts": {
+            "base-divergence": 88
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 9,
+          "tier_counts": {
+            "report-only": 58,
+            "review": 15,
+            "strict": 15
+          }
+        },
+        "counts_identical": true,
+        "current": {
+          "divergence_s_max": 11.88,
+          "divergence_s_p50": 3.86,
+          "divergence_s_p90": 8.61,
+          "errors": 0,
+          "findings_total": 88,
+          "fired": 20,
+          "lane_counts": {
+            "base-divergence": 88
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 9,
+          "tier_counts": {
+            "report-only": 58,
+            "review": 15,
+            "strict": 15
+          }
+        },
+        "timing_delta_pct": {
+          "divergence_s_max": -0.6688963210702347,
+          "divergence_s_p50": -5.623471882640587,
+          "divergence_s_p90": -14.498510427010933
+        }
+      }
+    },
+    "current": {
+      "metadata": {
+        "arms": {
+          "default": [],
+          "near": [
+            "--mode",
+            "syntax,semantic,near"
+          ]
+        },
+        "commands": {
+          "replay": "eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl",
+          "summarize": "eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos summarize --records /tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl --out bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json"
+        },
+        "eligible_pool_cap": 200,
+        "jobs": 6,
+        "max_changed_src_lines": 600,
+        "min_changed_src_lines": 3,
+        "nose_binary": "target/release/nose",
+        "nose_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+        "nose_version": "nose 0.17.0",
+        "per_repo": 3,
+        "query_depth": 800,
+        "query_template": "nose query . base=<parent> top=0 --format json [arm args]",
+        "raw_records": {
+          "path": "/tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl",
+          "sha256": "e21094024246d87f9edc907f51898789fbe7435e16a48b100c6fb83c164a6d1e"
+        },
+        "repos": [
+          "git",
+          "redis",
+          "hugo",
+          "minio",
+          "netty",
+          "rxjava",
+          "scrapy",
+          "sympy",
+          "rubocop",
+          "sidekiq",
+          "clap",
+          "tokio",
+          "jest",
+          "rxjs"
+        ],
+        "schema_version": 2,
+        "selection": "even sample over newest eligible first-parent commits",
+        "source_commit": "08052e90e060e16b42f274c65cf1c5da30542757",
+        "source_dirty": true,
+        "supported_exts": [
+          ".c",
+          ".cjs",
+          ".go",
+          ".h",
+          ".html",
+          ".java",
+          ".js",
+          ".jsx",
+          ".mjs",
+          ".py",
+          ".rb",
+          ".rs",
+          ".svelte",
+          ".ts",
+          ".tsx",
+          ".vue"
+        ],
+        "timeout_s": 240,
+        "timing_fields": [
+          "duration_s"
+        ]
+      },
+      "path": "bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json",
+      "per_arm": {
+        "default": {
+          "divergence_s_max": 10.59,
+          "divergence_s_p50": 4.23,
+          "divergence_s_p90": 9.2,
+          "errors": 0,
+          "findings_per_fire_max": 34,
+          "findings_per_fire_p50": 1,
+          "findings_per_fire_p90": 7,
+          "findings_per_replay_p50": 0,
+          "findings_per_replay_p90": 3,
+          "findings_total": 71,
+          "fire_rate": 0.4524,
+          "fired": 19,
+          "lane_counts": {
+            "base-divergence": 71
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 6,
+          "tier_counts": {
+            "report-only": 46,
+            "review": 13,
+            "strict": 12
+          }
+        },
+        "near": {
+          "divergence_s_max": 11.88,
+          "divergence_s_p50": 3.86,
+          "divergence_s_p90": 8.61,
+          "errors": 0,
+          "findings_per_fire_max": 42,
+          "findings_per_fire_p50": 2,
+          "findings_per_fire_p90": 8,
+          "findings_per_replay_p50": 0,
+          "findings_per_replay_p90": 3,
+          "findings_total": 88,
+          "fire_rate": 0.4762,
+          "fired": 20,
+          "lane_counts": {
+            "base-divergence": 88
+          },
+          "new_copy_fired": 0,
+          "replays": 42,
+          "strict_fired": 9,
+          "tier_counts": {
+            "report-only": 58,
+            "review": 15,
+            "strict": 15
+          }
+        }
+      },
+      "sha256": "6c084f89eaefabe495f869306502909780c5c44b862795fa49c3653f4f68ab78"
+    },
+    "interpretation": {
+      "reason": "Replay counts, lane counts, tier counts, and errors are identical. The largest positive p50/p90 movement is default p50 +11.6%, below the 20% replay timing threshold; default p90 is +3.3% and near p50/p90 improved.",
+      "runtime_triage_required": false,
+      "selected_replay_set": "default replay.py repo set, per-repo 3, default and near arms"
+    }
+  },
+  "bounds": {
+    "default_on_readiness_claim": false,
+    "final_epic_closeout": false,
+    "history_mining_pr_ci": false,
+    "policy_changed": false
+  },
+  "commands": {
+    "build_baseline": "git worktree add --detach /tmp/nose-688-base-551758d5 551758d5139372a58645f411ac3b887d679c755a && cargo build --manifest-path /tmp/nose-688-base-551758d5/Cargo.toml --release -p nose-cli",
+    "build_current": "cargo build --release -p nose-cli",
+    "nonbase_allrepos": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json",
+    "nonbase_nose_slice": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --repos-root . --repo crates/nose-cli/src --repo crates/nose-cli/tests/cli --iterations 9 --warmups 1 --output bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json",
+    "nonbase_same_binary_control": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-08052e90 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 08052e90 --baseline-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json",
+    "replay_baseline": "/tmp/nose-688-base-551758d5/eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl",
+    "replay_current": "eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl"
+  },
+  "conclusion": {
+    "base_replay_counts_identical": true,
+    "base_replay_errors": 0,
+    "non_base_bytes_identical_all_repos": true,
+    "non_base_families_identical_all_repos": true,
+    "non_base_hashes_identical_all_repos": true,
+    "non_base_hashes_identical_nose_slice": true,
+    "optimization_opened": false,
+    "runtime_triage_opened": false,
+    "unexplained_runtime_regression": false
+  },
+  "generated_on": "2026-07-06",
+  "issue": 688,
+  "non_base_product_output": {
+    "allrepos": {
+      "command": "nose query <repo> all top=0 --mode semantic --format json",
+      "path": "bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json",
+      "provenance": {
+        "baseline_binary": "/private/tmp/nose-688/nose-551758d5",
+        "baseline_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+        "baseline_source_ref": "551758d5",
+        "baseline_source_sha": "551758d5139372a58645f411ac3b887d679c755a",
+        "current_binary": "/private/tmp/nose-688/nose-08052e90",
+        "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+        "current_source_ref": "08052e90",
+        "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+        "harness": "scripts/query-regression-harness.py",
+        "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json",
+        "working_tree_status_before_measurement": ""
+      },
+      "runtime_threshold_triggers": [
+        {
+          "baseline_median_ms": 51.59137537702918,
+          "current_median_ms": 85.77762497588992,
+          "delta_ms": 34.18624959886074,
+          "delta_pct": 66.26349723966074,
+          "repo": "faraday"
+        }
+      ],
+      "sha256": "a4dc6ab8ddcaac9b123065a00d0ba5042364988a741051d73b5965e5aae24810",
+      "stability": {
+        "byte_mismatch_repos": [],
+        "bytes_identical": true,
+        "families_identical": true,
+        "family_mismatch_repos": [],
+        "hash_mismatch_repos": [],
+        "hashes_identical": true,
+        "internally_deterministic": true,
+        "nondeterministic_repos": [],
+        "repos": 120
+      },
+      "summary": {
+        "aggregate_baseline_median_ms": 56301.32029252127,
+        "aggregate_current_median_ms": 56835.43049916625,
+        "aggregate_delta_pct": 0.9486637326974553
+      }
+    },
+    "interpretation": {
+      "allrepos_runtime_trigger_count": 1,
+      "faraday_current_vs_baseline_trigger": [
+        {
+          "baseline_median_ms": 51.59137537702918,
+          "current_median_ms": 85.77762497588992,
+          "delta_ms": 34.18624959886074,
+          "delta_pct": 66.26349723966074,
+          "repo": "faraday"
+        }
+      ],
+      "faraday_same_binary_control": {
+        "baseline_median_ms": 61.703292187303305,
+        "current_median_ms": 53.0500840395689,
+        "delta_ms": -8.653208147734404,
+        "delta_pct": -14.023900250682209
+      },
+      "ordinary_product_output_stable": true,
+      "reason": "All output hashes, byte counts, and family counts are stable. The only all-repos runtime threshold trigger is a small faraday wall-time wobble that is not reproduced in the same-binary control; aggregate current-vs-baseline movement is +0.95% and same-binary aggregate movement is -0.40%.",
+      "runtime_triage_required": false,
+      "same_binary_control_runtime_trigger_count": 1
+    },
+    "nose_slice": {
+      "command": "nose query <repo> all top=0 --mode semantic --format json",
+      "path": "bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json",
+      "provenance": {
+        "baseline_binary": "/private/tmp/nose-688/nose-551758d5",
+        "baseline_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+        "baseline_source_ref": "551758d5",
+        "baseline_source_sha": "551758d5139372a58645f411ac3b887d679c755a",
+        "current_binary": "/private/tmp/nose-688/nose-08052e90",
+        "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+        "current_source_ref": "08052e90",
+        "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+        "harness": "scripts/query-regression-harness.py",
+        "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-551758d5 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 551758d5 --baseline-source-sha 551758d5139372a58645f411ac3b887d679c755a --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --repos-root . --repo crates/nose-cli/src --repo crates/nose-cli/tests/cli --iterations 9 --warmups 1 --output bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json",
+        "working_tree_status_before_measurement": "?? bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json\n?? bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json"
+      },
+      "runtime_threshold_triggers": [],
+      "sha256": "425afd85a5fdf8fcb28ecb048f794be14c795bf5b64f5de6bedc4862a6293201",
+      "stability": {
+        "byte_mismatch_repos": [],
+        "bytes_identical": true,
+        "families_identical": true,
+        "family_mismatch_repos": [],
+        "hash_mismatch_repos": [],
+        "hashes_identical": true,
+        "internally_deterministic": true,
+        "nondeterministic_repos": [],
+        "repos": 2
+      },
+      "summary": {
+        "aggregate_baseline_median_ms": 124.20820770785213,
+        "aggregate_current_median_ms": 125.37441588938236,
+        "aggregate_delta_pct": 0.9389139438138053
+      }
+    },
+    "same_binary_control": {
+      "command": "nose query <repo> all top=0 --mode semantic --format json",
+      "path": "bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json",
+      "provenance": {
+        "baseline_binary": "/private/tmp/nose-688/nose-08052e90",
+        "baseline_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+        "baseline_source_ref": "08052e90",
+        "baseline_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+        "current_binary": "/private/tmp/nose-688/nose-08052e90",
+        "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+        "current_source_ref": "08052e90",
+        "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+        "harness": "scripts/query-regression-harness.py",
+        "harness_command": "scripts/query-regression-harness.py --baseline-binary /tmp/nose-688/nose-08052e90 --current-binary /tmp/nose-688/nose-08052e90 --baseline-source-ref 08052e90 --baseline-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --current-source-ref 08052e90 --current-source-sha 08052e90e060e16b42f274c65cf1c5da30542757 --all-repos --iterations 3 --warmups 1 --output bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json",
+        "working_tree_status_before_measurement": "?? bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json"
+      },
+      "runtime_threshold_triggers": [
+        {
+          "baseline_median_ms": 89.28554179146886,
+          "current_median_ms": 117.1080837957561,
+          "delta_ms": 27.822542004287243,
+          "delta_pct": 31.16130724643893,
+          "repo": "boltons"
+        }
+      ],
+      "sha256": "e2e8469fc9e5f4f7d3f4e9a092c3be385c0fa9ce2ddf278e3fd1a78797ce78cb",
+      "stability": {
+        "byte_mismatch_repos": [],
+        "bytes_identical": true,
+        "families_identical": true,
+        "family_mismatch_repos": [],
+        "hash_mismatch_repos": [],
+        "hashes_identical": true,
+        "internally_deterministic": true,
+        "nondeterministic_repos": [],
+        "repos": 120
+      },
+      "summary": {
+        "aggregate_baseline_median_ms": 58206.39175269753,
+        "aggregate_current_median_ms": 57973.761706613004,
+        "aggregate_delta_pct": -0.3996640902822191
+      }
+    }
+  },
+  "provenance": {
+    "baseline_binary": "/tmp/nose-688/nose-551758d5",
+    "baseline_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+    "baseline_source_ref": "551758d5",
+    "baseline_source_sha": "551758d5139372a58645f411ac3b887d679c755a",
+    "current_binary": "/tmp/nose-688/nose-08052e90",
+    "current_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "current_source_ref": "08052e90",
+    "current_source_sha": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "nose_version": "nose 0.17.0",
+    "working_tree_status_at_summary": [
+      "?? bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json",
+      "?? bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json",
+      "?? bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json",
+      "?? bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json",
+      "?? bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json"
+    ]
+  },
+  "references": {
+    "final_policy_a38ecb8b": {
+      "path": "eval/divergence_fire/policy_eval_final_head_a38ecb8b_2026_07_06.json",
+      "sha256": "e4b9f84badff2b15f7545399465ea54521bf5f8495be9add3f965717ac77d9d2"
+    },
+    "full_final_replay_a38ecb8b": {
+      "path": "eval/divergence_fire/replay_summary_final_head_a38ecb8b_2026_07_06.json",
+      "sha256": "4e51396cb58521e5f50104e43a8f48b8c64e9a36634e77a17bd2f230495f00eb"
+    },
+    "history_687": {
+      "path": "bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json",
+      "sha256": "a374215dba130a43bd1a39f17b7583b64f61c4fbca03f8192c5809394f1f97d5",
+      "summary": {
+        "commits_analyzed": 11,
+        "commits_considered": 11,
+        "commits_skipped": 0,
+        "findings": 17,
+        "gate_fail_default_findings": 0,
+        "gate_fail_default_groups": 0,
+        "groups": 17,
+        "lane_counts": {
+          "base-divergence": 17
+        },
+        "query_failed_commits": 0,
+        "report_only_findings": 17,
+        "review_findings": 0,
+        "strict_findings": 0,
+        "strict_groups": 0,
+        "taxonomy_hint_counts": {
+          "test_scaffolding": 17
+        },
+        "tier_counts": {
+          "report-only": 17
+        }
+      }
+    },
+    "pilot_687": {
+      "path": "bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json",
+      "sha256": "939edcd318fa606373e0a3af1dd608d523f2f1471056b1cbcc882f1e7aec32f4"
+    }
+  },
+  "schema": "nose.divergent_gate_product_runtime.v1",
+  "source_policy": {
+    "checked_artifacts_contain_source": false,
+    "raw_query_stdout_tracked": false,
+    "raw_replay_jsonl_tracked": false,
+    "source_bearing_keys_forbidden": [
+      "base_code",
+      "change_diff",
+      "current_code",
+      "diff",
+      "patch",
+      "snippet",
+      "snippets",
+      "source_text"
+    ]
+  },
+  "validation_commands": [
+    {
+      "command": "python3 scripts/query-regression-harness.py --self-test",
+      "status": "passed"
+    },
+    {
+      "command": "python3 scripts/runtime-triage-harness.py --self-test",
+      "status": "passed"
+    },
+    {
+      "command": "python3 eval/divergence_fire/replay.py check-artifacts",
+      "status": "passed"
+    },
+    {
+      "command": "python3 scripts/check-divergent-history-artifacts.py",
+      "status": "passed"
+    }
+  ]
+}

--- a/bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json
@@ -1,0 +1,1192 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "schema_version": 2,
+    "arms": {
+      "default": [],
+      "near": [
+        "--mode",
+        "syntax,semantic,near"
+      ]
+    },
+    "repos": [
+      "git",
+      "redis",
+      "hugo",
+      "minio",
+      "netty",
+      "rxjava",
+      "scrapy",
+      "sympy",
+      "rubocop",
+      "sidekiq",
+      "clap",
+      "tokio",
+      "jest",
+      "rxjs"
+    ],
+    "per_repo": 3,
+    "timeout_s": 240,
+    "jobs": 6,
+    "query_depth": 800,
+    "eligible_pool_cap": 200,
+    "min_changed_src_lines": 3,
+    "max_changed_src_lines": 600,
+    "supported_exts": [
+      ".c",
+      ".cjs",
+      ".go",
+      ".h",
+      ".html",
+      ".java",
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".py",
+      ".rb",
+      ".rs",
+      ".svelte",
+      ".ts",
+      ".tsx",
+      ".vue"
+    ],
+    "query_template": "nose query . base=<parent> top=0 --format json [arm args]",
+    "timing_fields": [
+      "duration_s"
+    ],
+    "selection": "even sample over newest eligible first-parent commits",
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "83496fbef04f123569bc6f8b36be957b634a3f8a2ad1514dd70df819ba12f39b",
+    "nose_version": "nose 0.17.0",
+    "source_commit": "551758d5139372a58645f411ac3b887d679c755a",
+    "source_dirty": false,
+    "commands": {
+      "replay": "/tmp/nose-688-base-551758d5/eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl",
+      "summarize": "/tmp/nose-688-base-551758d5/eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos summarize --records /tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl --out /Users/ak/prjs/cc/nose/bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json"
+    },
+    "raw_records": {
+      "path": "/tmp/nose-688/divfire-551758d5-r14-p3.raw.jsonl",
+      "sha256": "956992876089eb8b83ce68191682319c9cfb798014c3e7ac8b59e562a85ffaa3"
+    }
+  },
+  "per_arm": {
+    "default": {
+      "replays": 42,
+      "errors": 0,
+      "fired": 19,
+      "fire_rate": 0.4524,
+      "strict_fired": 6,
+      "new_copy_fired": 0,
+      "findings_total": 71,
+      "lane_counts": {
+        "base-divergence": 71
+      },
+      "tier_counts": {
+        "report-only": 46,
+        "review": 13,
+        "strict": 12
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 3,
+      "findings_per_fire_p50": 1,
+      "findings_per_fire_p90": 7,
+      "findings_per_fire_max": 34,
+      "divergence_s_p50": 3.79,
+      "divergence_s_p90": 8.91,
+      "divergence_s_max": 10.38
+    },
+    "near": {
+      "replays": 42,
+      "errors": 0,
+      "fired": 20,
+      "fire_rate": 0.4762,
+      "strict_fired": 9,
+      "new_copy_fired": 0,
+      "findings_total": 88,
+      "lane_counts": {
+        "base-divergence": 88
+      },
+      "tier_counts": {
+        "report-only": 58,
+        "review": 15,
+        "strict": 15
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 3,
+      "findings_per_fire_p50": 2,
+      "findings_per_fire_p90": 8,
+      "findings_per_fire_max": 42,
+      "divergence_s_p50": 4.09,
+      "divergence_s_p90": 10.07,
+      "divergence_s_max": 11.96
+    }
+  },
+  "per_repo": {
+    "clap": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 1.17,
+        "divergence_s_p90": 1.2
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 3,
+        "divergence_s_p50": 1.3,
+        "divergence_s_p90": 1.78
+      }
+    },
+    "git": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 5.18,
+        "divergence_s_p90": 5.35
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 6.86,
+        "divergence_s_p90": 6.98
+      }
+    },
+    "hugo": {
+      "default": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 3.96,
+        "divergence_s_p90": 4.34
+      },
+      "near": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 4.54,
+        "divergence_s_p90": 4.74
+      }
+    },
+    "jest": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 6,
+        "divergence_s_p50": 2.11,
+        "divergence_s_p90": 3.73
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 6,
+        "divergence_s_p50": 1.54,
+        "divergence_s_p90": 3.1
+      }
+    },
+    "minio": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 3,
+        "divergence_s_p50": 4.25,
+        "divergence_s_p90": 4.41
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 3,
+        "divergence_s_p50": 4.44,
+        "divergence_s_p90": 4.85
+      }
+    },
+    "netty": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 8.91,
+        "divergence_s_p90": 9.5
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 11.83,
+        "divergence_s_p90": 11.96
+      }
+    },
+    "redis": {
+      "default": {
+        "replays": 3,
+        "fired": 3,
+        "findings": 6,
+        "divergence_s_p50": 3.3,
+        "divergence_s_p90": 3.37
+      },
+      "near": {
+        "replays": 3,
+        "fired": 3,
+        "findings": 8,
+        "divergence_s_p50": 4.09,
+        "divergence_s_p90": 4.58
+      }
+    },
+    "rubocop": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 2.65,
+        "divergence_s_p90": 3.79
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 3.05,
+        "divergence_s_p90": 3.78
+      }
+    },
+    "rxjava": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 37,
+        "divergence_s_p50": 6.73,
+        "divergence_s_p90": 7.34
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 46,
+        "divergence_s_p50": 8.22,
+        "divergence_s_p90": 10.07
+      }
+    },
+    "rxjs": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.08,
+        "divergence_s_p90": 1.21
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.11,
+        "divergence_s_p90": 1.55
+      }
+    },
+    "scrapy": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 8,
+        "divergence_s_p50": 1.14,
+        "divergence_s_p90": 1.24
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 11,
+        "divergence_s_p50": 1.14,
+        "divergence_s_p90": 2.07
+      }
+    },
+    "sidekiq": {
+      "default": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 3.91,
+        "divergence_s_p90": 10.38
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 3.24,
+        "divergence_s_p90": 9.23
+      }
+    },
+    "sympy": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 9.44,
+        "divergence_s_p90": 9.56
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 8.72,
+        "divergence_s_p90": 10.68
+      }
+    },
+    "tokio": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 1.41,
+        "divergence_s_p90": 1.59
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 1.49,
+        "divergence_s_p90": 1.93
+      }
+    }
+  },
+  "selected_replays": [
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "5ca60e9079e79c44eee4e226fabec943b8138ef8",
+      "parent": "df1efca03509f736e26d2f16766b7ea06acc3ecf",
+      "subject": "Merge pull request #5731 from epage/bash",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.98
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "5ca60e9079e79c44eee4e226fabec943b8138ef8",
+      "parent": "df1efca03509f736e26d2f16766b7ea06acc3ecf",
+      "subject": "Merge pull request #5731 from epage/bash",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.16
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "a380b65fe9eceade90bce8aeb13c205265fcceee",
+      "parent": "25eb6fb7fd63d02217024aa112c1fa268771945a",
+      "subject": "Merge pull request #6023 from epage/template",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.17
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "a380b65fe9eceade90bce8aeb13c205265fcceee",
+      "parent": "25eb6fb7fd63d02217024aa112c1fa268771945a",
+      "subject": "Merge pull request #6023 from epage/template",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.3
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.2
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.78
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "1678b7de977043f31242d2029259797eee620236",
+      "parent": "fb5516997ef3f882d8e53ce70ba6077533683621",
+      "subject": "Merge branch 'mm/line-log-use-standard-diff-output'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.35
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "1678b7de977043f31242d2029259797eee620236",
+      "parent": "fb5516997ef3f882d8e53ce70ba6077533683621",
+      "subject": "Merge branch 'mm/line-log-use-standard-diff-output'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.66
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "db227bce2224b55b11954a5f292a0b035b7d9279",
+      "parent": "394c18092f3e2a773333a08d3f8241322a97aa39",
+      "subject": "Merge branch 'ob/core-attributesfile-in-repository'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 4.87
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "db227bce2224b55b11954a5f292a0b035b7d9279",
+      "parent": "394c18092f3e2a773333a08d3f8241322a97aa39",
+      "subject": "Merge branch 'ob/core-attributesfile-in-repository'",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 6.98
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.18
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.86
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "1eea9fba0b7ff174d1e30b2307bef54842f422fc",
+      "parent": "9a5c7e0d244ca7ae1065fc809277edffd50211f5",
+      "subject": "commands: Fix environment isolation for configuration settings",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.34
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "1eea9fba0b7ff174d1e30b2307bef54842f422fc",
+      "parent": "9a5c7e0d244ca7ae1065fc809277edffd50211f5",
+      "subject": "commands: Fix environment isolation for configuration settings",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.74
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "3850881f2a9b718f049b8330a2b9e37119900499",
+      "parent": "a18bec1123e582da818dc8a841285d1a8eb27de4",
+      "subject": "modules: Include JSON error info from go mod download in error messages",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.95
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "3850881f2a9b718f049b8330a2b9e37119900499",
+      "parent": "a18bec1123e582da818dc8a841285d1a8eb27de4",
+      "subject": "modules: Include JSON error info from go mod download in error messages",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.54
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.96
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.42
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "6813dfa8c78f0232726db88e31c04780d785b3bf",
+      "parent": "7cf3b8d24ae3753522a28728eacd034cd6381b0b",
+      "subject": "feat(jest-fake-timers): Add feature to configure how timers advance  (#15871)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 2.11
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "6813dfa8c78f0232726db88e31c04780d785b3bf",
+      "parent": "7cf3b8d24ae3753522a28728eacd034cd6381b0b",
+      "subject": "feat(jest-fake-timers): Add feature to configure how timers advance  (#15871)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 1.54
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.73
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.1
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "f48a959f16a3fa12a4a2383091425a4e03502677",
+      "parent": "2950cbbdc18614f35a7cc1a8b59dbc283bde9315",
+      "subject": "feat(runtime): use `compileFunction` over `new Script` (#15461)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.16
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "f48a959f16a3fa12a4a2383091425a4e03502677",
+      "parent": "2950cbbdc18614f35a7cc1a8b59dbc283bde9315",
+      "subject": "feat(runtime): use `compileFunction` over `new Script` (#15461)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.18
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.0
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.32
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "a0e3f1cc1823d4f447e9bf2a4c7aaab9116dbcb4",
+      "parent": "b1bc641105405b8b0f13de3f825be6ba7172929a",
+      "subject": "internal: add handling of KVS config parse (#21079)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.41
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "a0e3f1cc1823d4f447e9bf2a4c7aaab9116dbcb4",
+      "parent": "b1bc641105405b8b0f13de3f825be6ba7172929a",
+      "subject": "internal: add handling of KVS config parse (#21079)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.85
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "cefc43e4daa4cbb490ef6726ea374e26a93eb85e",
+      "parent": "25e34fda5fed89b37176654adfacbc5fc7572d01",
+      "subject": "simplify the Get()/GetMultiple() re-use GetRaw() for both (#179)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.25
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "cefc43e4daa4cbb490ef6726ea374e26a93eb85e",
+      "parent": "25e34fda5fed89b37176654adfacbc5fc7572d01",
+      "subject": "simplify the Get()/GetMultiple() re-use GetRaw() for both (#179)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.44
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.91
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.96
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "4dae9ee6e41d1c41a48e958aad969c1a8e96bd1d",
+      "parent": "6ecb63d60a7dd6542f852bb5c965909b50ec6f97",
+      "subject": "Epoll: Use correct inital EpollIoOps (#16728)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 7.74
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "4dae9ee6e41d1c41a48e958aad969c1a8e96bd1d",
+      "parent": "6ecb63d60a7dd6542f852bb5c965909b50ec6f97",
+      "subject": "Epoll: Use correct inital EpollIoOps (#16728)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 11.83
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "89966319b932589c9800be6e3499129feed31766",
+      "parent": "b2ac3e4b610891727ede7ed6e395fcd0410a5dc5",
+      "subject": "Native transports: Fix undefined behaviour when GetStringUTFChars fails while open FD (#16450)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.5
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "89966319b932589c9800be6e3499129feed31766",
+      "parent": "b2ac3e4b610891727ede7ed6e395fcd0410a5dc5",
+      "subject": "Native transports: Fix undefined behaviour when GetStringUTFChars fails while open FD (#16450)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.38
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.37
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.58
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "818046d031902e27b7286f22f8fcf6fa7f7e5478",
+      "parent": "e8240017fd82fb62b2aa1e4705d5084042284a19",
+      "subject": "Avoid memory allocation on quicklist iteration (#14720)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 2.23
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "818046d031902e27b7286f22f8fcf6fa7f7e5478",
+      "parent": "e8240017fd82fb62b2aa1e4705d5084042284a19",
+      "subject": "Avoid memory allocation on quicklist iteration (#14720)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 3.57
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "ef741a95a2338c95cc9a9fc193a5142d57c04fe2",
+      "parent": "40c140bf16ca88cc67e6262c813fde1d8ea8242f",
+      "subject": "fix handleExpiredIdmpEntries to mark keys as modified (#14933)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 3.3
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "ef741a95a2338c95cc9a9fc193a5142d57c04fe2",
+      "parent": "40c140bf16ca88cc67e6262c813fde1d8ea8242f",
+      "subject": "fix handleExpiredIdmpEntries to mark keys as modified (#14933)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.09
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "467a42494dbdc2eef7bad2cd696f8cabb171e3a1",
+      "parent": "33ba2d3e1b21fe71f89f681858736f188ded2490",
+      "subject": "[Fix #11051] Fix Style/AccessModifierDeclarations inline autocorrect dropping comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.65
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "467a42494dbdc2eef7bad2cd696f8cabb171e3a1",
+      "parent": "33ba2d3e1b21fe71f89f681858736f188ded2490",
+      "subject": "[Fix #11051] Fix Style/AccessModifierDeclarations inline autocorrect dropping comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.78
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.79
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.62
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "9c62a14d61e5af15e0b3ddca83302a9d4c574a29",
+      "parent": "d011fde70b887e3a85b60e86b4d8c075e01d0e55",
+      "subject": "Merge pull request #14956 from lovro-bikic/redundant-interpolation-unfreeze-string-new",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.1
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "9c62a14d61e5af15e0b3ddca83302a9d4c574a29",
+      "parent": "d011fde70b887e3a85b60e86b4d8c075e01d0e55",
+      "subject": "Merge pull request #14956 from lovro-bikic/redundant-interpolation-unfreeze-string-new",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.05
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "597d2493f9b807580f46277f8102bd874833fba7",
+      "parent": "3f386be351eb7c62379d124a2f65894a9961e604",
+      "subject": "Suppress UndeliverableException handling in tests (#6987) (#6996)",
+      "ok": true,
+      "findings": 34,
+      "duration_s": 7.34
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "597d2493f9b807580f46277f8102bd874833fba7",
+      "parent": "3f386be351eb7c62379d124a2f65894a9961e604",
+      "subject": "Suppress UndeliverableException handling in tests (#6987) (#6996)",
+      "ok": true,
+      "findings": 42,
+      "duration_s": 10.07
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "624c4fb55bcbf0489a00db370154738c7d89408b",
+      "parent": "84736107209babc762ddd4394115afbe65a961c8",
+      "subject": "Update Schedulers.java (#7453)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.75
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "624c4fb55bcbf0489a00db370154738c7d89408b",
+      "parent": "84736107209babc762ddd4394115afbe65a961c8",
+      "subject": "Update Schedulers.java (#7453)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.22
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 6.73
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 7.38
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "5a9406e9c1c4459c1f727bb476a94bdc87b3316b",
+      "parent": "fce318a6455a179a197d9d126d9fc09b535788ef",
+      "subject": "chore: remove unused browser testing code and deps",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.08
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "5a9406e9c1c4459c1f727bb476a94bdc87b3316b",
+      "parent": "fce318a6455a179a197d9d126d9fc09b535788ef",
+      "subject": "chore: remove unused browser testing code and deps",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.55
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "627c76e88e27d9c428adf39eaba91cb41a839664",
+      "parent": "debc24e3c7fe6f4fbaba2ce36b579add15e99836",
+      "subject": "refactor(throttle): use new `operate` function",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.97
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "627c76e88e27d9c428adf39eaba91cb41a839664",
+      "parent": "debc24e3c7fe6f4fbaba2ce36b579add15e99836",
+      "subject": "refactor(throttle): use new `operate` function",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.11
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.21
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.86
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "16929c0991e143b6c5d3c8f1a192f8c25b9cd7d0",
+      "parent": "6a42bc645076b40450ae3c055f7c39d1c325b1fc",
+      "subject": "Exclude deprecated code from coverage. (#7241)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.74
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "16929c0991e143b6c5d3c8f1a192f8c25b9cd7d0",
+      "parent": "6a42bc645076b40450ae3c055f7c39d1c325b1fc",
+      "subject": "Exclude deprecated code from coverage. (#7241)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 1.14
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "2c1c10e923b9fb1c3c6c5069a01e46c4414746e4",
+      "parent": "3019393686b801fec253b1f1762babcdc6af357a",
+      "subject": "Remove deprecated offsite spider middleware. (#6926)",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 1.24
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "2c1c10e923b9fb1c3c6c5069a01e46c4414746e4",
+      "parent": "3019393686b801fec253b1f1762babcdc6af357a",
+      "subject": "Remove deprecated offsite spider middleware. (#6926)",
+      "ok": true,
+      "findings": 8,
+      "duration_s": 2.07
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.14
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.96
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "88af4193584c6ba4b5a01ce5ce6320085cb31703",
+      "parent": "a8a4f77709f12b3514d857056921645771b4b32e",
+      "subject": "Add terminate action to Busy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.91
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "88af4193584c6ba4b5a01ce5ce6320085cb31703",
+      "parent": "a8a4f77709f12b3514d857056921645771b4b32e",
+      "subject": "Add terminate action to Busy",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.08
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.38
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.23
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "e952aa0e40b9be40df364a25d6c23df6d79fa24f",
+      "parent": "ff0a840f373cf545373a34cbeacb49bf5138a2f8",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.61
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "e952aa0e40b9be40df364a25d6c23df6d79fa24f",
+      "parent": "ff0a840f373cf545373a34cbeacb49bf5138a2f8",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.24
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "50cf0dc31597bdb9f4e2568ad50d777eb5d0bbc0",
+      "parent": "ab96a4e7c5df772b64f8c12000b058f3e4982bc6",
+      "subject": "Merge pull request #29325 from tharu-jwd/refine-heaviside",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.56
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "50cf0dc31597bdb9f4e2568ad50d777eb5d0bbc0",
+      "parent": "ab96a4e7c5df772b64f8c12000b058f3e4982bc6",
+      "subject": "Merge pull request #29325 from tharu-jwd/refine-heaviside",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.72
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "947efe679a0c47c4f655dd973496b8cab89b2837",
+      "parent": "d671b70c7dc5475aaf6f08daa28fd2c8b15edeca",
+      "subject": "Merge pull request #28946 from Davide-sd/gradient_of_vector_field",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.6
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "947efe679a0c47c4f655dd973496b8cab89b2837",
+      "parent": "d671b70c7dc5475aaf6f08daa28fd2c8b15edeca",
+      "subject": "Merge pull request #28946 from Davide-sd/gradient_of_vector_field",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.13
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.44
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.68
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "09f92b5aedec6085863f570fe882915d0c2740f1",
+      "parent": "e65040f061008ca5a94d21721aa8b544c078c606",
+      "subject": "sync: clarify that recv returns None once closed and no more messages (#7920)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.41
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "09f92b5aedec6085863f570fe882915d0c2740f1",
+      "parent": "e65040f061008ca5a94d21721aa8b544c078c606",
+      "subject": "sync: clarify that recv returns None once closed and no more messages (#7920)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.49
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.59
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.93
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "c8116ecd7bba1dae71bfac25600420ec73fbc2b1",
+      "parent": "5471a5835e8bc406c2adc2b66d3020c00ab6a685",
+      "subject": "stream: work around the rustc bug in `StreamExt::collect` (#7754)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.29
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "c8116ecd7bba1dae71bfac25600420ec73fbc2b1",
+      "parent": "5471a5835e8bc406c2adc2b66d3020c00ab6a685",
+      "subject": "stream: work around the rustc bug in `StreamExt::collect` (#7754)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.37
+    }
+  ]
+}

--- a/bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json
+++ b/bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json
@@ -1,0 +1,1192 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "schema_version": 2,
+    "arms": {
+      "default": [],
+      "near": [
+        "--mode",
+        "syntax,semantic,near"
+      ]
+    },
+    "repos": [
+      "git",
+      "redis",
+      "hugo",
+      "minio",
+      "netty",
+      "rxjava",
+      "scrapy",
+      "sympy",
+      "rubocop",
+      "sidekiq",
+      "clap",
+      "tokio",
+      "jest",
+      "rxjs"
+    ],
+    "per_repo": 3,
+    "timeout_s": 240,
+    "jobs": 6,
+    "query_depth": 800,
+    "eligible_pool_cap": 200,
+    "min_changed_src_lines": 3,
+    "max_changed_src_lines": 600,
+    "supported_exts": [
+      ".c",
+      ".cjs",
+      ".go",
+      ".h",
+      ".html",
+      ".java",
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".py",
+      ".rb",
+      ".rs",
+      ".svelte",
+      ".ts",
+      ".tsx",
+      ".vue"
+    ],
+    "query_template": "nose query . base=<parent> top=0 --format json [arm args]",
+    "timing_fields": [
+      "duration_s"
+    ],
+    "selection": "even sample over newest eligible first-parent commits",
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "460162e8f0ae8c132b976e94a32918aae87348166299b2eefa8786a2cf4039ac",
+    "nose_version": "nose 0.17.0",
+    "source_commit": "08052e90e060e16b42f274c65cf1c5da30542757",
+    "source_dirty": true,
+    "commands": {
+      "replay": "eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos replay --per-repo 3 --jobs 6 --timeout 240 --out /tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl",
+      "summarize": "eval/divergence_fire/replay.py --repos-root /Users/ak/prjs/cc/nose/bench/repos summarize --records /tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl --out bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json"
+    },
+    "raw_records": {
+      "path": "/tmp/nose-688/divfire-08052e90-r14-p3.raw.jsonl",
+      "sha256": "e21094024246d87f9edc907f51898789fbe7435e16a48b100c6fb83c164a6d1e"
+    }
+  },
+  "per_arm": {
+    "default": {
+      "replays": 42,
+      "errors": 0,
+      "fired": 19,
+      "fire_rate": 0.4524,
+      "strict_fired": 6,
+      "new_copy_fired": 0,
+      "findings_total": 71,
+      "lane_counts": {
+        "base-divergence": 71
+      },
+      "tier_counts": {
+        "report-only": 46,
+        "review": 13,
+        "strict": 12
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 3,
+      "findings_per_fire_p50": 1,
+      "findings_per_fire_p90": 7,
+      "findings_per_fire_max": 34,
+      "divergence_s_p50": 4.23,
+      "divergence_s_p90": 9.2,
+      "divergence_s_max": 10.59
+    },
+    "near": {
+      "replays": 42,
+      "errors": 0,
+      "fired": 20,
+      "fire_rate": 0.4762,
+      "strict_fired": 9,
+      "new_copy_fired": 0,
+      "findings_total": 88,
+      "lane_counts": {
+        "base-divergence": 88
+      },
+      "tier_counts": {
+        "report-only": 58,
+        "review": 15,
+        "strict": 15
+      },
+      "findings_per_replay_p50": 0,
+      "findings_per_replay_p90": 3,
+      "findings_per_fire_p50": 2,
+      "findings_per_fire_p90": 8,
+      "findings_per_fire_max": 42,
+      "divergence_s_p50": 3.86,
+      "divergence_s_p90": 8.61,
+      "divergence_s_max": 11.88
+    }
+  },
+  "per_repo": {
+    "clap": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 0.93,
+        "divergence_s_p90": 1.06
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 3,
+        "divergence_s_p50": 1.24,
+        "divergence_s_p90": 1.3
+      }
+    },
+    "git": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 5.48,
+        "divergence_s_p90": 5.55
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 6.49,
+        "divergence_s_p90": 7.16
+      }
+    },
+    "hugo": {
+      "default": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 5.2,
+        "divergence_s_p90": 5.39
+      },
+      "near": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 4.62,
+        "divergence_s_p90": 5.02
+      }
+    },
+    "jest": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 6,
+        "divergence_s_p50": 2.09,
+        "divergence_s_p90": 4.23
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 6,
+        "divergence_s_p50": 1.96,
+        "divergence_s_p90": 3.14
+      }
+    },
+    "minio": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 3,
+        "divergence_s_p50": 4.79,
+        "divergence_s_p90": 5.85
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 3,
+        "divergence_s_p50": 4.27,
+        "divergence_s_p90": 5.04
+      }
+    },
+    "netty": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 9.3,
+        "divergence_s_p90": 10.03
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 11.8,
+        "divergence_s_p90": 11.88
+      }
+    },
+    "redis": {
+      "default": {
+        "replays": 3,
+        "fired": 3,
+        "findings": 6,
+        "divergence_s_p50": 3.07,
+        "divergence_s_p90": 3.4
+      },
+      "near": {
+        "replays": 3,
+        "fired": 3,
+        "findings": 8,
+        "divergence_s_p50": 4.24,
+        "divergence_s_p90": 4.46
+      }
+    },
+    "rubocop": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 2.72,
+        "divergence_s_p90": 2.9
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 2,
+        "divergence_s_p50": 3.25,
+        "divergence_s_p90": 3.86
+      }
+    },
+    "rxjava": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 37,
+        "divergence_s_p50": 6.94,
+        "divergence_s_p90": 7.74
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 46,
+        "divergence_s_p50": 8.41,
+        "divergence_s_p90": 8.61
+      }
+    },
+    "rxjs": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.39,
+        "divergence_s_p90": 1.54
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 1.25,
+        "divergence_s_p90": 1.56
+      }
+    },
+    "scrapy": {
+      "default": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 8,
+        "divergence_s_p50": 1.01,
+        "divergence_s_p90": 1.25
+      },
+      "near": {
+        "replays": 3,
+        "fired": 2,
+        "findings": 11,
+        "divergence_s_p50": 1.39,
+        "divergence_s_p90": 1.46
+      }
+    },
+    "sidekiq": {
+      "default": {
+        "replays": 3,
+        "fired": 0,
+        "findings": 0,
+        "divergence_s_p50": 4.63,
+        "divergence_s_p90": 10.59
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 3.19,
+        "divergence_s_p90": 7.47
+      }
+    },
+    "sympy": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 6.95,
+        "divergence_s_p90": 9.53
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 1,
+        "divergence_s_p50": 8.38,
+        "divergence_s_p90": 10.76
+      }
+    },
+    "tokio": {
+      "default": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 1.17,
+        "divergence_s_p90": 1.38
+      },
+      "near": {
+        "replays": 3,
+        "fired": 1,
+        "findings": 2,
+        "divergence_s_p50": 1.84,
+        "divergence_s_p90": 1.91
+      }
+    }
+  },
+  "selected_replays": [
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "5ca60e9079e79c44eee4e226fabec943b8138ef8",
+      "parent": "df1efca03509f736e26d2f16766b7ea06acc3ecf",
+      "subject": "Merge pull request #5731 from epage/bash",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 0.93
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "5ca60e9079e79c44eee4e226fabec943b8138ef8",
+      "parent": "df1efca03509f736e26d2f16766b7ea06acc3ecf",
+      "subject": "Merge pull request #5731 from epage/bash",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.03
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "a380b65fe9eceade90bce8aeb13c205265fcceee",
+      "parent": "25eb6fb7fd63d02217024aa112c1fa268771945a",
+      "subject": "Merge pull request #6023 from epage/template",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 0.86
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "a380b65fe9eceade90bce8aeb13c205265fcceee",
+      "parent": "25eb6fb7fd63d02217024aa112c1fa268771945a",
+      "subject": "Merge pull request #6023 from epage/template",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.3
+    },
+    {
+      "repo": "clap",
+      "arm": "default",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.06
+    },
+    {
+      "repo": "clap",
+      "arm": "near",
+      "commit": "c96f222c35c4ef4bd3ab9927809b2724532a8f6e",
+      "parent": "87ec1ad80dc174563cba130772823562e4427560",
+      "subject": "Merge pull request #6368 from truffle-dev/fix/fish-env-escaping",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.24
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "1678b7de977043f31242d2029259797eee620236",
+      "parent": "fb5516997ef3f882d8e53ce70ba6077533683621",
+      "subject": "Merge branch 'mm/line-log-use-standard-diff-output'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.55
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "1678b7de977043f31242d2029259797eee620236",
+      "parent": "fb5516997ef3f882d8e53ce70ba6077533683621",
+      "subject": "Merge branch 'mm/line-log-use-standard-diff-output'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.49
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "db227bce2224b55b11954a5f292a0b035b7d9279",
+      "parent": "394c18092f3e2a773333a08d3f8241322a97aa39",
+      "subject": "Merge branch 'ob/core-attributesfile-in-repository'",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.48
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "db227bce2224b55b11954a5f292a0b035b7d9279",
+      "parent": "394c18092f3e2a773333a08d3f8241322a97aa39",
+      "subject": "Merge branch 'ob/core-attributesfile-in-repository'",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 5.99
+    },
+    {
+      "repo": "git",
+      "arm": "default",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.08
+    },
+    {
+      "repo": "git",
+      "arm": "near",
+      "commit": "ffaa2eddd07afa5a86daaf0f9fd8838fb283dc2d",
+      "parent": "15dc60dcd1410a01b5e30b018895c3bd454735e5",
+      "subject": "Merge branch 'ds/path-walk-filters'",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.16
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "1eea9fba0b7ff174d1e30b2307bef54842f422fc",
+      "parent": "9a5c7e0d244ca7ae1065fc809277edffd50211f5",
+      "subject": "commands: Fix environment isolation for configuration settings",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.39
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "1eea9fba0b7ff174d1e30b2307bef54842f422fc",
+      "parent": "9a5c7e0d244ca7ae1065fc809277edffd50211f5",
+      "subject": "commands: Fix environment isolation for configuration settings",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.02
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "3850881f2a9b718f049b8330a2b9e37119900499",
+      "parent": "a18bec1123e582da818dc8a841285d1a8eb27de4",
+      "subject": "modules: Include JSON error info from go mod download in error messages",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.2
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "3850881f2a9b718f049b8330a2b9e37119900499",
+      "parent": "a18bec1123e582da818dc8a841285d1a8eb27de4",
+      "subject": "modules: Include JSON error info from go mod download in error messages",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.48
+    },
+    {
+      "repo": "hugo",
+      "arm": "default",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.02
+    },
+    {
+      "repo": "hugo",
+      "arm": "near",
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "parent": "ca68936d61b4cf0c1d3a45f5d4eb0a564a3c78ef",
+      "subject": "images: Add quality setting per image format",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.62
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "6813dfa8c78f0232726db88e31c04780d785b3bf",
+      "parent": "7cf3b8d24ae3753522a28728eacd034cd6381b0b",
+      "subject": "feat(jest-fake-timers): Add feature to configure how timers advance  (#15871)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 2.09
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "6813dfa8c78f0232726db88e31c04780d785b3bf",
+      "parent": "7cf3b8d24ae3753522a28728eacd034cd6381b0b",
+      "subject": "feat(jest-fake-timers): Add feature to configure how timers advance  (#15871)",
+      "ok": true,
+      "findings": 5,
+      "duration_s": 1.96
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.23
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "c885d68d5e42da4ca64c0ab688b6761f2cd3dd74",
+      "parent": "d43a0ae0e9769b0ad0dc0d819646e2b68ce62b37",
+      "subject": "chore: enforce changelog entry on PRs via GitHub Actions (#16199)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.14
+    },
+    {
+      "repo": "jest",
+      "arm": "default",
+      "commit": "f48a959f16a3fa12a4a2383091425a4e03502677",
+      "parent": "2950cbbdc18614f35a7cc1a8b59dbc283bde9315",
+      "subject": "feat(runtime): use `compileFunction` over `new Script` (#15461)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.38
+    },
+    {
+      "repo": "jest",
+      "arm": "near",
+      "commit": "f48a959f16a3fa12a4a2383091425a4e03502677",
+      "parent": "2950cbbdc18614f35a7cc1a8b59dbc283bde9315",
+      "subject": "feat(runtime): use `compileFunction` over `new Script` (#15461)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.17
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.79
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "10b0a234d25bf47e99b9c90989c84c405b5e81ce",
+      "parent": "18f97e70b19db6b2940ae8a1b14c4665d2eeca36",
+      "subject": "fix: update metric descriptions to specify current MinIO server instance (#21638)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.27
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "a0e3f1cc1823d4f447e9bf2a4c7aaab9116dbcb4",
+      "parent": "b1bc641105405b8b0f13de3f825be6ba7172929a",
+      "subject": "internal: add handling of KVS config parse (#21079)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.85
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "a0e3f1cc1823d4f447e9bf2a4c7aaab9116dbcb4",
+      "parent": "b1bc641105405b8b0f13de3f825be6ba7172929a",
+      "subject": "internal: add handling of KVS config parse (#21079)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 5.04
+    },
+    {
+      "repo": "minio",
+      "arm": "default",
+      "commit": "cefc43e4daa4cbb490ef6726ea374e26a93eb85e",
+      "parent": "25e34fda5fed89b37176654adfacbc5fc7572d01",
+      "subject": "simplify the Get()/GetMultiple() re-use GetRaw() for both (#179)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.79
+    },
+    {
+      "repo": "minio",
+      "arm": "near",
+      "commit": "cefc43e4daa4cbb490ef6726ea374e26a93eb85e",
+      "parent": "25e34fda5fed89b37176654adfacbc5fc7572d01",
+      "subject": "simplify the Get()/GetMultiple() re-use GetRaw() for both (#179)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.24
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.2
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "2394530bdb6837d928c2ec0b4d8f598487059ef9",
+      "parent": "0bd1657a601da85c324d28562dc7d1ae220ad3a7",
+      "subject": "Auto-port 4.2: MQTT: Reject malformed no-payload packets with non-zero Remaining Length (#16890)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.8
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "4dae9ee6e41d1c41a48e958aad969c1a8e96bd1d",
+      "parent": "6ecb63d60a7dd6542f852bb5c965909b50ec6f97",
+      "subject": "Epoll: Use correct inital EpollIoOps (#16728)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 10.03
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "4dae9ee6e41d1c41a48e958aad969c1a8e96bd1d",
+      "parent": "6ecb63d60a7dd6542f852bb5c965909b50ec6f97",
+      "subject": "Epoll: Use correct inital EpollIoOps (#16728)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 11.88
+    },
+    {
+      "repo": "netty",
+      "arm": "default",
+      "commit": "89966319b932589c9800be6e3499129feed31766",
+      "parent": "b2ac3e4b610891727ede7ed6e395fcd0410a5dc5",
+      "subject": "Native transports: Fix undefined behaviour when GetStringUTFChars fails while open FD (#16450)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.3
+    },
+    {
+      "repo": "netty",
+      "arm": "near",
+      "commit": "89966319b932589c9800be6e3499129feed31766",
+      "parent": "b2ac3e4b610891727ede7ed6e395fcd0410a5dc5",
+      "subject": "Native transports: Fix undefined behaviour when GetStringUTFChars fails while open FD (#16450)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 11.13
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.4
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "parent": "1b3721eb22f1e6c9663e6af6e87e532f23ca9713",
+      "subject": "Avoid double-walk on find-then-insert via raxFindLink + raxInsertAt (#15252)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.46
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "818046d031902e27b7286f22f8fcf6fa7f7e5478",
+      "parent": "e8240017fd82fb62b2aa1e4705d5084042284a19",
+      "subject": "Avoid memory allocation on quicklist iteration (#14720)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 3.07
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "818046d031902e27b7286f22f8fcf6fa7f7e5478",
+      "parent": "e8240017fd82fb62b2aa1e4705d5084042284a19",
+      "subject": "Avoid memory allocation on quicklist iteration (#14720)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 3.44
+    },
+    {
+      "repo": "redis",
+      "arm": "default",
+      "commit": "ef741a95a2338c95cc9a9fc193a5142d57c04fe2",
+      "parent": "40c140bf16ca88cc67e6262c813fde1d8ea8242f",
+      "subject": "fix handleExpiredIdmpEntries to mark keys as modified (#14933)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 2.6
+    },
+    {
+      "repo": "redis",
+      "arm": "near",
+      "commit": "ef741a95a2338c95cc9a9fc193a5142d57c04fe2",
+      "parent": "40c140bf16ca88cc67e6262c813fde1d8ea8242f",
+      "subject": "fix handleExpiredIdmpEntries to mark keys as modified (#14933)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 4.24
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "467a42494dbdc2eef7bad2cd696f8cabb171e3a1",
+      "parent": "33ba2d3e1b21fe71f89f681858736f188ded2490",
+      "subject": "[Fix #11051] Fix Style/AccessModifierDeclarations inline autocorrect dropping comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.7
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "467a42494dbdc2eef7bad2cd696f8cabb171e3a1",
+      "parent": "33ba2d3e1b21fe71f89f681858736f188ded2490",
+      "subject": "[Fix #11051] Fix Style/AccessModifierDeclarations inline autocorrect dropping comments",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 3.17
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.9
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "810c790a68123a8c4aae6607bfa792e9d9275585",
+      "parent": "1ec05543769f7cd7b89bf9bf2d6c0e2f071af6a1",
+      "subject": "Fix incorrect autocorrect for `Style/StructInheritance` cop",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.25
+    },
+    {
+      "repo": "rubocop",
+      "arm": "default",
+      "commit": "9c62a14d61e5af15e0b3ddca83302a9d4c574a29",
+      "parent": "d011fde70b887e3a85b60e86b4d8c075e01d0e55",
+      "subject": "Merge pull request #14956 from lovro-bikic/redundant-interpolation-unfreeze-string-new",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 2.72
+    },
+    {
+      "repo": "rubocop",
+      "arm": "near",
+      "commit": "9c62a14d61e5af15e0b3ddca83302a9d4c574a29",
+      "parent": "d011fde70b887e3a85b60e86b4d8c075e01d0e55",
+      "subject": "Merge pull request #14956 from lovro-bikic/redundant-interpolation-unfreeze-string-new",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.86
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "597d2493f9b807580f46277f8102bd874833fba7",
+      "parent": "3f386be351eb7c62379d124a2f65894a9961e604",
+      "subject": "Suppress UndeliverableException handling in tests (#6987) (#6996)",
+      "ok": true,
+      "findings": 34,
+      "duration_s": 6.65
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "597d2493f9b807580f46277f8102bd874833fba7",
+      "parent": "3f386be351eb7c62379d124a2f65894a9961e604",
+      "subject": "Suppress UndeliverableException handling in tests (#6987) (#6996)",
+      "ok": true,
+      "findings": 42,
+      "duration_s": 8.61
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "624c4fb55bcbf0489a00db370154738c7d89408b",
+      "parent": "84736107209babc762ddd4394115afbe65a961c8",
+      "subject": "Update Schedulers.java (#7453)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.94
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "624c4fb55bcbf0489a00db370154738c7d89408b",
+      "parent": "84736107209babc762ddd4394115afbe65a961c8",
+      "subject": "Update Schedulers.java (#7453)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.39
+    },
+    {
+      "repo": "rxjava",
+      "arm": "default",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 7.74
+    },
+    {
+      "repo": "rxjava",
+      "arm": "near",
+      "commit": "fc0fca7e70ef997ce573b0a652a0fde7689422a1",
+      "parent": "3bda03c26cc5dd6e136388d1dee76a593b4234ab",
+      "subject": "test: simplify SingleRetryTest callables (#8120)",
+      "ok": true,
+      "findings": 4,
+      "duration_s": 8.41
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "5a9406e9c1c4459c1f727bb476a94bdc87b3316b",
+      "parent": "fce318a6455a179a197d9d126d9fc09b535788ef",
+      "subject": "chore: remove unused browser testing code and deps",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.39
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "5a9406e9c1c4459c1f727bb476a94bdc87b3316b",
+      "parent": "fce318a6455a179a197d9d126d9fc09b535788ef",
+      "subject": "chore: remove unused browser testing code and deps",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "627c76e88e27d9c428adf39eaba91cb41a839664",
+      "parent": "debc24e3c7fe6f4fbaba2ce36b579add15e99836",
+      "subject": "refactor(throttle): use new `operate` function",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.14
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "627c76e88e27d9c428adf39eaba91cb41a839664",
+      "parent": "debc24e3c7fe6f4fbaba2ce36b579add15e99836",
+      "subject": "refactor(throttle): use new `operate` function",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.09
+    },
+    {
+      "repo": "rxjs",
+      "arm": "default",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.54
+    },
+    {
+      "repo": "rxjs",
+      "arm": "near",
+      "commit": "9c8fa65ea161f97cc90ea9b4679b0ae104a29ffb",
+      "parent": "2587ee852eb43eeb0883a7787bac2944d823392b",
+      "subject": "docs: remove duplicate deprecated note on retryWhen (#7465)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.56
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "16929c0991e143b6c5d3c8f1a192f8c25b9cd7d0",
+      "parent": "6a42bc645076b40450ae3c055f7c39d1c325b1fc",
+      "subject": "Exclude deprecated code from coverage. (#7241)",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 1.25
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "16929c0991e143b6c5d3c8f1a192f8c25b9cd7d0",
+      "parent": "6a42bc645076b40450ae3c055f7c39d1c325b1fc",
+      "subject": "Exclude deprecated code from coverage. (#7241)",
+      "ok": true,
+      "findings": 3,
+      "duration_s": 1.07
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "2c1c10e923b9fb1c3c6c5069a01e46c4414746e4",
+      "parent": "3019393686b801fec253b1f1762babcdc6af357a",
+      "subject": "Remove deprecated offsite spider middleware. (#6926)",
+      "ok": true,
+      "findings": 7,
+      "duration_s": 0.82
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "2c1c10e923b9fb1c3c6c5069a01e46c4414746e4",
+      "parent": "3019393686b801fec253b1f1762babcdc6af357a",
+      "subject": "Remove deprecated offsite spider middleware. (#6926)",
+      "ok": true,
+      "findings": 8,
+      "duration_s": 1.46
+    },
+    {
+      "repo": "scrapy",
+      "arm": "default",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.01
+    },
+    {
+      "repo": "scrapy",
+      "arm": "near",
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "parent": "4a165508591da164393c448eebc86c9aa48081da",
+      "subject": "fix typos (#7564)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.39
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "88af4193584c6ba4b5a01ce5ce6320085cb31703",
+      "parent": "a8a4f77709f12b3514d857056921645771b4b32e",
+      "subject": "Add terminate action to Busy",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.63
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "88af4193584c6ba4b5a01ce5ce6320085cb31703",
+      "parent": "a8a4f77709f12b3514d857056921645771b4b32e",
+      "subject": "Add terminate action to Busy",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 3.19
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.59
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "a0573b8208a3516f7fb1ffdabe0afd44f8466af2",
+      "parent": "bec4e6818c8facb189e504f673aa37a2014a821e",
+      "subject": "Add unit tests for Sidekiq::Web::Route (#7023)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 7.47
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "default",
+      "commit": "e952aa0e40b9be40df364a25d6c23df6d79fa24f",
+      "parent": "ff0a840f373cf545373a34cbeacb49bf5138a2f8",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 4.2
+    },
+    {
+      "repo": "sidekiq",
+      "arm": "near",
+      "commit": "e952aa0e40b9be40df364a25d6c23df6d79fa24f",
+      "parent": "ff0a840f373cf545373a34cbeacb49bf5138a2f8",
+      "subject": "fmt",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 2.65
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "50cf0dc31597bdb9f4e2568ad50d777eb5d0bbc0",
+      "parent": "ab96a4e7c5df772b64f8c12000b058f3e4982bc6",
+      "subject": "Merge pull request #29325 from tharu-jwd/refine-heaviside",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 6.79
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "50cf0dc31597bdb9f4e2568ad50d777eb5d0bbc0",
+      "parent": "ab96a4e7c5df772b64f8c12000b058f3e4982bc6",
+      "subject": "Merge pull request #29325 from tharu-jwd/refine-heaviside",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 8.38
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "947efe679a0c47c4f655dd973496b8cab89b2837",
+      "parent": "d671b70c7dc5475aaf6f08daa28fd2c8b15edeca",
+      "subject": "Merge pull request #28946 from Davide-sd/gradient_of_vector_field",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 6.95
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "947efe679a0c47c4f655dd973496b8cab89b2837",
+      "parent": "d671b70c7dc5475aaf6f08daa28fd2c8b15edeca",
+      "subject": "Merge pull request #28946 from Davide-sd/gradient_of_vector_field",
+      "ok": true,
+      "findings": 1,
+      "duration_s": 5.48
+    },
+    {
+      "repo": "sympy",
+      "arm": "default",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 9.53
+    },
+    {
+      "repo": "sympy",
+      "arm": "near",
+      "commit": "d2b78381d01b43cf2c3cd55876c1a9ee59be213c",
+      "parent": "78371c0fd648ecc47a5e2df31867fe96c2e987d4",
+      "subject": "Merge pull request #29821 from generatingfunctions/latex_beta_args",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 10.76
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "09f92b5aedec6085863f570fe882915d0c2740f1",
+      "parent": "e65040f061008ca5a94d21721aa8b544c078c606",
+      "subject": "sync: clarify that recv returns None once closed and no more messages (#7920)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.16
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "09f92b5aedec6085863f570fe882915d0c2740f1",
+      "parent": "e65040f061008ca5a94d21721aa8b544c078c606",
+      "subject": "sync: clarify that recv returns None once closed and no more messages (#7920)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.84
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.17
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "parent": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "ok": true,
+      "findings": 2,
+      "duration_s": 1.91
+    },
+    {
+      "repo": "tokio",
+      "arm": "default",
+      "commit": "c8116ecd7bba1dae71bfac25600420ec73fbc2b1",
+      "parent": "5471a5835e8bc406c2adc2b66d3020c00ab6a685",
+      "subject": "stream: work around the rustc bug in `StreamExt::collect` (#7754)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.38
+    },
+    {
+      "repo": "tokio",
+      "arm": "near",
+      "commit": "c8116ecd7bba1dae71bfac25600420ec73fbc2b1",
+      "parent": "5471a5835e8bc406c2adc2b66d3020c00ab6a685",
+      "subject": "stream: work around the rustc bug in `StreamExt::collect` (#7754)",
+      "ok": true,
+      "findings": 0,
+      "duration_s": 1.25
+    }
+  ]
+}

--- a/docs/divergent-gate-product-runtime-688.md
+++ b/docs/divergent-gate-product-runtime-688.md
@@ -1,0 +1,74 @@
+# Divergent Gate Product Runtime 688
+
+Issue #688 records product-output and runtime evidence for the #681 divergent
+gate productization work through #687. It is not the final epic closeout and
+does not claim default-on readiness.
+
+## Checked Artifacts
+
+- Product/runtime summary: [issue-688-product-output-runtime-summary-2026-07-06.v1.json](../bench/divergent_history/issue-688-product-output-runtime-summary-2026-07-06.v1.json)
+  is the checked index artifact.
+- Non-`base=` all-repos query regression: [issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json](../bench/divergent_history/issue-688-nonbase-allrepos-query-regression-2026-07-06.v1.json)
+  compares `551758d5` with `08052e90` across all 120 pinned corpus repos.
+- Non-`base=` same-binary control: [issue-688-nonbase-same-binary-control-2026-07-06.v1.json](../bench/divergent_history/issue-688-nonbase-same-binary-control-2026-07-06.v1.json)
+  prices ordinary wall-time noise on the same 120 repos.
+- Focused nose slice: [issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json](../bench/divergent_history/issue-688-nonbase-nose-slice-query-regression-2026-07-06.v1.json)
+  covers `crates/nose-cli/src` and `crates/nose-cli/tests/cli`.
+- Bounded replay summaries: [baseline](../bench/divergent_history/issue-688-replay-summary-baseline-551758d5-r14-p3-2026-07-06.v1.json)
+  and [current](../bench/divergent_history/issue-688-replay-summary-current-08052e90-r14-p3-2026-07-06.v1.json)
+  replay the divergent gate over the default 14-repo set with `per-repo 3`.
+
+Raw replay JSONL remains under `/tmp/nose-688/` and is not checked in. The
+checked summaries record raw sha256 values.
+
+## Non-Base Product Output
+
+Command shape:
+
+```sh
+nose query <repo> all top=0 --mode semantic --format json
+```
+
+All-repos result:
+
+| measure | value |
+|---|---:|
+| repos | 120 |
+| output hash drift | 0 |
+| byte-count drift | 0 |
+| family-count drift | 0 |
+| aggregate median | `56301.32ms -> 56835.43ms` |
+| aggregate delta | `+0.95%` |
+
+One small repo, `faraday`, crossed the repo-level runtime threshold in the
+baseline/current run (`51.59ms -> 85.78ms`). The same-binary control did not
+reproduce it (`61.70ms -> 53.05ms`) and measured aggregate `-0.40%`, so no
+runtime triage or optimization was opened.
+
+Focused nose slice result:
+
+| path | output | families | median |
+|---|---|---:|---:|
+| `crates/nose-cli/src` | identical | 2 | `80.95ms -> 80.97ms` |
+| `crates/nose-cli/tests/cli` | identical | 0 | `43.26ms -> 44.40ms` |
+
+## Base Replay Runtime
+
+The bounded replay used the default `eval/divergence_fire/replay.py` repo set,
+`per-repo 3`, default and near arms, and raw records outside git.
+
+| arm | count result | p50 | p90 |
+|---|---|---:|---:|
+| default | identical counts, tiers, lanes, errors 0 | `3.79s -> 4.23s` | `8.91s -> 9.20s` |
+| near | identical counts, tiers, lanes, errors 0 | `4.09s -> 3.86s` | `10.07s -> 8.61s` |
+
+The largest positive p50/p90 movement was default p50 `+11.6%`, below the 20%
+replay timing threshold. No runtime triage or optimization work was opened.
+
+## Validation
+
+The docs gate validates this packet through
+`scripts/check-divergent-history-artifacts.py`. The checker verifies referenced
+sha256 values, non-`base=` hash/byte/family stability, deterministic per-repo
+outputs, replay errors, replay count stability, replay timing thresholds, and
+absence of source-bearing summary keys.

--- a/docs/home.md
+++ b/docs/home.md
@@ -149,6 +149,7 @@ fundamentals; the rest is grouped by area.
 - [dogfooding](dogfooding.md) — the current nose-on-nose duplication gate and baseline workflow.
 - [dogfooding history](dogfooding-history.md) — detailed nose-on-nose review log and accepted-family decisions.
 - [divergent-history-mining-pilot-687](divergent-history-mining-pilot-687.md) — checked #687 evidence for bounded divergent history mining and a non-required observe-only pilot.
+- [divergent-gate-product-runtime-688](divergent-gate-product-runtime-688.md) — checked #688 product-output and runtime evidence for the opt-in divergent gate.
 - [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.
 - [query-json-agent-audit-2026-06-10](query-json-agent-audit-2026-06-10.md) — machine-contract audit for consumer 1's evidence surface.
 - [query-json-agent-audit-2026-06-13](query-json-agent-audit-2026-06-13.md) — re-validation after the gap fixes (incl. the graded witness): all five gaps closed, 8/8 decidable from JSON alone.

--- a/scripts/check-divergent-history-artifacts.py
+++ b/scripts/check-divergent-history-artifacts.py
@@ -14,6 +14,19 @@ from typing import Any
 ROOT = Path(__file__).resolve().parent.parent
 HISTORY_ARTIFACT = ROOT / "bench/divergent_history/issue-687-cli-tests-2026-07-06.v1.json"
 PILOT_ARTIFACT = ROOT / "bench/divergent_history/issue-687-maintainer-pilot-2026-07-06.v1.json"
+ISSUE_688_SUMMARY = (
+    ROOT / "bench/divergent_history/issue-688-product-output-runtime-summary-2026-07-06.v1.json"
+)
+SOURCE_BEARING_KEYS = {
+    "base_code",
+    "change_diff",
+    "current_code",
+    "diff",
+    "patch",
+    "snippet",
+    "snippets",
+    "source_text",
+}
 
 
 def require(condition: bool, message: str) -> None:
@@ -34,7 +47,21 @@ def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text())
 
 
-def main() -> int:
+def find_source_bearing_keys(value: Any, path: str = "$") -> list[str]:
+    matches: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            next_path = f"{path}.{key}"
+            if key in SOURCE_BEARING_KEYS:
+                matches.append(next_path)
+            matches.extend(find_source_bearing_keys(nested, next_path))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            matches.extend(find_source_bearing_keys(nested, f"{path}[{index}]"))
+    return matches
+
+
+def validate_issue_687() -> None:
     subprocess.run(
         [
             sys.executable,
@@ -79,6 +106,101 @@ def main() -> int:
         and str(raw_query.get("path", "")).startswith("target/"),
         "pilot raw query path must be an untracked target/ artifact",
     )
+
+
+def referenced_artifact(row: dict[str, Any]) -> tuple[Path, dict[str, Any]]:
+    path = ROOT / row["path"]
+    require(row.get("sha256") == sha256_file(path), f"stale sha: {row['path']}")
+    return path, load_json(path)
+
+
+def validate_query_regression(row: dict[str, Any]) -> None:
+    _path, data = referenced_artifact(row)
+    stability = row.get("stability") or {}
+    require(stability.get("hashes_identical") is True, f"hash drift in {row['path']}")
+    require(stability.get("bytes_identical") is True, f"byte-count drift in {row['path']}")
+    require(stability.get("families_identical") is True, f"family-count drift in {row['path']}")
+    require(stability.get("internally_deterministic") is True, f"nondeterministic run in {row['path']}")
+    by_repo = data.get("summary", {}).get("by_repo", {})
+    require(len(by_repo) == stability.get("repos"), f"repo count mismatch in {row['path']}")
+    for repo, labels in by_repo.items():
+        baseline = labels["baseline"]
+        current = labels["current"]
+        require(baseline["hashes"] == current["hashes"], f"{row['path']} {repo} hash drift")
+        require(baseline["bytes"] == current["bytes"], f"{row['path']} {repo} byte drift")
+        require(baseline["families"] == current["families"], f"{row['path']} {repo} family drift")
+        for key in ("hashes", "bytes", "families"):
+            require(
+                len(baseline[key]) == 1,
+                f"{row['path']} {repo} baseline {key} nondeterministic",
+            )
+            require(
+                len(current[key]) == 1,
+                f"{row['path']} {repo} current {key} nondeterministic",
+            )
+
+
+def validate_replay_pair(summary: dict[str, Any]) -> None:
+    replay = summary["base_replay_runtime"]
+    for label in ("baseline", "current"):
+        _path, data = referenced_artifact(replay[label])
+        require(data.get("schema_version") == 2, f"replay schema mismatch: {replay[label]['path']}")
+        for arm, arm_row in data.get("per_arm", {}).items():
+            require(arm_row.get("errors") == 0, f"replay errors in {replay[label]['path']} {arm}")
+
+    for arm, row in replay["comparison"].items():
+        require(row.get("counts_identical") is True, f"replay counts drift for {arm}")
+        for key in ("divergence_s_p50", "divergence_s_p90"):
+            require(
+                row["timing_delta_pct"][key] < 20.0,
+                f"replay {arm} {key} exceeded 20% threshold",
+            )
+
+
+def validate_issue_688() -> None:
+    summary = load_json(ISSUE_688_SUMMARY)
+    require(
+        summary.get("schema") == "nose.divergent_gate_product_runtime.v1",
+        "issue 688 summary schema mismatch",
+    )
+    require(
+        summary.get("bounds", {}).get("default_on_readiness_claim") is False,
+        "issue 688 must not claim default-on readiness",
+    )
+    require(
+        summary.get("bounds", {}).get("final_epic_closeout") is False,
+        "issue 688 must not claim final epic closeout",
+    )
+    non_base = summary["non_base_product_output"]
+    validate_query_regression(non_base["allrepos"])
+    validate_query_regression(non_base["same_binary_control"])
+    validate_query_regression(non_base["nose_slice"])
+    require(
+        non_base["interpretation"].get("runtime_triage_required") is False,
+        "issue 688 unexpectedly requires runtime triage",
+    )
+    validate_replay_pair(summary)
+    conclusion = summary["conclusion"]
+    for key in (
+        "non_base_hashes_identical_all_repos",
+        "non_base_bytes_identical_all_repos",
+        "non_base_families_identical_all_repos",
+        "non_base_hashes_identical_nose_slice",
+        "base_replay_counts_identical",
+    ):
+        require(conclusion.get(key) is True, f"issue 688 conclusion {key} is not true")
+    require(conclusion.get("unexplained_runtime_regression") is False, "unexplained runtime regression")
+    require(conclusion.get("runtime_triage_opened") is False, "runtime triage should not be opened")
+    require(conclusion.get("optimization_opened") is False, "optimization should not be opened")
+    require(
+        not find_source_bearing_keys(summary),
+        "issue 688 summary contains source-bearing keys",
+    )
+
+
+def main() -> int:
+    validate_issue_687()
+    validate_issue_688()
     print("divergent history checked artifacts OK")
     return 0
 


### PR DESCRIPTION
## Summary
- add checked #688 product-output/runtime evidence for the #681 divergent gate productization range
- record all-120 non-`base=` query regression, same-binary control, focused nose slice, and bounded `base=` replay summaries
- extend divergent-history artifact validation to enforce #688 sha links, non-`base=` output stability, replay count/timing thresholds, and no source-bearing summary keys

Closes #688

## Evidence
- 120/120 non-`base=` corpus repos kept identical stdout hashes, byte counts, and family counts across `551758d5 -> 08052e90`
- focused `crates/nose-cli/src` and `crates/nose-cli/tests/cli` query outputs stayed identical
- bounded replay counts/tier/lane summaries stayed identical with 0 errors; largest positive p50/p90 movement was default p50 +11.6%, below the 20% investigation threshold
- no runtime triage or optimization was opened

## Validation
- `python3 scripts/query-regression-harness.py --self-test`
- `python3 scripts/runtime-triage-harness.py --self-test`
- `python3 eval/divergence_fire/replay.py check-artifacts`
- `python3 scripts/check-divergent-history-artifacts.py`
- `python3 -m json.tool bench/divergent_history/issue-688-product-output-runtime-summary-2026-07-06.v1.json >/dev/null`
- `python3 -m py_compile scripts/check-divergent-history-artifacts.py scripts/divergent-history-mining.py`
- `./scripts/check-docs.sh`
- `git diff --check`
- pre-push fast local CI
