### PR TITLE
type4: record audit-ready closeout

### DIFF
--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -490,6 +490,20 @@ helpers split. The boltons/fzf replay remains an executable `split` blocker beca
 pair lacks a shared integer-only domain. The open-surface audit now removes #724 from the
 current actionable slice while keeping the real pair as proof-fact-prerequisite evidence.
 
+## Audit-Ready Epic Closeout
+
+Closed #785 by recording the #778 closeout in `issue_778_closeout.v1.json` and
+`issue_778_closeout.md`. The closeout is intentionally conservative: all six in-scope
+audit-ready rows are absent from the current actionable open audit, and every newly
+admitted surface has passing replay evidence or an explicit executable split blocker.
+
+The final replay/blocker matrix keeps Swift collection membership and empty checks as
+replay-backed controlled admissions; Swift string affix, JavaScript `every`, and Rust
+`Iterator::all` as controlled admissions with focused replay plus named boundary splits;
+and Go numeric clamp as a controlled typed-integer bridge while the boltons/fzf real pair
+remains split until fzf-side bound-order and shared integer-domain facts exist. The seven
+remaining open rows stay out of scope as `blocked-by-unmodeled-facts`.
+
 ## Current Next Work
 
 - Continue the real-corpus frontier loop in small batches: pick one proof invariant,

--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -274,6 +274,10 @@ Use `frontier_target_packets.v1.json`, `real_frontier.v1.json`, focused cases, a
 [`docs/type4-adversarial-coverage.md`](../../docs/type4-adversarial-coverage.md) for the
 current workflow.
 
+Epic closeouts that summarize an admission batch's final replay/blocker disposition live
+beside the frontier artifacts. The #778 audit-ready admission closeout is recorded in
+`issue_778_closeout.v1.json` and `issue_778_closeout.md`.
+
 ## Frontier evidence platform
 
 `frontier_platform.py` is a companion to the prioritizer that ranks axes by **presence

--- a/bench/type4/issue_778_closeout.md
+++ b/bench/type4/issue_778_closeout.md
@@ -1,0 +1,41 @@
+# Type-4 #778 Closeout
+
+Closeout issue: #785
+
+Status: complete with replay-backed controlled admissions or explicit executable split blockers.
+
+## Summary
+
+The #778 audit-ready admission epic is closed at the proof frontier, not by widening detector admission to every plausible real pair. The current audit artifact reports:
+
+- actionable in-scope open rows: 0
+- unexpected actionable open rows: 0
+- out-of-scope blocked rows: 7
+- real-frontier replays: 29/29 passed, 0 unavailable
+- executable expectations: 157/157 passed
+- proof-carrying frontier verdict: `no-exact-admission-ready-packets`
+
+## In-Scope Disposition
+
+| issue | surface | packet | disposition |
+|---|---|---|---|
+| #779 | Swift `Array.contains` collection membership | `membership-contains-2026-07-08` | replay-backed controlled admission |
+| #780 | Swift `Array` empty/non-empty checks | `collection-empty-check-2026-07-08` | replay-backed controlled admission |
+| #782 | Swift `String.hasPrefix` / `hasSuffix` | `string-prefix-suffix-2026-07-08` | controlled admission with focused replay; broader real-corpus string-affix pairs still require separate audit |
+| #784 | JavaScript dense-literal `every` / counterexample loop | `reduction-minmax-anyall-2026-07-08` | controlled admission with focused replay; sparse/append-only/value-payload boundaries stay split |
+| #783 | Rust `Iterator::all` / counterexample loop | `reduction-minmax-anyall-2026-07-08` | controlled admission with focused replay; effect, mutation, and source-provenance boundaries stay split |
+| #724 | Go typed integer min/max clamp bridge | `numeric-clamp-2026-06-06` | controlled admission with executable real-pair blocker for boltons/fzf |
+
+## Blocked Rows
+
+The remaining 7 open audit rows are intentionally outside #778. Grouped by capability, they require neutral fact modeling before detector admission:
+
+- Swift `Sequence.compactMap` option emission
+- Java/Swift flat-map aggregate reductions
+- Swift one-level flat-map flattening
+- Swift dictionary default lookup
+- Ruby/Swift option presence/defaulting channel-coordinate admission
+
+## Closeout Rule
+
+#778 did not use language spelling as proof. Each admitted surface has focused positives, adjacent hard negatives, executable expectations, and replay coverage. Real-corpus pairs that still lack source identity, bound order, receiver/API identity, mutation, callback effect, or value-domain facts remain executable split blockers instead of being forced through.

