### PR TITLE
Add executable Type-4 focused expectations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: cargo build --release
       - name: semantic-pack example conformance
         run: target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+      - name: Type-4 executable focused expectations
+        run: NOSE_BIN=target/release/nose bench/type4/adversarial/scripts/type4-exec-check
       - name: test
         run: cargo test --release
       - name: duplication gate (nose on itself)

--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -245,14 +245,17 @@ frontier platform.
 
 ```sh
 bench/type4/adversarial/scripts/type4-check
+NOSE_BIN=target/debug/nose bench/type4/adversarial/scripts/type4-exec-check
 bench/type4/adversarial/scripts/type4-report
 bench/type4/adversarial/scripts/type4-next --limit 3
 ```
 
 `type4-check` validates target packets, real-frontier evidence links, focused fixture
-paths, and packet-level hard-negative groups. `type4-report` summarizes packet,
-focused-case, and hard-negative group coverage. `type4-next` prints task cards directly
-from `frontier_target_packets.v1.json`.
+paths, and packet-level hard-negative groups. `type4-exec-check` is the executable
+perimeter gate: it runs declared focused-case `nose query` expectations and fails when an
+admitted positive or hard-negative split drifts. `type4-report` summarizes packet,
+focused-case, executable expectation, and hard-negative group coverage. `type4-next` prints
+task cards directly from `frontier_target_packets.v1.json`.
 
 When `nose verify --leads` has produced a leads JSON file, use
 `bench/type4/adversarial/scripts/type4-ingest-leads <leads.json> --axis <axis> --draft-json`

--- a/bench/type4/adversarial/README.md
+++ b/bench/type4/adversarial/README.md
@@ -14,6 +14,7 @@ What remains here is deliberately small:
 - `scripts/type4-next` prints task cards from `../frontier_target_packets.v1.json`.
 - `scripts/type4-check` validates target packets, real-frontier evidence links, focused
   case fixture paths, and hard-negative group references.
+- `scripts/type4-exec-check` runs executable focused-case expectations through `nose query`.
 - `scripts/type4-report` summarizes target packets, focused cases, and hard-negative groups.
 - `scripts/type4-ingest-leads` summarizes `nose verify --leads` JSON and emits draft target
   packet skeletons for manual curation.
@@ -22,9 +23,14 @@ What remains here is deliberately small:
 
 ```sh
 bench/type4/adversarial/scripts/type4-check
+NOSE_BIN=target/debug/nose bench/type4/adversarial/scripts/type4-exec-check
 bench/type4/adversarial/scripts/type4-next --limit 3
 bench/type4/adversarial/scripts/type4-report
 ```
+
+`type4-check` is structural and does not require a built `nose` binary. `type4-exec-check`
+is the executable proof-perimeter gate: it runs each declared focused expectation and fails
+if a positive/split witness drifts from the current detector result.
 
 `type4-next` does not infer new work from this directory. It reads target packets generated
 by the frontier platform. When `nose verify --leads` produces leads, run

--- a/bench/type4/adversarial/cases/cases.v1.json
+++ b/bench/type4/adversarial/cases/cases.v1.json
@@ -354,6 +354,26 @@
       "claim": "Clamp composition is not sound when lo<=hi is not proven.",
       "mutation": "remove or invert the bound-order proof",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp/clamp.py", "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs"],
