### PR TITLE
Close divergent gate productization docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ break.
   default-surface families by sharing admission-resolver provenance test
   helpers for Rust `HashMap::from`, Java `Map.of`, and JavaScript `Set`/`Map`
   constructor scenarios.
+- Clarified the #681 divergent-edit opt-in gate closeout docs: `gate.fail_default`
+  remains the sole default CI authority, the checked strict precision baseline is
+  0.562, and non-strict tiers remain advisory.
 - Polished divergent-edit v2 CI documentation and output copy: SARIF messages now name
   strict/review/report-only tiers directly, human `base=<ref>` output explains report-only
   reasons more specifically, and CI examples pin detection modes plus `top=0` SARIF uploads.

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -44,10 +44,11 @@ nose query <path> --format json                    # the ranked triage surface (
 nose query <path> base=origin/main --format json   # PR-time divergence (the base view)
 ```
 
-Parse the family objects — `families[]` in the dashboard or list view
-(dashboard also keeps `top_candidates[]` as a compatibility alias), `items[]` in the `base` view
-([query JSON](query-json.md)). Do not scrape human output. The per-family decision procedure
-below applies to both a `nose query` row and a JSON family — they carry the same evidence fields.
+Parse `families[]` in the dashboard or list view (dashboard also keeps
+`top_candidates[]` as a compatibility alias). The per-family decision procedure below applies
+to normal `nose query` rows and JSON families — they carry the same evidence fields.
+The PR-time `base` view emits `items[]`; use the divergent-edit procedure below for those
+records instead. Do not scrape human output.
 
 ## Per-family decision procedure
 
@@ -131,15 +132,19 @@ Read the fields in this order — each step either decides or narrows:
 `nose query <path> base=<ref> --format json` (the `base` view) emits one `items[]`
 finding per divergence, each carrying the v2 gate fields: `tier`, `tier_reasons[]`,
 `taxonomy_hint`, and `gate.fail_default`, plus legacy `fire_eligible` compatibility
-evidence, `witness_kind`, `scope`, and per-changed-site `touches_shared`. For a harm pass over the top
-findings, judge each as
+evidence, `witness_kind`, `scope`, and per-changed-site `touches_shared`. For propagation
+triage over the top findings, judge each as
 should-propagate / intentional-divergence / not-a-clone using the changed member's
 diff and the un-updated sibling's body. Most fires are not propagation hazards; the
-`strict` tier is the default-failing high-precision slice ([experiments](experiments.md)
-measured the base rates). Do not reconstruct the default gate from `fire_eligible`;
-use `gate.fail_default`. Treat `lane="new-copy"` as report-only context: inspect
-its `current_only[]` current-tree sites when useful, but do not ask CI to fail on it
-unless a later measured policy explicitly promotes that lane.
+current checked strict baseline has precision 0.562 ([experiments](experiments.md)
+measured the base rates), so treat it as opt-in review-gate evidence, not a
+default-on blocking claim. Do not reconstruct the default gate from `fire_eligible`;
+only `gate.fail_default=true` blocks in the opt-in enforcing workflow. `review`,
+`report-only`, `suppressed`, mixed/test findings, and `lane="new-copy"` are advisory:
+inspect their evidence when useful, but do not ask CI to fail on them unless a later
+measured policy explicitly promotes a lane. `taxonomy_hint` guides inspection; it does
+not declare correctness or harm. Adding `near` to PR-time `base=` is an explicit audit
+opt-in, not the default recommendation.
 
 ## Validation
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -65,9 +65,9 @@ For a broader exact gate, pin both exact channels and keep only substantial find
 nose query src --mode syntax,semantic --min-value 300 --min-members 3 --fail-on any
 ```
 
-To include Type-3 near-duplicates in an audit ratchet, add `near` and tune the fuzzy
-threshold. This is usually better as a report or ratchet with `--min-value` than as a
-bare "any finding fails" gate:
+To include Type-3 near-duplicates, make that an explicit audit or ratchet opt-in:
+add `near` and tune the fuzzy threshold. This is usually better as a report or ratchet
+with `--min-value` than as a bare "any finding fails" gate:
 
 ```sh
 nose query src --mode syntax,semantic,near:0.70 --min-value 300 --min-members 3 --fail-on any
@@ -191,9 +191,9 @@ It is truncated by the active top limit in the same way.
 
 ## Divergent-edit v2 gate tiers
 
-The divergent-edit gate (`nose query . base=<ref>`) uses an explicit tiered
-contract so CI wrappers can distinguish blockers from review-only context without
-re-running nose internals:
+The divergent-edit gate (`nose query . base=<ref>`) is an opt-in PR review gate.
+It uses an explicit tiered contract so CI wrappers can distinguish default-failing
+items from review-only context without re-running nose internals:
 
 ```sh
 nose query . base="origin/${GITHUB_BASE_REF}" --mode syntax,semantic --fail-on any
