### PR TITLE
type4: freeze blocked proof fact slice

### DIFF
--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -504,6 +504,19 @@ and Go numeric clamp as a controlled typed-integer bridge while the boltons/fzf 
 remains split until fzf-side bound-order and shared integer-domain facts exist. The seven
 remaining open rows stay out of scope as `blocked-by-unmodeled-facts`.
 
+## Neutral-Fact Blocked Admission Slice
+
+Started #791 through #792 by freezing the seven remaining open
+`blocked-by-unmodeled-facts` rows in `open_surface_admission_audit`. Unlike #778, this batch
+is not a surface-admission queue yet: the selected Ruby, Swift, Java, and map/HOF rows must
+first be grouped by reusable neutral proof facts.
+
+The frozen order is now option absence-channel identity, HOF callback purity, filter-map
+coordinates, one-level flat-map source/flatten facts, flat-map aggregate guard coordinates,
+Swift Dictionary default receiver/fallback facts, and final closeout. The audit check treats
+new unexpected blocked rows as drift while allowing frozen rows to become actionable or leave
+the open audit as their facts land.
+
 ## Current Next Work
 
 - Continue the real-corpus frontier loop in small batches: pick one proof invariant,

--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -332,9 +332,10 @@ The committed artifacts are `semantic_pattern_cards.v1.json` and
 for the next proof-backed language-surface admission. It separates rows whose
 neutral facts are modeled from rows that still need surface-specific focused
 positives, adjacent hard negatives, executable expectations, or proof-fact