+      "executable_expectations": [
+        {
+          "id": "clamp_unproven_ternary_stays_split",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_minmax_guarded"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_ternary_unproven"}
+          ]
+        },
+        {
+          "id": "clamp_swapped_ternary_stays_split",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_minmax_guarded"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_ternary_swapped_bounds"}
+          ]
+        }
+      ],
       "evidence": "Focused tests reject missing and non-exiting guards, swapped bounds, wrong nesting, unproven ternary clamps, and unproven Rust .clamp(lo, hi); numeric_clamp smoke reports 0/4 hard-negative false merges and the bridge corpus verifies with 0 false merges."
     },
     {
@@ -363,6 +383,17 @@
       "claim": "Floating-point NaN/min/max behavior is not covered by integer clamp facts.",
       "mutation": "numeric domain becomes floatish",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp/clamp.py", "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py"],
+      "executable_expectations": [
+        {
+          "id": "clamp_float_ternary_stays_split",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_minmax_guarded"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_ternary_float"}
+          ]
+        }
+      ],
       "evidence": "Float-annotated clamp min/max and ternary forms remain outside the integer Clamp canon; numeric_clamp smoke includes a float boundary hard negative and the bridge corpus verifies with 0 false merges."
     },
     {
@@ -371,6 +402,17 @@
       "semantic_family": "numeric.clamp",
       "claim": "A two-comparison clamp can converge with proof-backed min/max clamp composition under the same integer lo<=hi proof.",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py"],
+      "executable_expectations": [
+        {
+          "id": "clamp_python_guarded_ternary_matches_minmax",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py",
+          "expect": "same-family",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_minmax_guarded"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_ternary_guarded"}
+          ]
+        }
+      ],
       "evidence": "Focused equivalence tests prove the guarded lower-first Python ternary clamp converges with proof-backed min/max Clamp while unproven, swapped-bound, and float ternaries stay split. The bridge fixture also keeps the upper-first spelling visible as adjacent corpus evidence, not as a broader admission claim."
     },
     {
@@ -379,6 +421,26 @@
       "semantic_family": "numeric.clamp",
       "claim": "Language library clamp forms can converge with proof-backed min/max clamp composition when the same integer bound proof is available.",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs"],
+      "executable_expectations": [
+        {
+          "id": "clamp_rust_literal_method_matches_literal_minmax",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge",
+          "expect": "same-family",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "name": "clamp_literal_method"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.py", "name": "clamp_literal_minmax"}
+          ]
+        },
+        {
+          "id": "clamp_rust_guarded_method_matches_guarded_minmax",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs",
+          "expect": "same-family",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "start_line": 5, "end_line": 9},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "start_line": 12, "end_line": 16}
+          ]
+        }
+      ],
       "evidence": "Focused equivalence tests prove literal ordered Rust .clamp converges with literal min/max Clamp, and guarded Rust .clamp converges with guarded Rust x.max(lo).min(hi) under the same lo<=hi proof. The bridge corpus verifies that unproven, custom-method, and float boundaries stay split."
     },
     {
@@ -388,6 +450,26 @@
       "claim": "A method named clamp is not a numeric library clamp without a proven numeric receiver and bound-order proof.",
       "mutation": "custom receiver method or parameter bounds without lo<=hi proof",
       "fixtures": ["bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs"],
+      "executable_expectations": [
+        {
+          "id": "clamp_rust_unproven_method_stays_split",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "name": "clamp_literal_method"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "name": "clamp_unproven_method"}
+          ]
+        },
+        {
+          "id": "clamp_rust_custom_method_stays_split",
+          "fixture": "bench/type4/adversarial/cases/numeric_clamp_bridge",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "name": "clamp_literal_method"},
+            {"file": "bench/type4/adversarial/cases/numeric_clamp_bridge/clamp_bridge.rs", "name": "clamp_custom_method"}
+          ]
+        }
+      ],
       "evidence": "Focused equivalence tests keep unproven Rust x.clamp(lo, hi) and custom Wrap::clamp forms split from literal/proof-backed Clamp values; the bridge corpus verifies with 0 false merges."
     },
     {
@@ -396,6 +478,17 @@
       "semantic_family": "python.loop_demorgan_all",
       "claim": "A Python all(...) universal predicate can converge with an early-return loop that returns False on the De Morgan counterexample and True after exhaustion.",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/positive.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_positive_currently_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py", "name": "all_not_zero_or_one"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py", "name": "loop_no_zero_or_one"}
