### PR TITLE
Tighten proof-carrying frontier closeout gates

### DIFF
--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -371,7 +371,7 @@
       "semantic_family": "numeric.clamp",
       "claim": "A two-comparison clamp can converge with proof-backed min/max clamp composition under the same integer lo<=hi proof.",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py"],
-      "evidence": "Focused equivalence tests and the bridge corpus show guarded lower-first and upper-first Python ternary clamps converging with proof-backed min/max Clamp while unproven, swapped-bound, and float ternaries stay split."
+      "evidence": "Focused equivalence tests prove the guarded lower-first Python ternary clamp converges with proof-backed min/max Clamp while unproven, swapped-bound, and float ternaries stay split. The bridge fixture also keeps the upper-first spelling visible as adjacent corpus evidence, not as a broader admission claim."
     },
     {
       "id": "clamp_library_method_bridge",
@@ -379,7 +379,7 @@
       "semantic_family": "numeric.clamp",
       "claim": "Language library clamp forms can converge with proof-backed min/max clamp composition when the same integer bound proof is available.",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs"],
-      "evidence": "Rust numeric .clamp now converges with literal ordered min/max clamps and with guarded Rust x.max(lo).min(hi) under the same lo<=hi proof. The bridge corpus verifies with 0 false merges."
+      "evidence": "Focused equivalence tests prove literal ordered Rust .clamp converges with literal min/max Clamp, and guarded Rust .clamp converges with guarded Rust x.max(lo).min(hi) under the same lo<=hi proof. The bridge corpus verifies that unproven, custom-method, and float boundaries stay split."
     },
     {
       "id": "clamp_method_name_only_boundary",

--- a/bench/type4/adversarial/scripts/_type4_adversarial.py
+++ b/bench/type4/adversarial/scripts/_type4_adversarial.py
@@ -16,6 +16,7 @@ PACKETS_PATH = TYPE4_ROOT / "frontier_target_packets.v1.json"
 REAL_FRONTIER_PATH = TYPE4_ROOT / "real_frontier.v1.json"
 CASES_PATH = ROOT / "cases" / "cases.v1.json"
 CASE_REF_PREFIX = "bench/type4/adversarial/cases/cases.v1.json::"
+REGRESSION_GATE_SEPARATOR = "::"
 HARD_NEGATIVE_CONVENTION_CATEGORIES = {
     "numeric",
     "boolean",
@@ -221,6 +222,8 @@ def validate_all(
             f"{CASE_REF_PREFIX}{case_id}"
             for case_id in group.get("positive_cases", []) + group.get("hard_negative_cases", [])
         }
+        for gate_ref in group.get("regression_gates", []):
+            _validate_regression_gate_ref(gate_ref, case_by_id, group_id, errors)
         missing_case_gates = sorted(expected_case_gates - set(group.get("regression_gates", [])))
         if missing_case_gates:
             errors.append(
@@ -234,6 +237,49 @@ def validate_all(
 def _require(item: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
     if field not in item or item[field] in ("", None, []):
         errors.append(f"{label} missing required field {field}")
+
+
+def _validate_regression_gate_ref(
+    gate_ref: Any,
+    case_by_id: dict[str, dict[str, Any]],
+    group_id: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(gate_ref, str) or not gate_ref:
+        errors.append(f"hard-negative group {group_id} has an empty regression gate")
+        return
+    if gate_ref.startswith(CASE_REF_PREFIX):
+        case_id = gate_ref.removeprefix(CASE_REF_PREFIX)
+        if case_id not in case_by_id:
+            errors.append(
+                f"hard-negative group {group_id} regression gate references "
+                f"unknown focused case {case_id}"
+            )
+        return
+    if REGRESSION_GATE_SEPARATOR not in gate_ref:
+        errors.append(
+            f"hard-negative group {group_id} regression gate {gate_ref!r} must be "
+            "a focused case ref or path::symbol"
+        )
+        return
+    path_text, symbol = gate_ref.split(REGRESSION_GATE_SEPARATOR, 1)
+    if not path_text or not symbol:
+        errors.append(
+            f"hard-negative group {group_id} regression gate {gate_ref!r} must be "
+            "a focused case ref or path::symbol"
+        )
+        return
+    gate_path = REPO_ROOT / path_text
+    if not gate_path.is_file():
+        errors.append(
+            f"hard-negative group {group_id} regression gate file does not exist: {path_text}"
+        )
+        return
+    if symbol not in gate_path.read_text():
+        errors.append(
+            f"hard-negative group {group_id} regression gate symbol {symbol!r} "
+            f"not found in {path_text}"
+        )
 
 
 def _check_unique(

--- a/bench/type4/frontier_platform.py
+++ b/bench/type4/frontier_platform.py
@@ -1180,6 +1180,17 @@ def check_artifact(path: Path, expected: str, mismatches: list[str]) -> None:
         mismatches.append(repo_rel(path))
 
 
+def check_packet_artifacts(packet_doc: dict, packets_json_out: Path, packets_md_out: Path) -> None:
+    mismatches: list[str] = []
+    check_artifact(
+        packets_json_out,
+        json.dumps(packet_doc, indent=2, sort_keys=True) + "\n",
+        mismatches,
+    )
+    check_artifact(packets_md_out, packets_markdown(packet_doc), mismatches)
+    assert not mismatches, f"frontier target packet artifacts are stale: {', '.join(mismatches)}"
+
+
 def check_artifacts(
     platform_result: dict,
     packet_doc: dict,
@@ -1195,13 +1206,9 @@ def check_artifacts(
         mismatches,
     )
     check_artifact(markdown_out, markdown_report(platform_result), mismatches)
-    check_artifact(
-        packets_json_out,
-        json.dumps(packet_doc, indent=2, sort_keys=True) + "\n",
-        mismatches,
-    )
-    check_artifact(packets_md_out, packets_markdown(packet_doc), mismatches)
-    assert not mismatches, f"frontier platform artifacts are stale: {', '.join(mismatches)}"
+    if mismatches:
+        raise AssertionError(f"frontier platform artifacts are stale: {', '.join(mismatches)}")
+    check_packet_artifacts(packet_doc, packets_json_out, packets_md_out)
 
 
 def packets_markdown(packet_doc: dict) -> str:
@@ -1509,7 +1516,14 @@ def selftest() -> int:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--selftest", action="store_true", help="run corpus-free correctness checks")
-    ap.add_argument("--check", action="store_true", help="fail if committed platform/packet artifacts are stale; skips when bench/repos is absent")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "fail if committed platform/packet artifacts are stale; without bench/repos, "
+            "checks packet artifacts against the committed platform artifact"
+        ),
+    )
     ap.add_argument("--corpus", type=Path, default=pf.DEFAULT_CORPUS)
     ap.add_argument("--repos-root", type=Path, default=pf.DEFAULT_REPOS_ROOT)
     ap.add_argument("--max-bytes", type=int, default=512_000)
@@ -1535,7 +1549,22 @@ def main() -> int:
         return selftest()
 
     if args.check and not frontier_repos_available(args.corpus, args.repos_root):
-        print("skipped frontier platform artifact check — bench/repos corpus is not available")
+        platform_json_out = args.json_out or DEFAULT_JSON_OUT
+        if not platform_json_out.exists():
+            raise AssertionError(
+                f"frontier platform artifact is missing: {repo_rel(platform_json_out)}"
+            )
+        platform_result = json.loads(platform_json_out.read_text())
+        packet_doc = build_packets(platform_result, args.real_frontier, args.corpus)
+        check_packet_artifacts(
+            packet_doc,
+            args.packets_json_out or DEFAULT_PACKETS_JSON_OUT,
+            args.packets_md_out or DEFAULT_PACKETS_MD_OUT,
+        )
+        print(
+            "skipped frontier platform breadth check — bench/repos corpus is not available; "
+            "checked target packet artifacts against the committed platform artifact"
+        )
         return 0
 
     nose_binary = None

--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -233,8 +233,8 @@
     },
     "focused_cases": {
       "path": "bench/type4/adversarial/cases/cases.v1.json",
-      "sha256": "3c5cb511c601ae30086c7dea69c5a0fdb4d55c535a1a5ffe80e1adbca56e248c",
-      "size_bytes": 33315
+      "sha256": "57985f4c327a4bfd240b9d59c4901e6a7edff00057335cade6d0682498680373",
+      "size_bytes": 33506
     },
     "real_frontier": {
       "path": "bench/type4/real_frontier.v1.json",

--- a/bench/type4/proof_carrying_frontier.py
+++ b/bench/type4/proof_carrying_frontier.py
@@ -85,6 +85,7 @@ COEVO_VERDICTS = {
 }
 
 HARD_NEGATIVE_CASE_REF_PREFIX = "bench/type4/adversarial/cases/cases.v1.json::"
+REGRESSION_GATE_SEPARATOR = "::"
 HARD_NEGATIVE_CONVENTION_CATEGORIES = {
     "numeric",
     "boolean",
@@ -339,6 +340,41 @@ def case_refs(values: list[str]) -> set[str]:
     return {case_id for ref in values if (case_id := case_ref_id(ref))}
 
 
+def validate_regression_gate_ref(
+    gate_ref: str, case_by_id: dict[str, dict[str, Any]], group_id: str
+) -> None:
+    if not isinstance(gate_ref, str) or not gate_ref:
+        raise FrontierError(f"hard-negative group {group_id} has an empty regression gate")
+    if (case_id := case_ref_id(gate_ref)) is not None:
+        if case_id not in case_by_id:
+            raise FrontierError(
+                f"hard-negative group {group_id} regression gate references "
+                f"unknown focused case {case_id}"
+            )
+        return
+    if REGRESSION_GATE_SEPARATOR not in gate_ref:
+        raise FrontierError(
+            f"hard-negative group {group_id} regression gate {gate_ref!r} must be "
+            "a focused case ref or path::symbol"
+        )
+    path_text, symbol = gate_ref.split(REGRESSION_GATE_SEPARATOR, 1)
+    if not path_text or not symbol:
+        raise FrontierError(
+            f"hard-negative group {group_id} regression gate {gate_ref!r} must be "
+            "a focused case ref or path::symbol"
+        )
+    gate_path = ROOT / path_text
+    if not gate_path.is_file():
+        raise FrontierError(
+            f"hard-negative group {group_id} regression gate file does not exist: {path_text}"
+        )
+    if symbol not in gate_path.read_text():
+        raise FrontierError(
+            f"hard-negative group {group_id} regression gate symbol {symbol!r} "
+            f"not found in {path_text}"
+        )
+
+
 def validate_focused_cases_doc(focused_cases: dict[str, Any]) -> tuple[
     dict[str, dict[str, Any]], dict[str, dict[str, Any]], set[str]
 ]:
@@ -427,6 +463,8 @@ def validate_focused_cases_doc(focused_cases: dict[str, Any]) -> tuple[
             f"{HARD_NEGATIVE_CASE_REF_PREFIX}{case_id}"
             for case_id in group["positive_cases"] + group["hard_negative_cases"]
         }
+        for gate_ref in group["regression_gates"]:
+            validate_regression_gate_ref(gate_ref, case_by_id, group_id)
         missing_case_gates = sorted(expected_case_gates - set(group["regression_gates"]))
         if missing_case_gates:
             raise FrontierError(
@@ -1107,6 +1145,7 @@ def write_artifacts(
 
 
 def selftest() -> None:
+    file_gate = "bench/type4/proof_carrying_frontier.py::selftest"
     packet = {
         "packet_id": "p",
         "candidate_axis": "axis",
@@ -1144,7 +1183,7 @@ def selftest() -> None:
             "scope": "none",
             "capabilities": ["none"],
             "positive_gates": [f"{HARD_NEGATIVE_CASE_REF_PREFIX}positive"],
-            "hard_negative_gates": [f"{HARD_NEGATIVE_CASE_REF_PREFIX}negative"],
+            "hard_negative_gates": [f"{HARD_NEGATIVE_CASE_REF_PREFIX}negative", file_gate],
             "remaining_real_pair_gap": "missing proof",
         },
         "blocked_by": ["missing proof"],
@@ -1171,6 +1210,7 @@ def selftest() -> None:
                 "positive_cases": ["positive"],
                 "hard_negative_cases": ["negative"],
                 "regression_gates": [
+                    file_gate,
                     f"{HARD_NEGATIVE_CASE_REF_PREFIX}positive",
                     f"{HARD_NEGATIVE_CASE_REF_PREFIX}negative",
                 ],
@@ -1298,6 +1338,17 @@ def selftest() -> None:
             focused_cases,
         )
         raise AssertionError("unknown hard-negative group was not detected")
+    except FrontierError:
+        pass
+    try:
+        bad_cases = json.loads(json.dumps(focused_cases))
+        bad_cases["hard_negative_groups"][0]["regression_gates"] = [
+            "bench/type4/proof_carrying_frontier.py::missing_selftest_symbol",
+            f"{HARD_NEGATIVE_CASE_REF_PREFIX}positive",
+            f"{HARD_NEGATIVE_CASE_REF_PREFIX}negative",
+        ]
+        validate_hard_negative_linkage(packets, bad_cases)
+        raise AssertionError("unknown file regression gate symbol was not detected")
     except FrontierError:
         pass
     no_model = dict(packet)

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -101,8 +101,8 @@
       },
       "focused_cases": {
         "path": "bench/type4/adversarial/cases/cases.v1.json",
-        "sha256": "3c5cb511c601ae30086c7dea69c5a0fdb4d55c535a1a5ffe80e1adbca56e248c",
-        "size_bytes": 33315
+        "sha256": "57985f4c327a4bfd240b9d59c4901e6a7edff00057335cade6d0682498680373",
+        "size_bytes": 33506
       },
       "real_frontier": {
         "path": "bench/type4/real_frontier.v1.json",

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -23,6 +23,7 @@ if command -v python3 >/dev/null 2>&1; then
     python3 bench/type4/frontier_platform.py --check
     python3 bench/type4/proof_carrying_frontier.py --selftest
     python3 bench/type4/proof_carrying_frontier.py --check
+    bench/type4/adversarial/scripts/type4-check
 else
     echo "skipped semantic-pack example check — python3 not installed"
 fi


### PR DESCRIPTION
## Summary
- make frontier_platform.py --check validate target packet artifacts even when bench/repos is unavailable
- run type4-check from check-docs so focused fixtures and hard-negative groups are covered in CI
- resolve hard-negative regression gates to focused cases or path::symbol targets
- tighten numeric clamp bridge evidence wording to match the observed controlled-slice behavior

## Review findings addressed
- Sagan: CI could miss stale target packet artifacts without bench/repos; type4-check was not wired into CI
- Mill: numeric clamp positive-case prose overclaimed product behavior; hard-negative linkage only checked raw strings

## Verification
- python3 bench/type4/frontier_platform.py --check --repos-root /tmp/nose-no-such-repos
- python3 bench/type4/frontier_platform.py --selftest && python3 bench/type4/frontier_platform.py --check
- python3 bench/type4/proof_carrying_frontier.py --selftest && python3 bench/type4/proof_carrying_frontier.py --check
- bench/type4/adversarial/scripts/type4-check && bench/type4/adversarial/scripts/type4-report
- ./scripts/check-docs.sh
- cargo test -p nose-cli numeric_clamp --test equivalence
- pre-push fast local CI

Refs #712