@@ -215,7 +215,7 @@ the SARIF invocation.
 
 | tier | default CI effect | SARIF rule id | SARIF level |
 |---|---|---|---|
-| `strict` | fails `base=<ref> --fail-on any` | `nose.divergent.strict` | `error` |
+| `strict` | fails only when `properties.gate.fail_default == true` | `nose.divergent.strict` | `error` |
 | `review` | visible, non-failing by default | `nose.divergent.review` | `warning` |
 | `report-only` | visible advisory, never default-failing | `nose.divergent.report-only` | `note` |
 | `suppressed` | omitted from active output and never failing | not emitted in normal SARIF | none |
@@ -232,15 +232,25 @@ metadata.
 The legacy `fire_eligible` field remains in JSON as the serialized v1 conservative
 verdict. In the current implementation it is computed from proven shared-logic touch
 and not-all-test scope, so mixed-scope findings may still be `fire_eligible=true`.
-Wrappers should read `tier` or `gate.fail_default` directly. They should not reconstruct
-gate behavior from raw fields such as `touches_shared`, `scope`, `witness_kind`, or
-`graded` when a `tier` is present.
+Wrappers should display `tier`, but decide pass/fail only from `gate.fail_default`.
+They should not reconstruct gate behavior from raw fields such as `touches_shared`,
+`scope`, `witness_kind`, or `graded` when a `tier` is present.
 
 Structured ignores apply before the gate: a suppressed divergent-edit family must not
 produce a `strict` failure, and report-only lanes such as newly added clone evidence
 must not fail default CI. Newly added clone evidence appears as `lane="new-copy"`,
 `tier="report-only"`, `base_family_id=null`, and current-tree `current_only[]` sites;
 `properties.gate.fail_default` remains `false` in SARIF.