+          ]
+        }
+      ],
       "evidence": "The README-shaped positive pair is a current detector miss, so the frontier packet records it as proof-fact-prerequisite rather than admitted behavior."
     },
     {
@@ -405,6 +498,17 @@
       "claim": "Changing the empty-iterable result breaks all(...) vacuous truth.",
       "mutation": "fallthrough return True -> False",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_vacuous_truth_stays_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py", "name": "all_not_zero_or_one"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py", "name": "loop_wrong_empty_truth"}
+          ]
+        }
+      ],
       "evidence": "The hard-negative fixture includes loop_wrong_empty_truth, which returns False for empty input while all(...) returns True."
     },
     {
@@ -414,6 +518,17 @@
       "claim": "Observed predicate or loop-body effects prevent treating the loop and all(...) as pure boolean rewrites.",
       "mutation": "insert observed append before the counterexample return",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_side_effect_stays_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py", "name": "all_not_zero_or_one"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py", "name": "loop_with_observed_effect"}
+          ]
+        }
+      ],
       "evidence": "The hard-negative fixture uses the same `(xs, seen)` signature on both functions; loop_with_observed_effect mutates the seen list, so the split depends on observable effects rather than arity."
     },
     {
@@ -423,6 +538,17 @@
       "claim": "Python and/or can return operand payloads in value contexts, so this packet's De Morgan step is safe only for boolean-only predicates.",
       "mutation": "boolean predicate result is replaced by a value-returning `and` operand",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/value_return.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_value_return_stays_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/value_return.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/value_return.py", "name": "boolean_demorgan_predicate"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/value_return.py", "name": "value_returning_operand"}
+          ]
+        }
+      ],
       "evidence": "The hard-negative fixture includes value_returning_operand and marker so future admission must prove boolean-only operands rather than rewriting value-returning `and` payloads."
     },
     {
@@ -432,6 +558,17 @@
       "claim": "Changing the De Morgan predicate changes behavior even when the surface still contains != and or.",
       "mutation": "`x != 0 and x != 1` -> `x != 0 or x != 1`",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/changed_predicate.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_changed_predicate_stays_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/changed_predicate.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/changed_predicate.py", "name": "all_not_zero_or_one"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/changed_predicate.py", "name": "all_changed_predicate"}
