### PR TITLE
Add filter-map semantic pattern card

### DIFF
--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -1090,8 +1090,8 @@
     },
     "proof_fact_registry": {
       "path": "bench/type4/proof_fact_registry.v1.json",
-      "sha256": "a41d78f8ec67c27b813eb0a7183216559f50b20acf8e32477a053b4148e65bd5",
-      "size_bytes": 27367
+      "sha256": "5b4738b612c1b69b08d956505a80db3774e1c469e1bfa083eaf3b6358b8c164a",
+      "size_bytes": 34504
     },
     "python_loop_demorgan_proof_facts": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -114,8 +114,8 @@
       },
       "proof_fact_registry": {
         "path": "bench/type4/proof_fact_registry.v1.json",
-        "sha256": "a41d78f8ec67c27b813eb0a7183216559f50b20acf8e32477a053b4148e65bd5",
-        "size_bytes": 27367
+        "sha256": "5b4738b612c1b69b08d956505a80db3774e1c469e1bfa083eaf3b6358b8c164a",
+        "size_bytes": 34504
       },
       "python_loop_demorgan_proof_facts": {
         "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_fact_registry.md
+++ b/bench/type4/proof_fact_registry.md
@@ -34,6 +34,10 @@ packet-specific current status locally.
 | `quantifier.vacuous-truth` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only closes the empty-input boundary for a separately proven counterexample loop. |
 | `iteration.same-source-identity` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only rules out different receivers, iterators, or traversal sources. |
 | `effect.pure-predicate` | `modeled-controlled` | `focused-executable`, `source-evidence` | Only permits comparing short-circuit boundaries after predicate effects are closed. |
+| `effect.pure-callback` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes callback effect/timing boundaries for separately proven HoF facts. |
+| `hof.filter-map.drop-condition-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both surfaces drop the same source elements. |
+| `hof.filter-map.emitted-value-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that present branches, maps, or guarded pushes emit the same value. |
+| `option.absence-channel.identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes absence-vs-payload channel boundaries. |
 | `map.default.absence-fallback` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Requires receiver identity, key/default coordinates, and mutation closure. |
 | `map.receiver.source-identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both sides query the same map value source. |
 | `map.default.key-fallback-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes the key/default coordinate boundary. |

--- a/bench/type4/proof_fact_registry.v1.json
+++ b/bench/type4/proof_fact_registry.v1.json
@@ -265,6 +265,132 @@
     },
     {
       "accepted_evidence": [
+        "callback bodies made only of local value construction, comparisons, field reads, and pure arithmetic over the current element",
+        "no logging, mutation, assignment, yield, await, throw, or helper call with unknown effects inside the callback",
+        "focused hard negatives that keep observed callback effects behavior-defining"
+      ],
+      "detector_admission_implication": "Does not admit HoF convergence by itself; receiver/source identity, callback meaning, and output-channel facts remain separate requirements.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "effect.pure-callback",
+      "hard_negative_conventions": [
+        "boolean.effect-safety",
+        "loop.short-circuit",
+        "protocol-boundary.callback-effect"
+      ],
+      "implementation_guidance": [
+        "Use this for map/filter/filter_map/flat_map callbacks, not just boolean predicates.",
+        "Treat helper calls, mutation, logging, yield, await, throw, and assignment as closed without separate effect evidence.",
+        "Keep evaluation timing and observed callback effects out of value-only HoF facts."
+      ],
+      "rejected_evidence": [
+        "callbacks that print, log, mutate, assign, yield, await, throw, or call unproven helpers",
+        "callbacks whose laziness or evaluation timing is observable",
+        "receiver or captured-state mutation during callback execution"
+      ],
+      "semantic_family": "effect.purity",
+      "status": "specified-not-modeled",
+      "summary": "Higher-order callback rewrites may compare value outputs only after callback effects and evaluation timing are proven unobservable for the admitted surface.",
+      "title": "Pure callback/effect safety"
+    },
+    {
+      "accepted_evidence": [
+        "filter_map, compactMap, or equivalent callback forms whose absence branch drops exactly the same elements as the explicit filter predicate",
+        "guarded builders that push only on the same drop-condition complement",
+        "match, if-let, and and_then-style option forms that expose the same absence condition"
+      ],
+      "detector_admission_implication": "Does not admit filter-map convergence by itself; emitted value, source identity, option channel, and callback purity facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "hof.filter-map.drop-condition-coordinate",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "boolean.changed-predicate"
+      ],
+      "implementation_guidance": [
+        "Treat the drop condition as a first-class coordinate distinct from the emitted value expression.",
+        "Reject changed predicates, inverted predicates, extra filters, and post-filter drops unless a separate proof connects them.",
+        "Keep explicit filter+map chains and option-producing callbacks connected through this fact, not through API spelling."
+      ],
+      "rejected_evidence": [
+        "same emitted value with a changed filter/drop predicate",
+        "extra post-filter conditions that can remove emitted values",
+        "truthiness checks that decide dropping from the emitted payload instead of the option channel"
+      ],
+      "semantic_family": "hof.filter_map",
+      "status": "specified-not-modeled",
+      "summary": "Filter-map convergence requires proof that both surfaces drop exactly the same source elements before emitted values are compared.",
+      "title": "Filter-map drop-condition coordinate"
+    },
+    {
+      "accepted_evidence": [
+        "the Some/Just/present branch emits the same value coordinate as the explicit map expression",
+        "guarded builders push the same value expression as the option-producing callback emits",
+        "literal, parameter, field, or arithmetic coordinates are preserved through lowering"
+      ],
+      "detector_admission_implication": "Does not admit filter-map convergence by itself; drop condition, source identity, option channel, and callback purity facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "hof.filter-map.emitted-value-coordinate",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "value.coordinate"
+      ],
+      "implementation_guidance": [
+        "Compare emitted values independently from the condition that decides whether a value is emitted.",
+        "Reject Some/Just payload changes, derived payloads, and wrong pushed values unless a separate value proof connects them.",
+        "Keep wrapped absence payloads as emitted values when the option channel says they are present."
+      ],
+      "rejected_evidence": [
+        "same drop condition with a changed emitted value",
+        "mapping Option/Maybe values as payloads instead of emitting their inner present values",
+        "derived emitted values without a value-equivalence proof"
+      ],
+      "semantic_family": "hof.filter_map",
+      "status": "specified-not-modeled",
+      "summary": "Filter-map convergence requires the present branch, explicit map expression, or guarded push to emit the same value coordinate.",
+      "title": "Filter-map emitted value coordinate"
+    },
+    {
+      "accepted_evidence": [
+        "language API evidence that distinguishes the option/nullable absence channel from present payload values",
+        "falsey payloads such as 0, false, or empty strings that remain emitted when wrapped as present values",
+        "wrapped absence payloads such as Some(None) that remain present values in nested option domains"
+      ],
+      "detector_admission_implication": "Does not admit optional-emission convergence by itself; it only closes the absence-vs-payload channel boundary.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "option.absence-channel.identity",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "boolean.value-context",
+        "protocol-boundary.api-identity"
+      ],
+      "implementation_guidance": [
+        "Model absence by the option/nullable channel, not by payload truthiness.",
+        "Preserve falsey present payloads and nested absence payloads as emitted values.",
+        "Require API identity evidence for language-specific helpers such as Rust Option, Swift Optional, Kotlin nullable values, or JS nullish protocols."
+      ],
+      "rejected_evidence": [
+        "truthy filters that drop falsey present payloads",
+        "nullish/defaulting idioms that erase present null payload distinctions",
+        "custom option-like helpers without API identity evidence"
+      ],
+      "semantic_family": "option.absence_channel",
+      "status": "specified-not-modeled",
+      "summary": "Optional-emission rewrites may drop only the proven absence channel; falsey and nested present payloads remain behavior-defining values.",
+      "title": "Option absence channel identity"
+    },
+    {
+      "accepted_evidence": [
         "map get/index lookup paired with an explicit fallback only for absent keys",
         "membership guard plus lookup returning the same fallback for absence",
         "language API evidence that separates absent-key fallback from present key with null/nil/None payload"

--- a/bench/type4/semantic_pattern_cards.md
+++ b/bench/type4/semantic_pattern_cards.md
@@ -14,6 +14,7 @@ proof-carrying frontier gates required by the linked pattern.
 |---|---|---:|---:|
 | `numeric.clamp.proven-integer-bounds` | `controlled-slice-admitted` | 2 | 4 |
 | `map.default.absence-lookup` | `pattern-carded` | 4 | 5 |
+| `hof.filter-map.option-emission` | `pattern-carded` | 5 | 4 |
 
 ## `numeric.clamp.proven-integer-bounds`
 
@@ -55,3 +56,23 @@ Map-default lookup surfaces are equivalent only when they read the same stable m
 | Java | static Map.of field imports with getOrDefault-style absence fallback | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_java_static_literal |
 | Rust | use-imported const entry arrays consumed by HashMap::from | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::map_default_imported_rust_const_literal |
 | Swift | Dictionary default subscript after receiver-coordinate proof | `open` |  |
+
+## `hof.filter-map.option-emission`
+
+**Optional-emission filter-map**
+
+Filter-map style surfaces are equivalent to explicit filter+map or guarded builders only when they traverse the same source, drop the same elements through a proven absence channel, emit the same present value, and callback effects are closed.
+
+- status: `pattern-carded`
+- rationale: The hof_filter_map corpus already contains cross-language positives plus hard negatives for None-as-value, changed payloads, falsey payloads, wrapped None payloads, and effectful callbacks; carding the pattern makes future compactMap/filter_map work attach to optional-emission facts instead of per-language API names.
+- required facts: `iteration.same-source-identity`, `effect.pure-callback`, `hof.filter-map.drop-condition-coordinate`, `hof.filter-map.emitted-value-coordinate`, `option.absence-channel.identity`
+- hard-negative templates: `hof.filter-map.changed-drop-condition`, `hof.filter-map.changed-emitted-value`, `option.none-as-payload`, `option.falsey-payload`, `effect.observed-callback-effect`, `iteration.source-identity`
+- boundaries: the drop condition is independent from the emitted value expression; None/Null/Nil absence drops an element, but falsey present payloads are still emitted; wrapped absence payloads such as Some(None) remain present payloads in nested option domains; observed callback effects and evaluation timing are behavior-defining
+- evidence: `bench/type4/adversarial/cases/cases.v1.json::filter_map_filter_map_equiv`, `bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv`, `bench/type4/adversarial/cases/cases.v1.json::filter_map_none_boundary`, `bench/type4/adversarial/cases/cases.v1.json::filter_map_value_change`, `bench/type4/adversarial/cases/cases.v1.json::filter_map_falsey_value_boundary`, `bench/type4/adversarial/cases/cases.v1.json::filter_map_wrapped_none_payload`, `bench/type4/adversarial/cases/cases.v1.json::hof_effectful_lambda`, `bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity`, `bench/type4/proof_fact_registry.v1.json::effect.pure-callback`, `bench/type4/proof_fact_registry.v1.json::hof.filter-map.drop-condition-coordinate`, `bench/type4/proof_fact_registry.v1.json::hof.filter-map.emitted-value-coordinate`, `bench/type4/proof_fact_registry.v1.json::option.absence-channel.identity`
+
+| language | surface | status | evidence |
+|---|---|---|---|
+| Python | filtered comprehensions as explicit drop-condition plus emitted-value surfaces | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::filter_map_filter_map_equiv |
+| JS/TS | filter().map() chains with the same predicate and mapped value coordinates | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv |
+| Rust | Iterator::filter_map with Some/None, match guards, and pure Option::and_then callbacks | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv |
+| Swift | Sequence.compactMap after optional-result channel and callback-effect proof | `open` |  |

--- a/bench/type4/semantic_pattern_cards.v1.json
+++ b/bench/type4/semantic_pattern_cards.v1.json
@@ -130,6 +130,73 @@
       ],
       "status": "pattern-carded",
       "title": "Absence-preserving map default lookup"
+    },
+    {
+      "boundaries": [
+        "the drop condition is independent from the emitted value expression",
+        "None/Null/Nil absence drops an element, but falsey present payloads are still emitted",
+        "wrapped absence payloads such as Some(None) remain present payloads in nested option domains",
+        "observed callback effects and evaluation timing are behavior-defining"
+      ],
+      "evidence_refs": [
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_filter_map_equiv",
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv",
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_none_boundary",
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_value_change",
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_falsey_value_boundary",
+        "bench/type4/adversarial/cases/cases.v1.json::filter_map_wrapped_none_payload",
+        "bench/type4/adversarial/cases/cases.v1.json::hof_effectful_lambda",
+        "bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity",
+        "bench/type4/proof_fact_registry.v1.json::effect.pure-callback",
+        "bench/type4/proof_fact_registry.v1.json::hof.filter-map.drop-condition-coordinate",
+        "bench/type4/proof_fact_registry.v1.json::hof.filter-map.emitted-value-coordinate",
+        "bench/type4/proof_fact_registry.v1.json::option.absence-channel.identity"
+      ],
+      "hard_negative_templates": [
+        "hof.filter-map.changed-drop-condition",
+        "hof.filter-map.changed-emitted-value",
+        "option.none-as-payload",
+        "option.falsey-payload",
+        "effect.observed-callback-effect",
+        "iteration.source-identity"
+      ],
+      "language_surfaces": [
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::filter_map_filter_map_equiv",
+          "language": "Python",
+          "status": "modeled-controlled",
+          "surface": "filtered comprehensions as explicit drop-condition plus emitted-value surfaces"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv",
+          "language": "JS/TS",
+          "status": "modeled-controlled",
+          "surface": "filter().map() chains with the same predicate and mapped value coordinates"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv",
+          "language": "Rust",
+          "status": "modeled-controlled",
+          "surface": "Iterator::filter_map with Some/None, match guards, and pure Option::and_then callbacks"
+        },
+        {
+          "language": "Swift",
+          "status": "open",
+          "surface": "Sequence.compactMap after optional-result channel and callback-effect proof"
+        }
+      ],
+      "law": "Filter-map style surfaces are equivalent to explicit filter+map or guarded builders only when they traverse the same source, drop the same elements through a proven absence channel, emit the same present value, and callback effects are closed.",
+      "pattern_id": "hof.filter-map.option-emission",
+      "rationale": "The hof_filter_map corpus already contains cross-language positives plus hard negatives for None-as-value, changed payloads, falsey payloads, wrapped None payloads, and effectful callbacks; carding the pattern makes future compactMap/filter_map work attach to optional-emission facts instead of per-language API names.",
+      "required_facts": [
+        "iteration.same-source-identity",
+        "effect.pure-callback",
+        "hof.filter-map.drop-condition-coordinate",
+        "hof.filter-map.emitted-value-coordinate",
+        "option.absence-channel.identity"
+      ],
+      "status": "pattern-carded",
+      "title": "Optional-emission filter-map"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
- add the language-neutral `hof.filter-map.option-emission` semantic pattern card
- add proof facts for pure callbacks, drop-condition coordinates, emitted-value coordinates, and option absence-channel identity
- refresh generated semantic pattern, PCF, and readiness artifacts

## Validation
- `python3 bench/type4/semantic_pattern_cards.py --check`
- `scripts/check-docs.sh`
- `bench/type4/adversarial/scripts/type4-check`
- `python3 bench/type4/proof_carrying_frontier.py --check`
- `git diff --check`
- `scripts/check-ci-local.sh --fast`
- pre-push fast local CI gate