### PR TITLE
Add map default semantic pattern card

### DIFF
--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -1090,8 +1090,8 @@
     },
     "proof_fact_registry": {
       "path": "bench/type4/proof_fact_registry.v1.json",
-      "sha256": "d1bcb9ff2100c84cc90d6c9ca63da0485ab9ce4d5fe03f5bb9788ffa5588159d",
-      "size_bytes": 21039
+      "sha256": "a41d78f8ec67c27b813eb0a7183216559f50b20acf8e32477a053b4148e65bd5",
+      "size_bytes": 27367
     },
     "python_loop_demorgan_proof_facts": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -114,8 +114,8 @@
       },
       "proof_fact_registry": {
         "path": "bench/type4/proof_fact_registry.v1.json",
-        "sha256": "d1bcb9ff2100c84cc90d6c9ca63da0485ab9ce4d5fe03f5bb9788ffa5588159d",
-        "size_bytes": 21039
+        "sha256": "a41d78f8ec67c27b813eb0a7183216559f50b20acf8e32477a053b4148e65bd5",
+        "size_bytes": 27367
       },
       "python_loop_demorgan_proof_facts": {
         "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_fact_registry.md
+++ b/bench/type4/proof_fact_registry.md
@@ -34,6 +34,10 @@ packet-specific current status locally.
 | `quantifier.vacuous-truth` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only closes the empty-input boundary for a separately proven counterexample loop. |
 | `iteration.same-source-identity` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only rules out different receivers, iterators, or traversal sources. |
 | `effect.pure-predicate` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only permits comparing short-circuit boundaries after predicate effects are closed. |
+| `map.default.absence-fallback` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Requires receiver identity, key/default coordinates, and mutation closure. |
+| `map.receiver.source-identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both sides query the same map value source. |
+| `map.default.key-fallback-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes the key/default coordinate boundary. |
+| `map.receiver.no-intervening-mutation` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes mutation and stale-receiver boundaries. |
 
 ## Compatibility Aliases
 

--- a/bench/type4/proof_fact_registry.v1.json
+++ b/bench/type4/proof_fact_registry.v1.json
@@ -265,6 +265,130 @@
     },
     {
       "accepted_evidence": [
+        "map get/index lookup paired with an explicit fallback only for absent keys",
+        "membership guard plus lookup returning the same fallback for absence",
+        "language API evidence that separates absent-key fallback from present key with null/nil/None payload"
+      ],
+      "detector_admission_implication": "Does not admit map-default convergence by itself; receiver identity, key/default coordinates, and mutation closure remain separate facts.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "map.default.absence-fallback",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "protocol-boundary.api-identity"
+      ],
+      "implementation_guidance": [
+        "Model only absence-default APIs or guards whose fallback fires on missing keys.",
+        "Keep nullish/truthy defaulting and present-null payload semantics outside this fact.",
+        "Require a separate API identity proof for language helpers such as Python get, JS Map.get with has, Java Map.getOrDefault, Rust HashMap lookup, and Swift dictionary default subscripts."
+      ],
+      "rejected_evidence": [
+        "nullish coalescing on a map read without absent-key proof",
+        "truthy/default idioms that treat present falsey values as absent",
+        "custom helper names without API identity evidence"
+      ],
+      "semantic_family": "map.default_lookup",
+      "status": "specified-not-modeled",
+      "summary": "Map-default lookup may converge only when the fallback is proven to represent absent-key behavior, not nullish or truthy value replacement.",
+      "title": "Map default absence fallback"
+    },
+    {
+      "accepted_evidence": [
+        "the compared lookups read from the same local map binding, imported immutable map, or statically proven map literal source",
+        "module/export/static field provenance for imported literal maps",
+        "no alias changes the receiver between construction/import and lookup"
+      ],
+      "detector_admission_implication": "Does not admit map-default convergence by itself; it only proves that both sides query the same map value source.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "map.receiver.source-identity",
+      "hard_negative_conventions": [
+        "loop.iterator-identity",
+        "protocol-boundary.api-identity"
+      ],
+      "implementation_guidance": [
+        "Reuse import/projection evidence for cross-file literal map sources.",
+        "Reject same-shaped literals or same variable names that do not share source provenance.",
+        "Keep different map receivers split even when key and default literals match."
+      ],
+      "rejected_evidence": [
+        "different map bindings or imported exports",
+        "same-shaped map literals with no shared provenance",
+        "receiver aliases whose source cannot be traced"
+      ],
+      "semantic_family": "map.default_lookup",
+      "status": "specified-not-modeled",
+      "summary": "Map-default surfaces must query the same proven map source before key/default and fallback semantics can be compared.",
+      "title": "Map receiver source identity"
+    },
+    {
+      "accepted_evidence": [
+        "the lookup key coordinates are equal on both surfaces",
+        "the fallback/default value coordinates are equal on both surfaces",
+        "literal, imported, or parameter coordinates are preserved through lowering"
+      ],
+      "detector_admission_implication": "Does not admit map-default convergence by itself; it only closes the key/default coordinate boundary.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "map.default.key-fallback-coordinate",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "boolean.truth-table"
+      ],
+      "implementation_guidance": [
+        "Treat key and fallback as independent coordinates.",
+        "Reject swapped, changed, or derived keys/defaults unless a separate value proof connects them.",
+        "Keep wrong-key and wrong-default hard negatives adjacent to any admitted map-default surface."
+      ],
+      "rejected_evidence": [
+        "same receiver with a changed lookup key",
+        "same receiver/key with a changed fallback value",
+        "derived keys or defaults without value-equivalence proof"
+      ],
+      "semantic_family": "map.default_lookup",
+      "status": "specified-not-modeled",
+      "summary": "Map-default convergence requires the same map receiver, the same lookup key, and the same fallback/default value coordinates.",
+      "title": "Map key/default coordinate identity"
+    },
+    {
+      "accepted_evidence": [
+        "no writes, updates, deletes, or mutating method calls can affect the map receiver before lookup",
+        "imported literal maps are immutable or treated as frozen evidence",
+        "guard and lookup read the same receiver state"
+      ],
+      "detector_admission_implication": "Does not admit map-default convergence by itself; it only closes mutation and stale-receiver boundaries.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "map.receiver.no-intervening-mutation",
+      "hard_negative_conventions": [
+        "boolean.effect-safety",
+        "collection.cardinality"
+      ],
+      "implementation_guidance": [
+        "Reject receiver mutation between map construction/import and lookup.",
+        "Reject guard/read pairs if mutation can happen between the guard and the read.",
+        "Treat cross-file imported maps as stable only when import/export evidence proves immutable literal provenance."
+      ],
+      "rejected_evidence": [
+        "assignment or update to the map receiver before lookup",
+        "helper calls that may mutate the map receiver",
+        "guarded lookups with intervening writes"
+      ],
+      "semantic_family": "map.default_lookup",
+      "status": "specified-not-modeled",
+      "summary": "Map-default surfaces require a stable receiver state; mutation between receiver proof and lookup is behavior-defining.",
+      "title": "Map receiver mutation closure"
+    },
+    {
+      "accepted_evidence": [
         "comparison predicates whose results are booleans",
         "the same element variable and the same literal/value coordinates on both sides",
         "a boolean context where operand values are not observed"

--- a/bench/type4/semantic_pattern_cards.md
+++ b/bench/type4/semantic_pattern_cards.md
@@ -13,6 +13,7 @@ proof-carrying frontier gates required by the linked pattern.
 | pattern | status | proof facts | surfaces |
 |---|---|---:|---:|
 | `numeric.clamp.proven-integer-bounds` | `controlled-slice-admitted` | 2 | 4 |
+| `map.default.absence-lookup` | `pattern-carded` | 4 | 5 |
 
 ## `numeric.clamp.proven-integer-bounds`
 
@@ -33,3 +34,24 @@ Integer clamp surfaces are equivalent only when they compute the same bounded va
 | Rust | integer .clamp(lo, hi) when literal or guard evidence proves lo <= hi | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::clamp_library_method_bridge |
 | Go | generic min/max Constrain-style helpers after integer-domain and bound-order proof | `open` | bench/type4/frontier_target_packets.v1.json::numeric-clamp-2026-06-06 |
 | JS/TS | number-domain min/max clamp forms until float/NaN boundaries are excluded | `closed` |  |
+
+## `map.default.absence-lookup`
+
+**Absence-preserving map default lookup**
+
+Map-default lookup surfaces are equivalent only when they read the same stable map source with the same key and fallback, and the fallback is proven to mean absent-key behavior.
+
+- status: `pattern-carded`
+- rationale: The frontier platform records map_default_lookup as a high-breadth multi-language candidate with focused cross-file evidence and adjacent mutation/wrong-map negatives; carding it keeps future work on map semantics instead of API spelling.
+- required facts: `map.default.absence-fallback`, `map.receiver.source-identity`, `map.default.key-fallback-coordinate`, `map.receiver.no-intervening-mutation`
+- hard-negative templates: `map.receiver-mutation`, `map.wrong-receiver`, `map.changed-key`, `map.changed-fallback`, `map.nullish-vs-absent-default`, `protocol-boundary.api-identity`
+- boundaries: absent-key fallback is distinct from nullish, truthy, or falsey value replacement; the map receiver must be the same proven source, including imported immutable literal sources; the lookup key and fallback/default coordinates must match independently; receiver mutation between construction/import, guard, and lookup is behavior-defining
+- evidence: `bench/type4/adversarial/cases/cases.v1.json::map_default_imported_literal`, `bench/type4/adversarial/cases/cases.v1.json::map_default_imported_js_ts_literal`, `bench/type4/adversarial/cases/cases.v1.json::map_default_imported_java_static_literal`, `bench/type4/adversarial/cases/cases.v1.json::map_default_imported_rust_const_literal`, `bench/type4/adversarial/cases/cases.v1.json::map_default_mutated_receiver`, `bench/type4/adversarial/cases/cases.v1.json::map_default_wrong_map`, `bench/type4/proof_fact_registry.v1.json::map.default.absence-fallback`, `bench/type4/proof_fact_registry.v1.json::map.receiver.source-identity`, `bench/type4/proof_fact_registry.v1.json::map.default.key-fallback-coordinate`, `bench/type4/proof_fact_registry.v1.json::map.receiver.no-intervening-mutation`
+
+| language | surface | status | evidence |
+|---|---|---|---|
+| Python | dict.get and membership-guarded literal/imported map lookup | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_literal |
+| JS/TS | named imports from unmutated sibling map/object exports | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_js_ts_literal |
+| Java | static Map.of field imports with getOrDefault-style absence fallback | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_java_static_literal |
+| Rust | use-imported const entry arrays consumed by HashMap::from | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_rust_const_literal |
+| Swift | Dictionary default subscript after receiver-coordinate proof | `open` |  |

--- a/bench/type4/semantic_pattern_cards.v1.json
+++ b/bench/type4/semantic_pattern_cards.v1.json
@@ -60,6 +60,76 @@
       ],
       "status": "controlled-slice-admitted",
       "title": "Proof-backed integer clamp"
+    },
+    {
+      "boundaries": [
+        "absent-key fallback is distinct from nullish, truthy, or falsey value replacement",
+        "the map receiver must be the same proven source, including imported immutable literal sources",
+        "the lookup key and fallback/default coordinates must match independently",
+        "receiver mutation between construction/import, guard, and lookup is behavior-defining"
+      ],
+      "evidence_refs": [
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_literal",
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_js_ts_literal",
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_java_static_literal",
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_rust_const_literal",
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_mutated_receiver",
+        "bench/type4/adversarial/cases/cases.v1.json::map_default_wrong_map",
+        "bench/type4/proof_fact_registry.v1.json::map.default.absence-fallback",
+        "bench/type4/proof_fact_registry.v1.json::map.receiver.source-identity",
+        "bench/type4/proof_fact_registry.v1.json::map.default.key-fallback-coordinate",
+        "bench/type4/proof_fact_registry.v1.json::map.receiver.no-intervening-mutation"
+      ],
+      "hard_negative_templates": [
+        "map.receiver-mutation",
+        "map.wrong-receiver",
+        "map.changed-key",
+        "map.changed-fallback",
+        "map.nullish-vs-absent-default",
+        "protocol-boundary.api-identity"
+      ],
+      "language_surfaces": [
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_literal",
+          "language": "Python",
+          "status": "modeled-controlled",
+          "surface": "dict.get and membership-guarded literal/imported map lookup"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_js_ts_literal",
+          "language": "JS/TS",
+          "status": "modeled-controlled",
+          "surface": "named imports from unmutated sibling map/object exports"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_java_static_literal",
+          "language": "Java",
+          "status": "modeled-controlled",
+          "surface": "static Map.of field imports with getOrDefault-style absence fallback"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::map_default_imported_rust_const_literal",
+          "language": "Rust",
+          "status": "modeled-controlled",
+          "surface": "use-imported const entry arrays consumed by HashMap::from"
+        },
+        {
+          "language": "Swift",
+          "status": "open",
+          "surface": "Dictionary default subscript after receiver-coordinate proof"
+        }
+      ],
+      "law": "Map-default lookup surfaces are equivalent only when they read the same stable map source with the same key and fallback, and the fallback is proven to mean absent-key behavior.",
+      "pattern_id": "map.default.absence-lookup",
+      "rationale": "The frontier platform records map_default_lookup as a high-breadth multi-language candidate with focused cross-file evidence and adjacent mutation/wrong-map negatives; carding it keeps future work on map semantics instead of API spelling.",
+      "required_facts": [
+        "map.default.absence-fallback",
+        "map.receiver.source-identity",
+        "map.default.key-fallback-coordinate",
+        "map.receiver.no-intervening-mutation"
+      ],
+      "status": "pattern-carded",
+      "title": "Absence-preserving map default lookup"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
- add the language-neutral `map.default.absence-lookup` semantic pattern card
- add four specified-not-modeled proof facts for absence fallback, receiver source identity, key/default coordinates, and receiver mutation closure
- refresh generated semantic pattern, PCF, and readiness artifacts

## Validation
- `python3 bench/type4/semantic_pattern_cards.py --check`
- `scripts/check-docs.sh`
- `bench/type4/adversarial/scripts/type4-check`
- `git diff --check`
- `scripts/check-ci-local.sh --fast`
- pre-push fast local CI gate