--- a/bench/type4/issue_778_closeout.v1.json
+++ b/bench/type4/issue_778_closeout.v1.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": 1,
+  "tool_version": "manual-closeout/1",
+  "closeout_date": "2026-07-09",
+  "epic_issue": 778,
+  "closeout_issue": 785,
+  "status": "complete-with-replay-or-executable-blockers",
+  "source_artifacts": [
+    "bench/type4/open_surface_admission_audit.v1.json",
+    "bench/type4/proof_carrying_frontier.v1.json",
+    "bench/type4/frontier_readiness.v1.json",
+    "bench/type4/frontier_target_packets.v1.json",
+    "bench/type4/real_frontier.v1.json",
+    "bench/type4/real_frontier_replay.v1.json",
+    "bench/type4/real_frontier_replay_status.v1.json",
+    "bench/type4/executable_expectations.v1.json"
+  ],
+  "audit_summary": {
+    "current_actionable_open_count": 0,
+    "in_scope_count": 6,
+    "in_scope_currently_open": 0,
+    "out_of_scope_blocked_open_count": 7,
+    "unexpected_actionable_open_count": 0,
+    "validation_error_count": 0
+  },
+  "real_frontier_replay_summary": {
+    "entry_count": 29,
+    "passed": 29,
+    "failed": 0,
+    "unavailable": 0,
+    "query_count": 11
+  },
+  "executable_expectation_summary": {
+    "expectation_count": 157,
+    "passed": 157,
+    "failed": 0,
+    "query_count": 20
+  },
+  "proof_carrying_frontier_verdict": "no-exact-admission-ready-packets",
+  "in_scope_dispositions": [
+    {
+      "issue": 779,
+      "surface": "Swift Array.contains collection membership",
+      "packet_id": "membership-contains-2026-07-08",
+      "disposition": "replay-backed-controlled-admission",
+      "replay_ids": [
+        "collection-membership-focused-controlled-pair"
+      ],
+      "blocked_exact_real_pair": false
+    },
+    {
+      "issue": 780,
+      "surface": "Swift Array isEmpty/count empty and non-empty checks",
+      "packet_id": "collection-empty-check-2026-07-08",
+      "disposition": "replay-backed-controlled-admission",
+      "replay_ids": [
+        "collection-empty-focused-controlled-pair",
+        "collection-empty-swift-focused-controlled-pair",
+        "collection-nonempty-focused-controlled-pair",
+        "collection-nonempty-swift-focused-controlled-pair"
+      ],
+      "blocked_exact_real_pair": false
+    },
+    {
+      "issue": 782,
+      "surface": "Swift String.hasPrefix/hasSuffix and affix-coordinate bindings",
+      "packet_id": "string-prefix-suffix-2026-07-08",
+      "disposition": "controlled-admission-with-focused-replay",
+      "replay_ids": [
+        "string-affix-prefix-focused-controlled-pair",
+        "string-affix-suffix-focused-controlled-pair",
+        "string-affix-parameter-coordinate-controlled-pair",
+        "string-affix-swift-prefix-focused-controlled-pair",
+        "string-affix-swift-suffix-focused-controlled-pair",
+        "string-affix-swift-suffix-parameter-coordinate-controlled-pair",
+        "string-affix-swift-literal-binding-controlled-pair"
+      ],
+      "blocked_exact_real_pair": true,
+      "blocker": "non-focused real-corpus string-affix pairs still require separate audit before exact real-pair admission"
+    },
+    {
+      "issue": 784,
+      "surface": "JavaScript dense-literal Array.prototype.every versus counterexample loop",
+      "packet_id": "reduction-minmax-anyall-2026-07-08",
+      "disposition": "controlled-admission-with-focused-replay-and-boundary-splits",
+      "replay_ids": [
+        "reduction-javascript-every-dense-literal-controlled-pair",
+        "reduction-javascript-every-array-param-boundary-controlled-pair"
+      ],
+      "blocked_exact_real_pair": true,
+      "blocker": "array-parameter, callback-argument, value-returning predicate, and append-only local-array facts remain closed unless separately modeled"
+    },
+    {
+      "issue": 783,
+      "surface": "Rust Iterator::all versus counterexample loop",
+      "packet_id": "reduction-minmax-anyall-2026-07-08",
+      "disposition": "controlled-admission-with-focused-replay-and-boundary-splits",
+      "replay_ids": [
+        "reduction-rust-all-focused-controlled-pair",
+        "reduction-rust-all-effect-boundary-controlled-pair",
+        "reduction-rust-all-mutating-borrow-boundary-controlled-pair"
+      ],
+      "blocked_exact_real_pair": true,
+      "blocker": "effectful callbacks, loop effects, consumed iterators, mutating borrows, and broader source-provenance expansions remain outside the admitted slice"
+    },
+    {
+      "issue": 724,
+      "surface": "Go typed integer min/max clamp bridge",
+      "packet_id": "numeric-clamp-2026-06-06",
+      "disposition": "controlled-admission-with-executable-real-pair-blocker",
+      "replay_ids": [
+        "numeric-clamp-boltons-fzf-real-pair"
+      ],
+      "blocked_exact_real_pair": true,
+      "blocker": "the boltons/fzf real pair remains split until fzf-side bound-order evidence and a shared integer-only domain proof exist"
+    }
+  ],
+  "out_of_scope_blocked_selectors": [
+    "hof.filter-map.option-emission:Swift:blocked-by-unmodeled-facts",
+    "hof.flat-map.aggregate-reduction:Java:blocked-by-unmodeled-facts",
+    "hof.flat-map.aggregate-reduction:Swift:blocked-by-unmodeled-facts",
+    "hof.flat-map.one-level-flatten:Swift:blocked-by-unmodeled-facts",
+    "map.default.absence-lookup:Swift:blocked-by-unmodeled-facts",
+    "option.presence-default.proven-channel-coordinate:Ruby:blocked-by-unmodeled-facts",
+    "option.presence-default.proven-channel-coordinate:Swift:blocked-by-unmodeled-facts"
+  ],
+  "done_criteria": [
+    "every #778 in-scope row is absent from the current actionable open audit",
+    "every #778 in-scope admitted surface has a passing real-frontier replay or an explicit executable split blocker",
+    "no unsupported real pair was forced into same-family admission",
+    "the remaining open audit rows are blocked by unmodeled neutral facts and are out of scope for #778"
+  ],
+  "validation_commands": [
+    "python3 -m json.tool bench/type4/issue_778_closeout.v1.json >/dev/null",
+    "jq -n -e --slurpfile closeout bench/type4/issue_778_closeout.v1.json --slurpfile audit bench/type4/open_surface_admission_audit.v1.json --slurpfile replay bench/type4/real_frontier_replay_status.v1.json --slurpfile exec bench/type4/executable_expectations.v1.json '($closeout[0].audit_summary.current_actionable_open_count == $audit[0].epic_slices.epic_778.summary.current_actionable_open_count) and ($closeout[0].real_frontier_replay_summary.passed == $replay[0].passed) and ($closeout[0].executable_expectation_summary.passed == $exec[0].passed)'",
+    "python3 bench/type4/real_frontier_replay.py --selftest",
+    "python3 bench/type4/real_frontier_replay.py --stable-report --check",
+    "python3 bench/type4/proof_carrying_frontier.py --check",
+    "python3 bench/type4/open_surface_admission_audit.py --check",
+    "bench/type4/adversarial/scripts/type4-check",
+    "bench/type4/adversarial/scripts/type4-exec-check --stable-report --json-out bench/type4/executable_expectations.v1.json",
+    "./scripts/check-docs.sh",
+    "./scripts/check-ci-local.sh --fast"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a durable #778/#785 closeout artifact in JSON and Markdown
- record the final replay/blocker disposition for all six #778 in-scope surfaces
- link the closeout from Type-4 README and ITERATIONS resume notes

## Closeout decision
This closes #785. After this PR merges, #778 can be closed because:
- the #778 audit slice has 0 current actionable open rows
- all six in-scope rows are no longer present in the current open audit
- every admitted surface has passing real-frontier replay or an explicit executable split blocker
- the remaining 7 open rows are out-of-scope `blocked-by-unmodeled-facts` rows for a later fact-modeling epic

The closeout deliberately does not force exact admission for unsupported real pairs. In particular, the #724 boltons/fzf numeric clamp pair remains a passing executable `split` blocker until fzf-side bound-order and shared integer-domain facts exist.

Closes #785
Refs #778

## Independent review
Before opening this PR, three independent reviews checked:
- closeout JSON/source-artifact consistency
- #785/#778 closure defensibility and #724 blocker handling
- documentation and artifact hygiene

Applied feedback:
- included the new closeout artifacts in the commit
- added `real_frontier.v1.json` and `frontier_target_packets.v1.json` to provenance sources
- clarified that the 7 blocked rows are grouped by capability in the Markdown
- added JSON parse/source-summary check commands to the validation list

## Verification
- `python3 -m json.tool bench/type4/issue_778_closeout.v1.json >/dev/null`
- `jq -n -e --slurpfile closeout bench/type4/issue_778_closeout.v1.json --slurpfile audit bench/type4/open_surface_admission_audit.v1.json --slurpfile replay bench/type4/real_frontier_replay_status.v1.json --slurpfile exec bench/type4/executable_expectations.v1.json '...'`
- `python3 bench/type4/real_frontier_replay.py --selftest`
- `python3 bench/type4/real_frontier_replay.py --stable-report --check`
- `python3 bench/type4/proof_carrying_frontier.py --check`
- `python3 bench/type4/open_surface_admission_audit.py --check`
- `bench/type4/adversarial/scripts/type4-check`
- `bench/type4/adversarial/scripts/type4-exec-check --stable-report --json-out bench/type4/executable_expectations.v1.json`
- `git diff --check`
- `./scripts/check-docs.sh`
- `./scripts/check-duplication.sh`
- `./scripts/check-ci-local.sh --fast`