+
+Checked closeout evidence supports opt-in enforcement, not default-on blocking. The
+final replay/policy artifacts record 560 replay records with 0 errors and v2 strict
+precision 0.562 while retaining 45/45 confirmed v1 missed-propagation positives
+([results](../eval/divergence_fire/RESULTS.md), [policy artifact](../eval/divergence_fire/policy_eval_final_head_a38ecb8b_2026_07_06.json)).
+The [CI examples](examples/ci/divergent-edit-observe-only.yml) and
+[enforcing workflow](examples/ci/divergent-edit-enforcing.yml) show the recommended
+observe-only-to-enforcing rollout, the [#687 pilot](divergent-history-mining-pilot-687.md)
+keeps history mining offline, and the [#688 evidence](divergent-gate-product-runtime-688.md)
+records non-`base=` product-output stability plus runtime checks.
 
 When a strict divergent-edit finding is accepted as intentional, commit a structured
 ignore with a reason/owner/expiry instead of teaching the wrapper to reinterpret the

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -58,9 +58,10 @@ touched, not that the change definitely belongs there. Inspect each flagged sibl
 
 The report and the gate are deliberately different surfaces. The report shows active
 base-tree divergence findings plus bounded advisory lanes; on
-`nose query <path> base=<ref>`, **`--fail-on any` fires only on unsuppressed `strict`
-findings** ([experiments](experiments.md)). A `strict`
-finding must satisfy the legacy conservative shared-logic proof and the v2 tier policy:
+`nose query <path> base=<ref>`, **`--fail-on any` fires only when an emitted item has
+`gate.fail_default=true`**. Today that means an unsuppressed `strict` finding
+([experiments](experiments.md)). A default-failing finding must satisfy the legacy
+conservative shared-logic proof and the v2 tier policy:
 
 - the diff **provably touches lines the changed copy shares with its un-updated
   sibling** — by the family's own equivalence proof for `exact-value-graph` families
@@ -71,21 +72,23 @@ finding must satisfy the legacy conservative shared-logic proof and the v2 tier 
 - the family is production scope (`scope="prod"`). Mixed and all-test findings remain
   visible, but they are `report-only` by default.
 
-Measured on replayed merged PRs against judge-labeled findings: the v1 conservative
-`fire_eligible` policy kept every genuine missed propagation while firing 73% less
-often than span-overlap firing (change-level: 15% of merged changes vs 33%), at 3.7×
-the precision. The #672 v2 strict policy keeps the same confirmed positives on the
-checked #670 labelset while demoting mixed/test evidence from default-failing output.
+Measured on replayed merged PRs against judge-labeled findings: the final checked v2
+strict baseline fires on 80 findings, with 45 true positives and 35 false positives,
+for strict precision 0.562. It retains 45/45 confirmed v1 missed-propagation
+positives while demoting mixed/test evidence from default-failing output. The
+remaining strict false positives split into 17 `no_propagation_needed`, 13
+`intentional_divergence`, and 5 `not_a_clone` findings. This supports an opt-in
+review gate; it is not a default-on blocking readiness claim.
 Each JSON finding carries legacy `fire_eligible`, the v2 `tier` and `gate.fail_default`,
 `witness_kind`, `scope`, per-changed-site `touches_shared`, and — for near families —
 the family's [graded witness](graded-witness.md) (`graded`: `equal_modulo_holes`,
 `holes`, `patterns`, `referent_mismatches`, `caveat_names`), so a CI wrapper can use
-the emitted tier without re-deriving the analysis.
+the emitted `gate.fail_default` value without re-deriving the analysis.
 
 The graded witness is **evidence for the consumer, not a fire gate**: a clean
 `equal_modulo_holes` family is a strong missed-propagation candidate, while a
-`referent-mismatch` / `decorator-differs` family is one whose copies are not really
-the same logic (a likely false fire the consumer can down-rank). It deliberately does
+`referent-mismatch` / `decorator-differs` family is evidence that the copies may have
+different roles or referents. It deliberately does
 **not** gate legacy `fire_eligible` — a decorator or a same-named-but-different-referent
 difference does not stop a shared-*body* fix from being a genuine missed propagation,
 so suppressing on it would risk the keep-every-propagation property the shared-logic policy
@@ -98,18 +101,19 @@ presentation evidence; the v2 tier decides whether that proof is default-failing
 the useful signal is not only the top-ranked finding. The v2 contract therefore
 separates **what nose reports** from **what may fail CI** with an explicit tier on
 each divergent-edit finding. The v1 `fire_eligible` field remains as compatibility
-evidence, but default CI uses the v2 `strict` tier.
+evidence, but default CI uses `gate.fail_default`; the current policy sets it only for
+unsuppressed `strict` findings.
 
 | tier | CI behavior | evidence requirement | intended reader action |
 |---|---|---|---|
-| `strict` | `base=<ref> --fail-on any` exits non-zero when at least one unsuppressed `strict` finding is shown | `fire_eligible=true`, `scope="prod"`, `taxonomy_hint="missed_propagation"`, and no higher-priority report-only or suppression reason | treat as a likely missed sibling edit; block or require an explicit suppression |
-| `review` | reported in human/JSON/SARIF, does not fail by default | base-tree divergent-edit candidate that is not suppressed, not report-only, and not strict | inspect during review; optionally fail in a custom wrapper |
+| `strict` | `base=<ref> --fail-on any` exits non-zero only when the item has `gate.fail_default=true` | `fire_eligible=true`, `scope="prod"`, `taxonomy_hint="missed_propagation"`, and no higher-priority report-only or suppression reason | treat as a likely missed sibling edit; propagate it or require an explicit suppression |
+| `review` | reported in human/JSON/SARIF, does not fail by default | base-tree divergent-edit candidate that is not suppressed, not report-only, and not strict | inspect during review; keep advisory unless a later measured policy changes it |
 | `report-only` | reported only as advisory evidence, never fails default CI | useful context outside the default gate: test-only scaffolding, grouping artifacts, or newly added current-tree copies with no base member | use as reviewer/agent context; do not treat as a blocker |
 | `suppressed` | omitted from active human/SARIF gate output and never fails | matched by a structured ignore or accepted suppression | audit through the ignore file, not through repeated PR noise |
 
 The v2 enums are closed for schema v8. Adding, renaming, or removing one requires a
 schema bump. `taxonomy_hint` is an evidence label for routing and UI copy, not a
-claim that the code is correct or incorrect:
+claim that the code is harmful, correct, intentional, or not a clone:
 
 | taxonomy bucket | product meaning | v2 routing |
 |---|---|---|
@@ -162,7 +166,8 @@ The `base=` view shares [`nose query`](usage.md#nose-query)'s detection flags �
 difference from a plain `nose query`: when `--mode` is omitted the `base=` view defaults to
 the conservative `syntax,semantic` mix (a plain `nose query` also runs `near`) — it feeds a
 gate, where a false fire costs more than a missed candidate. Add `--mode syntax,semantic,near`
-to include the fuzzy channel. `base=` is a diff view, not a family list view, so ordinary
+only for an explicit audit that opts into the fuzzy channel; the documented enforcing mode is
+`syntax,semantic`. `base=` is a diff view, not a family list view, so ordinary
 query filters (`path~`, `witness=`, `group=`, `since=`, `id=`) are rejected instead of ignored.
 
 | flag / term | effect |
@@ -231,8 +236,8 @@ divergence:
 
 ## In CI
 
-Run it on a pull request and fail the build (or post SARIF annotations) when a change
-lands in one copy but not its clones:
+Run it on a pull request as an opt-in review gate, or first post SARIF annotations without
+failing, when a change lands in one copy but not its clones:
 
 ```sh
 nose query . base="origin/${GITHUB_BASE_REF}" --mode syntax,semantic --fail-on any
@@ -243,7 +248,7 @@ nose query . base="origin/${GITHUB_BASE_REF}" --mode syntax,semantic --format sa
 Pin `--mode` in CI even though the `base=` default is already conservative; it makes
 upgrade diffs explicit. `top=0` is the complete-upload spelling for SARIF. Report-only
 findings, including mixed/test scope and `new-copy` current-tree evidence, remain visible
-but do not fail the default gate.
+but do not fail the default gate; only `gate.fail_default=true` does.
 
 Base-divergence SARIF results are anchored on the **un-updated sibling** (where the fix
 may be missing). GitHub can show inline code-scanning annotations only when the reported
@@ -269,6 +274,6 @@ schema.
 - The default base-divergence lane detects clone families at the base. A clone whose copy is
   **newly added** in the change has no base member, so it is considered only by the bounded
   `new-copy` report-only lane when the diff is small enough to keep runtime predictable.
-- The harm ordering is a structural heuristic (~0.6–0.65 on mined divergence labels; see
+- The hazard ordering is a structural heuristic (~0.6–0.65 on mined divergence labels; see
   [hazard-benchmark](hazard-benchmark.md)). It prioritizes candidates; it does not certify
   them.

--- a/docs/home.md
+++ b/docs/home.md
@@ -148,6 +148,7 @@ fundamentals; the rest is grouped by area.
 - [field-evaluation](field-evaluation.md) — qualitative results from running nose on real third-party projects.
 - [dogfooding](dogfooding.md) — the current nose-on-nose duplication gate and baseline workflow.
 - [dogfooding history](dogfooding-history.md) — detailed nose-on-nose review log and accepted-family decisions.
+- [divergent fire-precision results](../eval/divergence_fire/RESULTS.md) — final #681 replay/policy closeout for the opt-in divergent-edit gate, including the checked strict precision baseline and retention evidence.
 - [divergent-history-mining-pilot-687](divergent-history-mining-pilot-687.md) — checked #687 evidence for bounded divergent history mining and a non-required observe-only pilot.
 - [divergent-gate-product-runtime-688](divergent-gate-product-runtime-688.md) — checked #688 product-output and runtime evidence for the opt-in divergent gate.
 - [reinvented-helper-audit-2026-06-13](reinvented-helper-audit-2026-06-13.md) — the hand-labeled field audit that promoted the reinvented-helper channel to the default surface.

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -101,7 +101,8 @@ touches_shared, tree}`.
 `limit` is the numeric row limit or `null` for `top=0`. `fire_eligible` is the legacy v1
 conservative gate verdict. In the current implementation it means the diff provably touches
 shared logic and the family is not all-test scaffolding. `strict` counts the v2 default-failing
-items.
+items, but it is only a summary count; CI decisions should read each emitted item's
+`gate.fail_default`, ideally from a `top=0` run.
 
 The v8 base-view additions for divergent-edit v2 are intentionally schema-breaking
 instead of silent v7 additions: CI wrappers and agents need stable enums for gate behavior.
@@ -117,8 +118,8 @@ The v8 `base.items[]` object adds:
 | `base_family_id` | string or null | The base-tree family id for `base-divergence`; `null` for `new-copy`. |
 | `tier` | string enum | `strict`, `review`, `report-only`, or `suppressed`. `strict` is the only default CI-failing tier; `review` and `report-only` are visible but non-failing; `suppressed` is emitted only by an explicit future suppressed/debug surface. |
 | `tier_reasons[]` | array of strings | Closed reason-code enum: `shared_logic_touched`, `shared_logic_not_touched`, `shared_logic_unproven`, `non_test_scope`, `test_scope`, `variant_signal`, `test_scaffolding`, `grouping_artifact`, `new_copy_no_base_member`, `structured_ignore`, or `unclassified`. |
-| `taxonomy_hint` | string or null | Closed false-fire bucket for routing and UI copy: `missed_propagation`, `no_propagation_needed`, `intentional_variant`, `test_scaffolding`, `grouping_artifact`, or `unclear`. This is evidence for consumers, not a correctness verdict. |
-| `gate` | object | `{eligible, fail_default, policy}` where `eligible` is true for `strict` and `review`, false for `report-only` and `suppressed`, `fail_default` is true only for unsuppressed `strict`, and `policy` names the policy version such as `divergent-edit-v2-strict`. |
+| `taxonomy_hint` | string or null | Closed evidence/routing bucket for UI copy: `missed_propagation`, `no_propagation_needed`, `intentional_variant`, `test_scaffolding`, `grouping_artifact`, or `unclear`. This guides inspection; it is not a harm or correctness verdict. |
+| `gate` | object | `{eligible, fail_default, policy}` where `eligible` is informational (`true` for `strict` and `review`, false for `report-only` and `suppressed`), `fail_default` is the authoritative default CI decision and is true only for unsuppressed `strict`, and `policy` names the policy version such as `divergent-edit-v2-strict`. |
 | `suppression` | object or null | Structured-ignore match metadata when a future suppressed/debug view asks for it: `{kind, reason, owner, expires_at}`. `kind` is the closed enum `structured-ignore` for v8. Active human/SARIF output omits suppressed findings by default. |
 
 Composition rules for v8:
@@ -137,11 +138,14 @@ Composition rules for v8:
   proof or mixed/test scope fails closed to `review` or `report-only`.
 - CI consumers should use each item's `gate.fail_default` as the authoritative
   default pass/fail decision. `summary.strict` is a count, `gate.policy` names
-  the policy that produced the decision, and `fire_eligible` is retained
-  compatibility evidence rather than the v2 gate.
+  the policy that produced the decision, `gate.eligible` is informational, and
+  `fire_eligible` is retained compatibility evidence rather than the v2 gate.
 - `report-only` is for advisory lanes: `test_scaffolding`, `grouping_artifact`,
   `test_scope`, or `new_copy_no_base_member`.
 - `suppressed` wins over all other tiers and must never set `gate.fail_default=true`.
+- The current policy emits `gate.fail_default=true` only for unsuppressed production
+  `strict` findings. Mixed/test, `new-copy`, `review`, `report-only`, and `suppressed`
+  findings remain non-failing advisory evidence.
 - Active v8 output counts only unsuppressed items: `summary.divergences` is the
   unsuppressed total before `top=N`, and `summary.shown_divergences` is
   `items.length`. A future suppressed/debug surface must expose suppressed rows


### PR DESCRIPTION
## Summary

- close out the #681 opt-in divergent-edit gate docs with the checked strict baseline and limits
- make gate.fail_default the explicit CI/SARIF pass/fail authority across divergent-edit, query JSON, CI, and agent guidance
- link the final replay/policy, #687 pilot, #688 product-output/runtime, and CI rollout evidence

Closes #689.

## Validation

- python3 eval/divergence_fire/replay.py selftest
- python3 eval/divergence_fire/replay.py check-artifacts
- python3 scripts/divergent-history-mining.py --self-test
- python3 scripts/query-regression-harness.py --self-test
- python3 scripts/runtime-triage-harness.py --self-test
- ./scripts/check-docs.sh
- python3 scripts/check-divergent-history-artifacts.py
- cargo test -p nose-cli --lib divergence
- cargo test -p nose-cli --test cli query_base
- cargo test -p nose-cli --test cli sarif
- git push pre-push fast local CI gates