### PR TITLE
Link Python loop De Morgan proof epic

### DIFF
--- a/bench/type4/frontier_platform.py
+++ b/bench/type4/frontier_platform.py
@@ -904,7 +904,7 @@ TARGET_PACKETS = [
         "real_frontier_replay_ids": ["python-loop-demorgan-readme-focused-real-pair"],
         "hard_negative_group_ids": ["python-loop-demorgan-all-proof-perimeter"],
         "owner_route": "proof-fact-prerequisite",
-        "owner_issue": None,
+        "owner_issue": "#734",
         "why_now": "The front-page README uses this same-language Type-4 example to explain "
         "semantic duplication, but the current detector still reports no semantic family for "
         "the two Python functions. Turning it into a proof-carrying packet makes the public "

--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -137,7 +137,7 @@
           "hard_negative_group_ids": [
             "python-loop-demorgan-all-proof-perimeter"
           ],
-          "owner_issue": null,
+          "owner_issue": "#734",
           "owner_route": "proof-fact-prerequisite",
           "packet_id": "python-loop-demorgan-all-2026-07-07",
           "planning_summary": "Model or cite reusable proof facts (python-loop-demorgan.universal-short-circuit, python-loop-demorgan.boolean-demorgan, python-loop-demorgan.effect-safety, python-loop-demorgan.iterator-identity) before opening detector admission.",
@@ -765,7 +765,7 @@
           "hard_negative_group_ids": [
             "python-loop-demorgan-all-proof-perimeter"
           ],
-          "owner_issue": null,
+          "owner_issue": "#734",
           "owner_route": "proof-fact-prerequisite",
           "packet_id": "python-loop-demorgan-all-2026-07-07",
           "planning_summary": "Model or cite reusable proof facts (python-loop-demorgan.universal-short-circuit, python-loop-demorgan.boolean-demorgan, python-loop-demorgan.effect-safety, python-loop-demorgan.iterator-identity) before opening detector admission.",
@@ -935,13 +935,13 @@
     },
     "real_frontier_replay_status": {
       "path": "bench/type4/real_frontier_replay_status.v1.json",
-      "sha256": "c2546f00b9676452960b6c07822e57804d42918c56aa7ba23ae9c795d850fdb9",
+      "sha256": "4f7df46e5488fea86b9aa9df47e8f7e76b98a489a208a598d4779e3b206a7bad",
       "size_bytes": 1618
     },
     "target_packets": {
       "path": "bench/type4/frontier_target_packets.v1.json",
-      "sha256": "5a72521521422282ef103539e41cc5903b8c5628c97b83260536eb12d02266f9",
-      "size_bytes": 18809
+      "sha256": "eb44b817fa6fed74f63eb313948090a8a0383f33742c603965e2e3dfaa56527c",
+      "size_bytes": 18811
     }
   },
   "source_report_verdict": "no-exact-admission-ready-packets",

--- a/bench/type4/frontier_target_packets.md
+++ b/bench/type4/frontier_target_packets.md
@@ -34,7 +34,7 @@ status) and adds team routing. See [frontier-platform](../../docs/frontier-platf
 
 ## `python-loop-demorgan-all-2026-07-07` — axis `python_loop_demorgan_all`
 
-- **owner route**: `proof-fact-prerequisite` (no team yet) · evidence tier: `frontier-recorded` · cost `medium` · risk `medium` · substrate `fragment-contract`
+- **owner route**: `proof-fact-prerequisite` (#734) · evidence tier: `frontier-recorded` · cost `medium` · risk `medium` · substrate `fragment-contract`
 - **breadth**: repo 7% · primary-language 25% (2/8) · dev 4 · held-out 4 · both-splits
 - **semantic claim**: Under the packet's proof conditions, a Python `all(x != 0 and x != 1 for x in xs)` universal predicate is equivalent to an early-return loop that returns False when `x == 0 or x == 1` and True after exhausting `xs`. The loop searches for a counterexample; for pure scalar comparisons where `==` and `!=` are complementary, De Morgan rewrites `not (x == 0 or x == 1)` to `x != 0 and x != 1`, so both forms accept exactly the same elements and both are true for an empty iterable.
 - **proof invariant**: Open the equivalence only when the loop is a pure universal counterexample scan over the same iterable: the only loop exit returns literal False on `not P(x)`, fallthrough returns literal True, empty iterables preserve vacuous truth, and the all(...) generator evaluates the same pure boolean predicate in the same order. The De Morgan step is allowed only for proven boolean operands such as comparisons; Python value-returning `and`/`or`, predicate side effects, overloaded comparisons, changed predicates, and changed empty-iterable results must remain non-equivalent.

--- a/bench/type4/frontier_target_packets.v1.json
+++ b/bench/type4/frontier_target_packets.v1.json
@@ -259,7 +259,7 @@
         }
       ],
       "notes": "This packet deliberately corrects the README-facing example from prose-only claim to auditable frontier evidence. It is not an exact-admission request yet: the current detector returns no semantic family for the positive fixture, and the hard negatives document the proof perimeter.",