-modeling. The audit can also carry an epic-specific frozen slice, such as
-`Epic #778 Audit Slice`, so a multi-PR admission batch has one checked source of
-truth for in-scope rows and out-of-scope blocked rows.
+modeling. The audit can also carry epic-specific frozen slices, such as
+`Epic #778 Audit Slice` for audit-ready admissions and `Epic #791
+Neutral-Fact Blocked Slice` for fact-modeling work, so a multi-PR batch has one
+checked source of truth for selected rows, intentionally open rows, and drift.
 
 ```sh
 python3 bench/type4/open_surface_admission_audit.py

--- a/bench/type4/open_surface_admission_audit.md
+++ b/bench/type4/open_surface_admission_audit.md
@@ -52,6 +52,46 @@ neutral proof facts before admission work is sound.
 | `blocked-by-unmodeled-facts` | `option.presence-default.proven-channel-coordinate` | Ruby | present | needs absence-channel identity before nil? admission | `option.absence-channel.identity` | nil comparison coverage exists in the sweep; Ruby nil? admission still needs a focused proof perimeter before modeled-controlled status |
 | `blocked-by-unmodeled-facts` | `option.presence-default.proven-channel-coordinate` | Swift | present | needs absence-channel identity before Optional presence/defaulting admission | `option.absence-channel.identity` | Optional nil presence probe coverage exists; defaulting and full API/coordinate/mutation perimeter remain open |
 
+## Epic #791 Neutral-Fact Blocked Slice
+
+This frozen slice tracks the open rows that are intentionally blocked
+until missing language-neutral proof facts are modeled. It is grouped by
+reusable proof fact stage before language surface so the next PRs do not
+admit Ruby, Swift, Java, or map/HOF spellings directly.
+
+- tracker issue: #791
+- setup issue: #792
+- predecessor issue: #778
+- closeout issue: #799
+- frozen blocked rows: 7 (7 currently blocked)
+- promoted or resolved frozen rows: 0
+- current blocked open rows: 7
+- unexpected blocked open rows: 0
+
+### Fact Groups And Admission Order
+
+| order | issue | fact group | fact statuses | unblocks | focused admission candidates after group lands | intentionally still open |
+|---|---|---|---|---|---|---|
+| 1 | #793 | `option.absence-channel` Option absence-channel identity | `option.absence-channel.identity`:specified-not-modeled | `option.presence-default.proven-channel-coordinate:Ruby`, `option.presence-default.proven-channel-coordinate:Swift`, `hof.filter-map.option-emission:Swift` | `option.presence-default.proven-channel-coordinate:Ruby`, `option.presence-default.proven-channel-coordinate:Swift` | hof.filter-map.option-emission:Swift waits for callback purity and filter-map coordinates |
+| 2 | #794 | `effect.hof-callback-purity` Higher-order callback effect safety | `effect.pure-callback`:specified-not-modeled | `hof.filter-map.option-emission:Swift`, `hof.flat-map.one-level-flatten:Swift`, `hof.flat-map.aggregate-reduction:Java`, `hof.flat-map.aggregate-reduction:Swift` |  | compactMap waits for option-emission coordinate facts; flatMap waits for one-level flatten and nested traversal facts |
+| 3 | #795 | `hof.filter-map.coordinates` Filter-map drop and emitted-value coordinates | `hof.filter-map.drop-condition-coordinate`:specified-not-modeled, `hof.filter-map.emitted-value-coordinate`:specified-not-modeled | `hof.filter-map.option-emission:Swift` | `hof.filter-map.option-emission:Swift` |  |
+| 4 | #796 | `hof.flat-map.one-level-stream` One-level flat-map source and emitted stream | `collection.flatten-depth.one-level`:specified-not-modeled, `hof.flat-map.nested-iteration-order`:specified-not-modeled, `hof.flat-map.emitted-value-coordinate`:specified-not-modeled | `hof.flat-map.one-level-flatten:Swift`, `hof.flat-map.aggregate-reduction:Java`, `hof.flat-map.aggregate-reduction:Swift` | `hof.flat-map.one-level-flatten:Swift` | flat-map aggregate reductions wait for aggregate guard-coordinate proof |
+| 5 | #797 | `hof.flat-map.aggregate-guard` Flat-map aggregate guard coordinate | `hof.flat-map.aggregate-guard-coordinate`:specified-not-modeled | `hof.flat-map.aggregate-reduction:Java`, `hof.flat-map.aggregate-reduction:Swift` | `hof.flat-map.aggregate-reduction:Java`, `hof.flat-map.aggregate-reduction:Swift` |  |
+| 6 | #798 | `map.default.receiver-fallback` Map default receiver and fallback coordinates | `map.default.absence-fallback`:specified-not-modeled, `map.receiver.source-identity`:specified-not-modeled, `map.default.key-fallback-coordinate`:specified-not-modeled, `map.receiver.no-intervening-mutation`:specified-not-modeled | `map.default.absence-lookup:Swift` | `map.default.absence-lookup:Swift` |  |
+| 7 | #799 | `blocked-surface-closeout` Blocked-surface closeout and replay evidence |  |  |  | any row still open after #793-#798 must carry stronger blocker or replay evidence |
+
+### Frozen Rows
+
+| order | issue | priority | pattern | language | current state | blocker | missing facts | work | surface |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | #793 | `blocked-by-unmodeled-facts` | `option.presence-default.proven-channel-coordinate` | Ruby | present | model required facts before detector admission | `option.absence-channel.identity` | model absence-channel identity before Ruby nil?/nil comparison admission | nil comparison coverage exists in the sweep; Ruby nil? admission still needs a focused proof perimeter before modeled-controlled status |
+| 2 | #793 | `blocked-by-unmodeled-facts` | `option.presence-default.proven-channel-coordinate` | Swift | present | model required facts before detector admission | `option.absence-channel.identity` | model absence-channel identity before Swift Optional presence/defaulting admission | Optional nil presence probe coverage exists; defaulting and full API/coordinate/mutation perimeter remain open |
+| 3 | #795 | `blocked-by-unmodeled-facts` | `hof.filter-map.option-emission` | Swift | present | model required facts before detector admission | `effect.pure-callback`, `hof.filter-map.drop-condition-coordinate`, `hof.filter-map.emitted-value-coordinate`, `option.absence-channel.identity` | model Swift compactMap drop-condition and emitted-value coordinates | Sequence.compactMap after optional-result channel and callback-effect proof |
+| 4 | #796 | `blocked-by-unmodeled-facts` | `hof.flat-map.one-level-flatten` | Swift | present | model required facts before detector admission | `effect.pure-callback`, `hof.flat-map.nested-iteration-order`, `hof.flat-map.emitted-value-coordinate`, `collection.flatten-depth.one-level` | model one-level flatten, nested-order, and emitted-value facts for Swift flatMap | Sequence.flatMap after focused one-level flatten and callback-effect evidence |
+| 5 | #797 | `blocked-by-unmodeled-facts` | `hof.flat-map.aggregate-reduction` | Java | present | model required facts before detector admission | `effect.pure-callback`, `hof.flat-map.nested-iteration-order`, `hof.flat-map.emitted-value-coordinate`, `collection.flatten-depth.one-level`, `hof.flat-map.aggregate-guard-coordinate` | connect Java Stream.flatMap aggregate reductions after flat-map source facts land | Stream.flatMap terminal reductions after flat-map source proof is connected to stream aggregate facts |
+| 6 | #797 | `blocked-by-unmodeled-facts` | `hof.flat-map.aggregate-reduction` | Swift | present | model required facts before detector admission | `effect.pure-callback`, `hof.flat-map.nested-iteration-order`, `hof.flat-map.emitted-value-coordinate`, `collection.flatten-depth.one-level`, `hof.flat-map.aggregate-guard-coordinate` | connect Swift flatMap terminal aggregates after one-level flatten facts land | Sequence.flatMap terminal aggregates after one-level flatten and terminal identity evidence |
+| 7 | #798 | `blocked-by-unmodeled-facts` | `map.default.absence-lookup` | Swift | present | model required facts before detector admission | `map.default.absence-fallback`, `map.receiver.source-identity`, `map.default.key-fallback-coordinate`, `map.receiver.no-intervening-mutation` | model Swift Dictionary default lookup receiver, key, fallback, and mutation facts | Dictionary default subscript after receiver-coordinate proof |
+
 ## Candidate Rows
 
 | priority | pattern | language | surface | status | evidence | blocker | facts | surface focused | pattern perimeter | coverage |

--- a/bench/type4/open_surface_admission_audit.py
+++ b/bench/type4/open_surface_admission_audit.py
@@ -133,6 +133,222 @@ EPIC_778_OUT_OF_SCOPE_ROWS = [
     },
 ]
 
+EPIC_791_BLOCKED_ROWS = [
+    {
+        "order": 1,
+        "issue": 793,
+        "pattern_id": "option.presence-default.proven-channel-coordinate",
+        "language": "Ruby",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": ["option.absence-channel.identity"],
+        "work": "model absence-channel identity before Ruby nil?/nil comparison admission",
+        "reason": "only the absence-channel fact is unmodeled, but the focused Ruby nil? perimeter is not sound until that fact lands",
+    },
+    {
+        "order": 2,
+        "issue": 793,
+        "pattern_id": "option.presence-default.proven-channel-coordinate",
+        "language": "Swift",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": ["option.absence-channel.identity"],
+        "work": "model absence-channel identity before Swift Optional presence/defaulting admission",
+        "reason": "probe evidence exists, but Optional presence/defaulting still needs a proven absence channel before focused admission",
+    },
+    {
+        "order": 3,
+        "issue": 795,
+        "pattern_id": "hof.filter-map.option-emission",
+        "language": "Swift",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.filter-map.drop-condition-coordinate",
+            "hof.filter-map.emitted-value-coordinate",
+            "option.absence-channel.identity",
+        ],
+        "work": "model Swift compactMap drop-condition and emitted-value coordinates",
+        "reason": "after option channel and callback purity, compactMap still needs filter-map coordinate facts before admission",
+    },
+    {
+        "order": 4,
+        "issue": 796,
+        "pattern_id": "hof.flat-map.one-level-flatten",
+        "language": "Swift",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+        ],
+        "work": "model one-level flatten, nested-order, and emitted-value facts for Swift flatMap",
+        "reason": "Sequence.flatMap admission requires a reusable one-level flatten proof, not Swift API spelling alone",
+    },
+    {
+        "order": 5,
+        "issue": 797,
+        "pattern_id": "hof.flat-map.aggregate-reduction",
+        "language": "Java",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate",
+        ],
+        "work": "connect Java Stream.flatMap aggregate reductions after flat-map source facts land",
+        "reason": "aggregate reduction facts are modeled, but flat-map traversal and guard-coordinate facts are still missing",
+    },
+    {
+        "order": 6,
+        "issue": 797,
+        "pattern_id": "hof.flat-map.aggregate-reduction",
+        "language": "Swift",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate",
+        ],
+        "work": "connect Swift flatMap terminal aggregates after one-level flatten facts land",
+        "reason": "terminal aggregate identity is reusable only after the flattened element stream and guard coordinates are proven",
+    },
+    {
+        "order": 7,
+        "issue": 798,
+        "pattern_id": "map.default.absence-lookup",
+        "language": "Swift",
+        "candidate_priority": "blocked-by-unmodeled-facts",
+        "planned_unmodeled_facts": [
+            "map.default.absence-fallback",
+            "map.receiver.source-identity",
+            "map.default.key-fallback-coordinate",
+            "map.receiver.no-intervening-mutation",
+        ],
+        "work": "model Swift Dictionary default lookup receiver, key, fallback, and mutation facts",
+        "reason": "default subscript admission needs absent-key fallback and receiver-coordinate proof instead of subscript spelling",
+    },
+]
+
+EPIC_791_FACT_GROUPS = [
+    {
+        "order": 1,
+        "issue": 793,
+        "group_id": "option.absence-channel",
+        "title": "Option absence-channel identity",
+        "facts": ["option.absence-channel.identity"],
+        "unblocks": [
+            "option.presence-default.proven-channel-coordinate:Ruby",
+            "option.presence-default.proven-channel-coordinate:Swift",
+            "hof.filter-map.option-emission:Swift",
+        ],
+        "focused_admission_after_group_lands": [
+            "option.presence-default.proven-channel-coordinate:Ruby",
+            "option.presence-default.proven-channel-coordinate:Swift",
+        ],
+        "still_open_until": [
+            "hof.filter-map.option-emission:Swift waits for callback purity and filter-map coordinates",
+        ],
+    },
+    {
+        "order": 2,
+        "issue": 794,
+        "group_id": "effect.hof-callback-purity",
+        "title": "Higher-order callback effect safety",
+        "facts": ["effect.pure-callback"],
+        "unblocks": [
+            "hof.filter-map.option-emission:Swift",
+            "hof.flat-map.one-level-flatten:Swift",
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift",
+        ],
+        "focused_admission_after_group_lands": [],
+        "still_open_until": [
+            "compactMap waits for option-emission coordinate facts",
+            "flatMap waits for one-level flatten and nested traversal facts",
+        ],
+    },
+    {
+        "order": 3,
+        "issue": 795,
+        "group_id": "hof.filter-map.coordinates",
+        "title": "Filter-map drop and emitted-value coordinates",
+        "facts": [
+            "hof.filter-map.drop-condition-coordinate",
+            "hof.filter-map.emitted-value-coordinate",
+        ],
+        "unblocks": ["hof.filter-map.option-emission:Swift"],
+        "focused_admission_after_group_lands": ["hof.filter-map.option-emission:Swift"],
+        "still_open_until": [],
+    },
+    {
+        "order": 4,
+        "issue": 796,
+        "group_id": "hof.flat-map.one-level-stream",
+        "title": "One-level flat-map source and emitted stream",
+        "facts": [
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+        ],
+        "unblocks": [
+            "hof.flat-map.one-level-flatten:Swift",
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift",
+        ],
+        "focused_admission_after_group_lands": ["hof.flat-map.one-level-flatten:Swift"],
+        "still_open_until": [
+            "flat-map aggregate reductions wait for aggregate guard-coordinate proof",
+        ],
+    },
+    {
+        "order": 5,
+        "issue": 797,
+        "group_id": "hof.flat-map.aggregate-guard",
+        "title": "Flat-map aggregate guard coordinate",
+        "facts": ["hof.flat-map.aggregate-guard-coordinate"],
+        "unblocks": [
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift",
+        ],
+        "focused_admission_after_group_lands": [
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift",
+        ],
+        "still_open_until": [],
+    },
+    {
+        "order": 6,
+        "issue": 798,
+        "group_id": "map.default.receiver-fallback",
+        "title": "Map default receiver and fallback coordinates",
+        "facts": [
+            "map.default.absence-fallback",
+            "map.receiver.source-identity",
+            "map.default.key-fallback-coordinate",
+            "map.receiver.no-intervening-mutation",
+        ],
+        "unblocks": ["map.default.absence-lookup:Swift"],
+        "focused_admission_after_group_lands": ["map.default.absence-lookup:Swift"],
+        "still_open_until": [],
+    },
+    {
+        "order": 7,
+        "issue": 799,
+        "group_id": "blocked-surface-closeout",
+        "title": "Blocked-surface closeout and replay evidence",
+        "facts": [],
+        "unblocks": [],
+        "focused_admission_after_group_lands": [],
+        "still_open_until": [
+            "any row still open after #793-#798 must carry stronger blocker or replay evidence",
+        ],
+    },
+]
+
 
 class OpenSurfaceAuditError(RuntimeError):
     pass
@@ -571,6 +787,7 @@ def build_report(
             by_fact[fact_id].append(entry)
 
     epic_778_slice = build_epic_778_slice(rows)
+    epic_791_slice = build_epic_791_slice(rows, fact_status_by_id)
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -591,6 +808,7 @@ def build_report(
         "by_surface_status": {key: value for key, value in sorted(by_surface_status.items())},
         "epic_slices": {
             "epic_778": epic_778_slice,
+            "epic_791": epic_791_slice,
         },
         "rows": rows,
     }
@@ -647,6 +865,8 @@ def epic_row_record(
         record["work"] = spec["work"]
     if "reason" in spec:
         record["reason"] = spec["reason"]
+    if "planned_unmodeled_facts" in spec:
+        record["planned_unmodeled_facts"] = spec["planned_unmodeled_facts"]
     if row is None:
         return record
     record.update({
@@ -801,6 +1021,194 @@ def build_epic_778_slice(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def build_epic_791_slice(
+    rows: list[dict[str, Any]],
+    fact_status_by_id: dict[str, str],
+) -> dict[str, Any]:
+    rows_by_selector: dict[str, dict[str, Any]] = {}
+    rows_by_surface: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    errors: list[str] = []
+    for row in rows:
+        selector = row_selector(
+            row["pattern_id"],
+            row["language"],
+            row["candidate_priority"],
+        )
+        if selector in rows_by_selector:
+            errors.append(f"duplicate open audit row selector: {selector}")
+        rows_by_selector[selector] = row
+        rows_by_surface[row_surface_key(row["pattern_id"], row["language"])].append(row)
+
+    frozen_selectors: set[str] = set()
+    frozen_surface_keys: set[str] = set()
+    planned_facts_by_surface: dict[str, set[str]] = {}
+    planned_fact_ids = {
+        fact_id
+        for group in EPIC_791_FACT_GROUPS
+        for fact_id in group["facts"]
+    }
+    for spec in EPIC_791_BLOCKED_ROWS:
+        selector = row_selector(
+            spec["pattern_id"],
+            spec["language"],
+            spec["candidate_priority"],
+        )
+        surface_key = row_surface_key(spec["pattern_id"], spec["language"])
+        if selector in frozen_selectors:
+            errors.append(f"duplicate epic #791 frozen selector: {selector}")
+        if surface_key in frozen_surface_keys:
+            errors.append(f"duplicate epic #791 frozen surface: {surface_key}")
+        frozen_selectors.add(selector)
+        frozen_surface_keys.add(surface_key)
+        planned_row_facts = set(spec.get("planned_unmodeled_facts", []))
+        unplanned_spec_facts = sorted(planned_row_facts - planned_fact_ids)
+        if unplanned_spec_facts:
+            errors.append(
+                f"epic #791 row {surface_key} references facts outside planned "
+                f"fact groups: {', '.join(unplanned_spec_facts)}"
+            )
+        planned_facts_by_surface[surface_key] = planned_row_facts
+    frozen_rows: list[dict[str, Any]] = []
+    for spec in EPIC_791_BLOCKED_ROWS:
+        selector = row_selector(
+            spec["pattern_id"],
+            spec["language"],
+            spec["candidate_priority"],
+        )
+        surface_key = row_surface_key(spec["pattern_id"], spec["language"])
+        row = rows_by_selector.get(selector)
+        current_state = "present"
+        if row is None:
+            current_surface_rows = rows_by_surface.get(surface_key, [])
+            if current_surface_rows:
+                row = current_surface_rows[0]
+                current_state = "present-with-different-priority"
+        if row is not None and row["candidate_priority"] == "blocked-by-unmodeled-facts":
+            current_unmodeled_facts = set(row.get("unmodeled_facts", []))
+            planned_row_facts = planned_facts_by_surface[surface_key]
+            facts_outside_plan = sorted(current_unmodeled_facts - planned_row_facts)
+            if facts_outside_plan:
+                errors.append(
+                    f"epic #791 row {surface_key} is blocked by unplanned fact(s): "
+                    + ", ".join(facts_outside_plan)
+                )
+            modeled_blockers = sorted(
+                fact_id
+                for fact_id in current_unmodeled_facts
+                if fact_status_by_id.get(fact_id) in MODELED_FACT_STATUSES
+            )
+            if modeled_blockers:
+                errors.append(
+                    f"epic #791 row {surface_key} is still blocked by modeled fact(s): "
+                    + ", ".join(modeled_blockers)
+                )
+        frozen_rows.append(
+            epic_row_record(spec, row, current_open_audit_state=current_state)
+        )
+
+    current_blocked = [
+        row
+        for row in rows
+        if row["candidate_priority"] == "blocked-by-unmodeled-facts"
+    ]
+    current_actionable = [
+        row
+        for row in rows
+        if row["candidate_priority"] in ACTIONABLE_PRIORITIES
+    ]
+    unexpected_blocked = [
+        group_entry(row)
+        for row in current_blocked
+        if row_selector(row["pattern_id"], row["language"], row["candidate_priority"])
+        not in frozen_selectors
+        and row_surface_key(row["pattern_id"], row["language"])
+        not in frozen_surface_keys
+    ]
+    if unexpected_blocked:
+        errors.extend(
+            "unexpected blocked open row outside epic #791 slice: "
+            + group_entry_label(row)
+            for row in unexpected_blocked
+        )
+
+    fact_groups: list[dict[str, Any]] = []
+    for group in EPIC_791_FACT_GROUPS:
+        for fact_id in group["facts"]:
+            if fact_id not in fact_status_by_id:
+                errors.append(
+                    f"epic #791 fact group {group['group_id']} references "
+                    f"unknown proof fact: {fact_id}"
+                )
+        for surface_key in (
+            group["unblocks"] + group["focused_admission_after_group_lands"]
+        ):
+            if surface_key not in frozen_surface_keys:
+                errors.append(
+                    f"epic #791 fact group {group['group_id']} references "
+                    f"unknown frozen surface: {surface_key}"
+                )
+        if group["facts"]:
+            group_fact_ids = set(group["facts"])
+            for surface_key in group["unblocks"]:
+                planned_row_facts = planned_facts_by_surface.get(surface_key, set())
+                if surface_key in frozen_surface_keys and not (
+                    group_fact_ids & planned_row_facts
+                ):
+                    errors.append(
+                        f"epic #791 fact group {group['group_id']} does not "
+                        f"cover any planned blocker for {surface_key}"
+                    )
+        fact_groups.append({
+            **group,
+            "fact_statuses": {
+                fact_id: fact_status_by_id.get(fact_id, "missing")
+                for fact_id in group["facts"]
+            },
+        })
+
+    return {
+        "issue": 791,
+        "title": "Model neutral facts for blocked Type-4 surfaces",
+        "setup_issue": 792,
+        "closeout_issue": 799,
+        "predecessor_issue": 778,
+        "source": "bench/type4/open_surface_admission_audit.v1.json",
+        "scope_policy": {
+            "frozen_priority": "blocked-by-unmodeled-facts",
+            "predecessor_must_be_closed": 778,
+            "group_by": "neutral proof fact before language surface",
+            "unexpected_blocked_rows_are_errors": True,
+            "resolved_or_promoted_rows_are_allowed": True,
+        },
+        "summary": {
+            "frozen_blocked_count": len(frozen_rows),
+            "frozen_currently_blocked": sum(
+                1
+                for row in frozen_rows
+                if row["current_open_audit_state"] == "present"
+                and row.get("current_candidate_priority")
+                == "blocked-by-unmodeled-facts"
+            ),
+            "frozen_promoted_or_resolved": sum(
+                1
+                for row in frozen_rows
+                if row["current_open_audit_state"] != "present"
+                or row.get("current_candidate_priority")
+                != "blocked-by-unmodeled-facts"
+            ),
+            "current_blocked_open_count": len(current_blocked),
+            "current_actionable_open_count": len(current_actionable),
+            "unexpected_blocked_open_count": len(unexpected_blocked),
+            "fact_group_count": len(fact_groups),
+            "validation_error_count": len(errors),
+        },
+        "frozen_rows": sorted(frozen_rows, key=lambda row: int(row["order"])),
+        "fact_groups": sorted(fact_groups, key=lambda group: int(group["order"])),
+        "unexpected_blocked_open_rows": unexpected_blocked,
+        "validation_errors": errors,
+    }
+
+
 def selftest_row(
     pattern_id: str,
     language: str,
@@ -920,6 +1328,148 @@ def selftest() -> None:
         raise OpenSurfaceAuditError(
             "selftest expected blocked in-scope regression to fail"
         )
+
+    fact_status_by_id = {
+        fact_id: "specified-not-modeled"
+        for group in EPIC_791_FACT_GROUPS
+        for fact_id in group["facts"]
+    }
+    blocked_fact_rows = [
+        selftest_row(
+            spec["pattern_id"],
+            spec["language"],
+            spec["candidate_priority"],
+            unmodeled_facts=list(spec["planned_unmodeled_facts"]),
+        )
+        for spec in EPIC_791_BLOCKED_ROWS
+    ]
+    blocked_fact_slice = build_epic_791_slice(blocked_fact_rows, fact_status_by_id)
+    if blocked_fact_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected clean #791 slice, got "
+            + "; ".join(blocked_fact_slice["validation_errors"])
+        )
+    expected_blocked_summary = {
+        "frozen_blocked_count": 7,
+        "frozen_currently_blocked": 7,
+        "frozen_promoted_or_resolved": 0,
+        "current_blocked_open_count": 7,
+        "current_actionable_open_count": 0,
+        "unexpected_blocked_open_count": 0,
+        "fact_group_count": 7,
+        "validation_error_count": 0,
+    }
+    if blocked_fact_slice["summary"] != expected_blocked_summary:
+        raise OpenSurfaceAuditError(
+            f"selftest #791 summary drifted: {blocked_fact_slice['summary']}"
+        )
+
+    resolved_blocked_rows = blocked_fact_rows[:-1]
+    resolved_blocked_slice = build_epic_791_slice(
+        resolved_blocked_rows,
+        fact_status_by_id,
+    )
+    if resolved_blocked_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected resolved #791 rows to be allowed, got "
+            + "; ".join(resolved_blocked_slice["validation_errors"])
+        )
+    if resolved_blocked_slice["summary"]["frozen_promoted_or_resolved"] != 1:
+        raise OpenSurfaceAuditError(
+            "selftest #791 resolved row was not counted as promoted/resolved"
+        )
+
+    promoted_spec = EPIC_791_BLOCKED_ROWS[-1]
+    promoted_surface_key = row_surface_key(
+        promoted_spec["pattern_id"],
+        promoted_spec["language"],
+    )
+    promoted_blocked_rows = [
+        row
+        for row in blocked_fact_rows
+        if row_surface_key(row["pattern_id"], row["language"]) != promoted_surface_key
+    ] + [
+        selftest_row(
+            promoted_spec["pattern_id"],
+            promoted_spec["language"],
+            "proof-fact-ready",
+        )
+    ]
+    promoted_blocked_slice = build_epic_791_slice(
+        promoted_blocked_rows,
+        fact_status_by_id,
+    )
+    if promoted_blocked_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected promoted #791 row to be allowed, got "
+            + "; ".join(promoted_blocked_slice["validation_errors"])
+        )
+    promoted_entry = promoted_blocked_slice["frozen_rows"][-1]
+    if (
+        promoted_entry["current_open_audit_state"]
+        != "present-with-different-priority"
+        or promoted_entry.get("current_candidate_priority") != "proof-fact-ready"
+    ):
+        raise OpenSurfaceAuditError(
+            f"selftest #791 promoted row was not recorded: {promoted_entry}"
+        )
+
+    unexpected_blocked_rows = blocked_fact_rows + [
+        selftest_row(
+            "selftest.unexpected-pattern",
+            "Swift",
+            "blocked-by-unmodeled-facts",
+            unmodeled_facts=["selftest.unexpected-fact"],
+        )
+    ]
+    unexpected_blocked_slice = build_epic_791_slice(
+        unexpected_blocked_rows,
+        fact_status_by_id,
+    )
+    if not unexpected_blocked_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected unexpected #791 blocked row to fail"
+        )
+
+    unplanned_blocker_rows = [
+        {
+            **blocked_fact_rows[0],
+            "unmodeled_facts": ["selftest.unplanned-fact"],
+        }
+    ] + blocked_fact_rows[1:]
+    unplanned_blocker_slice = build_epic_791_slice(
+        unplanned_blocker_rows,
+        fact_status_by_id,
+    )
+    if not unplanned_blocker_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected unplanned #791 blocker fact to fail"
+        )
+
+    modeled_fact_status_by_id = {
+        fact_id: "modeled-controlled"
+        for group in EPIC_791_FACT_GROUPS
+        for fact_id in group["facts"]
+    }
+    modeled_blocker_slice = build_epic_791_slice(
+        blocked_fact_rows,
+        modeled_fact_status_by_id,
+    )
+    if not modeled_blocker_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected modeled #791 blocker fact to fail"
+        )
+
+    missing_fact_status_by_id = dict(fact_status_by_id)
+    missing_fact_status_by_id.pop("option.absence-channel.identity")
+    missing_fact_slice = build_epic_791_slice(
+        blocked_fact_rows,
+        missing_fact_status_by_id,
+    )
+    if not missing_fact_slice["validation_errors"]:
+        raise OpenSurfaceAuditError(
+            "selftest expected unknown #791 fact group id to fail"
+        )
     print("selftest OK")
 
 
@@ -1024,6 +1574,97 @@ def render_epic_778_slice(slice_report: dict[str, Any]) -> list[str]:
     return lines
 
 
+def format_selector_items(items: list[str]) -> str:
+    if not items:
+        return ""
+    return ", ".join(f"`{item}`" for item in items)
+
+
+def render_epic_791_slice(slice_report: dict[str, Any]) -> list[str]:
+    summary = slice_report["summary"]
+    lines = [
+        "## Epic #791 Neutral-Fact Blocked Slice",
+        "",
+        "This frozen slice tracks the open rows that are intentionally blocked",
+        "until missing language-neutral proof facts are modeled. It is grouped by",
+        "reusable proof fact stage before language surface so the next PRs do not",
+        "admit Ruby, Swift, Java, or map/HOF spellings directly.",
+        "",
+        f"- tracker issue: #{slice_report['issue']}",
+        f"- setup issue: #{slice_report['setup_issue']}",
+        f"- predecessor issue: #{slice_report['predecessor_issue']}",
+        f"- closeout issue: #{slice_report['closeout_issue']}",
+        f"- frozen blocked rows: {summary['frozen_blocked_count']} "
+        f"({summary['frozen_currently_blocked']} currently blocked)",
+        f"- promoted or resolved frozen rows: {summary['frozen_promoted_or_resolved']}",
+        f"- current blocked open rows: {summary['current_blocked_open_count']}",
+        f"- unexpected blocked open rows: {summary['unexpected_blocked_open_count']}",
+        "",
+        "### Fact Groups And Admission Order",
+        "",
+        "| order | issue | fact group | fact statuses | unblocks | focused admission candidates after group lands | intentionally still open |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for group in slice_report["fact_groups"]:
+        statuses = ", ".join(
+            f"`{fact}`:{status}"
+            for fact, status in group["fact_statuses"].items()
+        )
+        lines.append(
+            "| "
+            f"{group['order']} | "
+            f"#{group['issue']} | "
+            f"`{group['group_id']}` {markdown_cell(group['title'])} | "
+            f"{statuses} | "
+            f"{format_selector_items(group['unblocks'])} | "
+            f"{format_selector_items(group['focused_admission_after_group_lands'])} | "
+            f"{markdown_cell('; '.join(group['still_open_until']))} |"
+        )
+    lines.extend([
+        "",
+        "### Frozen Rows",
+        "",
+        "| order | issue | priority | pattern | language | current state | blocker | missing facts | work | surface |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ])
+    for row in slice_report["frozen_rows"]:
+        current_state = row["current_open_audit_state"]
+        if row.get("current_candidate_priority") != row["candidate_priority"]:
+            current_state = (
+                f"{current_state} (`{row.get('current_candidate_priority', '')}`)"
+            )
+        lines.append(
+            "| "
+            f"{row['order']} | "
+            f"#{row['issue']} | "
+            f"`{row['candidate_priority']}` | "
+            f"`{row['pattern_id']}` | "
+            f"{row['language']} | "
+            f"{current_state} | "
+            f"{markdown_cell(row.get('likely_blocker', ''))} | "
+            f"{', '.join(f'`{fact}`' for fact in row.get('unmodeled_facts', []))} | "
+            f"{markdown_cell(row['work'])} | "
+            f"{markdown_cell(row.get('surface', ''))} |"
+        )
+    if slice_report["unexpected_blocked_open_rows"]:
+        lines.extend([
+            "",
+            "### Unexpected Blocked Rows",
+            "",
+            "| pattern | language | priority | blocker |",
+            "|---|---|---|---|",
+        ])
+        for row in slice_report["unexpected_blocked_open_rows"]:
+            lines.append(
+                "| "
+                f"`{row['pattern_id']}` | "
+                f"{row['language']} | "
+                f"`{row['candidate_priority']}` | "
+                f"{markdown_cell(row['likely_blocker'])} |"
+            )
+    return lines
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     summary = report["summary"]
     lines = [
@@ -1047,6 +1688,8 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
     ]
     lines.extend(render_epic_778_slice(report["epic_slices"]["epic_778"]))
+    lines.extend([""])
+    lines.extend(render_epic_791_slice(report["epic_slices"]["epic_791"]))
     lines.extend([
         "",
         "## Candidate Rows",
@@ -1228,6 +1871,11 @@ def main() -> int:
         if epic_778_errors:
             raise OpenSurfaceAuditError(
                 "epic #778 audit slice is invalid: " + "; ".join(epic_778_errors)
+            )
+        epic_791_errors = report["epic_slices"]["epic_791"]["validation_errors"]
+        if epic_791_errors:
+            raise OpenSurfaceAuditError(
+                "epic #791 audit slice is invalid: " + "; ".join(epic_791_errors)
             )
         json_text = json.dumps(report, indent=2, sort_keys=True) + "\n"
         markdown = render_markdown(report)

--- a/bench/type4/open_surface_admission_audit.v1.json
+++ b/bench/type4/open_surface_admission_audit.v1.json
@@ -944,6 +944,449 @@
       "title": "Audit-ready focused admissions for open Type-4 surfaces",
       "unexpected_actionable_open_rows": [],
       "validation_errors": []
+    },
+    "epic_791": {
+      "closeout_issue": 799,
+      "fact_groups": [
+        {
+          "fact_statuses": {
+            "option.absence-channel.identity": "specified-not-modeled"
+          },
+          "facts": [
+            "option.absence-channel.identity"
+          ],
+          "focused_admission_after_group_lands": [
+            "option.presence-default.proven-channel-coordinate:Ruby",
+            "option.presence-default.proven-channel-coordinate:Swift"
+          ],
+          "group_id": "option.absence-channel",
+          "issue": 793,
+          "order": 1,
+          "still_open_until": [
+            "hof.filter-map.option-emission:Swift waits for callback purity and filter-map coordinates"
+          ],
+          "title": "Option absence-channel identity",
+          "unblocks": [
+            "option.presence-default.proven-channel-coordinate:Ruby",
+            "option.presence-default.proven-channel-coordinate:Swift",
+            "hof.filter-map.option-emission:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {
+            "effect.pure-callback": "specified-not-modeled"
+          },
+          "facts": [
+            "effect.pure-callback"
+          ],
+          "focused_admission_after_group_lands": [],
+          "group_id": "effect.hof-callback-purity",
+          "issue": 794,
+          "order": 2,
+          "still_open_until": [
+            "compactMap waits for option-emission coordinate facts",
+            "flatMap waits for one-level flatten and nested traversal facts"
+          ],
+          "title": "Higher-order callback effect safety",
+          "unblocks": [
+            "hof.filter-map.option-emission:Swift",
+            "hof.flat-map.one-level-flatten:Swift",
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {
+            "hof.filter-map.drop-condition-coordinate": "specified-not-modeled",
+            "hof.filter-map.emitted-value-coordinate": "specified-not-modeled"
+          },
+          "facts": [
+            "hof.filter-map.drop-condition-coordinate",
+            "hof.filter-map.emitted-value-coordinate"
+          ],
+          "focused_admission_after_group_lands": [
+            "hof.filter-map.option-emission:Swift"
+          ],
+          "group_id": "hof.filter-map.coordinates",
+          "issue": 795,
+          "order": 3,
+          "still_open_until": [],
+          "title": "Filter-map drop and emitted-value coordinates",
+          "unblocks": [
+            "hof.filter-map.option-emission:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {
+            "collection.flatten-depth.one-level": "specified-not-modeled",
+            "hof.flat-map.emitted-value-coordinate": "specified-not-modeled",
+            "hof.flat-map.nested-iteration-order": "specified-not-modeled"
+          },
+          "facts": [
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate"
+          ],
+          "focused_admission_after_group_lands": [
+            "hof.flat-map.one-level-flatten:Swift"
+          ],
+          "group_id": "hof.flat-map.one-level-stream",
+          "issue": 796,
+          "order": 4,
+          "still_open_until": [
+            "flat-map aggregate reductions wait for aggregate guard-coordinate proof"
+          ],
+          "title": "One-level flat-map source and emitted stream",
+          "unblocks": [
+            "hof.flat-map.one-level-flatten:Swift",
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {
+            "hof.flat-map.aggregate-guard-coordinate": "specified-not-modeled"
+          },
+          "facts": [
+            "hof.flat-map.aggregate-guard-coordinate"
+          ],
+          "focused_admission_after_group_lands": [
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift"
+          ],
+          "group_id": "hof.flat-map.aggregate-guard",
+          "issue": 797,
+          "order": 5,
+          "still_open_until": [],
+          "title": "Flat-map aggregate guard coordinate",
+          "unblocks": [
+            "hof.flat-map.aggregate-reduction:Java",
+            "hof.flat-map.aggregate-reduction:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {
+            "map.default.absence-fallback": "specified-not-modeled",
+            "map.default.key-fallback-coordinate": "specified-not-modeled",
+            "map.receiver.no-intervening-mutation": "specified-not-modeled",
+            "map.receiver.source-identity": "specified-not-modeled"
+          },
+          "facts": [
+            "map.default.absence-fallback",
+            "map.receiver.source-identity",
+            "map.default.key-fallback-coordinate",
+            "map.receiver.no-intervening-mutation"
+          ],
+          "focused_admission_after_group_lands": [
+            "map.default.absence-lookup:Swift"
+          ],
+          "group_id": "map.default.receiver-fallback",
+          "issue": 798,
+          "order": 6,
+          "still_open_until": [],
+          "title": "Map default receiver and fallback coordinates",
+          "unblocks": [
+            "map.default.absence-lookup:Swift"
+          ]
+        },
+        {
+          "fact_statuses": {},
+          "facts": [],
+          "focused_admission_after_group_lands": [],
+          "group_id": "blocked-surface-closeout",
+          "issue": 799,
+          "order": 7,
+          "still_open_until": [
+            "any row still open after #793-#798 must carry stronger blocker or replay evidence"
+          ],
+          "title": "Blocked-surface closeout and replay evidence",
+          "unblocks": []
+        }
+      ],
+      "frozen_rows": [
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "coverage-sweep",
+          "issue": 793,
+          "language": "Ruby",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 1,
+          "pattern_focused_support": {
+            "hard_negative": 6,
+            "hard_negative_group": 1,
+            "positive": 3
+          },
+          "pattern_id": "option.presence-default.proven-channel-coordinate",
+          "planned_unmodeled_facts": [
+            "option.absence-channel.identity"
+          ],
+          "reason": "only the absence-channel fact is unmodeled, but the focused Ruby nil? perimeter is not sound until that fact lands",
+          "selector": "option.presence-default.proven-channel-coordinate:Ruby:blocked-by-unmodeled-facts",
+          "surface": "nil comparison coverage exists in the sweep; Ruby nil? admission still needs a focused proof perimeter before modeled-controlled status",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "option.absence-channel.identity"
+          ],
+          "work": "model absence-channel identity before Ruby nil?/nil comparison admission"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "probe-only",
+          "issue": 793,
+          "language": "Swift",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 2,
+          "pattern_focused_support": {
+            "hard_negative": 6,
+            "hard_negative_group": 1,
+            "positive": 3
+          },
+          "pattern_id": "option.presence-default.proven-channel-coordinate",
+          "planned_unmodeled_facts": [
+            "option.absence-channel.identity"
+          ],
+          "reason": "probe evidence exists, but Optional presence/defaulting still needs a proven absence channel before focused admission",
+          "selector": "option.presence-default.proven-channel-coordinate:Swift:blocked-by-unmodeled-facts",
+          "surface": "Optional nil presence probe coverage exists; defaulting and full API/coordinate/mutation perimeter remain open",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "option.absence-channel.identity"
+          ],
+          "work": "model absence-channel identity before Swift Optional presence/defaulting admission"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "missing",
+          "issue": 795,
+          "language": "Swift",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 3,
+          "pattern_focused_support": {
+            "hard_negative": 5,
+            "hard_negative_group": 0,
+            "positive": 2
+          },
+          "pattern_id": "hof.filter-map.option-emission",
+          "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.filter-map.drop-condition-coordinate",
+            "hof.filter-map.emitted-value-coordinate",
+            "option.absence-channel.identity"
+          ],
+          "reason": "after option channel and callback purity, compactMap still needs filter-map coordinate facts before admission",
+          "selector": "hof.filter-map.option-emission:Swift:blocked-by-unmodeled-facts",
+          "surface": "Sequence.compactMap after optional-result channel and callback-effect proof",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.filter-map.drop-condition-coordinate",
+            "hof.filter-map.emitted-value-coordinate",
+            "option.absence-channel.identity"
+          ],
+          "work": "model Swift compactMap drop-condition and emitted-value coordinates"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "missing",
+          "issue": 796,
+          "language": "Swift",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 4,
+          "pattern_focused_support": {
+            "hard_negative": 5,
+            "hard_negative_group": 0,
+            "positive": 2
+          },
+          "pattern_id": "hof.flat-map.one-level-flatten",
+          "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level"
+          ],
+          "reason": "Sequence.flatMap admission requires a reusable one-level flatten proof, not Swift API spelling alone",
+          "selector": "hof.flat-map.one-level-flatten:Swift:blocked-by-unmodeled-facts",
+          "surface": "Sequence.flatMap after focused one-level flatten and callback-effect evidence",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level"
+          ],
+          "work": "model one-level flatten, nested-order, and emitted-value facts for Swift flatMap"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "missing",
+          "issue": 797,
+          "language": "Java",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 5,
+          "pattern_focused_support": {
+            "hard_negative": 6,
+            "hard_negative_group": 0,
+            "positive": 4
+          },
+          "pattern_id": "hof.flat-map.aggregate-reduction",
+          "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate"
+          ],
+          "reason": "aggregate reduction facts are modeled, but flat-map traversal and guard-coordinate facts are still missing",
+          "selector": "hof.flat-map.aggregate-reduction:Java:blocked-by-unmodeled-facts",
+          "surface": "Stream.flatMap terminal reductions after flat-map source proof is connected to stream aggregate facts",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate"
+          ],
+          "work": "connect Java Stream.flatMap aggregate reductions after flat-map source facts land"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "missing",
+          "issue": 797,
+          "language": "Swift",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 6,
+          "pattern_focused_support": {
+            "hard_negative": 6,
+            "hard_negative_group": 0,
+            "positive": 4
+          },
+          "pattern_id": "hof.flat-map.aggregate-reduction",
+          "planned_unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate"
+          ],
+          "reason": "terminal aggregate identity is reusable only after the flattened element stream and guard coordinates are proven",
+          "selector": "hof.flat-map.aggregate-reduction:Swift:blocked-by-unmodeled-facts",
+          "surface": "Sequence.flatMap terminal aggregates after one-level flatten and terminal identity evidence",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "effect.pure-callback",
+            "hof.flat-map.nested-iteration-order",
+            "hof.flat-map.emitted-value-coordinate",
+            "collection.flatten-depth.one-level",
+            "hof.flat-map.aggregate-guard-coordinate"
+          ],
+          "work": "connect Swift flatMap terminal aggregates after one-level flatten facts land"
+        },
+        {
+          "candidate_priority": "blocked-by-unmodeled-facts",
+          "current_candidate_priority": "blocked-by-unmodeled-facts",
+          "current_open_audit_state": "present",
+          "evidence_level": "missing",
+          "issue": 798,
+          "language": "Swift",
+          "likely_blocker": "model required facts before detector admission",
+          "order": 7,
+          "pattern_focused_support": {
+            "hard_negative": 2,
+            "hard_negative_group": 0,
+            "positive": 4
+          },
+          "pattern_id": "map.default.absence-lookup",
+          "planned_unmodeled_facts": [
+            "map.default.absence-fallback",
+            "map.receiver.source-identity",
+            "map.default.key-fallback-coordinate",
+            "map.receiver.no-intervening-mutation"
+          ],
+          "reason": "default subscript admission needs absent-key fallback and receiver-coordinate proof instead of subscript spelling",
+          "selector": "map.default.absence-lookup:Swift:blocked-by-unmodeled-facts",
+          "surface": "Dictionary default subscript after receiver-coordinate proof",
+          "surface_focused_support": {
+            "hard_negative": 0,
+            "hard_negative_group": 0,
+            "positive": 0
+          },
+          "surface_status": "open",
+          "unmodeled_facts": [
+            "map.default.absence-fallback",
+            "map.receiver.source-identity",
+            "map.default.key-fallback-coordinate",
+            "map.receiver.no-intervening-mutation"
+          ],
+          "work": "model Swift Dictionary default lookup receiver, key, fallback, and mutation facts"
+        }
+      ],
+      "issue": 791,
+      "predecessor_issue": 778,
+      "scope_policy": {
+        "frozen_priority": "blocked-by-unmodeled-facts",
+        "group_by": "neutral proof fact before language surface",
+        "predecessor_must_be_closed": 778,
+        "resolved_or_promoted_rows_are_allowed": true,
+        "unexpected_blocked_rows_are_errors": true
+      },
+      "setup_issue": 792,
+      "source": "bench/type4/open_surface_admission_audit.v1.json",
+      "summary": {
+        "current_actionable_open_count": 0,
+        "current_blocked_open_count": 7,
+        "fact_group_count": 7,
+        "frozen_blocked_count": 7,
+        "frozen_currently_blocked": 7,
+        "frozen_promoted_or_resolved": 0,
+        "unexpected_blocked_open_count": 0,
+        "validation_error_count": 0
+      },
+      "title": "Model neutral facts for blocked Type-4 surfaces",
+      "unexpected_blocked_open_rows": [],
+      "validation_errors": []
     }
   },
   "rows": [

--- a/docs/type4-semantic-pattern-loop.md
+++ b/docs/type4-semantic-pattern-loop.md
@@ -111,11 +111,13 @@ adjacent hard negatives, and executable expectations. Leave
 modeled-controlled.
 
 When an epic selects multiple audit rows, freeze that selection in the audit
-artifact itself. The `Epic #778 Audit Slice` section records the chosen
-in-scope rows, the rows intentionally left out because they need new neutral
-facts, and the issue numbers that own each step. Later PRs should update that
-section by regenerating `open_surface_admission_audit.py` as rows leave the
-open audit instead of hand-editing the Markdown or re-triaging the whole queue.
+artifact itself. The epic slice records the chosen rows, the issue numbers that
+own each step, and the rows intentionally left open. For fact-modeling epics,
+such as `Epic #791 Neutral-Fact Blocked Slice`, group the work by reusable proof
+fact before language spelling and mark unexpected `blocked-by-unmodeled-facts`
+rows as drift. Later PRs should update the section by regenerating
+`open_surface_admission_audit.py` as rows leave the open audit instead of
+hand-editing the Markdown or re-triaging the whole queue.
 
 ## Eight-step loop
 


