### PR TITLE
Generalize loop De Morgan proof facts

### DIFF
--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -341,8 +341,8 @@ remains routed as a proof prerequisite until a real-corpus bound-order fact can 
 The README-facing Python loop plus De Morgan example is also a target packet now. It is a
 `real-pair-admitted`: the README-shaped `all(...)` predicate and early-return loop now
 land in the same semantic family, while the adjacent hard-negative perimeter remains
-split. The iterator-identity, effect-safety, universal short-circuit, and boolean-only
-De Morgan facts are modeled for the README fixture plus different-iterable,
+split. The same-source identity, pure-predicate, counterexample-loop, vacuous-truth, and
+boolean-only De Morgan facts are modeled for the README fixture plus different-iterable,
 observed-effect, helper-call, empty-truth, changed-predicate, and value-return hard
 negatives. The readiness artifact now has no non-admitted detector packet queued; both
 current target packets are reported under `admitted/resolved`.

--- a/bench/type4/frontier_platform.py
+++ b/bench/type4/frontier_platform.py
@@ -913,19 +913,23 @@ TARGET_PACKETS = [
             "model_status": "modeled-controlled",
             "facts": [
                 {
-                    "fact_id": "python-loop-demorgan.universal-short-circuit",
-                    "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop, wrong empty-truth boundary, and extra loop-effect closure",
+                    "fact_id": "quantifier.universal.counterexample-loop",
+                    "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop and extra loop-effect closure",
                 },
                 {
-                    "fact_id": "python-loop-demorgan.boolean-demorgan",
+                    "fact_id": "quantifier.vacuous-truth",
+                    "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates fallthrough True on exhaustion and the wrong empty-truth boundary",
+                },
+                {
+                    "fact_id": "boolean.demorgan.proven-bool-operands",
                     "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates comparison-only De Morgan, changed-predicate closure, and value-returning operand closure",
                 },
                 {
-                    "fact_id": "python-loop-demorgan.effect-safety",
+                    "fact_id": "effect.pure-predicate",
                     "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates pure local comparisons, observed loop effects, and helper-call closure",
                 },
                 {
-                    "fact_id": "python-loop-demorgan.iterator-identity",
+                    "fact_id": "iteration.same-source-identity",
                     "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates that the positive pair consumes arg[0]:xs on both sides and that the ys hard negative stays outside the fact",
                 },
             ],

--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -357,10 +357,11 @@
           "planning_summary": "No follow-up is queued from the readiness artifact.",
           "positive_gate_count": 1,
           "proof_fact_ids": [
-            "python-loop-demorgan.universal-short-circuit",
-            "python-loop-demorgan.boolean-demorgan",
-            "python-loop-demorgan.effect-safety",
-            "python-loop-demorgan.iterator-identity"
+            "quantifier.universal.counterexample-loop",
+            "quantifier.vacuous-truth",
+            "boolean.demorgan.proven-bool-operands",
+            "effect.pure-predicate",
+            "iteration.same-source-identity"
           ],
           "proof_fact_model_status": "modeled-controlled",
           "proof_facts": [
@@ -368,27 +369,49 @@
               "controlled_evidence": {
                 "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
                 "evidence_ids": [
-                  "python-loop-demorgan-universal-negative-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect",
                   "python-loop-demorgan-universal-positive-counterexample-loop"
                 ],
                 "observations": {
-                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect": "unsupported-universal-loop",
                   "python-loop-demorgan-universal-positive-counterexample-loop": "universal-loop"
                 },
-                "passed": 3,
+                "passed": 2,
                 "tool_version": "python-loop-demorgan-proof-facts/1"
               },
-              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop, wrong empty-truth boundary, and extra loop-effect closure",
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop and extra loop-effect closure",
               "evidence_requirements": [
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.universal-short-circuit",
+              "fact_id": "quantifier.universal.counterexample-loop",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Universal loop short-circuit and vacuous truth"
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier as counterexample loop"
+            },
+            {
+              "controlled_evidence": {
+                "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
+                "evidence_ids": [
+                  "python-loop-demorgan-universal-negative-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true"
+                ],
+                "observations": {
+                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true": "vacuous-truth"
+                },
+                "passed": 2,
+                "tool_version": "python-loop-demorgan-proof-facts/1"
+              },
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates fallthrough True on exhaustion and the wrong empty-truth boundary",
+              "evidence_requirements": [
+                "focused-executable",
+                "source-evidence"
+              ],
+              "fact_id": "quantifier.vacuous-truth",
+              "registry_status": "modeled-controlled",
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier vacuous truth"
             },
             {
               "controlled_evidence": {
@@ -411,10 +434,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.boolean-demorgan",
+              "fact_id": "boolean.demorgan.proven-bool-operands",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Boolean-only De Morgan"
+              "semantic_family": "boolean.demorgan",
+              "title": "De Morgan over proven boolean operands"
             },
             {
               "controlled_evidence": {
@@ -437,10 +460,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.effect-safety",
+              "fact_id": "effect.pure-predicate",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all effect safety"
+              "semantic_family": "effect.purity",
+              "title": "Pure predicate/effect safety"
             },
             {
               "controlled_evidence": {
@@ -461,10 +484,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.iterator-identity",
+              "fact_id": "iteration.same-source-identity",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all iterator identity"
+              "semantic_family": "iteration.source_identity",
+              "title": "Iteration same-source identity"
             }
           ],
           "proof_invariant": "Open the equivalence only when the loop is a pure universal counterexample scan over the same iterable: the only loop exit returns literal False on `not P(x)`, fallthrough returns literal True, empty iterables preserve vacuous truth, and the all(...) generator evaluates the same pure boolean predicate in the same order. The De Morgan step is allowed only for proven boolean operands such as comparisons; Python value-returning `and`/`or`, predicate side effects, helper calls without a separate purity proof, overloaded comparisons, changed predicates, and changed empty-iterable results must remain non-equivalent.",
@@ -828,10 +851,11 @@
           "planning_summary": "No follow-up is queued from the readiness artifact.",
           "positive_gate_count": 1,
           "proof_fact_ids": [
-            "python-loop-demorgan.universal-short-circuit",
-            "python-loop-demorgan.boolean-demorgan",
-            "python-loop-demorgan.effect-safety",
-            "python-loop-demorgan.iterator-identity"
+            "quantifier.universal.counterexample-loop",
+            "quantifier.vacuous-truth",
+            "boolean.demorgan.proven-bool-operands",
+            "effect.pure-predicate",
+            "iteration.same-source-identity"
           ],
           "proof_fact_model_status": "modeled-controlled",
           "proof_facts": [
@@ -839,27 +863,49 @@
               "controlled_evidence": {
                 "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
                 "evidence_ids": [
-                  "python-loop-demorgan-universal-negative-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect",
                   "python-loop-demorgan-universal-positive-counterexample-loop"
                 ],
                 "observations": {
-                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect": "unsupported-universal-loop",
                   "python-loop-demorgan-universal-positive-counterexample-loop": "universal-loop"
                 },
-                "passed": 3,
+                "passed": 2,
                 "tool_version": "python-loop-demorgan-proof-facts/1"
               },
-              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop, wrong empty-truth boundary, and extra loop-effect closure",
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop and extra loop-effect closure",
               "evidence_requirements": [
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.universal-short-circuit",
+              "fact_id": "quantifier.universal.counterexample-loop",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Universal loop short-circuit and vacuous truth"
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier as counterexample loop"
+            },
+            {
+              "controlled_evidence": {
+                "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
+                "evidence_ids": [
+                  "python-loop-demorgan-universal-negative-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true"
+                ],
+                "observations": {
+                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true": "vacuous-truth"
+                },
+                "passed": 2,
+                "tool_version": "python-loop-demorgan-proof-facts/1"
+              },
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates fallthrough True on exhaustion and the wrong empty-truth boundary",
+              "evidence_requirements": [
+                "focused-executable",
+                "source-evidence"
+              ],
+              "fact_id": "quantifier.vacuous-truth",
+              "registry_status": "modeled-controlled",
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier vacuous truth"
             },
             {
               "controlled_evidence": {
@@ -882,10 +928,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.boolean-demorgan",
+              "fact_id": "boolean.demorgan.proven-bool-operands",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Boolean-only De Morgan"
+              "semantic_family": "boolean.demorgan",
+              "title": "De Morgan over proven boolean operands"
             },
             {
               "controlled_evidence": {
@@ -908,10 +954,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.effect-safety",
+              "fact_id": "effect.pure-predicate",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all effect safety"
+              "semantic_family": "effect.purity",
+              "title": "Pure predicate/effect safety"
             },
             {
               "controlled_evidence": {
@@ -932,10 +978,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.iterator-identity",
+              "fact_id": "iteration.same-source-identity",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all iterator identity"
+              "semantic_family": "iteration.source_identity",
+              "title": "Iteration same-source identity"
             }
           ],
           "proof_invariant": "Open the equivalence only when the loop is a pure universal counterexample scan over the same iterable: the only loop exit returns literal False on `not P(x)`, fallthrough returns literal True, empty iterables preserve vacuous truth, and the all(...) generator evaluates the same pure boolean predicate in the same order. The De Morgan step is allowed only for proven boolean operands such as comparisons; Python value-returning `and`/`or`, predicate side effects, helper calls without a separate purity proof, overloaded comparisons, changed predicates, and changed empty-iterable results must remain non-equivalent.",
@@ -1044,33 +1090,33 @@
     },
     "proof_fact_registry": {
       "path": "bench/type4/proof_fact_registry.v1.json",
-      "sha256": "9772a9cf45c6cd9f79b87b98aef1a10a635d492f684cc9e524689484067b91f5",
-      "size_bytes": 11784
+      "sha256": "d1bcb9ff2100c84cc90d6c9ca63da0485ab9ce4d5fe03f5bb9788ffa5588159d",
+      "size_bytes": 21039
     },
     "python_loop_demorgan_proof_facts": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
-      "sha256": "ec9860242e6c1a4b95301f1c47d6d50c31aaef885224c5caa17363a7f664aeaa",
-      "size_bytes": 16544
+      "sha256": "2e539c5e73d31618c0b7fe9835458a5eb476900876258b8d81477a27d83d6323",
+      "size_bytes": 17639
     },
     "real_frontier": {
       "path": "bench/type4/real_frontier.v1.json",
-      "sha256": "529b331b135082cd2b2105a2b98829be251fadac6d8b8517de08af000d4e3000",
-      "size_bytes": 70707
+      "sha256": "22cbe37c2a42bcd22f9b5a9e28fda6cff01d5d44c0f284237ee4b5e40b09a35f",
+      "size_bytes": 70731
     },
     "real_frontier_replay": {
       "path": "bench/type4/real_frontier_replay.v1.json",
-      "sha256": "771b16c0131f37576608910f059b4543f553f730cbd6edbd14627bed0bf2d9f3",
-      "size_bytes": 2635
+      "sha256": "9b3e4d7a812cd2cf370bb4a29ae48fc69b226ecb795783c1cc7032f98e057399",
+      "size_bytes": 2655
     },
     "real_frontier_replay_status": {
       "path": "bench/type4/real_frontier_replay_status.v1.json",
-      "sha256": "64e8262819393740c33e7b223778885058ffcf5a03ef9d83874f66249321c3cd",
+      "sha256": "6cd3a2a4ad7b8f9afc83092e1e9e645cc3904f62e7754cd26684729742be1ae4",
       "size_bytes": 2115
     },
     "target_packets": {
       "path": "bench/type4/frontier_target_packets.v1.json",
-      "sha256": "a48b0b773f8c9002bcc60cb1b568894f659aedc29d37c73701eb3722f09d7944",
-      "size_bytes": 19194
+      "sha256": "4daf5d6672f011e871a0aaed47d1e499e434a03590b0cd66ce2fe3d7a0338a81",
+      "size_bytes": 19417
     }
   },
   "source_report_verdict": "no-exact-admission-ready-packets",

--- a/bench/type4/frontier_target_packets.v1.json
+++ b/bench/type4/frontier_target_packets.v1.json
@@ -264,20 +264,24 @@
       "proof_fact_model": {
         "facts": [
           {
-            "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop, wrong empty-truth boundary, and extra loop-effect closure",
-            "fact_id": "python-loop-demorgan.universal-short-circuit"
+            "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop and extra loop-effect closure",
+            "fact_id": "quantifier.universal.counterexample-loop"
+          },
+          {
+            "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates fallthrough True on exhaustion and the wrong empty-truth boundary",
+            "fact_id": "quantifier.vacuous-truth"
           },
           {
             "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates comparison-only De Morgan, changed-predicate closure, and value-returning operand closure",
-            "fact_id": "python-loop-demorgan.boolean-demorgan"
+            "fact_id": "boolean.demorgan.proven-bool-operands"
           },
           {
             "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates pure local comparisons, observed loop effects, and helper-call closure",
-            "fact_id": "python-loop-demorgan.effect-safety"
+            "fact_id": "effect.pure-predicate"
           },
           {
             "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates that the positive pair consumes arg[0]:xs on both sides and that the ys hard negative stays outside the fact",
-            "fact_id": "python-loop-demorgan.iterator-identity"
+            "fact_id": "iteration.same-source-identity"
           }
         ],
         "focused_tests": [

--- a/bench/type4/proof_carrying_frontier.md
+++ b/bench/type4/proof_carrying_frontier.md
@@ -40,7 +40,7 @@ report keeps the fuller evidence and admission boundary.
 | packet | axis | route | readiness | exec witnesses | real replay | proof facts | hard negatives | groups |
 |---|---|---|---|---|---|---:|---:|---:|
 | `numeric-clamp-2026-06-06` | `numeric_clamp` | `proof-fact-prerequisite` | `detector-admitted-controlled` | `covered (8/8)` | `passed (1/1)` | 2 | 4 | 1 |
-| `python-loop-demorgan-all-2026-07-07` | `python_loop_demorgan_all` | `team-a-detector` | `detector-admitted` | `covered (7/7)` | `passed (1/1)` | 4 | 6 | 1 |
+| `python-loop-demorgan-all-2026-07-07` | `python_loop_demorgan_all` | `team-a-detector` | `detector-admitted` | `covered (7/7)` | `passed (1/1)` | 5 | 6 | 1 |
 
 ## Packet Details
 

--- a/bench/type4/proof_carrying_frontier.py
+++ b/bench/type4/proof_carrying_frontier.py
@@ -111,6 +111,8 @@ PROOF_FACT_EVIDENCE_OBSERVATIONS = {
     "universal-loop",
     "wrong-empty-truth",
     "unsupported-universal-loop",
+    "vacuous-truth",
+    "unsupported-vacuous-truth",
     "effect-safe",
     "effectful",
     "unsupported-effect-safety",
@@ -331,10 +333,10 @@ def validate_python_loop_demorgan_proof_facts(
                 expected_refs[evidence_id] = fact_id
 
     if not expected_refs:
-        iterator_fact = proof_fact_registry.get("python-loop-demorgan.iterator-identity")
+        iterator_fact = proof_fact_registry.get("iteration.same-source-identity")
         if iterator_fact and iterator_fact["status"] == "modeled-controlled":
             raise FrontierError(
-                "python-loop-demorgan.iterator-identity is modeled-controlled but "
+                "iteration.same-source-identity is modeled-controlled but "
                 f"does not cite {evidence_artifact} controlled evidence"
             )
         return {}
@@ -2237,8 +2239,8 @@ def selftest() -> None:
         f"{repo_rel(DEFAULT_PYTHON_LOOP_DEMORGAN_PROOF_FACTS)}::iterator-selftest"
     )
     evidence_registry_doc = json.loads(json.dumps(registry_doc))
-    evidence_registry_doc["facts"][0]["fact_id"] = "python-loop-demorgan.iterator-identity"
-    evidence_registry_doc["facts"][0]["semantic_family"] = "python.loop_demorgan_all"
+    evidence_registry_doc["facts"][0]["fact_id"] = "iteration.same-source-identity"
+    evidence_registry_doc["facts"][0]["semantic_family"] = "iteration.source_identity"
     evidence_registry_doc["facts"][0]["controlled_evidence"] = [evidence_ref]
     evidence_registry = validate_proof_fact_registry(evidence_registry_doc)
     proof_evidence = {
@@ -2250,7 +2252,7 @@ def selftest() -> None:
         "results": [
             {
                 "evidence_id": "iterator-selftest",
-                "fact_id": "python-loop-demorgan.iterator-identity",
+                "fact_id": "iteration.same-source-identity",
                 "expect": "same-iterator",
                 "observed": "same-iterator",
                 "ok": True,
@@ -2262,7 +2264,7 @@ def selftest() -> None:
         DEFAULT_PYTHON_LOOP_DEMORGAN_PROOF_FACTS,
         evidence_registry,
     )
-    assert proof_evidence_by_fact["python-loop-demorgan.iterator-identity"]["passed"] == 1
+    assert proof_evidence_by_fact["iteration.same-source-identity"]["passed"] == 1
     missing_evidence = json.loads(json.dumps(proof_evidence))
     missing_evidence["results"][0]["evidence_id"] = "wrong-id"
     try:

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -114,33 +114,33 @@
       },
       "proof_fact_registry": {
         "path": "bench/type4/proof_fact_registry.v1.json",
-        "sha256": "9772a9cf45c6cd9f79b87b98aef1a10a635d492f684cc9e524689484067b91f5",
-        "size_bytes": 11784
+        "sha256": "d1bcb9ff2100c84cc90d6c9ca63da0485ab9ce4d5fe03f5bb9788ffa5588159d",
+        "size_bytes": 21039
       },
       "python_loop_demorgan_proof_facts": {
         "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
-        "sha256": "ec9860242e6c1a4b95301f1c47d6d50c31aaef885224c5caa17363a7f664aeaa",
-        "size_bytes": 16544
+        "sha256": "2e539c5e73d31618c0b7fe9835458a5eb476900876258b8d81477a27d83d6323",
+        "size_bytes": 17639
       },
       "real_frontier": {
         "path": "bench/type4/real_frontier.v1.json",
-        "sha256": "529b331b135082cd2b2105a2b98829be251fadac6d8b8517de08af000d4e3000",
-        "size_bytes": 70707
+        "sha256": "22cbe37c2a42bcd22f9b5a9e28fda6cff01d5d44c0f284237ee4b5e40b09a35f",
+        "size_bytes": 70731
       },
       "real_frontier_replay": {
         "path": "bench/type4/real_frontier_replay.v1.json",
-        "sha256": "771b16c0131f37576608910f059b4543f553f730cbd6edbd14627bed0bf2d9f3",
-        "size_bytes": 2635
+        "sha256": "9b3e4d7a812cd2cf370bb4a29ae48fc69b226ecb795783c1cc7032f98e057399",
+        "size_bytes": 2655
       },
       "real_frontier_replay_status": {
         "path": "bench/type4/real_frontier_replay_status.v1.json",
-        "sha256": "64e8262819393740c33e7b223778885058ffcf5a03ef9d83874f66249321c3cd",
+        "sha256": "6cd3a2a4ad7b8f9afc83092e1e9e645cc3904f62e7754cd26684729742be1ae4",
         "size_bytes": 2115
       },
       "target_packets": {
         "path": "bench/type4/frontier_target_packets.v1.json",
-        "sha256": "a48b0b773f8c9002bcc60cb1b568894f659aedc29d37c73701eb3722f09d7944",
-        "size_bytes": 19194
+        "sha256": "4daf5d6672f011e871a0aaed47d1e499e434a03590b0cd66ce2fe3d7a0338a81",
+        "size_bytes": 19417
       }
     },
     "target_packet_identity": {
@@ -783,39 +783,62 @@
         "owner_route": "team-a-detector",
         "packet_id": "python-loop-demorgan-all-2026-07-07",
         "proof_fact_model": {
-          "fact_count": 4,
+          "fact_count": 5,
           "fact_ids": [
-            "python-loop-demorgan.universal-short-circuit",
-            "python-loop-demorgan.boolean-demorgan",
-            "python-loop-demorgan.effect-safety",
-            "python-loop-demorgan.iterator-identity"
+            "quantifier.universal.counterexample-loop",
+            "quantifier.vacuous-truth",
+            "boolean.demorgan.proven-bool-operands",
+            "effect.pure-predicate",
+            "iteration.same-source-identity"
           ],
           "facts": [
             {
               "controlled_evidence": {
                 "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
                 "evidence_ids": [
-                  "python-loop-demorgan-universal-negative-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect",
                   "python-loop-demorgan-universal-positive-counterexample-loop"
                 ],
                 "observations": {
-                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
                   "python-loop-demorgan-universal-negative-extra-loop-effect": "unsupported-universal-loop",
                   "python-loop-demorgan-universal-positive-counterexample-loop": "universal-loop"
                 },
-                "passed": 3,
+                "passed": 2,
                 "tool_version": "python-loop-demorgan-proof-facts/1"
               },
-              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop, wrong empty-truth boundary, and extra loop-effect closure",
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates the positive counterexample loop and extra loop-effect closure",
               "evidence_requirements": [
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.universal-short-circuit",
+              "fact_id": "quantifier.universal.counterexample-loop",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Universal loop short-circuit and vacuous truth"
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier as counterexample loop"
+            },
+            {
+              "controlled_evidence": {
+                "artifact": "bench/type4/python_loop_demorgan_proof_facts.v1.json",
+                "evidence_ids": [
+                  "python-loop-demorgan-universal-negative-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true"
+                ],
+                "observations": {
+                  "python-loop-demorgan-universal-negative-empty-truth": "wrong-empty-truth",
+                  "python-loop-demorgan-vacuous-positive-fallthrough-true": "vacuous-truth"
+                },
+                "passed": 2,
+                "tool_version": "python-loop-demorgan-proof-facts/1"
+              },
+              "current_real_pair_status": "satisfied for controlled README/focused fixtures: python_loop_demorgan_proof_facts validates fallthrough True on exhaustion and the wrong empty-truth boundary",
+              "evidence_requirements": [
+                "focused-executable",
+                "source-evidence"
+              ],
+              "fact_id": "quantifier.vacuous-truth",
+              "registry_status": "modeled-controlled",
+              "semantic_family": "quantifier.universal",
+              "title": "Universal quantifier vacuous truth"
             },
             {
               "controlled_evidence": {
@@ -838,10 +861,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.boolean-demorgan",
+              "fact_id": "boolean.demorgan.proven-bool-operands",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Boolean-only De Morgan"
+              "semantic_family": "boolean.demorgan",
+              "title": "De Morgan over proven boolean operands"
             },
             {
               "controlled_evidence": {
@@ -864,10 +887,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.effect-safety",
+              "fact_id": "effect.pure-predicate",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all effect safety"
+              "semantic_family": "effect.purity",
+              "title": "Pure predicate/effect safety"
             },
             {
               "controlled_evidence": {
@@ -888,10 +911,10 @@
                 "focused-executable",
                 "source-evidence"
               ],
-              "fact_id": "python-loop-demorgan.iterator-identity",
+              "fact_id": "iteration.same-source-identity",
               "registry_status": "modeled-controlled",
-              "semantic_family": "python.loop_demorgan_all",
-              "title": "Loop/all iterator identity"
+              "semantic_family": "iteration.source_identity",
+              "title": "Iteration same-source identity"
             }
           ],
           "model_status": "modeled-controlled"

--- a/bench/type4/proof_fact_registry.md
+++ b/bench/type4/proof_fact_registry.md
@@ -29,9 +29,39 @@ packet-specific current status locally.
 |---|---|---|---|
 | `numeric-clamp.bound-order` | `modeled-controlled` | `formal-or-mechanized`, `focused-executable`, `source-evidence` | Requires `numeric-clamp.integer-domain`; does not admit a real pair by itself. |
 | `numeric-clamp.integer-domain` | `modeled-controlled` | `formal-or-mechanized`, `focused-executable`, `source-evidence` | Requires `numeric-clamp.bound-order`; does not admit a real pair by itself. |
-| `python-loop-demorgan.boolean-demorgan` | `modeled-controlled` | `focused-executable`, `source-evidence` | Requires universal short-circuit, effect safety, and iterator identity. |
-| `python-loop-demorgan.effect-safety` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only permits comparing short-circuit boundaries after effects are closed. |
-| `python-loop-demorgan.iterator-identity` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only rules out different receiver/iterator inputs. |
-| `python-loop-demorgan.universal-short-circuit` | `modeled-controlled` | `focused-executable`, `source-evidence` | Requires boolean De Morgan, effect safety, and iterator identity. |
+| `boolean.demorgan.proven-bool-operands` | `modeled-controlled` | `focused-executable`, `source-evidence` | Requires source identity, purity, counterexample-loop, and vacuous-truth facts. |
+| `quantifier.universal.counterexample-loop` | `modeled-controlled` | `focused-executable`, `source-evidence` | Requires vacuous truth, source identity, predicate purity, and any boolean rewrite facts. |
+| `quantifier.vacuous-truth` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only closes the empty-input boundary for a separately proven counterexample loop. |
+| `iteration.same-source-identity` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only rules out different receivers, iterators, or traversal sources. |
+| `effect.pure-predicate` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only permits comparing short-circuit boundaries after predicate effects are closed. |
+
+## Compatibility Aliases
+
+The Python loop/De Morgan packet first landed with packet-local fact IDs. New
+packets must cite the neutral IDs above; the old IDs are retained as `retired`
+aliases so historical artifacts remain understandable and validators can reject
+new packet-local citations.
+
+| retired alias | neutral fact |
+|---|---|
+| `python-loop-demorgan.boolean-demorgan` | `boolean.demorgan.proven-bool-operands` |
+| `python-loop-demorgan.effect-safety` | `effect.pure-predicate` |
+| `python-loop-demorgan.iterator-identity` | `iteration.same-source-identity` |
+| `python-loop-demorgan.universal-short-circuit` | `quantifier.universal.counterexample-loop`, `quantifier.vacuous-truth` |
+
+## Universal Quantifier Pattern Matrix
+
+This matrix records capability by language surface. Python is the first admitted
+surface through `python-loop-demorgan-all-2026-07-07`; the other columns are open
+candidates until they have their own evidence producer, focused replay, hard
+negatives, and PCF/readiness admission.
+
+| fact | Python `all(...)` + loop | Ruby `Enumerable#all?` | Rust `Iterator::all` | JS/TS `every` |
+|---|---|---|---|---|
+| `quantifier.universal.counterexample-loop` | modeled-controlled; packet admitted | open | open | open |
+| `quantifier.vacuous-truth` | modeled-controlled; packet admitted | open | open | open |
+| `iteration.same-source-identity` | modeled-controlled; packet admitted | open | open | open |
+| `effect.pure-predicate` | modeled-controlled; packet admitted | open | open | open |
+| `boolean.demorgan.proven-bool-operands` | modeled-controlled; packet admitted | open | open | open |
 
 Registry entries guide implementation work; they are not detector admission.

--- a/bench/type4/proof_fact_registry.v1.json
+++ b/bench/type4/proof_fact_registry.v1.json
@@ -72,14 +72,204 @@
       "accepted_evidence": [
         "comparison predicates whose results are booleans",
         "the same element variable and the same literal/value coordinates on both sides",
-        "a boolean context where operand values are not observed"
+        "a boolean context where operand values are not observed",
+        "language or source evidence that excludes overloaded, value-returning, or effectful boolean operands"
+      ],
+      "compatibility_aliases": [
+        "python-loop-demorgan.boolean-demorgan"
       ],
       "controlled_evidence": [
         "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-boolean-positive-comparison-demorgan",
         "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-boolean-negative-changed-predicate",
         "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-boolean-negative-value-returning-operand"
       ],
-      "detector_admission_implication": "Does not admit loop/all convergence by itself; universal short-circuit, effect safety, and iterator identity are separate facts.",
+      "detector_admission_implication": "Does not admit a quantifier/loop convergence by itself; source identity, purity, counterexample-loop, and vacuous-truth facts are separate requirements.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "boolean.demorgan.proven-bool-operands",
+      "hard_negative_conventions": [
+        "boolean.truth-table",
+        "boolean.value-context",
+        "boolean.effect-safety"
+      ],
+      "implementation_guidance": [
+        "Normalize De Morgan only when operands are proven boolean values.",
+        "Reject value-returning boolean contexts, overloaded comparison semantics, and predicate calls unless separate effect/purity evidence exists.",
+        "Attach new language surfaces by emitting boolean-operand evidence, not by adding language-specific detector branches."
+      ],
+      "rejected_evidence": [
+        "value-returning and/or operands whose value, not only truthiness, is observed",
+        "overloaded comparison or predicate calls with effects",
+        "changed predicates such as x != 0 or x != 1"
+      ],
+      "semantic_family": "boolean.demorgan",
+      "status": "modeled-controlled",
+      "summary": "A De Morgan rewrite may be used only when both sides operate on proven boolean operands, not on language-specific value-returning boolean expressions.",
+      "title": "De Morgan over proven boolean operands"
+    },
+    {
+      "accepted_evidence": [
+        "a universal quantifier/all/every surface over a single element predicate",
+        "an explicit loop whose only counterexample branch returns literal false",
+        "matching predicate coordinates between the quantifier and the loop counterexample",
+        "short-circuit order that stops at the first counterexample"
+      ],
+      "compatibility_aliases": [
+        "python-loop-demorgan.universal-short-circuit"
+      ],
+      "controlled_evidence": [
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-positive-counterexample-loop",
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-negative-extra-loop-effect"
+      ],
+      "detector_admission_implication": "Does not admit a loop/quantifier convergence by itself; vacuous truth, source identity, predicate purity, and any boolean rewrite facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "quantifier.universal.counterexample-loop",
+      "hard_negative_conventions": [
+        "loop.short-circuit",
+        "loop.empty-input",
+        "boolean.effect-safety"
+      ],
+      "implementation_guidance": [
+        "Model only loops where the counterexample branch is the sole early false exit.",
+        "Keep extra loop control, observed loop effects, and unsupported body shapes closed until separate evidence exists.",
+        "Pair this fact with quantifier.vacuous-truth before admitting an all/every-style surface."
+      ],
+      "rejected_evidence": [
+        "counterexample branches that return non-false payloads",
+        "loop bodies with extra observed effects, break, continue, else effects, or unsupported control",
+        "predicate-coordinate changes between the quantifier and the loop"
+      ],
+      "semantic_family": "quantifier.universal",
+      "status": "modeled-controlled",
+      "summary": "A universal quantifier can match an early-return loop only when the loop is a pure counterexample scan that returns false at the first not-P element.",
+      "title": "Universal quantifier as counterexample loop"
+    },
+    {
+      "accepted_evidence": [
+        "the quantifier surface returns true for an empty input",
+        "the explicit loop falls through to literal true after exhausting the same input",
+        "no loop else block, final payload, or post-loop effect changes the empty-input result"
+      ],
+      "compatibility_aliases": [
+        "python-loop-demorgan.universal-short-circuit"
+      ],
+      "controlled_evidence": [
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-vacuous-positive-fallthrough-true",
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-negative-empty-truth"
+      ],
+      "detector_admission_implication": "Does not admit a quantifier/loop convergence by itself; it only closes the empty-input boundary for a separately proven counterexample loop.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "quantifier.vacuous-truth",
+      "hard_negative_conventions": [
+        "loop.empty-input",
+        "loop.short-circuit"
+      ],
+      "implementation_guidance": [
+        "Treat empty-input behavior as a first-class proof fact, not as a side effect of loop-shape matching.",
+        "Keep loops that return false or a payload after exhaustion outside all/every admission.",
+        "Require this fact whenever a universal quantifier surface is matched to an explicit loop."
+      ],
+      "rejected_evidence": [
+        "fallthrough returns false or a non-boolean payload",
+        "post-loop code changes the empty-input result",
+        "collection APIs with non-vacuous empty behavior"
+      ],
+      "semantic_family": "quantifier.universal",
+      "status": "modeled-controlled",
+      "summary": "Universal quantifier rewrites must preserve the empty-input result: no counterexamples means true.",
+      "title": "Universal quantifier vacuous truth"
+    },
+    {
+      "accepted_evidence": [
+        "the quantifier and explicit loop consume the same local iterable binding or receiver place",
+        "no reassignment or mutation changes the source between the two forms",
+        "the quantifier element and loop element refer to the same traversal coordinate"
+      ],
+      "compatibility_aliases": [
+        "python-loop-demorgan.iterator-identity"
+      ],
+      "controlled_evidence": [
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-iterator-positive-same-binding",
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-iterator-negative-different-binding"
+      ],
+      "detector_admission_implication": "Does not admit a quantifier/loop convergence by itself; it only rules out different receivers, iterators, or traversal sources.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "iteration.same-source-identity",
+      "hard_negative_conventions": [
+        "loop.iterator-identity"
+      ],
+      "implementation_guidance": [
+        "Require same-source provenance for the quantifier and loop traversal.",
+        "Reject different iterable bindings, mutated receivers, and derived iterables whose order/cardinality relation is not proven.",
+        "Let each frontend emit receiver/place evidence for its language surface."
+      ],
+      "rejected_evidence": [
+        "different iterable bindings or receiver places",
+        "receiver or iterator mutation during traversal",
+        "derived iterables whose cardinality/order relationship is not proven"
+      ],
+      "semantic_family": "iteration.source_identity",
+      "status": "modeled-controlled",
+      "summary": "The quantifier and explicit loop must traverse the same source in the same order before their predicates can be compared.",
+      "title": "Iteration same-source identity"
+    },
+    {
+      "accepted_evidence": [
+        "local comparisons over the loop or quantifier element and literals",
+        "no calls, assignments, yields, awaits, mutations, or logging inside the predicate or loop body",
+        "no observed state before the early return or inside the quantifier predicate"
+      ],
+      "compatibility_aliases": [
+        "python-loop-demorgan.effect-safety"
+      ],
+      "controlled_evidence": [
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-positive-pure-local-comparisons",
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-negative-observed-loop-effect",
+        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-negative-helper-call"
+      ],
+      "detector_admission_implication": "Does not admit a quantifier/loop convergence by itself; it only permits comparing short-circuit boundaries after predicate effects are closed.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "effect.pure-predicate",
+      "hard_negative_conventions": [
+        "boolean.effect-safety",
+        "loop.short-circuit"
+      ],
+      "implementation_guidance": [
+        "Treat helper calls, mutation, logging, yield, await, and assignment as closed unless separate purity/effect evidence exists.",
+        "Keep short-circuit timing as behavior-defining when side effects can be observed.",
+        "Attach language surfaces through effect evidence producers or admitted purity resolvers."
+      ],
+      "rejected_evidence": [
+        "predicate helper calls unless callee purity is proven",
+        "observed counters or logging before return",
+        "iterator, receiver, or captured-state mutation during traversal"
+      ],
+      "semantic_family": "effect.purity",
+      "status": "modeled-controlled",
+      "summary": "The predicate must be pure enough that quantifier and loop short-circuiting observe the same effects and stop at the same first counterexample.",
+      "title": "Pure predicate/effect safety"
+    },
+    {
+      "accepted_evidence": [
+        "comparison predicates whose results are booleans",
+        "the same element variable and the same literal/value coordinates on both sides",
+        "a boolean context where operand values are not observed"
+      ],
+      "detector_admission_implication": "Retired compatibility alias; new packets must cite boolean.demorgan.proven-bool-operands.",
       "evidence_requirements": [
         "focused-executable",
         "source-evidence"
@@ -100,8 +290,11 @@
         "changed predicates such as x != 0 or x != 1"
       ],
       "semantic_family": "python.loop_demorgan_all",
-      "status": "modeled-controlled",
+      "status": "retired",
       "summary": "The counterexample guard not P may normalize through De Morgan only for proven boolean operands, for example not (x == 0 or x == 1) == (x != 0 and x != 1).",
+      "superseded_by": [
+        "boolean.demorgan.proven-bool-operands"
+      ],
       "title": "Boolean-only De Morgan"
     },
     {
@@ -110,12 +303,7 @@
         "no calls, assignments, yields, awaits, or mutations inside the predicate or loop body",
         "no observed state before the early return or inside the all(...) predicate"
       ],
-      "controlled_evidence": [
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-positive-pure-local-comparisons",
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-negative-observed-loop-effect",
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-effect-negative-helper-call"
-      ],
-      "detector_admission_implication": "Does not admit loop/all convergence by itself; it only permits comparing short-circuit boundaries after the predicate is effect-safe.",
+      "detector_admission_implication": "Retired compatibility alias; new packets must cite effect.pure-predicate.",
       "evidence_requirements": [
         "focused-executable",
         "source-evidence"
@@ -135,8 +323,11 @@
         "iterator or receiver mutation during traversal"
       ],
       "semantic_family": "python.loop_demorgan_all",
-      "status": "modeled-controlled",
+      "status": "retired",
       "summary": "The predicate must be pure and exact-safe so all(...) short-circuit and the early-return loop observe the same effects and stop at the same first counterexample.",
+      "superseded_by": [
+        "effect.pure-predicate"
+      ],
       "title": "Loop/all effect safety"
     },
     {
@@ -145,11 +336,7 @@
         "no reassignment or mutation changes the iterable between the two forms",
         "the generator and loop use the same element variable coordinate"
       ],
-      "controlled_evidence": [
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-iterator-positive-same-binding",
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-iterator-negative-different-binding"
-      ],
-      "detector_admission_implication": "Does not admit loop/all convergence by itself; it only rules out different receiver/iterator inputs.",
+      "detector_admission_implication": "Retired compatibility alias; new packets must cite iteration.same-source-identity.",
       "evidence_requirements": [
         "focused-executable",
         "source-evidence"
@@ -168,8 +355,11 @@
         "derived iterables whose cardinality/order relationship is not proven"
       ],
       "semantic_family": "python.loop_demorgan_all",
-      "status": "modeled-controlled",
+      "status": "retired",
       "summary": "The generator consumed by all(...) and the explicit loop must traverse the same iterable in the same order.",
+      "superseded_by": [
+        "iteration.same-source-identity"
+      ],
       "title": "Loop/all iterator identity"
     },
     {
@@ -179,12 +369,7 @@
         "fallthrough return is literal True",
         "empty iterables return True in both forms"
       ],
-      "controlled_evidence": [
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-positive-counterexample-loop",
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-negative-empty-truth",
-        "bench/type4/python_loop_demorgan_proof_facts.v1.json::python-loop-demorgan-universal-negative-extra-loop-effect"
-      ],
-      "detector_admission_implication": "Does not admit loop/all convergence by itself; boolean De Morgan, effect safety, and iterator identity remain separate facts.",
+      "detector_admission_implication": "Retired compatibility alias; new packets must cite quantifier.universal.counterexample-loop and quantifier.vacuous-truth.",
       "evidence_requirements": [
         "focused-executable",
         "source-evidence"
@@ -204,8 +389,12 @@
         "the loop consumes a different iterable or mutates the iterable"
       ],
       "semantic_family": "python.loop_demorgan_all",
-      "status": "modeled-controlled",
+      "status": "retired",
       "summary": "A Python early-return loop that returns False on the first counterexample and True after exhaustion is equivalent to all(P(x) for x in xs) only with vacuous truth and matching short-circuit behavior.",
+      "superseded_by": [
+        "quantifier.universal.counterexample-loop",
+        "quantifier.vacuous-truth"
+      ],
       "title": "Universal loop short-circuit and vacuous truth"
     }
   ],

--- a/bench/type4/python_loop_demorgan_proof_facts.py
+++ b/bench/type4/python_loop_demorgan_proof_facts.py
@@ -3,15 +3,16 @@
 
 The README-facing Python loop plus De Morgan packet is intentionally closed
 until reusable proof facts exist. This tool supplies a small, source-level
-controlled model for four facts:
+controlled model for five language-neutral facts:
 
-* iterator identity: an ``all(...)`` generator and an explicit ``for`` loop
+* same-source identity: an ``all(...)`` generator and an explicit ``for`` loop
   consume the same local iterable binding;
-* effect safety: the supported predicate/loop fragment has no calls,
+* pure predicate: the supported predicate/loop fragment has no calls,
   assignments, mutation, logging, ``yield``, ``await``, or other observable
   effects before the short-circuit decision.
-* universal short-circuit: the loop returns literal ``False`` on the first
-  counterexample and literal ``True`` after exhaustion;
+* counterexample-loop universal quantification: the loop returns literal
+  ``False`` on the first counterexample;
+* vacuous truth: the loop returns literal ``True`` after exhaustion;
 * boolean-only De Morgan: the predicate relation is the boolean comparison
   rewrite ``not (x == a or x == b)`` to ``x != a and x != b``.
 """
@@ -32,10 +33,11 @@ ROOT = HERE.parents[1]
 
 SCHEMA_VERSION = 1
 TOOL_VERSION = "python-loop-demorgan-proof-facts/1"
-FACT_ID_ITERATOR_IDENTITY = "python-loop-demorgan.iterator-identity"
-FACT_ID_EFFECT_SAFETY = "python-loop-demorgan.effect-safety"
-FACT_ID_UNIVERSAL_SHORT_CIRCUIT = "python-loop-demorgan.universal-short-circuit"
-FACT_ID_BOOLEAN_DEMORGAN = "python-loop-demorgan.boolean-demorgan"
+FACT_ID_ITERATION_SAME_SOURCE_IDENTITY = "iteration.same-source-identity"
+FACT_ID_EFFECT_PURE_PREDICATE = "effect.pure-predicate"
+FACT_ID_UNIVERSAL_COUNTEREXAMPLE_LOOP = "quantifier.universal.counterexample-loop"
+FACT_ID_VACUOUS_TRUTH = "quantifier.vacuous-truth"
+FACT_ID_BOOLEAN_DEMORGAN = "boolean.demorgan.proven-bool-operands"
 DEFAULT_JSON_OUT = HERE / "python_loop_demorgan_proof_facts.v1.json"
 
 ITERATOR_OBSERVATIONS = {"same-iterator", "different-iterator", "unsupported-iterator"}
@@ -43,6 +45,11 @@ UNIVERSAL_OBSERVATIONS = {
     "universal-loop",
     "wrong-empty-truth",
     "unsupported-universal-loop",
+}
+VACUOUS_TRUTH_OBSERVATIONS = {
+    "vacuous-truth",
+    "wrong-empty-truth",
+    "unsupported-vacuous-truth",
 }
 EFFECT_OBSERVATIONS = {
     "effect-safe",
@@ -58,6 +65,7 @@ BOOLEAN_OBSERVATIONS = {
 OBSERVATIONS = (
     ITERATOR_OBSERVATIONS
     | UNIVERSAL_OBSERVATIONS
+    | VACUOUS_TRUTH_OBSERVATIONS
     | EFFECT_OBSERVATIONS
     | BOOLEAN_OBSERVATIONS
 )
@@ -79,7 +87,7 @@ CONTROLLED_EVIDENCE = [
     {
         "check": "iterator-identity",
         "evidence_id": "python-loop-demorgan-iterator-positive-same-binding",
-        "fact_id": FACT_ID_ITERATOR_IDENTITY,
+        "fact_id": FACT_ID_ITERATION_SAME_SOURCE_IDENTITY,
         "case_id": "python_loop_demorgan_all_readme",
         "expectation_id": "python_loop_demorgan_positive_matches_loop",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
@@ -90,7 +98,7 @@ CONTROLLED_EVIDENCE = [
     {
         "check": "iterator-identity",
         "evidence_id": "python-loop-demorgan-iterator-negative-different-binding",
-        "fact_id": FACT_ID_ITERATOR_IDENTITY,
+        "fact_id": FACT_ID_ITERATION_SAME_SOURCE_IDENTITY,
         "case_id": "python_loop_demorgan_iterator_identity_boundary",
         "expectation_id": "python_loop_demorgan_iterator_identity_stays_split",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py",
@@ -101,7 +109,7 @@ CONTROLLED_EVIDENCE = [
     {
         "check": "effect-safety",
         "evidence_id": "python-loop-demorgan-effect-positive-pure-local-comparisons",
-        "fact_id": FACT_ID_EFFECT_SAFETY,
+        "fact_id": FACT_ID_EFFECT_PURE_PREDICATE,
         "case_id": "python_loop_demorgan_all_readme",
         "expectation_id": "python_loop_demorgan_positive_matches_loop",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
@@ -112,7 +120,7 @@ CONTROLLED_EVIDENCE = [
     {
         "check": "effect-safety",
         "evidence_id": "python-loop-demorgan-effect-negative-observed-loop-effect",
-        "fact_id": FACT_ID_EFFECT_SAFETY,
+        "fact_id": FACT_ID_EFFECT_PURE_PREDICATE,
         "case_id": "python_loop_demorgan_side_effect_boundary",
         "expectation_id": "python_loop_demorgan_side_effect_stays_split",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py",
@@ -123,7 +131,7 @@ CONTROLLED_EVIDENCE = [
     {
         "check": "effect-safety",
         "evidence_id": "python-loop-demorgan-effect-negative-helper-call",
-        "fact_id": FACT_ID_EFFECT_SAFETY,
+        "fact_id": FACT_ID_EFFECT_PURE_PREDICATE,
         "case_id": "python_loop_demorgan_helper_call_boundary",
         "expectation_id": "python_loop_demorgan_helper_call_stays_split",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/helper_call.py",
@@ -132,9 +140,9 @@ CONTROLLED_EVIDENCE = [
         "expect": "effectful",
     },
     {
-        "check": "universal-short-circuit",
+        "check": "universal-counterexample-loop",
         "evidence_id": "python-loop-demorgan-universal-positive-counterexample-loop",
-        "fact_id": FACT_ID_UNIVERSAL_SHORT_CIRCUIT,
+        "fact_id": FACT_ID_UNIVERSAL_COUNTEREXAMPLE_LOOP,
         "case_id": "python_loop_demorgan_all_readme",
         "expectation_id": "python_loop_demorgan_positive_matches_loop",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
@@ -143,9 +151,20 @@ CONTROLLED_EVIDENCE = [
         "expect": "universal-loop",
     },
     {
-        "check": "universal-short-circuit",
+        "check": "vacuous-truth",
+        "evidence_id": "python-loop-demorgan-vacuous-positive-fallthrough-true",
+        "fact_id": FACT_ID_VACUOUS_TRUTH,
+        "case_id": "python_loop_demorgan_all_readme",
+        "expectation_id": "python_loop_demorgan_positive_matches_loop",
+        "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
+        "all_function": "all_not_zero_or_one",
+        "loop_function": "loop_no_zero_or_one",
+        "expect": "vacuous-truth",
+    },
+    {
+        "check": "vacuous-truth",
         "evidence_id": "python-loop-demorgan-universal-negative-empty-truth",
-        "fact_id": FACT_ID_UNIVERSAL_SHORT_CIRCUIT,
+        "fact_id": FACT_ID_VACUOUS_TRUTH,
         "case_id": "python_loop_demorgan_vacuous_truth_boundary",
         "expectation_id": "python_loop_demorgan_vacuous_truth_stays_split",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py",
@@ -154,9 +173,9 @@ CONTROLLED_EVIDENCE = [
         "expect": "wrong-empty-truth",
     },
     {
-        "check": "universal-short-circuit",
+        "check": "universal-counterexample-loop",
         "evidence_id": "python-loop-demorgan-universal-negative-extra-loop-effect",
-        "fact_id": FACT_ID_UNIVERSAL_SHORT_CIRCUIT,
+        "fact_id": FACT_ID_UNIVERSAL_COUNTEREXAMPLE_LOOP,
         "case_id": "python_loop_demorgan_side_effect_boundary",
         "expectation_id": "python_loop_demorgan_side_effect_stays_split",
         "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py",
@@ -850,6 +869,18 @@ def universal_observation(
     return "unsupported-universal-loop"
 
 
+def vacuous_truth_observation(
+    all_shape: IteratorShape, loop_shape: UniversalShape
+) -> str:
+    if not all_shape.iterable.supported:
+        return "unsupported-vacuous-truth"
+    if loop_shape.early_false and loop_shape.fallthrough_true:
+        return "vacuous-truth"
+    if loop_shape.early_false and not loop_shape.fallthrough_true:
+        return "wrong-empty-truth"
+    return "unsupported-vacuous-truth"
+
+
 def extract_all_boolean_shape(fn: ast.FunctionDef) -> BooleanShape:
     iterator_shape = extract_all_generator_shape(fn)
     diagnostics = list(iterator_shape.diagnostics)
@@ -1044,10 +1075,14 @@ def result_for(entry: dict[str, str]) -> dict[str, Any]:
         all_shape = extract_all_effect_shape(functions[entry["all_function"]])
         loop_shape = extract_loop_effect_shape(functions[entry["loop_function"]])
         observed = effect_observation(all_shape, loop_shape)
-    elif check == "universal-short-circuit":
+    elif check == "universal-counterexample-loop":
         all_shape = extract_all_generator_shape(functions[entry["all_function"]])
         loop_shape = extract_universal_loop_shape(functions[entry["loop_function"]])
         observed = universal_observation(all_shape, loop_shape)
+    elif check == "vacuous-truth":
+        all_shape = extract_all_generator_shape(functions[entry["all_function"]])
+        loop_shape = extract_universal_loop_shape(functions[entry["loop_function"]])
+        observed = vacuous_truth_observation(all_shape, loop_shape)
     elif check == "boolean-demorgan":
         all_shape, loop_shape = boolean_shape_for_entry(entry, functions)
         observed = boolean_observation(all_shape, loop_shape)
@@ -1259,6 +1294,10 @@ def loop_form(xs):
         extract_all_generator_shape(good["all_form"]),
         extract_universal_loop_shape(good["loop_form"]),
     ) == "universal-loop"
+    assert vacuous_truth_observation(
+        extract_all_generator_shape(good["all_form"]),
+        extract_universal_loop_shape(good["loop_form"]),
+    ) == "vacuous-truth"
 
     wrong_empty_tree = ast.parse(
         """
@@ -1274,6 +1313,10 @@ def loop_form(xs):
     )
     wrong_empty = function_map(wrong_empty_tree)
     assert universal_observation(
+        extract_all_generator_shape(wrong_empty["all_form"]),
+        extract_universal_loop_shape(wrong_empty["loop_form"]),
+    ) == "wrong-empty-truth"
+    assert vacuous_truth_observation(
         extract_all_generator_shape(wrong_empty["all_form"]),
         extract_universal_loop_shape(wrong_empty["loop_form"]),
     ) == "wrong-empty-truth"

--- a/bench/type4/python_loop_demorgan_proof_facts.v1.json
+++ b/bench/type4/python_loop_demorgan_proof_facts.v1.json
@@ -1,10 +1,11 @@
 {
-  "evidence_count": 11,
+  "evidence_count": 12,
   "fact_ids": [
-    "python-loop-demorgan.boolean-demorgan",
-    "python-loop-demorgan.effect-safety",
-    "python-loop-demorgan.iterator-identity",
-    "python-loop-demorgan.universal-short-circuit"
+    "boolean.demorgan.proven-bool-operands",
+    "effect.pure-predicate",
+    "iteration.same-source-identity",
+    "quantifier.universal.counterexample-loop",
+    "quantifier.vacuous-truth"
   ],
   "failed": 0,
   "input_artifacts": {
@@ -47,11 +48,11 @@
     ],
     "tool": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.py",
-      "sha256": "b234f1d06a99fef5c8c8cfe3ded4db0fd33c7a6dde3b4341f0b77a14578bf589",
-      "size_bytes": 46352
+      "sha256": "ea9f2040dfd725e2e8787217c87aa77562af9bd051caaa455914f2d78707b72f",
+      "size_bytes": 48251
     }
   },
-  "passed": 11,
+  "passed": 12,
   "results": [
     {
       "case_id": "python_loop_demorgan_all_readme",
@@ -59,7 +60,7 @@
       "evidence_id": "python-loop-demorgan-iterator-positive-same-binding",
       "expect": "same-iterator",
       "expectation_id": "python_loop_demorgan_positive_matches_loop",
-      "fact_id": "python-loop-demorgan.iterator-identity",
+      "fact_id": "iteration.same-source-identity",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
       "observed": "same-iterator",
       "ok": true,
@@ -102,7 +103,7 @@
       "evidence_id": "python-loop-demorgan-iterator-negative-different-binding",
       "expect": "different-iterator",
       "expectation_id": "python_loop_demorgan_iterator_identity_stays_split",
-      "fact_id": "python-loop-demorgan.iterator-identity",
+      "fact_id": "iteration.same-source-identity",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/iterator_identity.py",
       "observed": "different-iterator",
       "ok": true,
@@ -145,7 +146,7 @@
       "evidence_id": "python-loop-demorgan-effect-positive-pure-local-comparisons",
       "expect": "effect-safe",
       "expectation_id": "python_loop_demorgan_positive_matches_loop",
-      "fact_id": "python-loop-demorgan.effect-safety",
+      "fact_id": "effect.pure-predicate",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
       "observed": "effect-safe",
       "ok": true,
@@ -174,7 +175,7 @@
       "evidence_id": "python-loop-demorgan-effect-negative-observed-loop-effect",
       "expect": "effectful",
       "expectation_id": "python_loop_demorgan_side_effect_stays_split",
-      "fact_id": "python-loop-demorgan.effect-safety",
+      "fact_id": "effect.pure-predicate",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py",
       "observed": "effectful",
       "ok": true,
@@ -205,7 +206,7 @@
       "evidence_id": "python-loop-demorgan-effect-negative-helper-call",
       "expect": "effectful",
       "expectation_id": "python_loop_demorgan_helper_call_stays_split",
-      "fact_id": "python-loop-demorgan.effect-safety",
+      "fact_id": "effect.pure-predicate",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/helper_call.py",
       "observed": "effectful",
       "ok": true,
@@ -234,11 +235,11 @@
     },
     {
       "case_id": "python_loop_demorgan_all_readme",
-      "check": "universal-short-circuit",
+      "check": "universal-counterexample-loop",
       "evidence_id": "python-loop-demorgan-universal-positive-counterexample-loop",
       "expect": "universal-loop",
       "expectation_id": "python_loop_demorgan_positive_matches_loop",
-      "fact_id": "python-loop-demorgan.universal-short-circuit",
+      "fact_id": "quantifier.universal.counterexample-loop",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
       "observed": "universal-loop",
       "ok": true,
@@ -270,12 +271,49 @@
       }
     },
     {
+      "case_id": "python_loop_demorgan_all_readme",
+      "check": "vacuous-truth",
+      "evidence_id": "python-loop-demorgan-vacuous-positive-fallthrough-true",
+      "expect": "vacuous-truth",
+      "expectation_id": "python_loop_demorgan_positive_matches_loop",
+      "fact_id": "quantifier.vacuous-truth",
+      "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
+      "observed": "vacuous-truth",
+      "ok": true,
+      "shapes": {
+        "all": {
+          "diagnostics": [],
+          "element": {
+            "expr": "x",
+            "provenance": "element:x",
+            "supported": true
+          },
+          "function": "all_not_zero_or_one",
+          "iterable": {
+            "expr": "xs",
+            "provenance": "arg[0]:xs",
+            "supported": true
+          },
+          "kind": "all-generator"
+        },
+        "loop": {
+          "counterexample": "x == 0 or x == 1",
+          "diagnostics": [],
+          "early_false": true,
+          "fallthrough_true": true,
+          "function": "loop_no_zero_or_one",
+          "kind": "for-loop-universal",
+          "supported": true
+        }
+      }
+    },
+    {
       "case_id": "python_loop_demorgan_vacuous_truth_boundary",
-      "check": "universal-short-circuit",
+      "check": "vacuous-truth",
       "evidence_id": "python-loop-demorgan-universal-negative-empty-truth",
       "expect": "wrong-empty-truth",
       "expectation_id": "python_loop_demorgan_vacuous_truth_stays_split",
-      "fact_id": "python-loop-demorgan.universal-short-circuit",
+      "fact_id": "quantifier.vacuous-truth",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/vacuous_truth.py",
       "observed": "wrong-empty-truth",
       "ok": true,
@@ -310,11 +348,11 @@
     },
     {
       "case_id": "python_loop_demorgan_side_effect_boundary",
-      "check": "universal-short-circuit",
+      "check": "universal-counterexample-loop",
       "evidence_id": "python-loop-demorgan-universal-negative-extra-loop-effect",
       "expect": "unsupported-universal-loop",
       "expectation_id": "python_loop_demorgan_side_effect_stays_split",
-      "fact_id": "python-loop-demorgan.universal-short-circuit",
+      "fact_id": "quantifier.universal.counterexample-loop",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/side_effect.py",
       "observed": "unsupported-universal-loop",
       "ok": true,
@@ -353,7 +391,7 @@
       "evidence_id": "python-loop-demorgan-boolean-positive-comparison-demorgan",
       "expect": "boolean-demorgan",
       "expectation_id": "python_loop_demorgan_positive_matches_loop",
-      "fact_id": "python-loop-demorgan.boolean-demorgan",
+      "fact_id": "boolean.demorgan.proven-bool-operands",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py",
       "observed": "boolean-demorgan",
       "ok": true,
@@ -408,7 +446,7 @@
       "evidence_id": "python-loop-demorgan-boolean-negative-changed-predicate",
       "expect": "changed-predicate",
       "expectation_id": "python_loop_demorgan_changed_predicate_stays_split",
-      "fact_id": "python-loop-demorgan.boolean-demorgan",
+      "fact_id": "boolean.demorgan.proven-bool-operands",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/changed_predicate.py",
       "observed": "changed-predicate",
       "ok": true,
@@ -463,7 +501,7 @@
       "evidence_id": "python-loop-demorgan-boolean-negative-value-returning-operand",
       "expect": "value-returning-operand",
       "expectation_id": "python_loop_demorgan_value_return_stays_split",
-      "fact_id": "python-loop-demorgan.boolean-demorgan",
+      "fact_id": "boolean.demorgan.proven-bool-operands",
       "fixture": "bench/type4/adversarial/cases/python_loop_demorgan/value_return.py",
       "observed": "value-returning-operand",
       "ok": true,

--- a/bench/type4/real_frontier.v1.json
+++ b/bench/type4/real_frontier.v1.json
@@ -61,7 +61,7 @@
         "different iterable identity: all(...) over xs is not equivalent to an early-return loop over ys"
    ],
    "batch": "2026-07-07-readme-loop-demorgan-frontier",
-      "notes": "Issue #739 detector admission record. The same-language README-facing proof target is now covered by the detector under modeled-controlled loop universal, boolean De Morgan, effect-safety, and iterator-identity proof facts."
+      "notes": "Issue #739 detector admission record. The same-language README-facing proof target is now covered by the detector under modeled-controlled counterexample-loop, vacuous-truth, same-source identity, pure-predicate, and boolean De Morgan proof facts."
   },
   {
    "case_id": "membership-java-enumset-of-junit5-doc-chronounit",

--- a/bench/type4/real_frontier_replay.v1.json
+++ b/bench/type4/real_frontier_replay.v1.json
@@ -74,7 +74,7 @@
           "path": "bench/type4/adversarial/cases/python_loop_demorgan/positive.py"
         }
       ],
-      "why_expected": "The README-facing same-language positive is admitted after modeling the loop/all universal, boolean De Morgan, effect-safety, and iterator-identity proof facts."
+      "why_expected": "The README-facing same-language positive is admitted after modeling the counterexample-loop, vacuous-truth, same-source identity, pure-predicate, and boolean De Morgan proof facts."
     }
   ],
   "schema_version": 1,

--- a/bench/type4/real_frontier_replay_status.v1.json
+++ b/bench/type4/real_frontier_replay_status.v1.json
@@ -4,18 +4,18 @@
   "input_artifacts": {
     "manifest": {
       "path": "bench/type4/real_frontier_replay.v1.json",
-      "sha256": "771b16c0131f37576608910f059b4543f553f730cbd6edbd14627bed0bf2d9f3",
-      "size_bytes": 2635
+      "sha256": "9b3e4d7a812cd2cf370bb4a29ae48fc69b226ecb795783c1cc7032f98e057399",
+      "size_bytes": 2655
     },
     "real_frontier": {
       "path": "bench/type4/real_frontier.v1.json",
-      "sha256": "529b331b135082cd2b2105a2b98829be251fadac6d8b8517de08af000d4e3000",
-      "size_bytes": 70707
+      "sha256": "22cbe37c2a42bcd22f9b5a9e28fda6cff01d5d44c0f284237ee4b5e40b09a35f",
+      "size_bytes": 70731
     },
     "target_packets": {
       "path": "bench/type4/frontier_target_packets.v1.json",
-      "sha256": "a48b0b773f8c9002bcc60cb1b568894f659aedc29d37c73701eb3722f09d7944",
-      "size_bytes": 19194
+      "sha256": "4daf5d6672f011e871a0aaed47d1e499e434a03590b0cd66ce2fe3d7a0338a81",
+      "size_bytes": 19417
     }
   },
   "nose_binary": "nose",

--- a/docs/frontier-platform.md
+++ b/docs/frontier-platform.md
@@ -173,6 +173,11 @@ float-NaN boundary remains closed. The current `python-loop-demorgan-all-2026-07
 packet is `detector-admitted` for the README/focused real pair and therefore appears
 under `admitted/resolved`, not as queued defender work.
 
+After a packet is admitted, use the
+[Type-4 semantic pattern loop](type4-semantic-pattern-loop.md) before repeating
+the work for another language. The repeat unit should be the semantic law and
+neutral proof facts, not the first language's syntax.
+
 ```sh
 python3 bench/type4/proof_carrying_frontier.py --check
 ```

--- a/docs/home.md
+++ b/docs/home.md
@@ -134,6 +134,7 @@ fundamentals; the rest is grouped by area.
 - [type4-adversarial-coverage](type4-adversarial-coverage.md) — focused Type-4 cases, target-packet task cards, and verifier-lead draft workflow.
 - [frontier-platform](frontier-platform.md) — corpus-balanced evidence platform that ranks the next Type-4 axis by presence breadth (not raw count) and separates the queue signal from human-verified evidence.
 - [proof-carrying frontier](proof-carrying-frontier.md) — target-packet admission report that requires linked evidence, proof invariants, hard negatives, blockers, and co-evolution guardrail context before exact Type-4 admission opens.
+- [Type-4 semantic pattern loop](type4-semantic-pattern-loop.md) — repeatable process for turning one admitted language surface into a language-neutral semantic pattern with proof facts, capability matrix, and reusable hard-negative templates.
 - [adversarial-coevolution](adversarial-coevolution.md) — the cross-axis campaign runbook: a white-box attacker derives structurally-missed patterns, an assessor prices them, a defender ships the largest sound generalization.
 - [hazard-ranking](hazard-ranking.md) — the evidence base for the experimental `sort=hazard` (a divergence-*propensity* signal; **not** a validated harm ranker — it ranks actual harm near chance) and the honest evaluation trail.
 - [hazard-benchmark](hazard-benchmark.md) — the evaluation criteria and labeled dataset hazard is measured against (repo selection, graded labels, quantitative sufficiency).

--- a/docs/proof-carrying-frontier.md
+++ b/docs/proof-carrying-frontier.md
@@ -82,10 +82,11 @@ and shared integer-domain evidence. Float NaN remains a closed domain boundary.
 
 `python-loop-demorgan-all-2026-07-07` is `detector-admitted`: the README-facing
 Python `all(...)` plus early-return loop example now replays as `same-family`, has 7/7
-executable focused expectations covered, and keeps controlled source evidence for all
-four required proof facts. The admission is limited to the packet's proof invariant:
-vacuous-truth, observed-effect, helper-call, value-return, changed-predicate, and
-iterator-identity hard negatives remain split.
+executable focused expectations covered, and keeps controlled source evidence for the
+five neutral proof facts: counterexample loop, vacuous truth, same-source identity,
+pure predicate, and boolean-only De Morgan. The admission is limited to the packet's
+proof invariant: vacuous-truth, observed-effect, helper-call, value-return,
+changed-predicate, and iterator-identity hard negatives remain split.
 
 This is the intended outcome. The report makes those boundaries explicit so the next
 worker extends proof evidence instead of adding selector-shaped detector shortcuts.
@@ -126,6 +127,9 @@ and readiness artifacts fail before merge.
   proof-sensitive semantic rewrites.
 - [Type-4 focused cases](type4-adversarial-coverage.md) maintain focused
   positive and hard-negative fixtures around target packets.
+- [Type-4 semantic pattern loop](type4-semantic-pattern-loop.md) explains how an
+  admitted packet graduates into reusable, language-neutral proof facts before
+  adding more language surfaces.
 
 The proof-carrying frontier report is the admission summary above those layers:
 it does not find new candidates, and it does not certify a proof. It tells the

--- a/docs/type4-adversarial-coverage.md
+++ b/docs/type4-adversarial-coverage.md
@@ -90,10 +90,15 @@ separate from admission readiness, names the next work item, and repeats stable 
 release notes. For example, numeric clamp is `admitted/resolved` only for its controlled
 detector slice; the current cross-language pair still lacks fzf-side bound-order evidence
 and shared integer-domain evidence, even though its focused executable perimeter is covered.
-The Python loop plus De Morgan packet is now `detector-admitted`: universal-loop,
-boolean-only De Morgan, iterator-identity, and effect-safety facts are all modeled for
-controlled evidence, the README-shaped positive replay is `same-family`, and the
-adjacent hard-negative boundaries remain explicit split gates.
+The Python loop plus De Morgan packet is now `detector-admitted`: counterexample-loop,
+vacuous-truth, same-source identity, pure-predicate, and boolean-only De Morgan facts are
+all modeled for controlled evidence, the README-shaped positive replay is `same-family`,
+and the adjacent hard-negative boundaries remain explicit split gates.
+
+When a packet teaches a reusable law, promote the next iteration through the
+[Type-4 semantic pattern loop](type4-semantic-pattern-loop.md): define the
+language-neutral facts and capability matrix first, then attach additional
+language surfaces through evidence producers and focused fixtures.
 
 ## Focused cases
 
@@ -150,9 +155,9 @@ packet. Its positive fixture captures `all(x != 0 and x != 1 for x in xs)` versu
 early-return counterexample loop; hard negatives cover vacuous truth, observed effects,
 helper-call purity, Python value-returning boolean operands, changed predicates, and
 different iterable identity. `python_loop_demorgan_proof_facts.py` machine-checks the
-iterator-identity, effect-safety, universal-loop, and boolean-only De Morgan source
-evidence against the positive, different-iterable, observed-effect, helper-call,
-empty-truth, changed-predicate, and value-return fixtures.
+neutral same-source identity, pure-predicate, counterexample-loop, vacuous-truth, and
+boolean-only De Morgan source evidence against the positive, different-iterable,
+observed-effect, helper-call, empty-truth, changed-predicate, and value-return fixtures.
 
 Good hard negatives attack exactly the proof invariant a rule needs:
 

--- a/docs/type4-semantic-pattern-loop.md
+++ b/docs/type4-semantic-pattern-loop.md
@@ -1,0 +1,182 @@
+# Type-4 semantic pattern loop
+
+This page is the operating loop for scaling Type-4 admission from one proven
+language surface into reusable semantic patterns. Use it when a frontier packet
+has taught us a general law, but the next step should be "attach another
+language surface" rather than "invent another language-specific detector rule."
+
+The loop sits above the [frontier platform](frontier-platform.md), focused
+cases in [Type-4 adversarial coverage](type4-adversarial-coverage.md), and the
+[proof-carrying frontier](proof-carrying-frontier.md). It must still obey the
+[design](design.md) constraint: exact semantic admission protects the
+zero-false-merge contract before recall.
+
+## Core rule
+
+Repeat by **semantic pattern**, not by language spelling.
+
+A language surface may be the first evidence for a pattern, but the reusable
+unit is the invariant:
+
+- bad repeat unit: "Python `all(...)` plus a loop";
+- good repeat unit: "universal quantifier equals a pure counterexample loop
+  over the same iteration source, with vacuous truth preserved."
+
+Language-specific code belongs in evidence producers, frontend lowering, and
+surface fixtures. Detector consumers should prefer neutral proof facts,
+admitted resolvers, or kernel contracts. If exact admission logic mentions a
+language name after the first proof slice, treat that as a design smell.
+
+## Pattern card
+
+Write a pattern card before opening detector behavior:
+
+```yaml
+pattern_id: quantifier.universal.counterexample-loop
+law: >
+  all(P(x) for x in xs) is equivalent to a loop that returns false on
+  not P(x) and true after exhausting xs.
+required_facts:
+  - quantifier.vacuous-truth
+  - quantifier.universal.counterexample-loop
+  - iteration.same-source-identity
+  - effect.pure-predicate
+  - boolean.demorgan.proven-bool-operands
+hard_negative_templates:
+  - loop.changed-empty-result
+  - loop.iterator-identity
+  - effect.observed-predicate-effect
+  - effect.helper-call-without-purity-proof
+  - boolean.value-context
+  - boolean.changed-predicate
+language_surfaces:
+  python:
+    status: admitted
+    evidence: python-loop-demorgan-all-2026-07-07
+  ruby:
+    status: open
+    surface: Enumerable#all?
+  rust:
+    status: open
+    surface: Iterator::all
+  js_ts:
+    status: open
+    surface: Array.prototype.every
+```
+
+Keep the card short enough to review in a PR. The detailed evidence still lives
+in `real_frontier.v1.json`, `frontier_target_packets.v1.json`, focused cases,
+proof fact artifacts, and generated PCF/readiness outputs.
+
+## Capability matrix
+
+Every reusable pattern should have a small matrix that distinguishes facts from
+surfaces:
+
+| fact | Python | Ruby | Rust | JS/TS |
+|---|---|---|---|---|
+| `quantifier.vacuous-truth` | modeled-controlled; packet admitted | open | open | open |
+| `quantifier.universal.counterexample-loop` | modeled-controlled; packet admitted | open | open | open |
+| `iteration.same-source-identity` | modeled-controlled; packet admitted | open | open | open |
+| `effect.pure-predicate` | modeled-controlled; packet admitted | open | open | open |
+| `boolean.demorgan.proven-bool-operands` | modeled-controlled; packet admitted | open | open | open |
+
+Use vocabulary like `open`, `modeled-controlled`, `admitted`, and
+`not-applicable`. Do not mark a language surface admitted because another
+language has the same-looking syntax. A language cell becomes admitted only
+after executable replay and PCF/readiness agree.
+
+## Eight-step loop
+
+1. Pick a frontier candidate from corpus evidence.
+   Start from `frontier_platform.py`, `real_frontier.v1.json`, `nose verify
+   --leads`, or a README/user-facing claim. Prevalence is only a queue signal;
+   it is not proof.
+
+2. Name the semantic law.
+   Write the pattern in language-neutral terms first. If the law cannot be
+   stated without language/API spelling, keep it as a local target packet until
+   the invariant is clearer.
+
+3. Define proof facts and boundaries.
+   Reuse existing proof fact vocabulary when possible. Add new neutral facts
+   only when they will apply to more than the first surface. Keep first-surface
+   fact IDs as compatibility aliases or packet-local evidence sources when
+   renaming would churn checked artifacts.
+
+4. Instantiate focused positives and hard negatives.
+   Use templates: vacuous truth, iterator identity, observed effects, helper
+   calls without purity proof, value-returning boolean operands, changed
+   predicate, wrong literal set, API identity, and domain/precondition
+   boundaries. Every positive needs adjacent negatives.
+
+5. Emit or cite source evidence.
+   Frontend/per-language modules may inspect syntax to emit source, domain,
+   guard, place/effect, sequence, or API evidence. Semantic consumers should
+   require admitted evidence, a resolver, or a kernel contract before assigning
+   meaning.
+
+6. Open detector behavior only from the neutral fact set.
+   The detector should consume the proof facts and shared value-graph law. A
+   second language surface should usually add evidence production and fixtures,
+   not a new detector branch.
+
+7. Replay the perimeter.
+   Refresh executable expectations, real-frontier replay, target packets,
+   proof-carrying frontier artifacts, readiness artifacts, and docs. The
+   positive may flip to `same-family`; hard negatives must stay `split`.
+
+8. Let CI and dogfooding price the change.
+   Run the Type-4 checks, docs checks, focused Rust/CLI tests, and self-query
+   duplication gate. If a stronger detector surfaces new nose-on-nose families,
+   either dedupe them or record the reviewed decision in
+   [dogfooding history](dogfooding-history.md) and the duplication baseline.
+
+## When to stop generalizing
+
+Stop and keep the work packet-local when:
+
+- the proof fact depends on one language's value semantics and has no clear
+  equivalent elsewhere;
+- the hard-negative template cannot be expressed for another surface;
+- the proposed neutral fact would hide a product/runtime boundary such as
+  laziness, exception timing, mutation, iterator invalidation, overloading, or
+  API identity;
+- the second language needs a different semantic law, not just a different
+  evidence producer.
+
+The goal is not to erase language differences. The goal is to make every
+cross-language admission explicit about which differences have proof evidence
+and which stay closed.
+
+## Seed: Python loop/De Morgan
+
+Issue #745 is the first vocabulary cleanup from this loop. PR #744 admitted the
+Python surface, and #745 promotes its packet-local facts into the neutral
+registry names that future language surfaces should cite:
+
+- positive: `all(x != 0 and x != 1 for x in xs)` and an early-return loop that
+  returns `False` on `x == 0 or x == 1`;
+- admitted behavior: the pair replays as `same-family`;
+- boundaries: vacuous truth, observed effects, helper calls, value-returning
+  boolean operands, changed predicates, and iterator mismatch remain `split`.
+
+The retired packet-local aliases are:
+
+- `python-loop-demorgan.boolean-demorgan`;
+- `python-loop-demorgan.universal-short-circuit`;
+- `python-loop-demorgan.iterator-identity`;
+- `python-loop-demorgan.effect-safety`;
+
+The canonical neutral facts are:
+
+- `boolean.demorgan.proven-bool-operands`;
+- `quantifier.universal.counterexample-loop`;
+- `quantifier.vacuous-truth`;
+- `iteration.same-source-identity`;
+- `effect.pure-predicate`.
+
+Use those canonical facts before adding another language surface for the same
+pattern.
+
+Back to [documentation home](home.md).


### PR DESCRIPTION
## Summary
- promote the Python loop/De Morgan packet-local proof facts into language-neutral semantic facts
- keep the old python-loop-demorgan fact ids as retired compatibility aliases
- split vacuous truth out from the counterexample-loop fact and regenerate target packet, replay, PCF, and readiness artifacts
- add the repeatable Type-4 semantic pattern loop doc and capability matrix for future language surfaces

## Verification
- scripts/check-docs.sh
- bench/type4/adversarial/scripts/type4-check
- python3 bench/type4/proof_carrying_frontier.py --check
- python3 bench/type4/real_frontier_replay.py --check
- git diff --check
- pre-push fast local CI

Closes #745