-      "owner_issue": null,
+      "owner_issue": "#734",
       "owner_route": "proof-fact-prerequisite",
       "packet_id": "python-loop-demorgan-all-2026-07-07",
       "proof_fact_model": {

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -129,13 +129,13 @@
       },
       "real_frontier_replay_status": {
         "path": "bench/type4/real_frontier_replay_status.v1.json",
-        "sha256": "c2546f00b9676452960b6c07822e57804d42918c56aa7ba23ae9c795d850fdb9",
+        "sha256": "4f7df46e5488fea86b9aa9df47e8f7e76b98a489a208a598d4779e3b206a7bad",
         "size_bytes": 1618
       },
       "target_packets": {
         "path": "bench/type4/frontier_target_packets.v1.json",
-        "sha256": "5a72521521422282ef103539e41cc5903b8c5628c97b83260536eb12d02266f9",
-        "size_bytes": 18809
+        "sha256": "eb44b817fa6fed74f63eb313948090a8a0383f33742c603965e2e3dfaa56527c",
+        "size_bytes": 18811
       }
     },
     "target_packet_identity": {
@@ -748,7 +748,7 @@
         "hard_negative_group_ids": [
           "python-loop-demorgan-all-proof-perimeter"
         ],
-        "owner_issue": null,
+        "owner_issue": "#734",
         "owner_route": "proof-fact-prerequisite",
         "packet_id": "python-loop-demorgan-all-2026-07-07",
         "proof_fact_model": {

--- a/bench/type4/real_frontier_replay_status.v1.json
+++ b/bench/type4/real_frontier_replay_status.v1.json
@@ -14,8 +14,8 @@
     },
     "target_packets": {
       "path": "bench/type4/frontier_target_packets.v1.json",
-      "sha256": "5a72521521422282ef103539e41cc5903b8c5628c97b83260536eb12d02266f9",
-      "size_bytes": 18809
+      "sha256": "eb44b817fa6fed74f63eb313948090a8a0383f33742c603965e2e3dfaa56527c",
+      "size_bytes": 18811
     }
   },
   "nose_binary": "nose",


### PR DESCRIPTION
## Summary
- Link `python-loop-demorgan-all-2026-07-07` to the new proof-tracking epic #734.
- Regenerate frontier target packet, replay status, proof-carrying frontier, and readiness artifacts so the owner issue is carried through the packet evidence.

## Verification
- `python3 bench/type4/real_frontier_replay.py --stable-report --check`
- `python3 bench/type4/proof_carrying_frontier.py --check`
- `python3 bench/type4/frontier_platform.py --check`
- `python3 -m py_compile bench/type4/frontier_platform.py bench/type4/proof_carrying_frontier.py bench/type4/real_frontier_replay.py`
- `git diff --check`
- `scripts/check-file-lengths.py --self-test && scripts/check-file-lengths.py --ratchet-base origin/main`
- pre-push fast local CI gates

Refs #734