### PR DESCRIPTION
## Summary

- Freeze the #791 blocked Type-4 audit slice in `open_surface_admission_audit` with 7 current `blocked-by-unmodeled-facts` rows.
- Group the slice by reusable neutral proof-fact stages instead of language/API spelling.
- Add validation so unexpected blocked rows, unplanned blocker facts, stale modeled blockers, unknown fact IDs, and bad fact-group surface references fail the audit check.
- Refresh generated audit artifacts and document the fact-modeling slice in the Type-4 workflow docs.

## Review

Three independent pre-PR reviews were requested.

- Reviewer 1 found a blocking gap: frozen rows were not tied to planned neutral facts. Fixed by adding `planned_unmodeled_facts`, stricter #791 validation, and selftests for unplanned/modeled/missing blocker drift. Re-review: no findings.
- Reviewer 2 found misleading wording around `can admit after group lands`. Fixed by renaming it to focused admission candidates after group lands. Re-review: no findings.
- Reviewer 3 found fact-group typo risk. Fixed by making missing proof fact IDs validation errors with selftest coverage. Re-review: no findings.

## Validation

- `python3 bench/type4/open_surface_admission_audit.py --selftest`
- `python3 bench/type4/open_surface_admission_audit.py --check`
- `python3 -m json.tool bench/type4/open_surface_admission_audit.v1.json >/dev/null`
- `git diff --check`
- `./scripts/check-docs.sh`
- `./scripts/check-ci-local.sh --fast`

Closes #792