+          ]
+        }
+      ],
       "evidence": "The hard-negative fixture includes all_changed_predicate, which is true for every scalar except impossible simultaneous 0 and 1."
     },
     {
@@ -441,6 +578,17 @@
       "claim": "The loop and all(...) must consume the same iterable; changing the iterated receiver changes behavior.",
       "mutation": "loop iterates ys while all(...) iterates xs",
       "fixtures": ["bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py"],
+      "executable_expectations": [
+        {
+          "id": "python_loop_demorgan_iterator_identity_stays_split",
+          "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py",
+          "expect": "split",
+          "members": [
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py", "name": "all_not_zero_or_one"},
+            {"file": "bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py", "name": "loop_different_iterable"}
+          ]
+        }
+      ],
       "evidence": "The hard-negative fixture uses the same `(xs, ys)` signature on both functions but drives the loop from ys, so future admission must prove same-iterator identity instead of matching only predicate shape."
     },
     {

--- a/bench/type4/adversarial/scripts/_type4_adversarial.py
+++ b/bench/type4/adversarial/scripts/_type4_adversarial.py
@@ -17,6 +17,7 @@ REAL_FRONTIER_PATH = TYPE4_ROOT / "real_frontier.v1.json"
 CASES_PATH = ROOT / "cases" / "cases.v1.json"
 CASE_REF_PREFIX = "bench/type4/adversarial/cases/cases.v1.json::"
 REGRESSION_GATE_SEPARATOR = "::"
+EXECUTABLE_EXPECTATIONS = {"same-family", "split"}
 HARD_NEGATIVE_CONVENTION_CATEGORIES = {
     "numeric",
     "boolean",
@@ -66,6 +67,14 @@ def hard_negative_convention_ids(cases: dict[str, Any]) -> set[str]:
     for values in conventions.values():
         if isinstance(values, list):
             result.update(item for item in values if isinstance(item, str))
+    return result
+
+
+def executable_expectation_items(cases: dict[str, Any]) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    result = []
+    for case in case_items(cases):
+        for expectation in case.get("executable_expectations", []):
+            result.append((case, expectation))
     return result
 
 
@@ -156,6 +165,7 @@ def validate_all(
         if packet.get("owner_route") == "proof-fact-prerequisite" and not packet.get("blocked_by"):
             errors.append(f"target packet {packet_id} is proof-fact-prerequisite but has no blocked_by list")
 
+    expectation_ids: set[str] = set()
     for case in case_items(cases):
         case_id = case.get("id", "?")
         for field in ("id", "kind", "semantic_family", "claim"):
@@ -163,6 +173,7 @@ def validate_all(
         for fixture in case.get("fixtures", []):
             if not (REPO_ROOT / fixture).exists():
                 errors.append(f"focused case {case_id} fixture does not exist: {fixture}")
+        _validate_executable_expectations(case, expectation_ids, errors)
 
     if not convention_ids:
         errors.append("cases.v1.json must define hard_negative_conventions")
@@ -237,6 +248,67 @@ def validate_all(
 def _require(item: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
     if field not in item or item[field] in ("", None, []):
         errors.append(f"{label} missing required field {field}")
+
+
+def _validate_executable_expectations(
+    case: dict[str, Any], expectation_ids: set[str], errors: list[str]
+) -> None:
+    case_id = case.get("id", "?")
+    expectations = case.get("executable_expectations", [])
+    if expectations in (None, []):
+        return
+    if not isinstance(expectations, list):
+        errors.append(f"focused case {case_id} executable_expectations must be a list")
+        return
+    for expectation in expectations:
+        label = f"focused case {case_id} executable expectation {expectation.get('id', '?')}"
+        for field in ("id", "fixture", "expect", "members"):
+            _require(expectation, field, label, errors)
+        expectation_id = expectation.get("id")
+        if expectation_id:
+            if expectation_id in expectation_ids:
+                errors.append(f"executable expectation id {expectation_id} appears more than once")
+            expectation_ids.add(expectation_id)
+        if expectation.get("expect") not in EXECUTABLE_EXPECTATIONS:
+            errors.append(
+                f"{label} expect must be one of {sorted(EXECUTABLE_EXPECTATIONS)}"
+            )
+        fixture = expectation.get("fixture")
+        if isinstance(fixture, str) and not (REPO_ROOT / fixture).exists():
+            errors.append(f"{label} fixture does not exist: {fixture}")
+        query = expectation.get("query", {})
+        if query and not isinstance(query, dict):
+            errors.append(f"{label} query must be an object")
+        elif isinstance(query, dict):
+            if query.get("mode", "semantic") != "semantic":
+                errors.append(f"{label} query.mode must be semantic")
+            for field in ("min_size", "min_lines"):
+                if field in query and not isinstance(query[field], int):
+                    errors.append(f"{label} query.{field} must be an integer")
+        members = expectation.get("members")
+        if not isinstance(members, list) or len(members) < 2:
+            errors.append(f"{label} members must contain at least two entries")
+            continue
+        for idx, member in enumerate(members, start=1):
+            member_label = f"{label} member {idx}"
+            if not isinstance(member, dict):
+                errors.append(f"{member_label} must be an object")
+                continue
+            _require(member, "file", member_label, errors)
+            member_file = member.get("file")
+            if isinstance(member_file, str) and not (REPO_ROOT / member_file).is_file():
+                errors.append(f"{member_label} file does not exist: {member_file}")
+            has_name = isinstance(member.get("name"), str) and bool(member["name"])
+            has_span = "start_line" in member and "end_line" in member
+            if not has_name and not has_span:
+                errors.append(f"{member_label} must define name or start_line/end_line")
+            if has_span:
+                if not isinstance(member.get("start_line"), int) or not isinstance(
+                    member.get("end_line"), int
+                ):
+                    errors.append(f"{member_label} start_line/end_line must be integers")
+                elif member["end_line"] < member["start_line"]:
+                    errors.append(f"{member_label} end_line must be >= start_line")
 
 
 def _validate_regression_gate_ref(

--- a/bench/type4/adversarial/scripts/type4-check
+++ b/bench/type4/adversarial/scripts/type4-check
@@ -12,6 +12,7 @@ from _type4_adversarial import (
     case_items,
     find_case,
     find_packet,
+    executable_expectation_items,
     load_all,
     packet_card,
     packet_items,
@@ -39,6 +40,7 @@ def main() -> int:
         "errors": errors,
         "target_packets": len(packet_items(packet_doc)),
         "focused_cases": len(case_items(cases)),
+        "executable_expectations": len(executable_expectation_items(cases)),
         "real_frontier_items": len(real_frontier.get("items", [])),
     }
     if args.json:
@@ -53,6 +55,7 @@ def main() -> int:
                 "ok: "
                 f"{summary['target_packets']} target packets, "
                 f"{summary['focused_cases']} focused cases, "
+                f"{summary['executable_expectations']} executable expectations, "
                 f"{summary['real_frontier_items']} real-frontier items"
             )
         if packet is not None:

--- a/bench/type4/adversarial/scripts/type4-exec-check
+++ b/bench/type4/adversarial/scripts/type4-exec-check
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Execute Type-4 focused-case query expectations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from _type4_adversarial import (
+    REPO_ROOT,
+    executable_expectation_items,
+    load_all,
+    validate_all,
+)
+
+
+TOOL_VERSION = "type4-exec-check/1"
+
+
+def query_families(payload: object) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [family for family in payload if isinstance(family, dict)]
+    if isinstance(payload, dict) and isinstance(payload.get("families"), list):
+        return [family for family in payload["families"] if isinstance(family, dict)]
+    raise ValueError("nose query JSON must be a list or an object with a families array")
+
+
+def run_query(nose: Path, expectation: dict[str, Any]) -> list[dict[str, Any]]:
+    query = expectation.get("query") or {}
+    mode = query.get("mode", "semantic")
+    min_size = str(query.get("min_size", 1))
+    min_lines = str(query.get("min_lines", 1))
+    cmd = [
+        str(nose),
+        "query",
+        str(REPO_ROOT / expectation["fixture"]),
+        "all",
+        "top=0",
+        "--mode",
+        mode,
+        "--format",
+        "json",
+        "--min-size",
+        min_size,
+        "--min-lines",
+        min_lines,
+    ]
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return query_families(json.loads(proc.stdout or "[]"))
+
+
+def loc_file(loc: dict[str, Any]) -> Path | None:
+    value = loc.get("file")
+    if not isinstance(value, str):
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return path.resolve()
+
+
+def loc_bounds(loc: dict[str, Any]) -> tuple[int, int] | None:
+    start = loc.get("start_line", loc.get("start"))
+    end = loc.get("end_line", loc.get("end"))
+    if start is None or end is None:
+        return None
+    return int(start), int(end)
+
+
+def overlaps(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    return not (a[1] < b[0] or b[1] < a[0])
+
+
+def member_matches_loc(member: dict[str, Any], loc: dict[str, Any]) -> bool:
+    expected_file = (REPO_ROOT / member["file"]).resolve()
+    if loc_file(loc) != expected_file:
+        return False
+    if member.get("name") and loc.get("name") != member["name"]:
+        return False
+    if "start_line" in member or "end_line" in member:
+        if "start_line" not in member or "end_line" not in member:
+            return False
+        bounds = loc_bounds(loc)
+        if bounds is None:
+            return False
+        if not overlaps((int(member["start_line"]), int(member["end_line"])), bounds):
+            return False
+    return True
+
+
+def family_matches_members(family: dict[str, Any], members: list[dict[str, Any]]) -> bool:
+    locations = family.get("locations", [])
+    if not isinstance(locations, list):
+        return False
+    return all(
+        any(isinstance(loc, dict) and member_matches_loc(member, loc) for loc in locations)
+        for member in members
+    )
+
+
+def matching_family(families: list[dict[str, Any]], members: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for family in families:
+        if family_matches_members(family, members):
+            return family
+    return None
+
+
+def result_for(case: dict[str, Any], expectation: dict[str, Any], families: list[dict[str, Any]]) -> dict[str, Any]:
+    match = matching_family(families, expectation["members"])
+    observed = "same-family" if match is not None else "split"
+    expected = expectation["expect"]
+    return {
+        "case_id": case["id"],
+        "expectation_id": expectation["id"],
+        "expect": expected,
+        "fixture": expectation["fixture"],
+        "observed": observed,
+        "ok": observed == expected,
+        "matching_family": summarize_family(match) if match is not None else None,
+    }
+
+
+def summarize_family(family: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "value": family.get("value"),
+        "witness": family.get("witness"),
+        "locations": [
+            {
+                "file": loc.get("file"),
+                "start": loc.get("start_line", loc.get("start")),
+                "end": loc.get("end_line", loc.get("end")),
+                "name": loc.get("name"),
+            }
+            for loc in family.get("locations", [])
+            if isinstance(loc, dict)
+        ],
+    }
+
+
+def default_nose() -> Path:
+    if os.environ.get("NOSE_BIN"):
+        return Path(os.environ["NOSE_BIN"])
+    debug = REPO_ROOT / "target" / "debug" / "nose"
+    if debug.exists():
+        return debug
+    return REPO_ROOT / "target" / "release" / "nose"
+
+
+def run_expectations(
+    nose: Path, only_case: str | None = None, only_expectation: str | None = None
+) -> dict[str, Any]:
+    packet_doc, cases, real_frontier = load_all()
+    errors = validate_all(packet_doc, cases, real_frontier)
+    if errors:
+        raise SystemExit("type4 structural check failed before execution:\n" + "\n".join(errors))
+
+    items = executable_expectation_items(cases)
+    if only_case:
+        items = [(case, exp) for case, exp in items if case["id"] == only_case]
+    if only_expectation:
+        items = [(case, exp) for case, exp in items if exp["id"] == only_expectation]
+    if not items:
+        raise SystemExit("no executable expectations matched the filters")
+
+    query_cache: dict[tuple[str, str, int, int], list[dict[str, Any]]] = {}
+    results = []
+    for case, expectation in items:
+        query = expectation.get("query") or {}
+        key = (
+            expectation["fixture"],
+            query.get("mode", "semantic"),
+            int(query.get("min_size", 1)),
+            int(query.get("min_lines", 1)),
+        )
+        if key not in query_cache:
+            query_cache[key] = run_query(nose, expectation)
+        results.append(result_for(case, expectation, query_cache[key]))
+
+    failed = [result for result in results if not result["ok"]]
+    return {
+        "schema_version": 1,
+        "tool_version": TOOL_VERSION,
+        "nose_binary": str(nose),
+        "expectation_count": len(results),
+        "query_count": len(query_cache),
+        "passed": len(results) - len(failed),
+        "failed": len(failed),
+        "results": results,
+    }
+
+
+def print_human(report: dict[str, Any]) -> None:
+    prefix = "ok" if report["failed"] == 0 else "FAIL"
+    print(
+        f"{prefix}: "
+        f"{report['passed']}/{report['expectation_count']} executable Type-4 "
+        f"expectations across {report['query_count']} query runs"
+    )
+    for result in report["results"]:
+        status = "ok" if result["ok"] else "FAIL"
+        print(
+            f"  {status} {result['expectation_id']} "
+            f"({result['case_id']}): expected {result['expect']}, observed {result['observed']}"
+        )
+
+
+def selftest() -> None:
+    member_a = {"file": "a.py", "name": "f"}
+    member_b = {"file": "a.py", "start_line": 10, "end_line": 12}
+    family = {
+        "locations": [
+            {"file": str(REPO_ROOT / "a.py"), "name": "f", "start": 1, "end": 3},
+            {"file": "a.py", "name": None, "start": 11, "end": 11},
+        ]
+    }
+    assert family_matches_members(family, [member_a, member_b])
+    assert not family_matches_members(
+        family, [member_a, {"file": "a.py", "start_line": 20, "end_line": 22}]
+    )
+    print("selftest OK")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nose", type=Path, default=default_nose())
+    parser.add_argument("--case", help="run one focused case id")
+    parser.add_argument("--expectation", help="run one expectation id")
+    parser.add_argument("--json", action="store_true", help="print JSON report")
+    parser.add_argument("--json-out", type=Path, help="write JSON report")
+    parser.add_argument("--selftest", action="store_true", help="run helper self-test")
+    args = parser.parse_args()
+
+    if args.selftest:
+        selftest()
+        return 0
+    if not args.nose.exists():
+        print(f"error: nose binary not found: {args.nose}", file=sys.stderr)
+        return 2
+
+    report = run_expectations(args.nose, args.case, args.expectation)
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_human(report)
+    return 1 if report["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/type4/adversarial/scripts/type4-report
+++ b/bench/type4/adversarial/scripts/type4-report
@@ -8,6 +8,7 @@ from collections import Counter
 
 from _type4_adversarial import (
     case_items,
+    executable_expectation_items,
     hard_negative_groups,
     load_all,
     packet_items,
@@ -36,9 +37,11 @@ def main() -> int:
 
     packets = packet_items(packet_doc)
     focused_cases = case_items(cases)
+    expectations = executable_expectation_items(cases)
     groups = hard_negative_groups(cases)
     print(f"target packets: {len(packets)}")
     print(f"focused cases: {len(focused_cases)}")
+    print(f"executable expectations: {len(expectations)}")
     print(f"hard-negative groups: {len(groups)}")
     print(f"real-frontier items: {len(real_frontier.get('items', []))}")
 
@@ -49,6 +52,10 @@ def main() -> int:
     print_counter(
         "focused cases by semantic family",
         Counter(case["semantic_family"] for case in focused_cases),
+    )
+    print_counter(
+        "executable expectations by family",
+        Counter(case["semantic_family"] for case, _expectation in expectations),
     )
     print_counter(
         "hard-negative groups by family",

--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -233,8 +233,8 @@
     },
     "focused_cases": {
       "path": "bench/type4/adversarial/cases/cases.v1.json",
-      "sha256": "57985f4c327a4bfd240b9d59c4901e6a7edff00057335cade6d0682498680373",
-      "size_bytes": 33506
+      "sha256": "053012c92ce5683b70946455f7161c2661487f24261dab8296ca8ea1844efb5f",
+      "size_bytes": 40786
     },
     "real_frontier": {
       "path": "bench/type4/real_frontier.v1.json",

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -101,8 +101,8 @@
       },
       "focused_cases": {
         "path": "bench/type4/adversarial/cases/cases.v1.json",
-        "sha256": "57985f4c327a4bfd240b9d59c4901e6a7edff00057335cade6d0682498680373",
-        "size_bytes": 33506
+        "sha256": "053012c92ce5683b70946455f7161c2661487f24261dab8296ca8ea1844efb5f",
+        "size_bytes": 40786
       },
       "real_frontier": {
         "path": "bench/type4/real_frontier.v1.json",

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -29,6 +29,7 @@ What remains is intentionally smaller:
 | `cases/cases.v1.json::hard_negative_groups` | packet-level positive/negative/gate linkage |
 | `cases/**` | small fixture corpora used by focused query gates, focused verifier checks, or boundary documentation |
 | `scripts/type4-check` | validate target packets, real-frontier links, and focused cases |
+| `scripts/type4-exec-check` | execute focused-case `nose query` expectations |
 | `scripts/type4-next` | print next task cards from `frontier_target_packets.v1.json` |
 | `scripts/type4-report` | summarize target packets and focused case coverage |
 | `scripts/type4-ingest-leads` | turn `nose verify --leads` JSON into draft target packets |
@@ -37,9 +38,17 @@ Run the basic checks:
 
 ```sh
 bench/type4/adversarial/scripts/type4-check
+NOSE_BIN=target/debug/nose bench/type4/adversarial/scripts/type4-exec-check
 bench/type4/adversarial/scripts/type4-report
 bench/type4/adversarial/scripts/type4-next --limit 3
 ```
+
+`type4-check` is the structural gate and intentionally does not require a built `nose`
+binary. `type4-exec-check` is the executable witness gate. It runs declared focused-case
+expectations through `nose query` and fails when a pair expected to be `same-family` is
+split, or when a pair expected to stay `split` is merged. CI runs this gate with the
+release binary after build, so packet perimeters can no longer drift as manifest-only
+strings.
 
 ## Target packets
 
@@ -84,6 +93,12 @@ real frontier evidence. Important cases should be promoted into an automatic gat
   zero-violation verifier corpus;
 - `query_regression compare` for product output/runtime and HoF value-graph budget checks;
 - formal obligations where a proof precondition is the boundary.
+
+Cases that are stable enough for direct detector replay can add
+`executable_expectations`. Each expectation names a fixture path, two or more members, and
+whether those members must currently be `same-family` or `split`. Positive frontier cases
+can still declare `split` while they are blocked-on-proof; that makes the current miss
+explicit and gives the admission PR a concrete expectation to flip when the proof lands.
 
 If a focused case is not used by a gate and does not clarify a target packet boundary, it is
 only historical context and should be deleted instead of preserved.

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -96,6 +96,11 @@ run_type4_frontier_evidence_checks() {
     python3 bench/type4/proof_carrying_frontier.py --check
 }
 
+run_type4_executable_expectations() {
+    need_cmd python3
+    NOSE_BIN="${1}" bench/type4/adversarial/scripts/type4-exec-check
+}
+
 run_regression_checker_selftests() {
     need_cmd python3
     python3 scripts/query-regression-harness.py --self-test
@@ -162,6 +167,10 @@ if [[ "$mode" == "fast" ]]; then
     step "nose-cli tests"
     cargo test -p nose-cli
 
+    step "Type-4 executable focused expectations"
+    cargo build -p nose-cli
+    run_type4_executable_expectations target/debug/nose
+
     step "docs wiki connectivity (awiki)"
     run_docs_wiki_lint
 
@@ -177,6 +186,9 @@ cargo build --release
 
 step "semantic-pack example conformance"
 target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+
+step "Type-4 executable focused expectations"
+run_type4_executable_expectations target/release/nose
 
 step "test (release)"
 cargo test --release


### PR DESCRIPTION
## Summary
- add `type4-exec-check`, an executable focused-case witness runner for Type-4 proof packets
- declare 14 current detector expectations across numeric clamp and Python loop/De Morgan focused cases
- validate executable expectation schema from `type4-check` / `type4-report`
- wire the runner into CI and local fast/full checks

## Verification
- `bench/type4/adversarial/scripts/type4-check`
- `NOSE_BIN=target/debug/nose bench/type4/adversarial/scripts/type4-exec-check`
- `NOSE_BIN=target/release/nose bench/type4/adversarial/scripts/type4-exec-check`
- `python3 bench/type4/proof_carrying_frontier.py --selftest && python3 bench/type4/proof_carrying_frontier.py --check`
- `./scripts/check-docs.sh`
- `./scripts/check-ci-local.sh --fast`
- pre-push fast local CI

Closes #726
Refs #725
