### PR TITLE
Add one-level flat-map semantic pattern card

### DIFF
--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -1090,8 +1090,8 @@
     },
     "proof_fact_registry": {
       "path": "bench/type4/proof_fact_registry.v1.json",
-      "sha256": "5b4738b612c1b69b08d956505a80db3774e1c469e1bfa083eaf3b6358b8c164a",
-      "size_bytes": 34504
+      "sha256": "76e750af2beabb9dd4c43a8cef023a2431f44bfd59e1db58fc9cc92238ad6ac9",
+      "size_bytes": 39761
     },
     "python_loop_demorgan_proof_facts": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -114,8 +114,8 @@
       },
       "proof_fact_registry": {
         "path": "bench/type4/proof_fact_registry.v1.json",
-        "sha256": "5b4738b612c1b69b08d956505a80db3774e1c469e1bfa083eaf3b6358b8c164a",
-        "size_bytes": 34504
+        "sha256": "76e750af2beabb9dd4c43a8cef023a2431f44bfd59e1db58fc9cc92238ad6ac9",
+        "size_bytes": 39761
       },
       "python_loop_demorgan_proof_facts": {
         "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_fact_registry.md
+++ b/bench/type4/proof_fact_registry.md
@@ -38,6 +38,9 @@ packet-specific current status locally.
 | `hof.filter-map.drop-condition-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both surfaces drop the same source elements. |
 | `hof.filter-map.emitted-value-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that present branches, maps, or guarded pushes emit the same value. |
 | `option.absence-channel.identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes absence-vs-payload channel boundaries. |
+| `hof.flat-map.nested-iteration-order` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves matching outer/inner traversal coordinates. |
+| `hof.flat-map.emitted-value-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves each matched nested coordinate emits the same value. |
+| `collection.flatten-depth.one-level` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes flattened-vs-nested output shape boundaries. |
 | `map.default.absence-fallback` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Requires receiver identity, key/default coordinates, and mutation closure. |
 | `map.receiver.source-identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both sides query the same map value source. |
 | `map.default.key-fallback-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes the key/default coordinate boundary. |

--- a/bench/type4/proof_fact_registry.v1.json
+++ b/bench/type4/proof_fact_registry.v1.json
@@ -391,6 +391,100 @@
     },
     {
       "accepted_evidence": [
+        "a flat-map, multi-clause comprehension, or nested builder whose output appends every inner element in outer iteration order",
+        "source evidence that the same inner collection is traversed for each corresponding outer element",
+        "no extra filter, early exit, mutation, or receiver substitution changes the outer/inner traversal coordinates"
+      ],
+      "detector_admission_implication": "Does not admit flat-map convergence by itself; flatten depth, emitted value, source identity, and callback purity facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "hof.flat-map.nested-iteration-order",
+      "hard_negative_conventions": [
+        "collection.cardinality",
+        "loop.iterator-identity"
+      ],
+      "implementation_guidance": [
+        "Track outer and inner iteration coordinates separately.",
+        "Reject changed inner receivers, reordered traversal, dropped outer iterations, and derived inner collections without source evidence.",
+        "Use this fact for one-level flat-map and for later flat-map aggregate surfaces."
+      ],
+      "rejected_evidence": [
+        "same emitted expression over a different inner collection",
+        "receiver mutation or substitution between outer and inner traversal",
+        "extra outer or inner filters without separate predicate-coordinate proof"
+      ],
+      "semantic_family": "hof.flat_map",
+      "status": "specified-not-modeled",
+      "summary": "Flat-map convergence requires the same nested traversal order: each outer element exposes the same inner source before emitted values are flattened.",
+      "title": "Flat-map nested iteration order"
+    },
+    {
+      "accepted_evidence": [
+        "the inner map, builder push, or yielded value computes the same expression for each matched outer/inner coordinate",
+        "literal, parameter, field, or arithmetic coordinates are preserved through comprehension, stream, and callback lowering",
+        "focused hard negatives that change the inner emitted value remain split"
+      ],
+      "detector_admission_implication": "Does not admit flat-map convergence by itself; traversal order, flatten depth, source identity, and callback purity facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "hof.flat-map.emitted-value-coordinate",
+      "hard_negative_conventions": [
+        "value.coordinate",
+        "collection.shape"
+      ],
+      "implementation_guidance": [
+        "Compare emitted values after outer and inner coordinates are matched.",
+        "Reject changed inner map expressions, wrong pushed values, and derived values without a value-equivalence proof.",
+        "Keep aggregate terminals separate; this fact only describes the flattened element stream."
+      ],
+      "rejected_evidence": [
+        "same nested traversal with a changed yielded or pushed expression",
+        "callbacks that emit the outer element instead of the inner mapped value",
+        "aggregate results whose terminal operation changes the observed value"
+      ],
+      "semantic_family": "hof.flat_map",
+      "status": "specified-not-modeled",
+      "summary": "Flat-map convergence requires the callback, comprehension, or nested builder to emit the same value for every matched nested iteration coordinate.",
+      "title": "Flat-map emitted value coordinate"
+    },
+    {
+      "accepted_evidence": [
+        "flatMap, flat_map, stream flatMap, or multi-clause comprehension semantics that flatten exactly one collection layer",
+        "nested builder loops that append inner elements into a single output collection",
+        "hard negatives where map-returning-collection or nested-list outputs remain nested"
+      ],
+      "detector_admission_implication": "Does not admit flat-map convergence by itself; it only closes the flattened-vs-nested shape boundary for separately proven traversal and value facts.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "collection.flatten-depth.one-level",
+      "hard_negative_conventions": [
+        "collection.shape",
+        "collection.cardinality",
+        "protocol-boundary.api-identity"
+      ],
+      "implementation_guidance": [
+        "Represent exactly one layer of flattening, not recursive flattening or identity map.",
+        "Reject map-returning-collection forms unless a flat-map or join proof supplies this fact.",
+        "Reject scalar callback results for APIs whose flat-map contract requires a collection."
+      ],
+      "rejected_evidence": [
+        "map returning a nested collection without flattening",
+        "recursive or depth-unbounded flattening",
+        "scalar callback results under a collection-producing flat-map contract"
+      ],
+      "semantic_family": "collection.flatten_depth",
+      "status": "specified-not-modeled",
+      "summary": "Flat-map and nested-builder rewrites must prove exactly one collection layer is flattened so nested-list/map shapes stay behavior-defining.",
+      "title": "One-level flatten depth"
+    },
+    {
+      "accepted_evidence": [
         "map get/index lookup paired with an explicit fallback only for absent keys",
         "membership guard plus lookup returning the same fallback for absence",
         "language API evidence that separates absent-key fallback from present key with null/nil/None payload"

--- a/bench/type4/semantic_pattern_cards.md
+++ b/bench/type4/semantic_pattern_cards.md
@@ -15,6 +15,7 @@ proof-carrying frontier gates required by the linked pattern.
 | `numeric.clamp.proven-integer-bounds` | `controlled-slice-admitted` | 2 | 4 |
 | `map.default.absence-lookup` | `pattern-carded` | 4 | 5 |
 | `hof.filter-map.option-emission` | `pattern-carded` | 5 | 4 |
+| `hof.flat-map.one-level-flatten` | `pattern-carded` | 5 | 5 |
 
 ## `numeric.clamp.proven-integer-bounds`
 
@@ -76,3 +77,24 @@ Filter-map style surfaces are equivalent to explicit filter+map or guarded build
 | JS/TS | filter().map() chains with the same predicate and mapped value coordinates | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv |
 | Rust | Iterator::filter_map with Some/None, match guards, and pure Option::and_then callbacks | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::filter_map_match_option_equiv |
 | Swift | Sequence.compactMap after optional-result channel and callback-effect proof | `open` |  |
+
+## `hof.flat-map.one-level-flatten`
+
+**One-level flat-map**
+
+One-level flat-map surfaces are equivalent to multi-clause comprehensions or nested builders only when they traverse the same outer and inner sources in order, emit the same inner value, flatten exactly one layer, and callback effects are closed.
+
+- status: `pattern-carded`
+- rationale: The flat_map focused corpus already proves Python comprehension, nested builder, JS flatMap/map, and Java Stream.flatMap positives while keeping nested-list, map-returning-stream, scalar callback, and effectful callback boundaries adjacent; carding it prevents future surfaces from treating flat-map as a spelling-only map variant.
+- required facts: `iteration.same-source-identity`, `effect.pure-callback`, `hof.flat-map.nested-iteration-order`, `hof.flat-map.emitted-value-coordinate`, `collection.flatten-depth.one-level`
+- hard-negative templates: `hof.flat-map.nested-list-shape`, `hof.flat-map.map-returning-collection`, `hof.flat-map.changed-inner-source`, `hof.flat-map.changed-emitted-value`, `hof.flat-map.scalar-callback-result`, `effect.observed-callback-effect`
+- boundaries: flat-map flattens exactly one collection layer, not zero layers or recursive depth; map-returning-collection surfaces remain nested unless one-level flattening is proven; outer and inner traversal coordinates must be preserved independently; scalar callback results and effectful callbacks stay outside pure one-level flat-map admission
+- evidence: `bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js`, `bench/type4/adversarial/cases/cases.v1.json::flat_map_vs_nested_list`, `bench/type4/adversarial/cases/cases.v1.json::flat_map_vs_map`, `bench/type4/adversarial/cases/cases.v1.json::java_stream_flat_map_py_comp`, `bench/type4/adversarial/cases/cases.v1.json::java_stream_map_not_flat_map`, `bench/type4/adversarial/cases/cases.v1.json::java_stream_effectful_lambda`, `bench/type4/adversarial/cases/cases.v1.json::hof_non_list_flat_map`, `bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity`, `bench/type4/proof_fact_registry.v1.json::effect.pure-callback`, `bench/type4/proof_fact_registry.v1.json::hof.flat-map.nested-iteration-order`, `bench/type4/proof_fact_registry.v1.json::hof.flat-map.emitted-value-coordinate`, `bench/type4/proof_fact_registry.v1.json::collection.flatten-depth.one-level`
+
+| language | surface | status | evidence |
+|---|---|---|---|
+| Python | multi-clause comprehensions and nested append builders | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js |
+| JS/TS | Array.flatMap callback returning a mapped inner collection | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js |
+| Java | Stream.flatMap over a proven inner stream plus pure map callback | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::java_stream_flat_map_py_comp |
+| Swift | Sequence.flatMap after focused one-level flatten and callback-effect evidence | `open` |  |
+| Rust | Iterator::flat_map remains closed for nested element collections until inner-source proof is attached | `closed` |  |

--- a/bench/type4/semantic_pattern_cards.v1.json
+++ b/bench/type4/semantic_pattern_cards.v1.json
@@ -197,6 +197,78 @@
       ],
       "status": "pattern-carded",
       "title": "Optional-emission filter-map"
+    },
+    {
+      "boundaries": [
+        "flat-map flattens exactly one collection layer, not zero layers or recursive depth",
+        "map-returning-collection surfaces remain nested unless one-level flattening is proven",
+        "outer and inner traversal coordinates must be preserved independently",
+        "scalar callback results and effectful callbacks stay outside pure one-level flat-map admission"
+      ],
+      "evidence_refs": [
+        "bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js",
+        "bench/type4/adversarial/cases/cases.v1.json::flat_map_vs_nested_list",
+        "bench/type4/adversarial/cases/cases.v1.json::flat_map_vs_map",
+        "bench/type4/adversarial/cases/cases.v1.json::java_stream_flat_map_py_comp",
+        "bench/type4/adversarial/cases/cases.v1.json::java_stream_map_not_flat_map",
+        "bench/type4/adversarial/cases/cases.v1.json::java_stream_effectful_lambda",
+        "bench/type4/adversarial/cases/cases.v1.json::hof_non_list_flat_map",
+        "bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity",
+        "bench/type4/proof_fact_registry.v1.json::effect.pure-callback",
+        "bench/type4/proof_fact_registry.v1.json::hof.flat-map.nested-iteration-order",
+        "bench/type4/proof_fact_registry.v1.json::hof.flat-map.emitted-value-coordinate",
+        "bench/type4/proof_fact_registry.v1.json::collection.flatten-depth.one-level"
+      ],
+      "hard_negative_templates": [
+        "hof.flat-map.nested-list-shape",
+        "hof.flat-map.map-returning-collection",
+        "hof.flat-map.changed-inner-source",
+        "hof.flat-map.changed-emitted-value",
+        "hof.flat-map.scalar-callback-result",
+        "effect.observed-callback-effect"
+      ],
+      "language_surfaces": [
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js",
+          "language": "Python",
+          "status": "modeled-controlled",
+          "surface": "multi-clause comprehensions and nested append builders"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::flat_map_py_loop_js",
+          "language": "JS/TS",
+          "status": "modeled-controlled",
+          "surface": "Array.flatMap callback returning a mapped inner collection"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::java_stream_flat_map_py_comp",
+          "language": "Java",
+          "status": "modeled-controlled",
+          "surface": "Stream.flatMap over a proven inner stream plus pure map callback"
+        },
+        {
+          "language": "Swift",
+          "status": "open",
+          "surface": "Sequence.flatMap after focused one-level flatten and callback-effect evidence"
+        },
+        {
+          "language": "Rust",
+          "status": "closed",
+          "surface": "Iterator::flat_map remains closed for nested element collections until inner-source proof is attached"
+        }
+      ],
+      "law": "One-level flat-map surfaces are equivalent to multi-clause comprehensions or nested builders only when they traverse the same outer and inner sources in order, emit the same inner value, flatten exactly one layer, and callback effects are closed.",
+      "pattern_id": "hof.flat-map.one-level-flatten",
+      "rationale": "The flat_map focused corpus already proves Python comprehension, nested builder, JS flatMap/map, and Java Stream.flatMap positives while keeping nested-list, map-returning-stream, scalar callback, and effectful callback boundaries adjacent; carding it prevents future surfaces from treating flat-map as a spelling-only map variant.",
+      "required_facts": [
+        "iteration.same-source-identity",
+        "effect.pure-callback",
+        "hof.flat-map.nested-iteration-order",
+        "hof.flat-map.emitted-value-coordinate",
+        "collection.flatten-depth.one-level"
+      ],
+      "status": "pattern-carded",
+      "title": "One-level flat-map"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
- add the language-neutral `hof.flat-map.one-level-flatten` semantic pattern card
- add proof facts for nested iteration order, emitted value coordinates, and one-level flatten depth
- reuse `effect.pure-callback` and `iteration.same-source-identity` from earlier loops
- refresh generated semantic pattern, PCF, and readiness artifacts

## Validation
- `python3 bench/type4/semantic_pattern_cards.py --check`
- `scripts/check-docs.sh`
- `bench/type4/adversarial/scripts/type4-check`
- `python3 bench/type4/proof_carrying_frontier.py --check`
- `git diff --check`
- `scripts/check-ci-local.sh --fast`
- pre-push fast local CI gate