### PR TITLE
Add flat-map aggregate semantic pattern card

### DIFF
--- a/bench/type4/frontier_readiness.v1.json
+++ b/bench/type4/frontier_readiness.v1.json
@@ -1090,8 +1090,8 @@
     },
     "proof_fact_registry": {
       "path": "bench/type4/proof_fact_registry.v1.json",
-      "sha256": "76e750af2beabb9dd4c43a8cef023a2431f44bfd59e1db58fc9cc92238ad6ac9",
-      "size_bytes": 39761
+      "sha256": "c6067a1ee223d297b1b1243e49302ce17c36e4c2312149a3151c4c4915c6c2ef",
+      "size_bytes": 45022
     },
     "python_loop_demorgan_proof_facts": {
       "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_carrying_frontier.v1.json
+++ b/bench/type4/proof_carrying_frontier.v1.json
@@ -114,8 +114,8 @@
       },
       "proof_fact_registry": {
         "path": "bench/type4/proof_fact_registry.v1.json",
-        "sha256": "76e750af2beabb9dd4c43a8cef023a2431f44bfd59e1db58fc9cc92238ad6ac9",
-        "size_bytes": 39761
+        "sha256": "c6067a1ee223d297b1b1243e49302ce17c36e4c2312149a3151c4c4915c6c2ef",
+        "size_bytes": 45022
       },
       "python_loop_demorgan_proof_facts": {
         "path": "bench/type4/python_loop_demorgan_proof_facts.v1.json",

--- a/bench/type4/proof_fact_registry.md
+++ b/bench/type4/proof_fact_registry.md
@@ -41,6 +41,9 @@ packet-specific current status locally.
 | `hof.flat-map.nested-iteration-order` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves matching outer/inner traversal coordinates. |
 | `hof.flat-map.emitted-value-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves each matched nested coordinate emits the same value. |
 | `collection.flatten-depth.one-level` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes flattened-vs-nested output shape boundaries. |
+| `reduction.identity-empty-behavior` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes seed and empty-input behavior for separately proven aggregate facts. |
+| `reduction.step-coordinate-identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves the terminal step, predicate, or contribution observes the same flattened element coordinate. |
+| `hof.flat-map.aggregate-guard-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves outer, inner, and terminal guard placement for flat-map aggregates. |
 | `map.default.absence-fallback` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Requires receiver identity, key/default coordinates, and mutation closure. |
 | `map.receiver.source-identity` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only proves that both sides query the same map value source. |
 | `map.default.key-fallback-coordinate` | `specified-not-modeled` | `focused-executable`, `source-evidence` | Only closes the key/default coordinate boundary. |

--- a/bench/type4/proof_fact_registry.v1.json
+++ b/bench/type4/proof_fact_registry.v1.json
@@ -485,6 +485,99 @@
     },
     {
       "accepted_evidence": [
+        "sum, reduce, any, all, or equivalent loop terminals with the same initial value or empty-input result",
+        "loop accumulators whose seed matches the aggregate terminal identity",
+        "focused hard negatives where changed seeds or empty-input behavior remain split"
+      ],
+      "detector_admission_implication": "Does not admit aggregate convergence by itself; it only closes seed and empty-input behavior for separately proven source, step, and effect facts.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "reduction.identity-empty-behavior",
+      "hard_negative_conventions": [
+        "loop.empty-input",
+        "collection.cardinality"
+      ],
+      "implementation_guidance": [
+        "Track aggregate identities such as additive 0, any false, all true, and explicit reduce seeds.",
+        "Reject selection reductions whose loop seed clamps behavior differently from the terminal API.",
+        "Keep terminal APIs that can throw on empty input outside this fact unless matching empty-input behavior is proven."
+      ],
+      "rejected_evidence": [
+        "wrong additive or multiplicative seed",
+        "zero-seeded max/min loops compared with unseeded terminal max/min",
+        "early-return loops with a mismatched fallthrough value"
+      ],
+      "semantic_family": "reduction.identity",
+      "status": "specified-not-modeled",
+      "summary": "Aggregate rewrites must preserve the terminal identity, explicit seed, and empty-input behavior before loop and higher-order reductions may converge.",
+      "title": "Reduction identity and empty-input behavior"
+    },
+    {
+      "accepted_evidence": [
+        "the aggregate step combines the accumulator with the same flattened element value",
+        "any/all predicates observe the same flattened element coordinate as the explicit early-return loop",
+        "focused hard negatives where changed terminal predicates or contribution expressions remain split"
+      ],
+      "detector_admission_implication": "Does not admit aggregate convergence by itself; source identity, flattening, identity/empty behavior, and effect facts remain separate.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "reduction.step-coordinate-identity",
+      "hard_negative_conventions": [
+        "value.coordinate",
+        "boolean.predicate-coordinate"
+      ],
+      "implementation_guidance": [
+        "Compare reduction step expressions after the flattened element coordinate is established.",
+        "For any/all terminals, compare the terminal predicate independently from upstream filters.",
+        "Reject aggregate terminals that observe the outer coordinate, nested row, or a changed predicate without a separate value proof."
+      ],
+      "rejected_evidence": [
+        "terminal any/all predicate changed while traversal is unchanged",
+        "reduction contribution changed from the flattened emitted value",
+        "aggregate over nested rows instead of flattened elements"
+      ],
+      "semantic_family": "reduction.step",
+      "status": "specified-not-modeled",
+      "summary": "Aggregate rewrites must preserve the reduction step, terminal predicate, or contribution expression for every proven flattened element coordinate.",
+      "title": "Reduction step coordinate identity"
+    },
+    {
+      "accepted_evidence": [
+        "outer and inner filters in a flat-map aggregate guard the same matched traversal coordinates",
+        "nested guarded loops and flat-map/filter chains preserve the same guard placement before aggregation",
+        "focused hard negatives where outer, inner, or terminal predicates are changed remain split"
+      ],
+      "detector_admission_implication": "Does not admit aggregate convergence by itself; it only closes guard placement after nested traversal and terminal step facts are proven.",
+      "evidence_requirements": [
+        "focused-executable",
+        "source-evidence"
+      ],
+      "fact_id": "hof.flat-map.aggregate-guard-coordinate",
+      "hard_negative_conventions": [
+        "loop.iterator-identity",
+        "boolean.predicate-coordinate"
+      ],
+      "implementation_guidance": [
+        "Track whether a predicate guards the outer traversal, inner traversal, or terminal aggregate.",
+        "Reject predicates moved across coordinates unless a separate equivalence proof preserves cardinality and short-circuit behavior.",
+        "Keep numeric or ordering predicates closed when their domain proof is missing."
+      ],
+      "rejected_evidence": [
+        "outer guard changed while inner and terminal expressions remain unchanged",
+        "inner guard changed while outer and terminal expressions remain unchanged",
+        "terminal predicate substituted for an upstream filter or vice versa"
+      ],
+      "semantic_family": "hof.flat_map",
+      "status": "specified-not-modeled",
+      "summary": "Filtered flat-map aggregate rewrites must preserve whether each guard belongs to the outer traversal, inner traversal, or terminal aggregate coordinate.",
+      "title": "Flat-map aggregate guard coordinate"
+    },
+    {
+      "accepted_evidence": [
         "map get/index lookup paired with an explicit fallback only for absent keys",
         "membership guard plus lookup returning the same fallback for absence",
         "language API evidence that separates absent-key fallback from present key with null/nil/None payload"

--- a/bench/type4/semantic_pattern_cards.md
+++ b/bench/type4/semantic_pattern_cards.md
@@ -16,6 +16,7 @@ proof-carrying frontier gates required by the linked pattern.
 | `map.default.absence-lookup` | `pattern-carded` | 4 | 5 |
 | `hof.filter-map.option-emission` | `pattern-carded` | 5 | 4 |
 | `hof.flat-map.one-level-flatten` | `pattern-carded` | 5 | 5 |
+| `hof.flat-map.aggregate-reduction` | `pattern-carded` | 9 | 5 |
 
 ## `numeric.clamp.proven-integer-bounds`
 
@@ -98,3 +99,24 @@ One-level flat-map surfaces are equivalent to multi-clause comprehensions or nes
 | Java | Stream.flatMap over a proven inner stream plus pure map callback | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::java_stream_flat_map_py_comp |
 | Swift | Sequence.flatMap after focused one-level flatten and callback-effect evidence | `open` |  |
 | Rust | Iterator::flat_map remains closed for nested element collections until inner-source proof is attached | `closed` |  |
+
+## `hof.flat-map.aggregate-reduction`
+
+**Flat-map aggregate reduction**
+
+Flat-map aggregate surfaces are equivalent to nested reductions only when the flattened stream is already proven, the aggregate identity and empty-input behavior match, and every terminal step, predicate, and guard observes the same coordinate.
+
+- status: `pattern-carded`
+- rationale: The flat_map_aggregate corpus links flat-map streams to sum and any/all nested loops while preserving adjacent hard negatives for wrong seeds, seeded max, nested rows, changed predicates, filter-coordinate changes, and outer-cardinality erasure; carding the aggregate layer keeps future detector work from collapsing terminal semantics into flat-map spelling.
+- required facts: `iteration.same-source-identity`, `effect.pure-callback`, `effect.pure-predicate`, `hof.flat-map.nested-iteration-order`, `hof.flat-map.emitted-value-coordinate`, `collection.flatten-depth.one-level`, `reduction.identity-empty-behavior`, `reduction.step-coordinate-identity`, `hof.flat-map.aggregate-guard-coordinate`
+- hard-negative templates: `reduction.changed-seed`, `reduction.changed-terminal-predicate`, `reduction.changed-empty-input-behavior`, `hof.flat-map.nested-row-aggregation`, `hof.flat-map.outer-cardinality-erasure`, `hof.flat-map.changed-outer-guard`, `hof.flat-map.changed-inner-guard`
+- boundaries: aggregate identity, explicit seed, and empty-input behavior must match; the terminal step or predicate must observe the same flattened element coordinate; outer, inner, and terminal guard predicates are separate coordinates; outer-cardinality effects remain behavior-defining even when the emitted value ignores the outer element; nested-row aggregation is distinct from aggregation over the flattened stream; JS/TS filtered relational terminals need independent numeric-predicate proof before cross-language admission
+- evidence: `bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop`, `bench/type4/adversarial/cases/cases.v1.json::any_flat_map_nested_loop`, `bench/type4/adversarial/cases/cases.v1.json::sum_filtered_flat_map_nested_loop`, `bench/type4/adversarial/cases/cases.v1.json::any_filtered_flat_map_early_return_loop`, `bench/type4/adversarial/cases/cases.v1.json::max_flat_map_nested_loop`, `bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_wrong_seed`, `bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_list`, `bench/type4/adversarial/cases/cases.v1.json::any_flat_map_wrong_predicate`, `bench/type4/adversarial/cases/cases.v1.json::flat_map_aggregate_outer_cardinality_boundary`, `bench/type4/adversarial/cases/cases.v1.json::flat_map_aggregate_filter_predicate_change`, `bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity`, `bench/type4/proof_fact_registry.v1.json::effect.pure-callback`, `bench/type4/proof_fact_registry.v1.json::effect.pure-predicate`, `bench/type4/proof_fact_registry.v1.json::hof.flat-map.nested-iteration-order`, `bench/type4/proof_fact_registry.v1.json::hof.flat-map.emitted-value-coordinate`, `bench/type4/proof_fact_registry.v1.json::collection.flatten-depth.one-level`, `bench/type4/proof_fact_registry.v1.json::reduction.identity-empty-behavior`, `bench/type4/proof_fact_registry.v1.json::reduction.step-coordinate-identity`, `bench/type4/proof_fact_registry.v1.json::hof.flat-map.aggregate-guard-coordinate`
+
+| language | surface | status | evidence |
+|---|---|---|---|
+| Python | sum, any, and all over multi-clause generators with equivalent nested reduction or early-return loops | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop |
+| JS/TS | Array.flatMap().reduce() over a proven flattened element stream with matching seed and contribution | `modeled-controlled` | bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop |
+| Java | Stream.flatMap terminal reductions after flat-map source proof is connected to stream aggregate facts | `open` |  |
+| Swift | Sequence.flatMap terminal aggregates after one-level flatten and terminal identity evidence | `open` |  |
+| Rust | Iterator::flat_map aggregate surfaces remain closed until nested source and terminal identity proofs are attached | `closed` |  |

--- a/bench/type4/semantic_pattern_cards.v1.json
+++ b/bench/type4/semantic_pattern_cards.v1.json
@@ -269,6 +269,91 @@
       ],
       "status": "pattern-carded",
       "title": "One-level flat-map"
+    },
+    {
+      "boundaries": [
+        "aggregate identity, explicit seed, and empty-input behavior must match",
+        "the terminal step or predicate must observe the same flattened element coordinate",
+        "outer, inner, and terminal guard predicates are separate coordinates",
+        "outer-cardinality effects remain behavior-defining even when the emitted value ignores the outer element",
+        "nested-row aggregation is distinct from aggregation over the flattened stream",
+        "JS/TS filtered relational terminals need independent numeric-predicate proof before cross-language admission"
+      ],
+      "evidence_refs": [
+        "bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop",
+        "bench/type4/adversarial/cases/cases.v1.json::any_flat_map_nested_loop",
+        "bench/type4/adversarial/cases/cases.v1.json::sum_filtered_flat_map_nested_loop",
+        "bench/type4/adversarial/cases/cases.v1.json::any_filtered_flat_map_early_return_loop",
+        "bench/type4/adversarial/cases/cases.v1.json::max_flat_map_nested_loop",
+        "bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_wrong_seed",
+        "bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_list",
+        "bench/type4/adversarial/cases/cases.v1.json::any_flat_map_wrong_predicate",
+        "bench/type4/adversarial/cases/cases.v1.json::flat_map_aggregate_outer_cardinality_boundary",
+        "bench/type4/adversarial/cases/cases.v1.json::flat_map_aggregate_filter_predicate_change",
+        "bench/type4/proof_fact_registry.v1.json::iteration.same-source-identity",
+        "bench/type4/proof_fact_registry.v1.json::effect.pure-callback",
+        "bench/type4/proof_fact_registry.v1.json::effect.pure-predicate",
+        "bench/type4/proof_fact_registry.v1.json::hof.flat-map.nested-iteration-order",
+        "bench/type4/proof_fact_registry.v1.json::hof.flat-map.emitted-value-coordinate",
+        "bench/type4/proof_fact_registry.v1.json::collection.flatten-depth.one-level",
+        "bench/type4/proof_fact_registry.v1.json::reduction.identity-empty-behavior",
+        "bench/type4/proof_fact_registry.v1.json::reduction.step-coordinate-identity",
+        "bench/type4/proof_fact_registry.v1.json::hof.flat-map.aggregate-guard-coordinate"
+      ],
+      "hard_negative_templates": [
+        "reduction.changed-seed",
+        "reduction.changed-terminal-predicate",
+        "reduction.changed-empty-input-behavior",
+        "hof.flat-map.nested-row-aggregation",
+        "hof.flat-map.outer-cardinality-erasure",
+        "hof.flat-map.changed-outer-guard",
+        "hof.flat-map.changed-inner-guard"
+      ],
+      "language_surfaces": [
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop",
+          "language": "Python",
+          "status": "modeled-controlled",
+          "surface": "sum, any, and all over multi-clause generators with equivalent nested reduction or early-return loops"
+        },
+        {
+          "evidence": "bench/type4/adversarial/cases/cases.v1.json::sum_flat_map_nested_loop",
+          "language": "JS/TS",
+          "status": "modeled-controlled",
+          "surface": "Array.flatMap().reduce() over a proven flattened element stream with matching seed and contribution"
+        },
+        {
+          "language": "Java",
+          "status": "open",
+          "surface": "Stream.flatMap terminal reductions after flat-map source proof is connected to stream aggregate facts"
+        },
+        {
+          "language": "Swift",
+          "status": "open",
+          "surface": "Sequence.flatMap terminal aggregates after one-level flatten and terminal identity evidence"
+        },
+        {
+          "language": "Rust",
+          "status": "closed",
+          "surface": "Iterator::flat_map aggregate surfaces remain closed until nested source and terminal identity proofs are attached"
+        }
+      ],
+      "law": "Flat-map aggregate surfaces are equivalent to nested reductions only when the flattened stream is already proven, the aggregate identity and empty-input behavior match, and every terminal step, predicate, and guard observes the same coordinate.",
+      "pattern_id": "hof.flat-map.aggregate-reduction",
+      "rationale": "The flat_map_aggregate corpus links flat-map streams to sum and any/all nested loops while preserving adjacent hard negatives for wrong seeds, seeded max, nested rows, changed predicates, filter-coordinate changes, and outer-cardinality erasure; carding the aggregate layer keeps future detector work from collapsing terminal semantics into flat-map spelling.",
+      "required_facts": [
+        "iteration.same-source-identity",
+        "effect.pure-callback",
+        "effect.pure-predicate",
+        "hof.flat-map.nested-iteration-order",
+        "hof.flat-map.emitted-value-coordinate",
+        "collection.flatten-depth.one-level",
+        "reduction.identity-empty-behavior",
+        "reduction.step-coordinate-identity",
+        "hof.flat-map.aggregate-guard-coordinate"
+      ],
+      "status": "pattern-carded",
+      "title": "Flat-map aggregate reduction"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
- add the language-neutral `hof.flat-map.aggregate-reduction` semantic pattern card
- add proof facts for aggregate identity/empty behavior, terminal step coordinates, and flat-map aggregate guard coordinates
- reuse the one-level flat-map facts from the previous loop plus callback/predicate purity facts
- refresh generated semantic pattern, PCF, and readiness artifacts

## Notes
- this records the existing modeled/closed perimeter; it does not admit new detector behavior
- JS/TS filtered relational terminals are explicitly kept behind independent numeric-predicate proof

## Validation
- `python3 bench/type4/semantic_pattern_cards.py --check`
- `scripts/check-docs.sh`
- `bench/type4/adversarial/scripts/type4-check`
- `python3 bench/type4/proof_carrying_frontier.py --check`
- `git diff --check`
- `scripts/check-ci-local.sh --fast`
- pre-push fast local CI gate