### PR TITLE
bench: refresh post-#817 missed-worthy frontier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
             --check-markdown bench/labels/missed_worthy_grouping_pricing_2026_07_11.summary.md
           python3 bench/labels/recall_ceiling_probe.py \
             --validate-closeout bench/labels/missed_worthy_frontier_closeout_2026_07_11.v1.json
+          python3 bench/labels/recall_ceiling_probe.py \
+            --validate bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+          python3 bench/labels/missed_worthy_stage_audit.py \
+            --validate bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json \
+            --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+          python3 bench/labels/recall_ceiling_probe.py \
+            --validate-decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json \
+            --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+          python3 bench/labels/missed_worthy_source_bounds.py \
+            --validate bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json \
+            --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+            --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
+          python3 bench/labels/missed_worthy_heldout_confirmation.py \
+            --validate bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json \
+            --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+            --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
       - name: current accepted-pair coverage artifacts
         run: |
           python3 bench/labels/accepted_pair_coverage.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added the #820 post-#817 missed-worthy frontier: snapshot-aware validation that preserves
+  #816, exact combined dev/held-out evaluation and zero-regression comparison, regenerated
+  raw stages, chronology- and source-bound dev decisions, a held-out-source-free mechanical
+  confirmation, and the bounded connected-witness follow-up #821.
 - Added the #816 current missed-worthy frontier audit: complete nose 0.18.0
   reproduction provenance, exact v5-worthy recall counts, a frozen seven-language
   dev source audit, raw extraction/candidate/accepted stage evidence, one-time

--- a/bench/labels/README.md
+++ b/bench/labels/README.md
@@ -186,6 +186,16 @@ success criterion before held-out;
 one-time passing confirmation to that gate. Method and results are documented in
 [`docs/accepted-pair-coverage-817.md`](../../docs/accepted-pair-coverage-817.md).
 
+The post-#817 #820 refresh is
+`recall_ceiling_probe_post_817_2026_07_12.v1.json`, paired with the combined product
+evaluation, regenerated dev stage audit, v2 dev decisions, source bounds, and one-time v2
+held-out stage confirmation. Frontier validation is keyed by the evaluation digest, so the
+historical #816 profile and post-#817 profile both remain strict while unregistered count
+substitutions fail. The source-bound comparison selects six coherent and three no-go rows
+from the complete candidate-only + sub-DAG>=20 dev cohort; same-unit and heterogeneous
+extraction evidence remain separate. Method, exact IDs, and #821 gates are in
+[`docs/missed-worthy-frontier-820.md`](../../docs/missed-worthy-frontier-820.md).
+
 `query_json_agent_audit_2026_06_10.json` records the #216 agent-usability audit of the
 query-JSON contract: 18 sampled families, JSON-only decisions graded against source,
 and the ranked evidence-gap list. See

--- a/bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
+++ b/bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
@@ -1,0 +1,924 @@
+{
+  "audit_method": {
+    "exploratory_preselection_ids": [
+      "curl:2a436119a08187ba",
+      "mockito:d82f6e75097748da",
+      "ripgrep:519afdcaed73af0d"
+    ],
+    "heldout_source_inspected": false,
+    "notes": "All rows use the frozen post-#817 selection and dev-only stage evidence. Sixteen exact hashes reuse unchanged #816 decisions. The three disclosed planning reads remain exploratory; the other sixteen new rows were reviewed only after selection and stage commits. No held-out source was rendered or judged.",
+    "selection_frozen_commit": "59530c575060abb0e6ce672efca4bad85e74c40f",
+    "stage_evidence_frozen_commit": "5d55ec439915e7a1994eaf1242f96a29303a2b81"
+  },
+  "classification_summary": {
+    "candidate-generation": 6,
+    "connected-anchor-or-subdag-construction": 7,
+    "no-coherent-general-mechanism": 9,
+    "same-unit-actionable-fragment": 3,
+    "unit-extraction-or-missing-unit-kind": 10
+  },
+  "decisions": [
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "mockito:db2a627e3c414165",
+      "candidate_sha256": "6f54e260b213a96cf5cb6661fe9c6aad46bdc484cbbd587c818993e953b2de41",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The first member is one six-argument overload, while the second label span crosses several three-to-five-argument overloads. The optimistic inline lift comes from adding the enclosing 325-line class, which is neither one sibling helper nor a pure single-return unit, so it is not evidence for helper inlining or one connected clone.",
+      "smallest_sound_invariant": "Do not turn a multi-method label span into one inline candidate unless one explicit, pure helper call accounts for the shared computation on both sides.",
+      "source_evidence": [
+        {
+          "end_line": 288,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "observation": "This side is one complete Answer6 adapter method.",
+          "start_line": 272
+        },
+        {
+          "end_line": 227,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "observation": "This label span contains multiple independent overload methods rather than one callable helper.",
+          "start_line": 119
+        }
+      ]
+    },
+    {
+      "blocker_classification": "same-unit-actionable-fragment",
+      "candidate_key": "gorm:b2cd9c61ce98289a",
+      "candidate_sha256": "89cbc2c55eac3f4c6c36d7bbf97711fe5602fd0b863de4b3190a4ee7991043c7",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "Both members are adjacent LEFT/RIGHT JOIN rows inside the same TestJoin table. The only extracted unit is the enclosing test function, so whole-unit pairing cannot represent the repeated struct-literal window without also reporting the entire already-parameterized test.",
+      "smallest_sound_invariant": "A same-unit proposal must identify two disjoint repeated initializer windows and keep the varying join type, name, and SQL text as explicit parameters.",
+      "source_evidence": [
+        {
+          "end_line": 40,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "observation": "Two disjoint table rows share the Join/Where initializer skeleton and vary only row data.",
+          "start_line": 19
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "packaging:aea1981ddc32dcf4",
+      "candidate_sha256": "47c95e3d4deac0f49167dd6cfcc855c1112af180394060c15aff79c19e4a5037",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The duplicated value is the ten-row pytest parameter table in decorators at lines 23-36 and 60-73. Function extraction starts at the def bodies, so the relevant decorator/table data never becomes a comparable unit even though nearby test functions do.",
+      "smallest_sound_invariant": "Extract a pytest parametrize decorator and its literal case table as test metadata, separate from the decorated function body.",
+      "source_evidence": [
+        {
+          "end_line": 36,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "observation": "The first decorator owns the repeated ten-case name table.",
+          "start_line": 23
+        },
+        {
+          "end_line": 73,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "observation": "The second decorator repeats that table for a different assertion body.",
+          "start_line": 60
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "serde_json:3f1d50e522be29ae",
+      "candidate_sha256": "e9c065ca3ff8bf83c2678ffe174e2b3a4740238cd7be16d38ba3c39a5bee4464",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "missing-unit",
+      "rationale": "Neither Rust test is extracted. Each function contains a local tuple struct plus a local Serialize impl, followed by the same three non-finite map assertions for f32 or f64, so candidate logic has no units to compare.",
+      "smallest_sound_invariant": "Rust test-function extraction must retain a function that contains local item declarations and impl blocks without promoting those local items into unrelated top-level units.",
+      "source_evidence": [
+        {
+          "end_line": 2037,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "observation": "The f32 test contains a local F32Bits type/impl and three repeated assertions.",
+          "start_line": 2011
+        },
+        {
+          "end_line": 2066,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "observation": "The f64 test has the same function shape with type-width substitutions.",
+          "start_line": 2040
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "curl:08e1435f8564adf7",
+      "candidate_sha256": "b5aeb2fa7a54e29886f9554ab06d42bb95879127b8b3cc627f14d655e545dbaf",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "Both unit tests contain one connected cleanup and failure-accounting tail, but raw extraction exposes only the larger enclosing functions and emits no candidate for the labeled region. A candidate must anchor the shared address-list exit, cleanup calls, and problem branch while excluding the different diagnostics before them.",
+      "smallest_sound_invariant": "Generate a cross-unit fragment only when one contiguous control-flow region has matching entry, exit, and side-effect order on both sides; disconnected whole-function mass is insufficient.",
+      "source_evidence": [
+        {
+          "end_line": 227,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "observation": "This connected tail advances the address list, releases three resources, and accounts for the problem flag.",
+          "start_line": 209
+        },
+        {
+          "end_line": 209,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "observation": "The second test has the same ordered tail after a different validation ladder.",
+          "start_line": 191
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "curl:2a436119a08187ba",
+      "candidate_sha256": "82a67204587605f18a10cfcea9666a15e6fd1a6b525a40dae287cc61435a208b",
+      "judgment_origin": "exploratory-before-820-freeze",
+      "observed_stage": "candidate-only",
+      "rationale": "The raw detector already emits a candidate for two cohesive validation ladders. Each converts an address, checks null asymmetry, compares address and port, and exits through the same problem path. This source was read before the #820 selection freeze, so the positive judgment remains exploratory.",
+      "smallest_sound_invariant": "Acceptance requires one connected mapped witness spanning the ordered guards and error exits on both sides; intersection mass alone cannot satisfy it.",
+      "source_evidence": [
+        {
+          "end_line": 190,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "observation": "The first loop has a connected conversion and four-check validation ladder with a common failure exit.",
+          "start_line": 149
+        },
+        {
+          "end_line": 189,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "observation": "The second loop implements the same ladder with only conversion diagnostic text changed.",
+          "start_line": 148
+        }
+      ]
+    },
+    {
+      "blocker_classification": "same-unit-actionable-fragment",
+      "candidate_key": "git:1d9b1c7f444d15d0",
+      "candidate_sha256": "0605378cce63ec592aafd62b787673acbb7a2b9697afbc18db849313fcfcfb29",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "These are disjoint branches inside set_option that parse the same true/false vocabulary, assign one option field, and return identically. The enclosing function would be misleading output, but the two six-line branches are bounded sites.",
+      "smallest_sound_invariant": "Compare only distinct non-overlapping statement windows with closed control flow inside one function, and emit those windows rather than the enclosing function.",
+      "source_evidence": [
+        {
+          "end_line": 81,
+          "file": "bench/repos/git/remote-curl.c",
+          "observation": "The progress branch parses a boolean, assigns one field, rejects other values, and returns.",
+          "start_line": 74
+        },
+        {
+          "end_line": 106,
+          "file": "bench/repos/git/remote-curl.c",
+          "observation": "The deepen-relative branch is a disjoint instance of the same bounded shape.",
+          "start_line": 99
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "tmux:6c7a09c2a9c5c2b2",
+      "candidate_sha256": "9b3c61ac9465a247ebfabfcf4a955aea2f93934b44a7d72bcef627ebe5964c06",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The ranges overlap on lines 341-346 and are shifted windows over one cursor-advancement sequence, not two refactoring locations. Treating them as a pair would duplicate one site and manufacture sliding-window clones.",
+      "smallest_sound_invariant": "Same-unit candidates must be disjoint after location collapse; overlapping or nested windows represent one site.",
+      "source_evidence": [
+        {
+          "end_line": 351,
+          "file": "bench/repos/tmux/layout-custom.c",
+          "observation": "Both members occupy this single parser sequence and share the comma check at lines 341-346.",
+          "start_line": 336
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "jq:c0adad57af0c4d06",
+      "candidate_sha256": "1072745a4b89b9daa9e056d5c50764034ea9a080206ea407b514c8f60d843dd4",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "gen_error and gen_const are complete sibling functions with the same allocate, constant assignment, and block-return graph, parameterized by opcode. Their structural intersection is too small to emit a candidate, while the inline ceiling incorrectly counts one whole sibling as augmentation.",
+      "smallest_sound_invariant": "Small sibling units may match when their complete operation graph agrees under explicit constant parameters; inline augmentation may not count one side twice.",
+      "source_evidence": [
+        {
+          "end_line": 151,
+          "file": "bench/repos/jq/src/compile.c",
+          "observation": "gen_error allocates ERRORK, stores the constant, and returns its block.",
+          "start_line": 146
+        },
+        {
+          "end_line": 158,
+          "file": "bench/repos/jq/src/compile.c",
+          "observation": "gen_const performs the same complete sequence for LOADK.",
+          "start_line": 153
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "delve:de84b1952aa09a8e",
+      "candidate_sha256": "9129174bbac4023a963efac616e7f35a52b736b11e1904ba1f0dfde0faab507f",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "Unsigned and signed DWARF constant readers reach candidate generation but not acceptance. Their switch/control skeleton is coherent, while every signed case adds a width-specific sign conversion, so the multiset mass is not yet a connected shared witness.",
+      "smallest_sound_invariant": "A shared witness may cover the opcode-width dispatch and common error/stack tail only if each signed conversion is exposed as an explicit variation rather than erased.",
+      "source_evidence": [
+        {
+          "end_line": 341,
+          "file": "bench/repos/delve/pkg/dwarf/op/op.go",
+          "observation": "constnu and constns share dispatch and tail control but the signed arm changes each decoded value.",
+          "start_line": 290
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "zap:23de1a83b5d5ff94",
+      "candidate_sha256": "5bc3f8cfe16e43bce128a9d5cff8cfa5b85e5930a321e16ac2e25e3da81771dd",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "Both MarshalLogArray methods are complete seven-line units implementing the same error-accumulating AppendObject loop for different slice element types. Symbol/receiver identity leaves only mass five and no direct candidate despite a coherent whole-method abstraction.",
+      "smallest_sound_invariant": "Candidate generation may abstract receiver and element symbols only while preserving the ordered fold of every AppendObject error into multierr.Append.",
+      "source_evidence": [
+        {
+          "end_line": 91,
+          "file": "bench/repos/zap/benchmarks/zap_test.go",
+          "observation": "The users receiver folds AppendObject errors across its slice.",
+          "start_line": 85
+        },
+        {
+          "end_line": 476,
+          "file": "bench/repos/zap/sugar.go",
+          "observation": "invalidPairs repeats the same ordered fold in production code.",
+          "start_line": 470
+        }
+      ]
+    },
+    {
+      "blocker_classification": "same-unit-actionable-fragment",
+      "candidate_key": "chi:154bd73cf15a6de5",
+      "candidate_sha256": "818c4cdb58b65284187992985c8c892352bf2def26eacc7b2b2d88a813984d10",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The repeated RouteHeaders setup lives in two t.Run closures, but extraction represents both only through the 176-line enclosing TestRouteHeaders function. The actionable unit is a same-function test window, not a whole-function semantic clone.",
+      "smallest_sound_invariant": "A Go subtest fragment must remain bounded to one t.Run callback and must not merge setup from neighboring subtests in the enclosing test.",
+      "source_evidence": [
+        {
+          "end_line": 108,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "observation": "One subtest builds the host route plus a default handler.",
+          "start_line": 90
+        },
+        {
+          "end_line": 179,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "observation": "A later subtest repeats the host route and next-handler setup without a default.",
+          "start_line": 160
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "cobra:db88c9b581c2c760",
+      "candidate_sha256": "3c255fd3352ee4dc071afc43147cd945d0a7353eda757f4898cbd85bfcf5ff11",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "missing-unit",
+      "rationale": "Two complete top-level test helpers differ only in their literal completion table, but the raw stage finds no overlapping unit. This supports retaining small Go helper declarations as units, not broadening acceptance.",
+      "smallest_sound_invariant": "Extract each complete named Go function as a distinct scope-bound unit even when small, before ordinary candidate generation.",
+      "source_evidence": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/cobra/completions_test.go",
+          "observation": "validArgsFunc is one complete helper with a two-row completion table.",
+          "start_line": 27
+        },
+        {
+          "end_line": 53,
+          "file": "bench/repos/cobra/completions_test.go",
+          "observation": "validArgsFunc2 repeats the full helper and changes only table values.",
+          "start_line": 41
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "graphhopper:2acc71582f85cc79",
+      "candidate_sha256": "a4d67823c8ec861ddf2b850b5744598119502832a5bb8a9af5cac9f2c45f5a51",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "The two BFS tests reach candidate generation but not acceptance. Their connected common block is the anonymous BreadthFirstSearch subclass that records visited nodes; the graph fixtures and expected traversal sequences intentionally differ.",
+      "smallest_sound_invariant": "The witness must be exactly the anonymous recorder subclass and must leave graph construction and expected traversal order outside the shared region.",
+      "source_evidence": [
+        {
+          "end_line": 59,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "observation": "testBFS defines the reusable recorder subclass before its larger graph fixture.",
+          "start_line": 44
+        },
+        {
+          "end_line": 98,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "observation": "testBFS2 repeats the same subclass before a different graph.",
+          "start_line": 83
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "gson:4014d594ab6a8e54",
+      "candidate_sha256": "4703ef0be15ca03e40b43336f7e8fefc53dd90edbf1a81d19ed170939c7047c3",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "wrap and unwrap are inverse lookup tables, not duplicate computations: every condition and return swaps primitive and wrapper roles. A shared bidirectional data table may be a valid manual design, but treating inverse mappings as one semantic clone would generalize far beyond this source fact.",
+      "smallest_sound_invariant": "Do not infer refactorability from parallel branch counts when corresponding predicates and results are reversed; a declared bidirectional mapping would be required.",
+      "source_evidence": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "observation": "wrap maps primitive class tokens to wrappers.",
+          "start_line": 63
+        },
+        {
+          "end_line": 99,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "observation": "unwrap intentionally reverses every mapping.",
+          "start_line": 87
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "mockito:d82f6e75097748da",
+      "candidate_sha256": "ffce9aa676545670fa722b6aac6c466679b9ecab9a930776e524c8bf20752790",
+      "judgment_origin": "exploratory-before-820-freeze",
+      "observed_stage": "candidate-only",
+      "rationale": "The candidate joins two complete tests sharing setup, invocation, listener verification, and a nested matcher. Expected count and found-versus-null are legitimate parameters. This source was read before the #820 freeze and is recorded as exploratory.",
+      "smallest_sound_invariant": "Accept only a connected witness mapping complete test phases and the nested matcher while retaining expected values as parameters.",
+      "source_evidence": [
+        {
+          "end_line": 60,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "observation": "The first test verifies the two-stubbing and found-stubbing case.",
+          "start_line": 32
+        },
+        {
+          "end_line": 89,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "observation": "The second test has the same phase graph for the default-answer case.",
+          "start_line": 62
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "commons-lang:7deea4aa415c6197",
+      "candidate_sha256": "e7d43c53204c6d5cc2532e8deac1d82bb99ce8646354117a395ef6eecd14d2aa",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "missing-unit",
+      "rationale": "Two complete JUnit methods enumerate the same comparison matrix for double and float, yet the raw stage exposes no overlapping units. Recovery first needs a full Java test-method unit rather than independent assertion rows.",
+      "smallest_sound_invariant": "Extract a complete test method as one scoped unit even when its body is a repeated assertion matrix; never combine rows within one method into locations.",
+      "source_evidence": [
+        {
+          "end_line": 294,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+          "observation": "testCompareDouble is a complete exhaustive matrix.",
+          "start_line": 211
+        },
+        {
+          "end_line": 379,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+          "observation": "testCompareFloat repeats it with the numeric type changed.",
+          "start_line": 296
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "poetry:08556e25e7ab80e4",
+      "candidate_sha256": "e2363e766aa4eec9fde3402b25b7638df17c4112fe28ed78fb42a4d4638f7d2e",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The two test functions share a connected Chef construction, fixture lookup, prepare call, wheel-name/tempdir checks, and cleanup. Different editable flags and one ZipFile assertion keep their whole-unit fingerprints apart, leaving no direct candidate despite a coherent test-helper shape.",
+      "smallest_sound_invariant": "Candidate abstraction may vary fixture name, editable mode, expected wheel name, and optional archive assertion while preserving Chef construction, prepare, and cleanup order.",
+      "source_evidence": [
+        {
+          "end_line": 80,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "observation": "The base directory test constructs Chef, prepares a fixture, checks the wheel, and unlinks it.",
+          "start_line": 63
+        },
+        {
+          "end_line": 125,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "observation": "The editable case repeats the lifecycle with an editable flag and one archive assertion.",
+          "start_line": 105
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "scrapy:be72d6b46ad8eaf1",
+      "candidate_sha256": "6963b79dc8e4de4ceecd58c6b4c029e31dfd9ff7de15f4a4d3dd6faa92274441",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "follow and follow_all both forward a long keyword list, but they implement different selector validation and call different superclass methods with scalar versus iterable URL contracts. The common multiset is mostly argument plumbing, not one connected computation whose extraction is clearly actionable.",
+      "smallest_sound_invariant": "Do not equate calls solely because their keyword names match; the callee and scalar-versus-iterable contract must remain identical for a shared call fragment.",
+      "source_evidence": [
+        {
+          "end_line": 219,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "observation": "follow validates one selector and calls super().follow with a scalar url.",
+          "start_line": 200
+        },
+        {
+          "end_line": 292,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "observation": "follow_all expands selector lists and calls super().follow_all with iterable urls.",
+          "start_line": 267
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "poetry:053a58bae5b5c441",
+      "candidate_sha256": "9e6f3d7b7cb1dd263a5146e3a3df310dc43024b44997023d6b8ee0f016abf688",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The repeated artifact is the identical four-row pytest parameter table at lines 40-47 and 135-142. Extracted function bodies differ by available versus failed keyring behavior, while decorator metadata is not represented as its own unit.",
+      "smallest_sound_invariant": "Represent the literal pytest case table independently from the decorated function so identical test data can be suggested without merging backend behavior.",
+      "source_evidence": [
+        {
+          "end_line": 47,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "observation": "The available-backend test declares the shared username/password table.",
+          "start_line": 40
+        },
+        {
+          "end_line": 142,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "observation": "The unavailable-backend test repeats the table verbatim.",
+          "start_line": 135
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "requests:8465ccbf517afa52",
+      "candidate_sha256": "214b609709c65f27e46ed4d9cfc080ae9a0686a1a7922de797bf0ab9c0cc537e",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "missing-unit",
+      "rationale": "The class-contained tests share prepare, read-to-end, rewind, and reread phases, but raw stage reports a missing unit. Initial offset and expected suffix are coherent parameters.",
+      "smallest_sound_invariant": "Extract each class-contained Python test method as a scoped unit, preserving its method boundary and setup-to-assertion order.",
+      "source_evidence": [
+        {
+          "end_line": 1997,
+          "file": "bench/repos/requests/tests/test_requests.py",
+          "observation": "test_rewind_body is one complete full-read scenario.",
+          "start_line": 1986
+        },
+        {
+          "end_line": 2011,
+          "file": "bench/repos/requests/tests/test_requests.py",
+          "observation": "test_rewind_partially_read_body repeats it with an initial offset.",
+          "start_line": 1999
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "thor:07e233ddffad07f0",
+      "candidate_sha256": "c3607b8739203183114dff0787b5aa08759c4fb42acca06dbd7fb183d1e90149",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "The two RSpec examples reach candidate generation but not acceptance. Their complete expectation sequence is connected and differs only in Basic versus Readline editor class/name, making a shared example plausible if that variation remains explicit.",
+      "smallest_sound_invariant": "The witness must preserve the ordered constructor, readline expectation, and public LineEditor assertion while parameterizing only the selected editor class and label.",
+      "source_evidence": [
+        {
+          "end_line": 22,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "observation": "The Readline example has a three-expectation sequence.",
+          "start_line": 17
+        },
+        {
+          "end_line": 42,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "observation": "The Basic example repeats the sequence with one class substitution.",
+          "start_line": 37
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "rspec-core:a1957f9937b645c3",
+      "candidate_sha256": "4b5c0e4ef02ef4adb85997167c46a25c3d219c181b06a45dc684b53d917153f8",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The members are fragments of two long expected transcripts. They share boilerplate prefix text but describe different successful and aborted histories. Inline mass comes from enclosing examples, not one pure helper or complete clone.",
+      "smallest_sound_invariant": "Do not turn shared prefixes of expected literals into a family unless the complete bounded values share one parameterizable structure.",
+      "source_evidence": [
+        {
+          "end_line": 220,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "observation": "This heredoc describes an aborted bisect and abort-specific output.",
+          "start_line": 207
+        },
+        {
+          "end_line": 42,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "observation": "This heredoc describes a successful multi-round bisect.",
+          "start_line": 29
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "rubocop:1eead1acc41e3d0d",
+      "candidate_sha256": "b9fe0551e7f284c68a940eae1203bc687056637aa0ecfff6c80435de3ac434ae",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "One member is a single offense example while the other spans over two hundred lines and many independent examples, negative cases, and contexts. The inline ceiling is suite-wide mass.",
+      "smallest_sound_invariant": "A span crossing independent tests cannot become one clone member by adding its enclosing suite or context.",
+      "source_evidence": [
+        {
+          "end_line": 262,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "observation": "This side is one complete hash-access offense example.",
+          "start_line": 249
+        },
+        {
+          "end_line": 249,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "observation": "The other span crosses many independent positive and negative examples.",
+          "start_line": 34
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "jekyll:2791928407ad302c",
+      "candidate_sha256": "83fed4df03ca9b53775245f533e6f4c4d841d5c20bac934c03948545976e4934",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "candidate-only",
+      "rationale": "The candidate joins complete sibling replacement methods. Both normalize an expected expression, build the same assignment, and call assert_equal; collection conversion is the parameter. A full-method connected witness is coherent even below the sub-DAG floor.",
+      "smallest_sound_invariant": "Map one complete sibling method control/data graph to the other, representing collection conversion as a parameter rather than erasing it.",
+      "source_evidence": [
+        {
+          "end_line": 134,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "observation": "The hash method normalizes braces and emits the shared template.",
+          "start_line": 124
+        },
+        {
+          "end_line": 146,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "observation": "The array method repeats the graph with percent/Array normalization.",
+          "start_line": 136
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "rack:b7b0b53fbcbab71c",
+      "candidate_sha256": "a28b9f78fb129b1e8c865743008ea1b9c245bb756a16eb93b5a7169e35284956",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "candidate-only",
+      "rationale": "The header checks share iteration and a status guard, but content-type returns while content-length mutates instance state and continues. Erasing this effect boundary would make an unsafe helper.",
+      "smallest_sound_invariant": "A shared control skeleton is insufficient when corresponding branches have different return and mutation effects.",
+      "source_evidence": [
+        {
+          "end_line": 799,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "observation": "The content-type check validates and returns.",
+          "start_line": 789
+        },
+        {
+          "end_line": 814,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "observation": "The content-length check validates, mutates state, and continues.",
+          "start_line": 804
+        }
+      ]
+    },
+    {
+      "blocker_classification": "connected-anchor-or-subdag-construction",
+      "candidate_key": "ripgrep:519afdcaed73af0d",
+      "candidate_sha256": "8cc801b76980e41c492850a8eb29d633df91772439d70a1e8022ff40c3830d00",
+      "judgment_origin": "exploratory-before-820-freeze",
+      "observed_stage": "candidate-only",
+      "rationale": "The candidate joins cohesive configuration blocks in separate by-line branches. Each sets the terminator and pushes normal and every-line TesterConfig rows. It is coherent, but the source was read before the #820 freeze and remains exploratory.",
+      "smallest_sound_invariant": "Accept only the connected statement-and-construction witness, retaining label and line-number state as parameters.",
+      "source_evidence": [
+        {
+          "end_line": 575,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "observation": "The no-line-number branch emits the normal and every-line configurations.",
+          "start_line": 559
+        },
+        {
+          "end_line": 613,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "observation": "The line-number branch repeats the connected two-row construction.",
+          "start_line": 597
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "serde_json:946bfa61cb71d562",
+      "candidate_sha256": "d9014a0c4450f8a1a2798507d4ccce4c51d43e7720bf3cb98d64d39ffa5b5756",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "candidate-only",
+      "rationale": "mul_test and imul_test share extensive numeric test data, but one operation returns a new value while the other mutates its receiver. A callback abstraction would need to erase a real effect/ownership distinction, so this is not direct evidence for a pure HOF law or one sound semantic match.",
+      "smallest_sound_invariant": "Do not fold returning and in-place mutation operations through one callback unless mutation, ownership, and result equivalence are proven explicitly.",
+      "source_evidence": [
+        {
+          "end_line": 502,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "observation": "mul returns a new ExtendedFloat and the test asserts that value.",
+          "start_line": 474
+        },
+        {
+          "end_line": 556,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "observation": "imul mutates its receiver and the helper asserts post-mutation state.",
+          "start_line": 527
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "serde_json:2515a9bc2af59ece",
+      "candidate_sha256": "62c870bf522611ae0c96dac81e5c421eab766b1e7bd25c2f84319fe7b8d2e427",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The members live in named local functions has_next_element and has_next_key nested in trait methods. Raw extraction exposes outer methods but not local items, so no candidate can represent their shared delimiter and error-control logic.",
+      "smallest_sound_invariant": "Extract a named Rust local function as its own scope-bound unit; do not assemble a fragment from unrelated outer-method parts.",
+      "source_evidence": [
+        {
+          "end_line": 1962,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "observation": "has_next_element is a complete local function inside next_element_seed.",
+          "start_line": 1937
+        },
+        {
+          "end_line": 2018,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "observation": "has_next_key is the corresponding local function inside next_key_seed.",
+          "start_line": 1990
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "serde_json:8dc63e0bf59dff86",
+      "candidate_sha256": "403bd910e440a367948b99a06941c25603cb84bbdf0205b255c951760a1f360e",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "These are matching whitespace-and-EOF prefixes of the same two Rust local functions. They confirm the local-item gap, but the prefix must not be admitted directly; complete local functions must be extracted first.",
+      "smallest_sound_invariant": "Surface complete named local items with scope identity, then apply connected matching to full units; a prefix alone is not a family.",
+      "source_evidence": [
+        {
+          "end_line": 1945,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "observation": "The sequence local function begins with whitespace parsing and a list EOF error.",
+          "start_line": 1937
+        },
+        {
+          "end_line": 1996,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "observation": "The map local function repeats it with an object EOF error.",
+          "start_line": 1990
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "swr:9b7a03feec3a4cce",
+      "candidate_sha256": "e2c696c8e4ae43729bbd7ed107be9b9fab9fa3238563adbba9db3581eba6e1a7",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "missing-unit",
+      "rationale": "Both members are try/catch mutation windows inside separate async it callbacks, and neither has an extracted unit. The enclosing test callbacks include different mutation histories, so candidate work cannot start until nested test/try regions are represented.",
+      "smallest_sound_invariant": "Extract one async test callback or try/catch window as a bounded test unit while preserving awaited mutation order and catch behavior.",
+      "source_evidence": [
+        {
+          "end_line": 1413,
+          "file": "bench/repos/swr/test/use-swr-local-mutation.test.tsx",
+          "observation": "The first test catches a failed optimistic mutation to baz.",
+          "start_line": 1403
+        },
+        {
+          "end_line": 1473,
+          "file": "bench/repos/swr/test/use-swr-local-mutation.test.tsx",
+          "observation": "The second test repeats the catch window with qux after a different history.",
+          "start_line": 1463
+        }
+      ]
+    },
+    {
+      "blocker_classification": "unit-extraction-or-missing-unit-kind",
+      "candidate_key": "axios:2169018b8e46a6b6",
+      "candidate_sha256": "7c053d4386e72b2a87fa6c19877b813c6e4c195e4d5bb916bdf49728b7356e01",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "missing-unit",
+      "rationale": "Both are complete async callbacks passed to it and repeat the request adapter plus assertion while varying maxRate data. Raw stage has no unit, so the boundary is a recognized test callback, not an arbitrary anonymous function.",
+      "smallest_sound_invariant": "For an explicit test-DSL call, extract its callback as one scoped test unit; do not generalize the allowlist to arbitrary callbacks.",
+      "source_evidence": [
+        {
+          "end_line": 56,
+          "file": "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js",
+          "observation": "The first it callback is a complete numeric maxRate case.",
+          "start_line": 43
+        },
+        {
+          "end_line": 71,
+          "file": "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js",
+          "observation": "The second repeats it for a tuple value.",
+          "start_line": 58
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "zod:e6c204c8d398e185",
+      "candidate_sha256": "82c6cd02f99bcee27a22f0ce51b8179097a191ccc81e7cc26fb29e62e74413e8",
+      "judgment_origin": "prior-frozen-816",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "isValidIP and isValidCidr are complete ten-line functions with identical two-version control flow and only regex-family substitutions. Their intersection mass is 12, below the anchor floor, and no direct candidate is emitted despite a coherent parameterized validator.",
+      "smallest_sound_invariant": "Generate a candidate only when both ordered v4/v6 guards and the final false return align, exposing the two regex references as paired parameters.",
+      "source_evidence": [
+        {
+          "end_line": 696,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "observation": "isValidIP checks v4 then v6 IP regexes and returns false otherwise.",
+          "start_line": 687
+        },
+        {
+          "end_line": 729,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "observation": "isValidCidr repeats the control flow with CIDR regexes.",
+          "start_line": 720
+        }
+      ]
+    },
+    {
+      "blocker_classification": "no-coherent-general-mechanism",
+      "candidate_key": "jest:4c55eff3b52a86ff",
+      "candidate_sha256": "9679975d447841d1d453dac826bd359d78fd5adc300ee1d3ae6b19b29672f6cc",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "The sync and async methods intentionally duplicate an algorithm across different effect models and APIs. Erasing await and Async suffixes is a language-specific shortcut, not a sound neutral witness.",
+      "smallest_sound_invariant": "Do not equate synchronous and asynchronous operations by erasing await or API suffixes; effect compatibility must be explicit.",
+      "source_evidence": [
+        {
+          "end_line": 388,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "observation": "resolveModule calls synchronous APIs and returns a string.",
+          "start_line": 373
+        },
+        {
+          "end_line": 410,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "observation": "resolveModuleAsync awaits distinct APIs and returns a Promise.",
+          "start_line": 390
+        }
+      ]
+    },
+    {
+      "blocker_classification": "candidate-generation",
+      "candidate_key": "axios:e4b2c19f4886a989",
+      "candidate_sha256": "250df6c0c2a309504c84e4f57ebcf127f92e4a1e04650aee84af6c1a364d352e",
+      "judgment_origin": "post-820-selection-freeze",
+      "observed_stage": "extracted-no-candidate",
+      "rationale": "getParams and getData are complete siblings with the same try/parse/catch/diagnostic/return graph, parameterized by input element and label. Extraction finds them but current small mass emits no candidate.",
+      "smallest_sound_invariant": "Generate a candidate for complete small sibling functions only when one connected control-and-effect graph matches under explicit parameters.",
+      "source_evidence": [
+        {
+          "end_line": 406,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "observation": "getParams parses one element and reports its JSON error.",
+          "start_line": 399
+        },
+        {
+          "end_line": 415,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "observation": "getData repeats the complete graph for another element.",
+          "start_line": 408
+        }
+      ]
+    }
+  ],
+  "dev_proposal": {
+    "cohort_comparison": {
+      "connected-candidate-subdag": {
+        "coverage": "complete",
+        "dev_ceiling": 9,
+        "selected_reviewed": 9,
+        "source_coherent": 6,
+        "source_no_go": 3
+      },
+      "missing-unit-extraction": {
+        "coverage": "sampled-heterogeneous",
+        "dev_ceiling": 33,
+        "selected_reviewed": 6,
+        "source_coherent": 6,
+        "source_no_go": 0
+      },
+      "same-unit-window": {
+        "coverage": "sampled",
+        "dev_ceiling": 16,
+        "selected_reviewed": 4,
+        "source_coherent": 3,
+        "source_no_go": 1
+      }
+    },
+    "dev_success_gate": {
+      "connected_witness_required": true,
+      "forbidden_recovery_ids": [
+        "gson:4014d594ab6a8e54",
+        "scrapy:be72d6b46ad8eaf1",
+        "serde_json:946bfa61cb71d562"
+      ],
+      "max_false_merges": 0,
+      "max_worthy_regressions": 0,
+      "required_recovery_ids": [
+        "curl:2a436119a08187ba",
+        "delve:de84b1952aa09a8e",
+        "graphhopper:2acc71582f85cc79",
+        "mockito:d82f6e75097748da",
+        "ripgrep:519afdcaed73af0d",
+        "thor:07e233ddffad07f0"
+      ]
+    },
+    "hard_negatives": [
+      "Do not admit disconnected optimistic multiset mass as a witness.",
+      "Do not infer A-C equivalence from A-B and B-C evidence.",
+      "Do not lower candidate or acceptance thresholds, ranking, or default-surface policy.",
+      "Do not recover gson:4014d594ab6a8e54, scrapy:be72d6b46ad8eaf1, or serde_json:946bfa61cb71d562.",
+      "Do not report an enclosing function for a bounded same-unit fragment.",
+      "Do not hide a language-specific shortcut inside the connected-witness rule."
+    ],
+    "heldout_source_confirmation": "not-run",
+    "mechanical_dev_ids": [
+      "curl:2a436119a08187ba",
+      "delve:de84b1952aa09a8e",
+      "graphhopper:2acc71582f85cc79",
+      "gson:4014d594ab6a8e54",
+      "mockito:d82f6e75097748da",
+      "ripgrep:519afdcaed73af0d",
+      "scrapy:be72d6b46ad8eaf1",
+      "serde_json:946bfa61cb71d562",
+      "thor:07e233ddffad07f0"
+    ],
+    "mechanism": "For an existing direct raw candidate, construct one actually connected shared control/data witness on both endpoints and require it for acceptance. Keep candidate generation, thresholds, ranking, default-surface policy, and grouping unchanged.",
+    "next_action": "open-connected-witness-implementation-issue",
+    "output_growth_budget": {
+      "max_default_output_growth_pct": 2,
+      "max_runtime_regression_ms": 5,
+      "max_runtime_regression_pct": 5,
+      "max_unrelated_added_rows": 0,
+      "pricing_protocol": "#809 alternating base/head plus same-binary control"
+    },
+    "selected_tranche": "connected-candidate-subdag-witness",
+    "selection_rationale": "The complete nine-row candidate-only plus sub-DAG>=20 dev cohort has six coherent witnesses and three no-go controls. Same-unit has three positives in a four-row sample but needs bounded-fragment output, while six sampled missing-unit rows are real yet split across unrelated language and construct boundaries.",
+    "separate_cohorts": {
+      "candidate-generation": "Extracted units without a raw candidate remain separate.",
+      "no-coherent-general-mechanism": "Mass accidents and effect mismatches remain hard negatives.",
+      "same-unit-window": "Disjoint fragment output needs its own language-bounded contract.",
+      "unit-extraction": "Go helpers, Java/Python tests, Rust local items, and JavaScript callbacks require separate extraction laws."
+    },
+    "smallest_sound_invariant": "Every newly accepted pair carries one connected mapped witness on both sides whose entry, exit, ordering, and relevant effects are preserved; multiset mass and transitive A-B-C overlap never substitute for it.",
+    "source_coherent_ids": [
+      "curl:2a436119a08187ba",
+      "delve:de84b1952aa09a8e",
+      "graphhopper:2acc71582f85cc79",
+      "mockito:d82f6e75097748da",
+      "ripgrep:519afdcaed73af0d",
+      "thor:07e233ddffad07f0"
+    ],
+    "source_no_go_ids": [
+      "gson:4014d594ab6a8e54",
+      "scrapy:be72d6b46ad8eaf1",
+      "serde_json:946bfa61cb71d562"
+    ],
+    "status": "frozen-before-heldout-confirmation"
+  },
+  "judgment_origin_summary": {
+    "exploratory-before-820-freeze": 3,
+    "post-820-selection-freeze": 16,
+    "prior-frozen-816": 16
+  },
+  "prior_decisions_artifact": {
+    "path": "bench/labels/missed_worthy_audit_decisions_2026_07_11.dev.v1.json",
+    "sha256": "137863fb62d02ac3784832d3f0729f0ff800ef2306e43d15e30c97f3eb621d8e"
+  },
+  "schema": "nose.missed_worthy_dev_audit.v2",
+  "selection_sha256": "419ab53ca32c9d33443c64dca03687220d2d92940e47bb8dd2df4b61e40d3712",
+  "source_artifact": {
+    "path": "bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json",
+    "sha256": "b3c3b8c6ba5581f5679bc6de685be52c63a40790640784f98c58597e002f57ac"
+  },
+  "split": "dev",
+  "stage_artifact": {
+    "path": "bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json",
+    "sha256": "2a3ca53a7933d78a8d52083f2c9788c6b686d08cffb5f85af380e56ee7719477"
+  }
+}

--- a/bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json
+++ b/bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json
@@ -1,0 +1,194 @@
+{
+  "decisions": {
+    "path": "bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json",
+    "sha256": "33bbdbd3a3aebc9467d156f3472b54224b3875b60a97c3fa47f2762fb0ba95a2"
+  },
+  "files": {
+    "bench/repos/axios/sandbox/client.html": {
+      "line_count": 522,
+      "sha256": "1343bd4c22fb019c10a26cffa97d391c45dc21ed938cb68fc3f52cbb72e6b08b",
+      "size_bytes": 14126
+    },
+    "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js": {
+      "line_count": 105,
+      "sha256": "aa3b03684c0f25aff1d95531e7bd37c0fa18c9ce86d0a2218924ffa1266d1e7b",
+      "size_bytes": 2694
+    },
+    "bench/repos/chi/middleware/route_headers_test.go": {
+      "line_count": 212,
+      "sha256": "dd48799f1da69155927452801354ef413a97b1a83109fc8ad5f0560ae1f66906",
+      "size_bytes": 5766
+    },
+    "bench/repos/cobra/completions_test.go": {
+      "line_count": 4129,
+      "sha256": "3f8a8aabe2d279b84313fbfa08a08728008a8bc61744ab3522e7cee73b3faba9",
+      "size_bytes": 119057
+    },
+    "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java": {
+      "line_count": 2017,
+      "sha256": "e9e84bb52075b749cf19b82fca03ccbf4df0a2cd7132e03ee0774936f6a93ca2",
+      "size_bytes": 105510
+    },
+    "bench/repos/curl/tests/unit/unit1607.c": {
+      "line_count": 233,
+      "sha256": "ef2139fecc490cf2d1a2af04773cca19ead31a55a85546e727810a161252f911",
+      "size_bytes": 7026
+    },
+    "bench/repos/curl/tests/unit/unit1609.c": {
+      "line_count": 216,
+      "sha256": "f6eb827476492d45e5dd3b29630e1395b8a9b072e45339614a795a85ec786fbd",
+      "size_bytes": 6656
+    },
+    "bench/repos/delve/pkg/dwarf/op/op.go": {
+      "line_count": 573,
+      "sha256": "afab18becd06663e000067a9a961fabc3739fea7a07f6e6b24bcb129c454d124",
+      "size_bytes": 14176
+    },
+    "bench/repos/git/remote-curl.c": {
+      "line_count": 1670,
+      "sha256": "9cc520ab00619ee8bc65409efc365d717674c47275d6eb777135983a6548b19b",
+      "size_bytes": 44923
+    },
+    "bench/repos/gorm/clause/joins_test.go": {
+      "line_count": 101,
+      "sha256": "c761c41314fbfc10542f242fd24a97e00914c4ab4a9cdba0ee6b801da42ad24f",
+      "size_bytes": 2695
+    },
+    "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java": {
+      "line_count": 114,
+      "sha256": "36a867368544e6d35ae7e8cda6ef4e755d870d4688bdb99c875f309e2db0b4cd",
+      "size_bytes": 3398
+    },
+    "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java": {
+      "line_count": 100,
+      "sha256": "dbee9175d2fb298f3a13589584590e99c638379e8be6f26d2c893259ca9756d7",
+      "size_bytes": 3516
+    },
+    "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb": {
+      "line_count": 150,
+      "sha256": "0bedbbdd222fd8f846f36c60c4f61f78199de1b3af1c95b90d84577d9d01bbfa",
+      "size_bytes": 4525
+    },
+    "bench/repos/jest/packages/jest-resolve/src/resolver.ts": {
+      "line_count": 962,
+      "sha256": "c341e57e91b2f50dcab1a2c811dece57ac3356f34290395eb8cd08ebce9bb4c8",
+      "size_bytes": 29174
+    },
+    "bench/repos/jq/src/compile.c": {
+      "line_count": 1397,
+      "sha256": "4ac446f5e38ad723e83cf763a9b7841a38ffdbf995dcf176e69d31ea6eaaa8c8",
+      "size_bytes": 44648
+    },
+    "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java": {
+      "line_count": 353,
+      "sha256": "d9574c12db0e790b4f81bc416fa31a0d7fe84832e919d25cb2df40d148d10969",
+      "size_bytes": 13662
+    },
+    "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java": {
+      "line_count": 206,
+      "sha256": "f7f1355c63bf70c11bc342bbab2e81c34923cdc98bb47cbe5438c34ff17e3bd1",
+      "size_bytes": 7969
+    },
+    "bench/repos/packaging/tests/test_utils.py": {
+      "line_count": 232,
+      "sha256": "566c84b0152388685eaf11abfbb9973039f301f42ffb05b1fa7ddb11c860c209",
+      "size_bytes": 6706
+    },
+    "bench/repos/poetry/tests/installation/test_chef.py": {
+      "line_count": 171,
+      "sha256": "1769d4cfbbafc138067891d8b4a6b7cf3bc58fb5a817ab34828c945cd475b567",
+      "size_bytes": 4995
+    },
+    "bench/repos/poetry/tests/utils/test_password_manager.py": {
+      "line_count": 408,
+      "sha256": "ae4c7b20e2352ff39994f0f1ae60d64104cf2ea77974b5a6d1530753c87bf4da",
+      "size_bytes": 12130
+    },
+    "bench/repos/rack/lib/rack/lint.rb": {
+      "line_count": 1000,
+      "sha256": "7ea50621021b3beeb10d5fef687c03727a02b5e8a6ada5247950798462ff85bb",
+      "size_bytes": 44976
+    },
+    "bench/repos/requests/tests/test_requests.py": {
+      "line_count": 3068,
+      "sha256": "c97eaf5958378b2117fdb88b5df031002772a9f24ba5484b91fe983c5f51cc80",
+      "size_bytes": 107631
+    },
+    "bench/repos/ripgrep/crates/searcher/src/testutil.rs": {
+      "line_count": 797,
+      "sha256": "34055e71ee830bdc897686554a3be65499150e1d67a7d4cde45d7bf9aa9e9e2b",
+      "size_bytes": 27568
+    },
+    "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb": {
+      "line_count": 224,
+      "sha256": "cd0a7bd8619060b4fe7fdb37492deabc58f8f3629dcea1d34c94e6f6c7faae1c",
+      "size_bytes": 9597
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb": {
+      "line_count": 429,
+      "sha256": "d3d56de1d121a4ed33644e400da65ce9eef7e98a595b31c1b49c91e597885aac",
+      "size_bytes": 12365
+    },
+    "bench/repos/scrapy/scrapy/http/response/text.py": {
+      "line_count": 314,
+      "sha256": "643bd223b3a19260f2bb30beb589baeafbb7d6da222b13bca4060d55d79a11a9",
+      "size_bytes": 11334
+    },
+    "bench/repos/serde_json/src/de.rs": {
+      "line_count": 2714,
+      "sha256": "4998d7e252eb513be85b298e287048b4fb283882e9ba7df905f572f07200f3f3",
+      "size_bytes": 86840
+    },
+    "bench/repos/serde_json/tests/lexical/float.rs": {
+      "line_count": 581,
+      "sha256": "0440f2d85c993bcccd925096d7f4136bf624ffd66b3c7ee565d158390685eb11",
+      "size_bytes": 14186
+    },
+    "bench/repos/serde_json/tests/test.rs": {
+      "line_count": 2567,
+      "sha256": "5c6e629525978c8fd190bdbbe3d62ff391bc8c8e86c143a0087b34ae2e7923e9",
+      "size_bytes": 76680
+    },
+    "bench/repos/swr/test/use-swr-local-mutation.test.tsx": {
+      "line_count": 1960,
+      "sha256": "165cbfe0ccd14cee6505c8a976dfd80ed978e287bca99d535203360aa939282f",
+      "size_bytes": 51494
+    },
+    "bench/repos/thor/spec/line_editor_spec.rb": {
+      "line_count": 44,
+      "sha256": "5bc7535b9e84f20d9984ce86965cf3678da4bd36f4b69227b72421d39b5393a5",
+      "size_bytes": 1344
+    },
+    "bench/repos/tmux/layout-custom.c": {
+      "line_count": 426,
+      "sha256": "e6d6efe80f16dcac9693c28cc48c98a3cd88da306e5e3223b5489abd701f2843",
+      "size_bytes": 9851
+    },
+    "bench/repos/zap/benchmarks/zap_test.go": {
+      "line_count": 173,
+      "sha256": "b1322c63b7fde7950e1819b6b50cc652b933b8f05d1a16b8f9344b950a434113",
+      "size_bytes": 4348
+    },
+    "bench/repos/zap/sugar.go": {
+      "line_count": 476,
+      "sha256": "de0dce48d7803a5438107a98dbeb692974f25ad0797f3d7b952b3a7f7eb5b447",
+      "size_bytes": 16003
+    },
+    "bench/repos/zod/packages/zod/src/v3/types.ts": {
+      "line_count": 5138,
+      "sha256": "1cfe15702dbccfc592bb46679bb6979c6b1b44b9790114a01447436849f0900d",
+      "size_bytes": 160328
+    }
+  },
+  "method": "line bounds derived from the hash-checked frozen source bytes",
+  "provenance": {
+    "git_sha": "4e0b067f9349eeb0b16fe97595186ac818a92e25",
+    "working_tree_status_before_measurement": ""
+  },
+  "schema": "nose.missed_worthy_source_bounds.dev.v1",
+  "source_artifact": {
+    "path": "bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json",
+    "sha256": "b3c3b8c6ba5581f5679bc6de685be52c63a40790640784f98c58597e002f57ac"
+  },
+  "split": "dev"
+}

--- a/bench/labels/missed_worthy_frontier.py
+++ b/bench/labels/missed_worthy_frontier.py
@@ -35,6 +35,10 @@ CHECKED_RECALL_PROFILES = {
         "dev": {"hits": 2626, "n": 2849},
         "heldout": {"hits": 1949, "n": 2091},
     },
+    "f7410ef73c1ab0ccd5ca23d938a032ee0a539ee57be662b4aa4d9045b93d6ce0": {
+        "dev": {"hits": 2691, "n": 2849},
+        "heldout": {"hits": 1996, "n": 2091},
+    },
 }
 REQUIRED_RESIDUAL_LANES = (
     "inline-ceiling",
@@ -1301,6 +1305,16 @@ def render_dev_context(artifact: dict[str, Any], output: Path, context_lines: in
 
 
 def run_self_test() -> None:
+    for digest, expected in CHECKED_RECALL_PROFILES.items():
+        checked = {
+            "sha256": digest,
+            "expected_worthy_recall": expected,
+        }
+        _require(
+            checked_recall_profile(checked) == expected,
+            f"registered recall profile {digest} did not round-trip",
+        )
+
     pre_817_input = {
         "sha256": "2664d2935eaf8e86243dcf3592225c9f4884154ac7757c1307fd2a4281688e2c",
         "expected_worthy_recall": {
@@ -1308,11 +1322,6 @@ def run_self_test() -> None:
             "heldout": {"hits": 1949, "n": 2091},
         },
     }
-    _require(
-        checked_recall_profile(pre_817_input)
-        == pre_817_input["expected_worthy_recall"],
-        "registered recall profile did not round-trip",
-    )
     unregistered = json.loads(json.dumps(pre_817_input))
     unregistered["sha256"] = "f" * 64
     try:

--- a/bench/labels/missed_worthy_frontier.py
+++ b/bench/labels/missed_worthy_frontier.py
@@ -41,6 +41,13 @@ CHECKED_RECALL_PROFILES = {
         "heldout": {"hits": 1996, "n": 2091},
     },
 }
+CHECKED_COMPARISON_PROFILES = {
+    "f7410ef73c1ab0ccd5ca23d938a032ee0a539ee57be662b4aa4d9045b93d6ce0": {
+        "delta": 112,
+        "recovered_count": 112,
+        "regressed_count": 0,
+    },
+}
 REQUIRED_RESIDUAL_LANES = (
     "inline-ceiling",
     "same-unit-window",
@@ -124,6 +131,19 @@ def validate_evaluation_recall(
             {"hits": actual.get("hits"), "n": actual.get("n")} == expected,
             f"checked evaluation {split} worthy recall drifted",
         )
+
+
+def validate_evaluation_comparison(evaluation: object, digest: str) -> None:
+    expected = CHECKED_COMPARISON_PROFILES.get(digest)
+    if expected is None:
+        return
+    _require(isinstance(evaluation, dict), "checked evaluation: expected an object")
+    comparison = evaluation.get("comparison")
+    _require(isinstance(comparison, dict), "checked evaluation comparison missing")
+    worthy = comparison.get("worthy_recall")
+    _require(isinstance(worthy, dict), "checked evaluation worthy comparison missing")
+    actual = {field: worthy.get(field) for field in expected}
+    _require(actual == expected, "checked evaluation comparison drifted")
 
 
 def project_path(path: str) -> Path:
@@ -497,6 +517,10 @@ def validate_artifact(
                 )
         evaluation = json.loads(resolved_inputs["evaluation_report"].read_text())
         validate_evaluation_recall(evaluation, expected_recall)
+        validate_evaluation_comparison(
+            evaluation,
+            inputs["evaluation_report"]["sha256"],
+        )
         corpus_payload = json.loads(resolved_inputs["corpus_manifest"].read_text())
         repositories = corpus_payload.get("repositories")
         _require(isinstance(repositories, list), "corpus manifest repositories missing")
@@ -1665,6 +1689,30 @@ def run_self_test() -> None:
         _require("heldout worthy recall drifted" in str(error), "metric drift failed unclearly")
     else:
         raise AssertionError("a checked evaluation metric substitution was accepted")
+
+    comparison_evaluation = {
+        "comparison": {
+            "worthy_recall": {
+                "delta": 112,
+                "recovered_count": 112,
+                "regressed_count": 0,
+            }
+        }
+    }
+    validate_evaluation_comparison(
+        comparison_evaluation,
+        "f7410ef73c1ab0ccd5ca23d938a032ee0a539ee57be662b4aa4d9045b93d6ce0",
+    )
+    comparison_evaluation["comparison"]["worthy_recall"]["regressed_count"] = 1
+    try:
+        validate_evaluation_comparison(
+            comparison_evaluation,
+            "f7410ef73c1ab0ccd5ca23d938a032ee0a539ee57be662b4aa4d9045b93d6ce0",
+        )
+    except ValueError as error:
+        _require("comparison drifted" in str(error), "comparison test failed unclearly")
+    else:
+        raise AssertionError("an evaluation comparison regression was accepted")
 
     def row(
         key: str,

--- a/bench/labels/missed_worthy_frontier.py
+++ b/bench/labels/missed_worthy_frontier.py
@@ -23,6 +23,7 @@ from query_schema import QUERY_SCHEMA_VERSION
 ROOT = Path(__file__).resolve().parents[2]
 ARTIFACT_SCHEMA = "nose.missed_worthy_frontier.v2"
 DECISIONS_SCHEMA = "nose.missed_worthy_dev_audit.v1"
+DECISIONS_SCHEMA_V2 = "nose.missed_worthy_dev_audit.v2"
 STAGE_AUDIT_SCHEMA = "nose.missed_worthy_stage_audit.dev.v1"
 CLOSEOUT_SCHEMA = "nose.missed_worthy_frontier_closeout.v1"
 SOURCE_BOUNDS_SCHEMA = "nose.missed_worthy_source_bounds.dev.v1"
@@ -63,6 +64,16 @@ VALID_BLOCKER_CLASSIFICATIONS = {
     "one-step-pure-helper-composition",
     "same-unit-actionable-fragment",
     "no-coherent-general-mechanism",
+}
+ISSUE_820_EXPLORATORY_PRESELECTION_KEYS = {
+    "curl:2a436119a08187ba",
+    "mockito:d82f6e75097748da",
+    "ripgrep:519afdcaed73af0d",
+}
+VALID_JUDGMENT_ORIGINS = {
+    "prior-frozen-816",
+    "exploratory-before-820-freeze",
+    "post-820-selection-freeze",
 }
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -713,13 +724,106 @@ def decision_summary(decisions: list[dict[str, Any]]) -> dict[str, int]:
     )
 
 
+def judgment_origin_summary(decisions: list[dict[str, Any]]) -> dict[str, int]:
+    return dict(sorted(Counter(decision["judgment_origin"] for decision in decisions).items()))
+
+
+def issue_820_cohort_comparison(
+    artifact: dict[str, Any],
+    stage_artifact: dict[str, Any],
+    decisions: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, int | str]], list[str], list[str], list[str]]:
+    """Derive the three frozen #820 dev cohorts and their reviewed evidence."""
+    candidates = {
+        record["candidate_key"]: record
+        for record in artifact["missed_worthy"]
+        if record["split"] == "dev"
+    }
+    stage_by_key = {
+        record["candidate_key"]: record for record in stage_artifact["candidates"]
+    }
+    decisions_by_key = {decision["candidate_key"]: decision for decision in decisions}
+    selected_keys = set(decisions_by_key)
+
+    connected_ids = sorted(
+        key
+        for key, candidate in candidates.items()
+        if stage_by_key.get(key, {}).get("stage") == "candidate-only"
+        and candidate["class"] == "subdag-ceiling"
+        and candidate.get("subdag_ge_20") is True
+    )
+    same_unit_ids = sorted(
+        key for key, candidate in candidates.items() if candidate["class"] == "same-unit-window"
+    )
+    missing_unit_ids = sorted(
+        key
+        for key in candidates
+        if stage_by_key.get(key, {}).get("stage") == "missing-unit"
+    )
+    _require(
+        set(connected_ids) <= selected_keys,
+        "the connected candidate/sub-DAG cohort is not completely source-reviewed",
+    )
+
+    connected_selected = [key for key in connected_ids if key in selected_keys]
+    same_unit_selected = [key for key in same_unit_ids if key in selected_keys]
+    missing_unit_selected = [key for key in missing_unit_ids if key in selected_keys]
+    connected_coherent = sorted(
+        key
+        for key in connected_selected
+        if decisions_by_key[key]["blocker_classification"]
+        == "connected-anchor-or-subdag-construction"
+    )
+    connected_no_go = sorted(set(connected_selected) - set(connected_coherent))
+    same_unit_coherent = sum(
+        decisions_by_key[key]["blocker_classification"]
+        == "same-unit-actionable-fragment"
+        for key in same_unit_selected
+    )
+    missing_unit_coherent = sum(
+        decisions_by_key[key]["blocker_classification"]
+        == "unit-extraction-or-missing-unit-kind"
+        for key in missing_unit_selected
+    )
+    comparison: dict[str, dict[str, int | str]] = {
+        "connected-candidate-subdag": {
+            "dev_ceiling": len(connected_ids),
+            "selected_reviewed": len(connected_selected),
+            "source_coherent": len(connected_coherent),
+            "source_no_go": len(connected_no_go),
+            "coverage": "complete",
+        },
+        "same-unit-window": {
+            "dev_ceiling": len(same_unit_ids),
+            "selected_reviewed": len(same_unit_selected),
+            "source_coherent": same_unit_coherent,
+            "source_no_go": len(same_unit_selected) - same_unit_coherent,
+            "coverage": "sampled",
+        },
+        "missing-unit-extraction": {
+            "dev_ceiling": len(missing_unit_ids),
+            "selected_reviewed": len(missing_unit_selected),
+            "source_coherent": missing_unit_coherent,
+            "source_no_go": len(missing_unit_selected) - missing_unit_coherent,
+            "coverage": "sampled-heterogeneous",
+        },
+    }
+    return comparison, connected_ids, connected_coherent, connected_no_go
+
+
 def validate_decisions(
     payload: object,
     artifact: dict[str, Any],
     stage_artifact: dict[str, Any],
+    *,
+    prior_decisions: dict[str, Any] | None = None,
 ) -> None:
     _require(isinstance(payload, dict), "decisions: expected an object")
-    _require(payload.get("schema") == DECISIONS_SCHEMA, "decisions: unsupported schema")
+    schema = payload.get("schema")
+    _require(
+        schema in {DECISIONS_SCHEMA, DECISIONS_SCHEMA_V2},
+        "decisions: unsupported schema",
+    )
     _require(payload.get("split") == "dev", "decisions must be dev-only")
     source = payload.get("source_artifact")
     _require(isinstance(source, dict), "source_artifact: expected an object")
@@ -795,13 +899,76 @@ def validate_decisions(
         payload.get("classification_summary") == decision_summary(decisions),
         "decision classification summary drifted",
     )
+
+    if schema == DECISIONS_SCHEMA_V2:
+        prior_record = payload.get("prior_decisions_artifact")
+        _require(isinstance(prior_record, dict), "prior decisions artifact missing")
+        _validate_hash(prior_record.get("sha256"), "prior decisions artifact hash invalid")
+        _require(
+            isinstance(prior_record.get("path"), str) and prior_record["path"],
+            "prior decisions artifact path missing",
+        )
+        _require(isinstance(prior_decisions, dict), "checked prior decisions are missing")
+        prior_rows = prior_decisions.get("decisions")
+        _require(isinstance(prior_rows, list), "checked prior decision rows are missing")
+        prior_by_candidate = {
+            (row["candidate_key"], row["candidate_sha256"]): row for row in prior_rows
+        }
+        selected_keys = {decision["candidate_key"] for decision in decisions}
+        exploratory_ids = sorted(
+            ISSUE_820_EXPLORATORY_PRESELECTION_KEYS & selected_keys
+        )
+        for index, decision in enumerate(decisions):
+            key = decision["candidate_key"]
+            prior = prior_by_candidate.get((key, decision["candidate_sha256"]))
+            if key in ISSUE_820_EXPLORATORY_PRESELECTION_KEYS:
+                expected_origin = "exploratory-before-820-freeze"
+            elif prior is not None:
+                expected_origin = "prior-frozen-816"
+            else:
+                expected_origin = "post-820-selection-freeze"
+            _require(
+                decision.get("judgment_origin") == expected_origin,
+                f"decisions[{index}].judgment_origin: chronology drifted",
+            )
+            _require(
+                decision["judgment_origin"] in VALID_JUDGMENT_ORIGINS,
+                f"decisions[{index}].judgment_origin: invalid",
+            )
+            if prior is not None:
+                reused = {key: value for key, value in decision.items() if key != "judgment_origin"}
+                _require(reused == prior, f"decisions[{index}]: prior frozen decision drifted")
+        _require(
+            payload.get("judgment_origin_summary") == judgment_origin_summary(decisions),
+            "judgment origin summary drifted",
+        )
+        method = payload.get("audit_method")
+        _require(isinstance(method, dict), "audit_method: expected an object")
+        _require(
+            method.get("heldout_source_inspected") is False,
+            "held-out source was inspected during the dev audit",
+        )
+        _require(
+            method.get("exploratory_preselection_ids") == exploratory_ids,
+            "exploratory preselection disclosure drifted",
+        )
+        for field in ("selection_frozen_commit", "stage_evidence_frozen_commit"):
+            value = method.get(field)
+            _require(
+                isinstance(value, str) and GIT_SHA_RE.fullmatch(value) is not None,
+                f"audit_method.{field}: invalid",
+            )
+        _require(
+            isinstance(method.get("notes"), str) and method["notes"].strip(),
+            "audit_method.notes: expected text",
+        )
+
     proposal = payload.get("dev_proposal")
     _require(isinstance(proposal, dict), "dev_proposal: expected an object")
     _require(
         proposal.get("status") == "frozen-before-heldout-confirmation",
         "dev proposal was not frozen before held-out confirmation",
     )
-    _require(proposal.get("route") in {"A", "B", "C", "D", "E"}, "invalid proposed route")
     _require(
         proposal.get("heldout_source_confirmation") == "not-run",
         "dev decision artifact must precede held-out confirmation",
@@ -812,13 +979,17 @@ def validate_decisions(
             f"dev_proposal.{field}: expected text",
         )
     hard_negatives = proposal.get("hard_negatives")
+    minimum_hard_negatives = 4 if schema == DECISIONS_SCHEMA_V2 else 2
     _require(
         isinstance(hard_negatives, list)
-        and len(hard_negatives) >= 2
+        and len(hard_negatives) >= minimum_hard_negatives
         and all(isinstance(item, str) and item.strip() for item in hard_negatives),
-        "dev_proposal.hard_negatives: expected at least two obligations",
+        f"dev_proposal.hard_negatives: expected at least {minimum_hard_negatives} obligations",
     )
-    if proposal["route"] == "A":
+
+    if schema == DECISIONS_SCHEMA:
+        _require(proposal.get("route") in {"A", "B", "C", "D", "E"}, "invalid proposed route")
+    if schema == DECISIONS_SCHEMA and proposal["route"] == "A":
         accepted = stage_artifact["summary"]["states"]["accepted-pair"]
         estimate = proposal.get("estimated_affected_dev_misses")
         _require(isinstance(estimate, dict), "route A needs a dev estimate")
@@ -826,9 +997,111 @@ def validate_decisions(
             estimate.get("lower_bound") == accepted,
             "route A lower bound must equal accepted raw dev pairs",
         )
+    if schema == DECISIONS_SCHEMA:
+        _require(
+            proposal.get("hof_route_d_status") == "deferred-no-direct-pure-callback-evidence",
+            "#806 may move only on direct pure-callback evidence",
+        )
+        return
+
     _require(
-        proposal.get("hof_route_d_status") == "deferred-no-direct-pure-callback-evidence",
-        "#806 may move only on direct pure-callback evidence",
+        proposal.get("selected_tranche") == "connected-candidate-subdag-witness",
+        "#820 selected an unsupported tranche",
+    )
+    for field in ("selection_rationale",):
+        _require(
+            isinstance(proposal.get(field), str) and proposal[field].strip(),
+            f"dev_proposal.{field}: expected text",
+        )
+    comparison, mechanical_ids, coherent_ids, no_go_ids = issue_820_cohort_comparison(
+        artifact,
+        stage_artifact,
+        decisions,
+    )
+    _require(
+        proposal.get("cohort_comparison") == comparison,
+        "#820 cohort comparison drifted",
+    )
+    _require(
+        proposal.get("mechanical_dev_ids") == mechanical_ids,
+        "#820 mechanical connected cohort drifted",
+    )
+    _require(
+        proposal.get("source_coherent_ids") == coherent_ids,
+        "#820 coherent connected cohort drifted",
+    )
+    _require(
+        proposal.get("source_no_go_ids") == no_go_ids,
+        "#820 connected no-go cohort drifted",
+    )
+    decisions_by_key = {decision["candidate_key"]: decision for decision in decisions}
+    for key in mechanical_ids:
+        _require(
+            decisions_by_key[key]["blocker_classification"]
+            in {
+                "connected-anchor-or-subdag-construction",
+                "no-coherent-general-mechanism",
+            },
+            f"{key}: connected cohort has an unrelated classification",
+        )
+    success_gate = proposal.get("dev_success_gate")
+    _require(
+        success_gate
+        == {
+            "required_recovery_ids": coherent_ids,
+            "forbidden_recovery_ids": no_go_ids,
+            "max_worthy_regressions": 0,
+            "max_false_merges": 0,
+            "connected_witness_required": True,
+        },
+        "#820 dev success gate drifted",
+    )
+    budget = proposal.get("output_growth_budget")
+    _require(isinstance(budget, dict), "#820 output-growth budget missing")
+    _require(
+        set(budget)
+        == {
+            "max_default_output_growth_pct",
+            "max_runtime_regression_pct",
+            "max_runtime_regression_ms",
+            "max_unrelated_added_rows",
+            "pricing_protocol",
+        },
+        "#820 output-growth budget fields drifted",
+    )
+    for field, upper in (
+        ("max_default_output_growth_pct", 5.0),
+        ("max_runtime_regression_pct", 5.0),
+        ("max_runtime_regression_ms", 5.0),
+    ):
+        value = budget.get(field)
+        _require(
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and 0 < value <= upper,
+            f"#820 {field} exceeds its bounded budget",
+        )
+    _require(budget.get("max_unrelated_added_rows") == 0, "#820 allows unrelated output")
+    _require(
+        isinstance(budget.get("pricing_protocol"), str) and budget["pricing_protocol"].strip(),
+        "#820 pricing protocol missing",
+    )
+    separate = proposal.get("separate_cohorts")
+    _require(
+        isinstance(separate, dict)
+        and set(separate)
+        == {
+            "candidate-generation",
+            "same-unit-window",
+            "unit-extraction",
+            "no-coherent-general-mechanism",
+        }
+        and all(isinstance(value, str) and value.strip() for value in separate.values()),
+        "#820 separate-cohort boundaries are incomplete",
+    )
+    _require(
+        proposal.get("next_action") == "open-connected-witness-implementation-issue",
+        "#820 result-dependent next action drifted",
     )
 
 
@@ -850,7 +1123,47 @@ def load_and_validate_decisions(path: Path, artifact_path: Path) -> dict[str, An
     _require(stage_path.is_file(), "stage artifact file is missing")
     _require(sha256_file(stage_path) == stage_source.get("sha256"), "stage artifact hash mismatch")
     stage_artifact = json.loads(stage_path.read_text(encoding="utf-8"))
-    validate_decisions(payload, artifact, stage_artifact)
+    prior_decisions = None
+    if payload.get("schema") == DECISIONS_SCHEMA_V2:
+        prior_source = payload.get("prior_decisions_artifact")
+        _require(isinstance(prior_source, dict), "prior decisions artifact missing")
+        prior_path_raw = prior_source.get("path")
+        _require(
+            isinstance(prior_path_raw, str) and prior_path_raw,
+            "prior decisions artifact path missing",
+        )
+        prior_path = project_path(prior_path_raw)
+        _require(prior_path.is_file(), "prior decisions artifact file is missing")
+        _require(
+            sha256_file(prior_path) == prior_source.get("sha256"),
+            "prior decisions artifact hash mismatch",
+        )
+        try:
+            unchecked_prior = json.loads(prior_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise ValueError(f"prior decisions artifact contains invalid JSON: {error}") from error
+        _require(
+            isinstance(unchecked_prior, dict)
+            and unchecked_prior.get("schema") == DECISIONS_SCHEMA,
+            "prior decisions artifact must use the frozen v1 schema",
+        )
+        prior_artifact_record = unchecked_prior.get("source_artifact")
+        _require(isinstance(prior_artifact_record, dict), "prior source artifact missing")
+        prior_artifact_raw = prior_artifact_record.get("path")
+        _require(
+            isinstance(prior_artifact_raw, str) and prior_artifact_raw,
+            "prior source artifact path missing",
+        )
+        prior_decisions = load_and_validate_decisions(
+            prior_path,
+            project_path(prior_artifact_raw),
+        )
+    validate_decisions(
+        payload,
+        artifact,
+        stage_artifact,
+        prior_decisions=prior_decisions,
+    )
     return payload
 
 
@@ -1265,7 +1578,7 @@ def load_and_validate_closeout(path: Path) -> dict[str, Any]:
 def render_dev_context(artifact: dict[str, Any], output: Path, context_lines: int = 8) -> None:
     candidates = {record["candidate_key"]: record for record in artifact["missed_worthy"]}
     lines = [
-        "# Frozen #816 dev audit context",
+        "# Frozen dev audit context",
         "",
         f"Selection SHA-256: `{artifact['dev_audit_selection']['sha256']}`",
         "",
@@ -1423,7 +1736,7 @@ def run_self_test() -> None:
     else:
         raise AssertionError("candidate tampering was accepted")
 
-    audited = rows[0]
+    audited = rows[2]
     selection_record = {
         "candidate_key": audited["candidate_key"],
         "candidate_sha256": audited["candidate_sha256"],
@@ -1498,6 +1811,136 @@ def run_self_test() -> None:
         _require("source_evidence" in str(error), "decision test failed for wrong reason")
     else:
         raise AssertionError("a decision without source evidence was accepted")
+
+    valid_v2 = json.loads(json.dumps(valid_decisions))
+    valid_v2["schema"] = "nose.missed_worthy_dev_audit.v2"
+    valid_v2["prior_decisions_artifact"] = {
+        "path": "prior-decisions.json",
+        "sha256": "2" * 64,
+    }
+    valid_v2["decisions"][0]["judgment_origin"] = "post-820-selection-freeze"
+    valid_v2["decisions"][0]["blocker_classification"] = (
+        "connected-anchor-or-subdag-construction"
+    )
+    valid_v2["classification_summary"] = {
+        "connected-anchor-or-subdag-construction": 1
+    }
+    valid_v2["judgment_origin_summary"] = {"post-820-selection-freeze": 1}
+    valid_v2["audit_method"] = {
+        "heldout_source_inspected": False,
+        "selection_frozen_commit": "2" * 40,
+        "stage_evidence_frozen_commit": "3" * 40,
+        "exploratory_preselection_ids": [],
+        "notes": "The synthetic row was reviewed after the selection freeze.",
+    }
+    valid_v2["dev_proposal"] = {
+        "status": "frozen-before-heldout-confirmation",
+        "selected_tranche": "connected-candidate-subdag-witness",
+        "heldout_source_confirmation": "not-run",
+        "mechanism": "Construct and score one connected shared witness already supported by a raw candidate.",
+        "smallest_sound_invariant": "Every admitted row carries one connected shared witness on both sides.",
+        "selection_rationale": "The complete candidate-only cohort has one coherent member.",
+        "cohort_comparison": {
+            "connected-candidate-subdag": {
+                "dev_ceiling": 1,
+                "selected_reviewed": 1,
+                "source_coherent": 1,
+                "source_no_go": 0,
+                "coverage": "complete",
+            },
+            "same-unit-window": {
+                "dev_ceiling": 0,
+                "selected_reviewed": 0,
+                "source_coherent": 0,
+                "source_no_go": 0,
+                "coverage": "sampled",
+            },
+            "missing-unit-extraction": {
+                "dev_ceiling": 0,
+                "selected_reviewed": 0,
+                "source_coherent": 0,
+                "source_no_go": 0,
+                "coverage": "sampled-heterogeneous",
+            },
+        },
+        "mechanical_dev_ids": [audited["candidate_key"]],
+        "source_coherent_ids": [audited["candidate_key"]],
+        "source_no_go_ids": [],
+        "dev_success_gate": {
+            "required_recovery_ids": [audited["candidate_key"]],
+            "forbidden_recovery_ids": [],
+            "max_worthy_regressions": 0,
+            "max_false_merges": 0,
+            "connected_witness_required": True,
+        },
+        "output_growth_budget": {
+            "max_default_output_growth_pct": 2.0,
+            "max_runtime_regression_pct": 5.0,
+            "max_runtime_regression_ms": 5.0,
+            "max_unrelated_added_rows": 0,
+            "pricing_protocol": "#809 alternating base/head plus same-binary control",
+        },
+        "hard_negatives": [
+            "Do not infer A-C from A-B and B-C.",
+            "Do not admit disconnected multiset mass.",
+            "Do not lower candidate or acceptance thresholds.",
+            "Do not recover a source-reviewed no-go row.",
+        ],
+        "separate_cohorts": {
+            "candidate-generation": "Remains outside connected candidate witnesses.",
+            "same-unit-window": "Requires bounded fragment output.",
+            "unit-extraction": "Requires a construct-specific extraction law.",
+            "no-coherent-general-mechanism": "Remains a hard negative.",
+        },
+        "next_action": "open-connected-witness-implementation-issue",
+    }
+    validate_decisions(
+        valid_v2,
+        fake_artifact,
+        fake_stage_artifact,
+        prior_decisions={"decisions": []},
+    )
+    invalid_origin = json.loads(json.dumps(valid_v2))
+    invalid_origin["decisions"][0]["judgment_origin"] = "prior-frozen-816"
+    invalid_origin["judgment_origin_summary"] = {"prior-frozen-816": 1}
+    try:
+        validate_decisions(
+            invalid_origin,
+            fake_artifact,
+            fake_stage_artifact,
+            prior_decisions={"decisions": []},
+        )
+    except ValueError as error:
+        _require("chronology drifted" in str(error), "origin test failed for wrong reason")
+    else:
+        raise AssertionError("a substituted judgment origin was accepted")
+
+    prior_row = {
+        key: value
+        for key, value in valid_v2["decisions"][0].items()
+        if key != "judgment_origin"
+    }
+    reused_v2 = json.loads(json.dumps(valid_v2))
+    reused_v2["decisions"][0]["judgment_origin"] = "prior-frozen-816"
+    reused_v2["judgment_origin_summary"] = {"prior-frozen-816": 1}
+    validate_decisions(
+        reused_v2,
+        fake_artifact,
+        fake_stage_artifact,
+        prior_decisions={"decisions": [prior_row]},
+    )
+    reused_v2["decisions"][0]["rationale"] = "A later review silently changed the rationale."
+    try:
+        validate_decisions(
+            reused_v2,
+            fake_artifact,
+            fake_stage_artifact,
+            prior_decisions={"decisions": [prior_row]},
+        )
+    except ValueError as error:
+        _require("prior frozen decision drifted" in str(error), "reuse test failed for wrong reason")
+    else:
+        raise AssertionError("a modified prior-frozen decision was accepted")
 
     with tempfile.TemporaryDirectory(prefix="nose-frontier-self-test-") as directory:
         output = Path(directory) / "canonical.json"

--- a/bench/labels/missed_worthy_frontier.py
+++ b/bench/labels/missed_worthy_frontier.py
@@ -30,9 +30,11 @@ SELECTION_SEED = "nose-issue-816-dev-audit-v1"
 SELECTION_PER_LANGUAGE = 5
 SUBDAG_FLOORS = (8, 12, 20)
 INLINE_FLOOR = 20
-EXPECTED_CURRENT_RECALL = {
-    "dev": {"hits": 2626, "n": 2849},
-    "heldout": {"hits": 1949, "n": 2091},
+CHECKED_RECALL_PROFILES = {
+    "2664d2935eaf8e86243dcf3592225c9f4884154ac7757c1307fd2a4281688e2c": {
+        "dev": {"hits": 2626, "n": 2849},
+        "heldout": {"hits": 1949, "n": 2091},
+    },
 }
 REQUIRED_RESIDUAL_LANES = (
     "inline-ceiling",
@@ -68,6 +70,45 @@ def canonical_json(value: object) -> str:
 
 def canonical_sha256(value: object) -> str:
     return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def registered_recall_profile(digest: object) -> dict[str, dict[str, int]]:
+    """Return the recall contract registered for an evaluation digest."""
+    _validate_hash(digest, "evaluation input sha256: invalid")
+    registered = CHECKED_RECALL_PROFILES.get(digest)
+    _require(registered is not None, f"evaluation report {digest} is unregistered")
+    return {split: dict(counts) for split, counts in registered.items()}
+
+
+def checked_recall_profile(evaluation_input: object) -> dict[str, dict[str, int]]:
+    """Validate and return the recall contract carried by an artifact input."""
+    _require(isinstance(evaluation_input, dict), "evaluation input: expected an object")
+    registered = registered_recall_profile(evaluation_input.get("sha256"))
+    _require(
+        evaluation_input.get("expected_worthy_recall") == registered,
+        "evaluation report recall differs from its registered profile",
+    )
+    return registered
+
+
+def validate_evaluation_recall(
+    evaluation: object,
+    expected_recall: dict[str, dict[str, int]],
+) -> None:
+    _require(isinstance(evaluation, dict), "checked evaluation: expected an object")
+    metrics = evaluation.get("metrics")
+    _require(isinstance(metrics, dict), "checked evaluation metrics missing")
+    for split, expected in expected_recall.items():
+        split_metrics = metrics.get(split)
+        _require(isinstance(split_metrics, dict), f"checked evaluation {split} missing")
+        overall = split_metrics.get("OVERALL")
+        _require(isinstance(overall, dict), f"checked evaluation {split} overall missing")
+        actual = overall.get("worthy_recall")
+        _require(isinstance(actual, dict), f"checked evaluation {split} recall missing")
+        _require(
+            {"hits": actual.get("hits"), "n": actual.get("n")} == expected,
+            f"checked evaluation {split} worthy recall drifted",
+        )
 
 
 def project_path(path: str) -> Path:
@@ -407,6 +448,7 @@ def validate_artifact(
         "query_schema",
     }
     _require(set(inputs) == required_inputs, "provenance.inputs: incomplete input set")
+    expected_recall = checked_recall_profile(inputs.get("evaluation_report"))
     resolved_inputs: dict[str, Path] = {}
     recall_labels = None
     corpus_payload = None
@@ -439,12 +481,7 @@ def validate_artifact(
                     "v6 current-output overlay entered worthy recall",
                 )
         evaluation = json.loads(resolved_inputs["evaluation_report"].read_text())
-        for split, expected in EXPECTED_CURRENT_RECALL.items():
-            actual = evaluation["metrics"][split]["OVERALL"]["worthy_recall"]
-            _require(
-                {"hits": actual["hits"], "n": actual["n"]} == expected,
-                f"checked evaluation {split} worthy recall drifted",
-            )
+        validate_evaluation_recall(evaluation, expected_recall)
         corpus_payload = json.loads(resolved_inputs["corpus_manifest"].read_text())
         repositories = corpus_payload.get("repositories")
         _require(isinstance(repositories, list), "corpus manifest repositories missing")
@@ -627,7 +664,7 @@ def validate_artifact(
     by_language, by_split = aggregate_metrics(query_runs, candidates)
     _require(payload.get("metrics_by_language") == by_language, "language metrics drifted")
     _require(payload.get("metrics") == by_split, "split metrics drifted")
-    for split, expected in EXPECTED_CURRENT_RECALL.items():
+    for split, expected in expected_recall.items():
         actual = by_split.get(split, {})
         _require(
             {"hits": actual.get("hit_arm1"), "n": actual.get("worthy")} == expected,
@@ -1264,6 +1301,49 @@ def render_dev_context(artifact: dict[str, Any], output: Path, context_lines: in
 
 
 def run_self_test() -> None:
+    pre_817_input = {
+        "sha256": "2664d2935eaf8e86243dcf3592225c9f4884154ac7757c1307fd2a4281688e2c",
+        "expected_worthy_recall": {
+            "dev": {"hits": 2626, "n": 2849},
+            "heldout": {"hits": 1949, "n": 2091},
+        },
+    }
+    _require(
+        checked_recall_profile(pre_817_input)
+        == pre_817_input["expected_worthy_recall"],
+        "registered recall profile did not round-trip",
+    )
+    unregistered = json.loads(json.dumps(pre_817_input))
+    unregistered["sha256"] = "f" * 64
+    try:
+        checked_recall_profile(unregistered)
+    except ValueError as error:
+        _require("unregistered" in str(error), "unregistered profile failed unclearly")
+    else:
+        raise AssertionError("an unregistered evaluation report was accepted")
+    substituted = json.loads(json.dumps(pre_817_input))
+    substituted["expected_worthy_recall"]["dev"]["hits"] += 1
+    try:
+        checked_recall_profile(substituted)
+    except ValueError as error:
+        _require("recall" in str(error), "recall substitution failed unclearly")
+    else:
+        raise AssertionError("a registered evaluation recall substitution was accepted")
+    evaluation = {
+        "metrics": {
+            split: {"OVERALL": {"worthy_recall": dict(counts)}}
+            for split, counts in pre_817_input["expected_worthy_recall"].items()
+        }
+    }
+    validate_evaluation_recall(evaluation, checked_recall_profile(pre_817_input))
+    evaluation["metrics"]["heldout"]["OVERALL"]["worthy_recall"]["hits"] -= 1
+    try:
+        validate_evaluation_recall(evaluation, checked_recall_profile(pre_817_input))
+    except ValueError as error:
+        _require("heldout worthy recall drifted" in str(error), "metric drift failed unclearly")
+    else:
+        raise AssertionError("a checked evaluation metric substitution was accepted")
+
     def row(
         key: str,
         language: str,

--- a/bench/labels/missed_worthy_heldout_confirmation.py
+++ b/bench/labels/missed_worthy_heldout_confirmation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One-time held-out confirmation for the frozen #816 dev proposal.
+"""One-time held-out stage confirmation for a frozen dev proposal.
 
 The dev proposal is loaded and validated before any held-out detector run.  This
 reuses the exact raw-stage method from ``missed_worthy_stage_audit.py`` and emits
@@ -19,7 +19,13 @@ import sys
 from typing import Any
 
 from labelset import sha256_file
-from missed_worthy_frontier import ROOT, load_and_validate_artifact, load_and_validate_decisions, relative_path
+from missed_worthy_frontier import (
+    DECISIONS_SCHEMA_V2,
+    ROOT,
+    load_and_validate_artifact,
+    load_and_validate_decisions,
+    relative_path,
+)
 from missed_worthy_stage_audit import (
     display_arg,
     display_command,
@@ -32,8 +38,12 @@ from missed_worthy_stage_audit import (
 
 
 SCHEMA = "nose.missed_worthy_stage_confirmation.heldout.v1"
+SCHEMA_V2 = "nose.missed_worthy_stage_confirmation.heldout.v2"
 MIN_ACCEPTED_PAIRS = 15
 MIN_ACCEPTED_LANGUAGES = 3
+EXPECTED_POST_817_ACCEPTED_PAIRS = 0
+EXPECTED_POST_817_CANDIDATE_SUBDAG = 2
+EXPECTED_POST_817_CANDIDATE_SUBDAG_LANGUAGES = ["C", "Java"]
 DEFAULT_ARTIFACT = ROOT / "bench" / "labels" / "recall_ceiling_probe_2026_07_11.v2.json"
 DEFAULT_DECISIONS = (
     ROOT / "bench" / "labels" / "missed_worthy_audit_decisions_2026_07_11.dev.v1.json"
@@ -57,6 +67,44 @@ def confirmation_result(summary: dict[str, Any]) -> dict[str, Any]:
         "passed": accepted >= MIN_ACCEPTED_PAIRS
         and len(languages) >= MIN_ACCEPTED_LANGUAGES,
     }
+
+
+def confirmation_result_v2(
+    summary: dict[str, Any],
+    records: list[dict[str, Any]],
+    source_candidates: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Check the pre-registered post-#817 mechanical stage expectation."""
+    candidate_only_subdag = []
+    for record in records:
+        source = source_candidates[record["candidate_key"]]
+        if (
+            record["stage"] == "candidate-only"
+            and source["class"] == "subdag-ceiling"
+            and source.get("subdag_ge_20") is True
+        ):
+            candidate_only_subdag.append(record["candidate_key"])
+    languages = sorted(
+        {source_candidates[key]["language"] for key in candidate_only_subdag}
+    )
+    accepted = summary["states"].get("accepted-pair", 0)
+    result = {
+        "expected_accepted_pairs": EXPECTED_POST_817_ACCEPTED_PAIRS,
+        "expected_candidate_only_subdag_ge20": EXPECTED_POST_817_CANDIDATE_SUBDAG,
+        "expected_candidate_only_subdag_ge20_languages": (
+            EXPECTED_POST_817_CANDIDATE_SUBDAG_LANGUAGES
+        ),
+        "observed_accepted_pairs": accepted,
+        "observed_candidate_only_subdag_ge20": len(candidate_only_subdag),
+        "observed_candidate_only_subdag_ge20_ids": sorted(candidate_only_subdag),
+        "observed_candidate_only_subdag_ge20_languages": languages,
+    }
+    result["passed"] = (
+        accepted == EXPECTED_POST_817_ACCEPTED_PAIRS
+        and len(candidate_only_subdag) == EXPECTED_POST_817_CANDIDATE_SUBDAG
+        and languages == EXPECTED_POST_817_CANDIDATE_SUBDAG_LANGUAGES
+    )
+    return result
 
 
 def collect(args: argparse.Namespace) -> dict[str, Any]:
@@ -95,7 +143,13 @@ def collect(args: argparse.Namespace) -> dict[str, Any]:
         )
     records.sort(key=lambda record: record["candidate_key"])
     summary = summarize(records)
-    result = confirmation_result(summary)
+    source_candidates = {record["candidate_key"]: record for record in heldout}
+    is_post_817 = decisions.get("schema") == DECISIONS_SCHEMA_V2
+    result = (
+        confirmation_result_v2(summary, records, source_candidates)
+        if is_post_817
+        else confirmation_result(summary)
+    )
     version = subprocess.run(
         [display_arg(args.nose), "--version"],
         cwd=ROOT,
@@ -105,7 +159,7 @@ def collect(args: argparse.Namespace) -> dict[str, Any]:
     )
     invocation = ["python3", relative_path(Path(__file__)), *sys.argv[1:]]
     return {
-        "schema": SCHEMA,
+        "schema": SCHEMA_V2 if is_post_817 else SCHEMA,
         "split": "heldout",
         "method": {
             "source_review": "none",
@@ -129,7 +183,9 @@ def collect(args: argparse.Namespace) -> dict[str, Any]:
                 "path": relative_path(args.decisions),
                 "sha256": sha256_file(args.decisions),
                 "commit": git_output("log", "-1", "--format=%H", "--", relative_path(args.decisions)),
-                "route": proposal["route"],
+                (
+                    "selected_tranche" if is_post_817 else "route"
+                ): proposal["selected_tranche"] if is_post_817 else proposal["route"],
             },
         },
         "failures": failures,
@@ -147,7 +203,8 @@ def require(condition: bool, message: str) -> None:
 
 def validate(payload: object, args: argparse.Namespace, *, check_binary: bool = False) -> None:
     require(isinstance(payload, dict), "confirmation must be an object")
-    require(payload.get("schema") == SCHEMA, "unsupported confirmation schema")
+    schema = payload.get("schema")
+    require(schema in {SCHEMA, SCHEMA_V2}, "unsupported confirmation schema")
     require(payload.get("split") == "heldout", "confirmation must be held-out")
     provenance = payload.get("provenance")
     require(isinstance(provenance, dict), "missing provenance")
@@ -165,7 +222,19 @@ def validate(payload: object, args: argparse.Namespace, *, check_binary: bool = 
     require(decision_record.get("path") == relative_path(args.decisions), "decision path drifted")
     require(decision_record.get("sha256") == sha256_file(args.decisions), "decision hash drifted")
     decisions = load_and_validate_decisions(args.decisions, args.artifact)
-    require(decision_record.get("route") == decisions["dev_proposal"]["route"], "route drifted")
+    is_post_817 = decisions.get("schema") == DECISIONS_SCHEMA_V2
+    require(
+        schema == (SCHEMA_V2 if is_post_817 else SCHEMA),
+        "confirmation schema does not match the dev decision contract",
+    )
+    if is_post_817:
+        require(
+            decision_record.get("selected_tranche")
+            == decisions["dev_proposal"]["selected_tranche"],
+            "selected tranche drifted",
+        )
+    else:
+        require(decision_record.get("route") == decisions["dev_proposal"]["route"], "route drifted")
     require(payload.get("failures") == [], "confirmation contains failures")
     require(payload.get("method", {}).get("source_review") == "none", "held-out source was judged")
 
@@ -184,10 +253,12 @@ def validate(payload: object, args: argparse.Namespace, *, check_binary: bool = 
         key = record["candidate_key"]
         validate_stage_record(record, expected[key])
     require(payload.get("summary") == summarize(records), "confirmation summary drifted")
-    require(
-        payload.get("confirmation_gate") == confirmation_result(payload["summary"]),
-        "confirmation gate drifted",
+    expected_gate = (
+        confirmation_result_v2(payload["summary"], records, expected)
+        if is_post_817
+        else confirmation_result(payload["summary"])
     )
+    require(payload.get("confirmation_gate") == expected_gate, "confirmation gate drifted")
     require(payload["confirmation_gate"]["passed"] is True, "held-out confirmation failed")
     validate_repository_runs(payload.get("repository_runs"), expected)
     if check_binary:
@@ -214,6 +285,49 @@ def run_self_test() -> None:
         },
     }
     require(confirmation_result(failing)["passed"] is False, "failing gate accepted")
+
+    post_817_candidates = {
+        "c-one": {
+            "candidate_key": "c-one",
+            "language": "C",
+            "class": "subdag-ceiling",
+            "subdag_ge_20": True,
+        },
+        "java-one": {
+            "candidate_key": "java-one",
+            "language": "Java",
+            "class": "subdag-ceiling",
+            "subdag_ge_20": True,
+        },
+    }
+    post_817_records = [
+        {"candidate_key": key, "stage": "candidate-only"}
+        for key in post_817_candidates
+    ]
+    post_817_summary = {
+        "states": {"candidate-only": 2},
+        "by_language": {"C": {"candidate-only": 1}, "Java": {"candidate-only": 1}},
+    }
+    require(
+        confirmation_result_v2(
+            post_817_summary,
+            post_817_records,
+            post_817_candidates,
+        )["passed"]
+        is True,
+        "post-817 passing gate rejected",
+    )
+    post_817_records[0]["stage"] = "accepted-pair"
+    post_817_summary["states"] = {"accepted-pair": 1, "candidate-only": 1}
+    require(
+        confirmation_result_v2(
+            post_817_summary,
+            post_817_records,
+            post_817_candidates,
+        )["passed"]
+        is False,
+        "post-817 accepted-pair drift passed",
+    )
     print("missed-worthy held-out confirmation self-test passed")
 
 

--- a/bench/labels/missed_worthy_source_bounds.py
+++ b/bench/labels/missed_worthy_source_bounds.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Freeze and validate source line bounds for the #816 dev audit evidence."""
+"""Freeze and validate source line bounds for a checked dev audit."""
 
 from __future__ import annotations
 

--- a/bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json
+++ b/bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json
@@ -1,0 +1,3358 @@
+{
+  "candidates": [
+    {
+      "candidate_key": "alacritty:9c6effe5d34be3b4",
+      "candidate_sha256": "451b8eb4b29c7aa3e718b144461bc554bb8900fde8dbdaca35cb8e90c4162cb4",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "alacritty",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "alacritty:f4fee9de42105372",
+      "candidate_sha256": "e06eb5a07a0425e8c706523e30ec74eafa3a2593a08d714778bd99516a939662",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        3
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "alacritty",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "axios:2169018b8e46a6b6",
+      "candidate_sha256": "7c053d4386e72b2a87fa6c19877b813c6e4c195e4d5bb916bdf49728b7356e01",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "axios",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "axios:e4b2c19f4886a989",
+      "candidate_sha256": "250df6c0c2a309504c84e4f57ebcf127f92e4a1e04650aee84af6c1a364d352e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "axios",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "bat:05ca8156de2d3b25",
+      "candidate_sha256": "528e229525fd01172d03e3df2417bfa917d2a7dee9ae0e11554f8e23e5b40f60",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "bat",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "bat:3da3e13d270dcbb0",
+      "candidate_sha256": "ba8f1da69b0c67ea4e564906d185986e2a74124db71fed210f20ff9f1b38fe18",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "bat",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "bat:6a12988f697482b6",
+      "candidate_sha256": "108703c7be53dd72626686364cff5b6acff7ae1f8dc1ffe49408fff93e775f1f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "bat",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "bat:7836101146be0e22",
+      "candidate_sha256": "1c073d7003d68460eca24d5c5e7380a7bc05ab222ac18b59a1c6230a68ee43b6",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "same-unit-window",
+      "repo": "bat",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "chi:154bd73cf15a6de5",
+      "candidate_sha256": "818c4cdb58b65284187992985c8c892352bf2def26eacc7b2b2d88a813984d10",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "chi",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "chi:8aa3c17d2ce27099",
+      "candidate_sha256": "beeefa55d64f8783cc6be859424fc022b3b6736b0e199416497de3ba755b93ad",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "chi",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "clap:26db8890dd78e8ec",
+      "candidate_sha256": "239f8fcc5e5e818a5f1d23098141cca0dd07dcb50a56f38b018554ff180456dd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "clap",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "clap:74091cb7bc4194da",
+      "candidate_sha256": "bd4a73247380b7e92dc5b8a9919ae044ccee42057b20b86689b81e082b013a06",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "same-unit-window",
+      "repo": "clap",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "clap:bb9832e72fa8ae15",
+      "candidate_sha256": "ad4d59be35c9cf519f0a171730079701dbd3ababf614bfee66976371f5cc2f8b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "clap",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "clap:f54bde1dd7bb3151",
+      "candidate_sha256": "2aae16d76e8a03c2122ce24d180bf806e958e4c61d74c784fb41647d359cd9cb",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "clap",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "cobra:db88c9b581c2c760",
+      "candidate_sha256": "3c255fd3352ee4dc071afc43147cd945d0a7353eda757f4898cbd85bfcf5ff11",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "cobra",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "commons-lang:1ae611d010ed2053",
+      "candidate_sha256": "a20bb130b5336d401a5161cd8283440b4457fa08c2b34972bf468233bd9cf98b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "commons-lang",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "commons-lang:2eceec2b9e4c1883",
+      "candidate_sha256": "a13880ddf164e97255331605780b7e776a98b054aee1be5207b3db97285cc707",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "commons-lang",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "commons-lang:7deea4aa415c6197",
+      "candidate_sha256": "e7d43c53204c6d5cc2532e8deac1d82bb99ce8646354117a395ef6eecd14d2aa",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "commons-lang",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "commons-lang:81a43aee2b3a31d7",
+      "candidate_sha256": "2621636f3998200d888dd37284e4b9d7c285267bb662606dd3553602c28a29f5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "commons-lang",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "curl:08e1435f8564adf7",
+      "candidate_sha256": "b5aeb2fa7a54e29886f9554ab06d42bb95879127b8b3cc627f14d655e545dbaf",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "curl",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "curl:2a436119a08187ba",
+      "candidate_sha256": "82a67204587605f18a10cfcea9666a15e6fd1a6b525a40dae287cc61435a208b",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        6,
+        6
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "curl",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "curl:4240a5f55e0db83b",
+      "candidate_sha256": "61f6b4e3adc68eccafe60af286eab02f8046d7d8bea7d80175b67227fe611006",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "unrecovered",
+      "repo": "curl",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "curl:b4ce193dda870c7b",
+      "candidate_sha256": "5cfe053f885fb5d1aa87b41d238f043bd9520eafb687fb66284101f8dde60d84",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "unrecovered",
+      "repo": "curl",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "curl:c06c2711b53dbd66",
+      "candidate_sha256": "a198b6ee87b0b44ae0121815e0e026651bb6a9b279c3467f9505159a46067605",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "unrecovered",
+      "repo": "curl",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "delve:de84b1952aa09a8e",
+      "candidate_sha256": "9129174bbac4023a963efac616e7f35a52b736b11e1904ba1f0dfde0faab507f",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "delve",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "devise:458679b19d6bcbfa",
+      "candidate_sha256": "4d23e77ce5493b3f4a9d48ee3b3e6aaed595b0a4ee18144c4e1b01229668b1ac",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "devise",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "fastlane:37ed5651c32ff32a",
+      "candidate_sha256": "8bcfbd306aa9a7f3af1477744ba2078db2cadab88d9d8049dd921ed534369c2a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "fastlane",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "fastlane:65e68827e870dbe0",
+      "candidate_sha256": "4f5bf9de13d6cfc527ac499767a7f9328484476a7498b02d1d7676386fe28dcd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "fastlane",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fd:5f935c3d9e9dd8fd",
+      "candidate_sha256": "3512441f56023053fe8cbf3feafced3fa28d4187ea337a7d5bfe6b89d8218203",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "fd",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "fd:a46e9200da364aff",
+      "candidate_sha256": "b032b4c288b83f07f7a6d7aca3121cf4134bfe25c658c1c96bc3c7aa4d077bfb",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "inline-ceiling",
+      "repo": "fd",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "git:1d9b1c7f444d15d0",
+      "candidate_sha256": "0605378cce63ec592aafd62b787673acbb7a2b9697afbc18db849313fcfcfb29",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "git",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:06b22e78705e5939",
+      "candidate_sha256": "aa83c19eca8526082e862bc635525321d62a6642af5711591b3181722bcf570c",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gorm",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gorm:07b0262946c3716d",
+      "candidate_sha256": "6e5d4b465b0515c217b45f8cfafdd587a3b3adc23c90d9f073d3a7535ab8f9ee",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "gorm",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gorm:768d763acc7c5c60",
+      "candidate_sha256": "92c1f5a1b229f9a4d164eb1cd54b7962bcee9793050bcbd2f161e2c5e0210edc",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gorm",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gorm:8478e206de15b28a",
+      "candidate_sha256": "cb90639932557afcb199f716b0bebd5a2cbe4cd9336c2ac4c7b631c16bdda739",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:85171013eba5ae62",
+      "candidate_sha256": "9968b486a51ccf4c49515b2bed50294b8941a2c61c94f642b800b87186759f64",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:9696bb6606c9a9ab",
+      "candidate_sha256": "88eb1b79919cb27cfc188983adc06e40fdb81cdf203f42237f3e0c5bd6d13f90",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:96d46442b02433a5",
+      "candidate_sha256": "0fdadd6599fa1fbd35d100e278c3bc42ac48ffec014512b65bbf73e525c3e221",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:9aec931ab49f2c6e",
+      "candidate_sha256": "c90aa10f70f5c9f6ebb2521fb86a11b6b01df7f60bc806e4ea0c94527ebc6424",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:a12cc73e717d5c78",
+      "candidate_sha256": "58cd262fe0b0783d69ce26d18920566995f740489f5b25d8e42c28b93225abe4",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "gorm",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gorm:b2cd9c61ce98289a",
+      "candidate_sha256": "89cbc2c55eac3f4c6c36d7bbf97711fe5602fd0b863de4b3190a4ee7991043c7",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:b47a856846cdf8fc",
+      "candidate_sha256": "6bdba2333e7272624c8cd1e6723962b2cdddfd6a5db9ad57c325b2143454d992",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "gorm",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gorm:fdc399645a7b3dfd",
+      "candidate_sha256": "82230bea90c26a350f067dd27b69406ad327b1dfe9cd5adf6992eb29097ae06f",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gorm",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "graphhopper:2acc71582f85cc79",
+      "candidate_sha256": "a4d67823c8ec861ddf2b850b5744598119502832a5bb8a9af5cac9f2c45f5a51",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "graphhopper",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gson:259a137cfe6cf7fd",
+      "candidate_sha256": "2f15d3120984cd0b1fb97885fc480760d97dc8d11ddc161bc43dd9e732fb8046",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:3f4ccba9d70e07f7",
+      "candidate_sha256": "b1ce1831ce91fc372f0727bf80cb99d35e5371e2ae2ec600c3a2f6126e3c7cc0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:4014d594ab6a8e54",
+      "candidate_sha256": "4703ef0be15ca03e40b43336f7e8fefc53dd90edbf1a81d19ed170939c7047c3",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "gson:579c5efb7564b4c6",
+      "candidate_sha256": "b108fc43ef8f64953f6db6f7b8ab6792f20028e43be9d790695875182a5d8494",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:68efa18d00d17764",
+      "candidate_sha256": "0a6205c27c0217b70691265c0cdf5d09dfccbcc26868b5d11f1c53d8701ebed3",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:9c7aefa30722a8cc",
+      "candidate_sha256": "e0b921da3781b44374761fb0187ded3c168f4607fef67f185bc12270bd916660",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:c83b927017bfa33d",
+      "candidate_sha256": "188ba2421d1b7b7da361b325cff041e9b4e3d01ccd8fb6cb5aaf83f7420240a0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "gson",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "gson:eab1115974df3594",
+      "candidate_sha256": "50ba7432a9498d6fe63e2ed3d58a908b2f2e516e9ca1ed3ccf0b6ccdce1881d6",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        3
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:f46d73b4e0ed55a9",
+      "candidate_sha256": "071dedfeb8cbc89eb44a3c57055c8a5af640e26689b4e9ef8306b5f952ccaeaa",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gson:f7385770c6e8a429",
+      "candidate_sha256": "57a8fe1011e16c02e530406802d87586bcf3f2159a0477110a4a78702811c0e6",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "gson",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "image:09688c2c17ddd091",
+      "candidate_sha256": "2f938edee451f0efe7d7e7abdc8db62abe9f9a8f401c83090babdc614afe9735",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "image",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "image:37f494cca9a333c3",
+      "candidate_sha256": "d314a68ffcab3f5607e5439bf2c20364eb4c1d7f6d23c5a2eef6a3d04ff445e1",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "image",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "image:3bb7b58ae7adf7d9",
+      "candidate_sha256": "e46f5ef3dc20c1e3e213d9f263515a46d784e69f91aec18a4b33cd2f9eeed7a0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "image",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "image:4a8e4387c0a05967",
+      "candidate_sha256": "6fe72a667b1b8cf64a710456d5573a48eafe24ebc846cd03a42aa2be4e8a5b9e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "image",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "image:98f7b2d07afc459a",
+      "candidate_sha256": "d6b293a5058880ce7f0bc6bce0ee3fb7bd0e3224fab8ac398aeb4718ba994fdd",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "image",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "jekyll:1d13d09079bfb05e",
+      "candidate_sha256": "c88be8cf4242b31bef8b3b2c80d7fdc97c2f12820faebd781476e8502aa18ec0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        5,
+        4
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "jekyll",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jekyll:25f8eeacf08b1049",
+      "candidate_sha256": "451debc6020cbe6166fd2f82d6c4e83882a5e6617d00bc9f418c4732c0f88226",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jekyll",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "jekyll:2791928407ad302c",
+      "candidate_sha256": "83fed4df03ca9b53775245f533e6f4c4d841d5c20bac934c03948545976e4934",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "jekyll",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "jekyll:4acc42e4917235f2",
+      "candidate_sha256": "409db47e223da0dc0b545721f7a6652732af3d43980f30c6aa6b9b8be4d3bbc5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "same-unit-window",
+      "repo": "jekyll",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jekyll:69d8954d1b741b57",
+      "candidate_sha256": "80818b8e8b860ec4b749d3bb3d0d566e952ce13e47bc5ea72e44afca58f981b8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jekyll",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "jest:4c55eff3b52a86ff",
+      "candidate_sha256": "9679975d447841d1d453dac826bd359d78fd5adc300ee1d3ae6b19b29672f6cc",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "jest",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jq:c0adad57af0c4d06",
+      "candidate_sha256": "1072745a4b89b9daa9e056d5c50764034ea9a080206ea407b514c8f60d843dd4",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "unrecovered",
+      "repo": "jq",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "lua:6b8e0cef12881b68",
+      "candidate_sha256": "950159e99f06cd51d02cdf8966db074d302a29c869b61a3d8f10d8d4a84b0c6d",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "lua",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "lua:bc0ae7caf5d8bfbb",
+      "candidate_sha256": "decfb45ed5046c4d00b07165ac575a9e5a07521c9533b12c8f4ef2867bf1795d",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "lua",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:1fa8be0a8e1c9121",
+      "candidate_sha256": "42d4422c9de45752d7ce62357ae5abf40c5bbb9779aa9d53b91330d2d481cf6b",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "mockito",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "mockito:290e05f149bee68c",
+      "candidate_sha256": "65dcd34289de25e2464c1b799f5af0e2b458efc7caf470f72d647ac74e66d3a7",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:46e9a5d46cce9beb",
+      "candidate_sha256": "aa540a5c54e74cb05bf995ce9bd1039f078ecdae91bfa95f85b5ce3af42ce089",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:5b64ce572e3c94e1",
+      "candidate_sha256": "202520aae20a7550476016cb53241adde944990c93ecec5ae94f3bcea1b7d1a3",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:706f73f0e5fd1978",
+      "candidate_sha256": "41ef2d25be10a843f49a15a4485fcd5e59f97dca1255710f59cf35846df4bc46",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "mockito",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "mockito:79be91c925ed1869",
+      "candidate_sha256": "23befe06dd4fe660db7d8dd01bede971bc7888540b78923a2f431e2a776ebc2a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "mockito",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "mockito:baf4c3da359dfc3d",
+      "candidate_sha256": "574b2fa645f4bf9f76e7772cf5960575f0be8b9292645f70d852f77eb2f4c92e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:d82f6e75097748da",
+      "candidate_sha256": "ffce9aa676545670fa722b6aac6c466679b9ecab9a930776e524c8bf20752790",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "mockito",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "mockito:db2a627e3c414165",
+      "candidate_sha256": "6f54e260b213a96cf5cb6661fe9c6aad46bdc484cbbd587c818993e953b2de41",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "mockito:e1ce9eafd54a610f",
+      "candidate_sha256": "18111f9faebf51418c2efa15ba273df9ad2740f7d28da304008b01603cff9e59",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "mockito",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "nats-server:5771783a43038bcb",
+      "candidate_sha256": "3f662100dce06ae51bf10c2426532fad29ab5ef12487e11f3f62103a5eb90dcd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "nats-server",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "netty:43870dd59c2be294",
+      "candidate_sha256": "65ef1dc1ed9449357fca6df1c46a572f991299108fc348b4371e919d7db2657f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "netty",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "nushell:46fd2ef00c8d9e98",
+      "candidate_sha256": "8127cff718c923f4c4a5a709effe980dbd9460858e14a41666d9f6fb320f262d",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "nushell",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "nushell:5e0a811d5b711a35",
+      "candidate_sha256": "c1cd3e5b51fbfae434975172db05f5fe9f87fd50abefd39d3a9e5bcea23cdba5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "nushell",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "nushell:5ed48a642e38d987",
+      "candidate_sha256": "0889bf08b1cf9dc62e6e61524cc405ed7876f62fde25754cdc4885c4d66ddf20",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "nushell",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "nushell:88118551cbcdb7f3",
+      "candidate_sha256": "7c46cb62826396e29ad10cad83e02209fcda151c92f0fd42cc7f08e03d5c0f52",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "nushell",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "nushell:b950a3c8f074b925",
+      "candidate_sha256": "7671f790119886fc9204cc53c05e2f851fd683acd3f2df8b9911465f487aeaa8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "nushell",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "nushell:c6f90bd8a5eb11d7",
+      "candidate_sha256": "7ee961d084bbb96fa3f01886ec71dc0d340dd50649d5523071a8e42291190f74",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "nushell",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "packaging:227533476889cd6e",
+      "candidate_sha256": "6595d48f121cb7492b8cd7382b9c5e8060c4028ccccf75059f8e44660ec22dfd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "packaging",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "packaging:9c308f351b219364",
+      "candidate_sha256": "1e0a0f5c4d7f7fec156b0f37adc2afd85121ea3a80ace737084c498202adfd33",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "packaging",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "packaging:aea1981ddc32dcf4",
+      "candidate_sha256": "47c95e3d4deac0f49167dd6cfcc855c1112af180394060c15aff79c19e4a5037",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "unrecovered",
+      "repo": "packaging",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "packaging:dff2a8be57aadc2d",
+      "candidate_sha256": "af3f9f0d1d642dafb77f7a4dea8475185fb564bdfb79775d2c97feca93992a7f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "unrecovered",
+      "repo": "packaging",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "poetry:053a58bae5b5c441",
+      "candidate_sha256": "9e6f3d7b7cb1dd263a5146e3a3df310dc43024b44997023d6b8ee0f016abf688",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "poetry",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "poetry:08556e25e7ab80e4",
+      "candidate_sha256": "e2363e766aa4eec9fde3402b25b7638df17c4112fe28ed78fb42a4d4638f7d2e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "poetry",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "poetry:e672109edfa67a72",
+      "candidate_sha256": "fe906c17c89e3f1855619d8e1fe56c7d5fdbd7428042f1117b8df46327b33686",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "poetry",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rack:b7b0b53fbcbab71c",
+      "candidate_sha256": "a28b9f78fb129b1e8c865743008ea1b9c245bb756a16eb93b5a7169e35284956",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rack",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "requests:8465ccbf517afa52",
+      "candidate_sha256": "214b609709c65f27e46ed4d9cfc080ae9a0686a1a7922de797bf0ab9c0cc537e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "requests",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "retrofit:4ce2a10ac749debd",
+      "candidate_sha256": "55557d01053d5d25e0fd00a2e0bbd655832aa24e9ca92e0d5a7c19b73f9d4a5f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "retrofit",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "retrofit:68bb7155ddaec5fc",
+      "candidate_sha256": "a66771d93accae2804d9f39ed6313d5a1fbe133080929e22bab9698f0e47fb9e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "retrofit",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "retrofit:a4f7b2b24dac8ef2",
+      "candidate_sha256": "ca0985690204aa85cb055c214011d6e7a6f75a0c1e3ae4922d5cc6e66eb182aa",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "retrofit",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "retrofit:ea9ce2ec096e44a2",
+      "candidate_sha256": "a6f45b7aa5f746ac164ffc9386d4d8625a434cfa63802c6e283816babd15f4e1",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "retrofit",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "retrofit:fa87ceae24540615",
+      "candidate_sha256": "f01175d6244d23e7c62e30b66988cf4089072805ed5bda5189aefabeb39e5084",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        8
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "retrofit",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rich:1cca23a830177a3b",
+      "candidate_sha256": "2904b1e9d0f510c2051857ad5353c131274ca453791565d5d296bcd9db6a2e08",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "rich",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rich:71efa9ae895b2852",
+      "candidate_sha256": "c0db31d870325d8a62aa85c6e485b768b26b18c883cbed60a25a31893ebb3975",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "rich",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:17b81b759c25a493",
+      "candidate_sha256": "38f0a0ae7529caea8cf34131dcde1fbb7e0d6f72fab8558b7bd1cff149a94de0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "ripgrep",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "ripgrep:1b6dd934f70b9533",
+      "candidate_sha256": "7dac6e253617bdfff6ea429db88f56fd1d3a1cfc2bc353a996b433be5843cf9b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:395768df3c164d72",
+      "candidate_sha256": "07d4d56528873eefb58d59a4da4302fe1a96e0045844aafc5a54306c4f0edb6a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "ripgrep",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "ripgrep:4b007c95b7bc5666",
+      "candidate_sha256": "866c09759a8efbe5bfac59be3567b2ca56a2fa41503809846695933c855fa433",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "inline-ceiling",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:519afdcaed73af0d",
+      "candidate_sha256": "8cc801b76980e41c492850a8eb29d633df91772439d70a1e8022ff40c3830d00",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "ripgrep",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "ripgrep:645645048b72111d",
+      "candidate_sha256": "da91e4edb67b4c4940e50d96d3236b20bbe98159a9ca12b08a73a306bf4be2e0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "unrecovered",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:70daf912736d8c82",
+      "candidate_sha256": "6d5ab713c2f94e97cda415936a0babc0a1e519bcefedfd0b47e8c04b493f755b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "ripgrep",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "ripgrep:8172f2a4057bdd27",
+      "candidate_sha256": "b1c227348e5cdcadb7898908d5c9a573578da32976077068ec057c08569da755",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "ripgrep",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "ripgrep:82baabefb13ac0e4",
+      "candidate_sha256": "6662affebb6d29b5e18fde36273be68a18502222638fee7b5308646defb731bd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        6,
+        5
+      ],
+      "language": "Rust",
+      "probe_class": "inline-ceiling",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:9194611e3dd97015",
+      "candidate_sha256": "9fb26bdd7c7b711187dff2789f996db4d1735c74a0b28cfd4365f28ac81f5d71",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "ripgrep:9b317c5d5b4ad4f5",
+      "candidate_sha256": "59d8278659467415a69792c275f845a03c5ef3e2016a6d854451ef01b80b03a6",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "ripgrep",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "ripgrep:9e4630087c22a3b0",
+      "candidate_sha256": "c5fbac4e0b11c206d847b0fa876d78077accb45db32ce6811f2d42ded69b6e92",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "ripgrep",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rspec-core:32a7d7612a8cb12a",
+      "candidate_sha256": "f979c3bddb1644744d426d435bbea1766666bfa6327edfb673db43b9e2365fc8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rspec-core",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rspec-core:7b5147536093e82e",
+      "candidate_sha256": "a7328e0efd287e778d364d11b9733d6404de64c85bfdf7aa19bbd81e41efe968",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rspec-core",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rspec-core:a1957f9937b645c3",
+      "candidate_sha256": "4b5c0e4ef02ef4adb85997167c46a25c3d219c181b06a45dc684b53d917153f8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rspec-core",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:107837ec875c769b",
+      "candidate_sha256": "c02dede825b90cf058f597c61f30be5831d7a9b32d9f93368fe6cd524be2c6e6",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:1eead1acc41e3d0d",
+      "candidate_sha256": "b9fe0551e7f284c68a940eae1203bc687056637aa0ecfff6c80435de3ac434ae",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:267fc66c0a4ce915",
+      "candidate_sha256": "7eb4711593614592a7a2852ea9267ecaf23a966b9bfd6b1f590023ad26fc8287",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:40711dc868c3de45",
+      "candidate_sha256": "68a188129c17a6db22e7b11f3f74ecedda2f72b32a465383a39d420860e61ade",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:40c914779a563002",
+      "candidate_sha256": "9b6bedfb8e05000737c1db547adaa54d41bb6bc6f14993be838cdbccd304e83d",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rubocop:42b457f15c15680c",
+      "candidate_sha256": "36f80cea602af56393213c46b24d85799bac0e2df5626b24077afe6c8fce09e9",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:66ab28d58fc0aa09",
+      "candidate_sha256": "21ff00cad2a4953c2bc3db6e75e268b3d728396d9c03be9b9edd0bc2c4c3de15",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:6af0178a5e70efbc",
+      "candidate_sha256": "32d6c8935886fb369c7968803f357c88ddfd1abe447876682650f32a659ef9dc",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:7bd6307d63463a53",
+      "candidate_sha256": "80d160c299ec4cc83b0e67a20b3ca373e1fcfedf19af461aaaabf71cbafe2e9a",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "inline-ceiling",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:8afc3058b26eb9b9",
+      "candidate_sha256": "0ac9cf5def628a085da23901ce057d57fb65267c023f1e462174ba6f211e895e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:8b9fd00e9f4e985b",
+      "candidate_sha256": "ab291e8517223219e63a5ead4bdd60065665cfc96540812cd38dbbaac4648180",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:9ad4362831b976ff",
+      "candidate_sha256": "54afe9b0c2f1abfd8fa2659b7df0d6357dd66a6f2d94073a7c1123ce094069f6",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:ace293d11479450b",
+      "candidate_sha256": "834c124160d6f8b5f545cf2290068387ffed7fc8b7545a21da575eed07626415",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:b956b31a66387140",
+      "candidate_sha256": "f10fd6d5e5ce6567584176484eec4ccf35a55ec2981673dab9e91dd6c4f350d6",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rubocop:c409de6f23092443",
+      "candidate_sha256": "152252ac9bb75ebc2c2a6eef6245a20ba6dd46c6f5df734e965628b1fd3f866f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "rubocop",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rubocop:c6c89e4eb592a4cf",
+      "candidate_sha256": "15162dc483074dd4ccaad90bd9bfa705a212eb90fb2f1ee6834b04f51a065b69",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rubocop:c8a5713da90ca9c8",
+      "candidate_sha256": "d73ac56fead222d8ef8c248f14d30e576176f3104351cc782464a3497d3810b4",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        5,
+        5
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "rubocop:fc6e340b14f9df88",
+      "candidate_sha256": "c26c95ff9498a5354650e4158d230c631e2521b17dc6fca4042a9373dda5bd92",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "rubocop",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "scrapy:533cc1e54f54c889",
+      "candidate_sha256": "ecbb3232eb5c714a8c6d2ffd28bf458ac128c5425416bbab358177b28e677eae",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Python",
+      "probe_class": "inline-ceiling",
+      "repo": "scrapy",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "scrapy:be72d6b46ad8eaf1",
+      "candidate_sha256": "6963b79dc8e4de4ceecd58c6b4c029e31dfd9ff7de15f4a4d3dd6faa92274441",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        3
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "scrapy",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "serde_json:2515a9bc2af59ece",
+      "candidate_sha256": "62c870bf522611ae0c96dac81e5c421eab766b1e7bd25c2f84319fe7b8d2e427",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "serde_json",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "serde_json:2f42630683e613dd",
+      "candidate_sha256": "6594478fb9ba1f90c3d4b3b21e59cdd5e12a6927c1d5f98598ba96994f61f348",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "serde_json",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "serde_json:3f1d50e522be29ae",
+      "candidate_sha256": "e9c065ca3ff8bf83c2678ffe174e2b3a4740238cd7be16d38ba3c39a5bee4464",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "serde_json",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "serde_json:8dc63e0bf59dff86",
+      "candidate_sha256": "403bd910e440a367948b99a06941c25603cb84bbdf0205b255c951760a1f360e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "serde_json",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "serde_json:946bfa61cb71d562",
+      "candidate_sha256": "d9014a0c4450f8a1a2798507d4ccce4c51d43e7720bf3cb98d64d39ffa5b5756",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "serde_json",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "serde_json:c38a8703c271821c",
+      "candidate_sha256": "7f02544a571f3bd454d08d3f0d49f92b37a412698d0a0fbfb8d55833fc64b524",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "serde_json",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "serde_json:d4ed845b75ad1b1c",
+      "candidate_sha256": "442501fd63a58d848455acfd96ee7a9720f0dd05fbff4df8c0a868ee93393179",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "serde_json",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "serde_json:e05e8bc1734e5ef0",
+      "candidate_sha256": "649ecb6f45b3368bbade2f08632c04706de604561e63f28231b10f56242f1ce0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "serde_json",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "sinatra:c8eba586fdfacedc",
+      "candidate_sha256": "44a40ca5891725586c168b2595f8993665311fa7ee56bc7f8de50927b5a72ee0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "sinatra",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "sinatra:e4ad961494fe684e",
+      "candidate_sha256": "33e03e00951de052ebf8c5199a22e79475c7d2d4d39bdff69ab278843a979058",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "sinatra",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "swr:9b7a03feec3a4cce",
+      "candidate_sha256": "e2c696c8e4ae43729bbd7ed107be9b9fab9fa3238563adbba9db3581eba6e1a7",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "swr",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "thor:07e233ddffad07f0",
+      "candidate_sha256": "c3607b8739203183114dff0787b5aa08759c4fb42acca06dbd7fb183d1e90149",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "thor",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "thor:c9e373f89995a6f6",
+      "candidate_sha256": "40bdfa3fc84c63f006826c975dbf01f4d5e7426ecc0fa4053ab37d9b0215df8c",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "thor",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "tmux:4d161d7f40bac6f1",
+      "candidate_sha256": "4f7c526daa79515217e08a28f45509a750a6a9374d57b58735554b3231e37f37",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "unrecovered",
+      "repo": "tmux",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "tmux:6c7a09c2a9c5c2b2",
+      "candidate_sha256": "9b3c61ac9465a247ebfabfcf4a955aea2f93934b44a7d72bcef627ebe5964c06",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "tmux",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "tmux:efdb8be4fa09f367",
+      "candidate_sha256": "d085f256956589d3913272f48bdf53d35a1a82556b92acae9b6720194f2dd9ca",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "tmux",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "zap:23de1a83b5d5ff94",
+      "candidate_sha256": "5bc3f8cfe16e43bce128a9d5cff8cfa5b85e5930a321e16ac2e25e3da81771dd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "zap",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "zap:c3ae8f9eecbafd9e",
+      "candidate_sha256": "28e6e7bc9e43e98ff6ff82aa2ec96bea150c305ffb57718a0dee635af908124a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "zap",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "zod:1ad07dedfa877a0e",
+      "candidate_sha256": "11962c0913e6ba545a54e9f762bc65a9aac0a6225f1e88ccb4985185751344cb",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "zod",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "zod:aa98d1623d4fda52",
+      "candidate_sha256": "c9144a02941d22cb0907d7c83547d2b9105241ca7c33f8f2cae6f3628f2d351e",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "zod",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "zod:e6c204c8d398e185",
+      "candidate_sha256": "82c6cd02f99bcee27a22f0ce51b8179097a191ccc81e7cc26fb29e62e74413e8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "zod",
+      "stage": "extracted-no-candidate"
+    }
+  ],
+  "failures": [],
+  "method": {
+    "interpretation": "A direct accepted pair is already admitted by the raw structural detector. Because query adds syntax and shape-candidate arms, this is a conservative accepted-pair witness, not a complete query simulation.",
+    "surface": "nose detect --candidates"
+  },
+  "provenance": {
+    "command": "python3 bench/labels/missed_worthy_stage_audit.py --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json --nose target/issue-820/release/nose --repos-root bench/repos --json-out bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json --check-binary",
+    "git_sha": "59530c575060abb0e6ce672efca4bad85e74c40f",
+    "nose": {
+      "path": "target/issue-820/release/nose",
+      "sha256": "5999e791c276a7d098099911b8252d35609d1ec7dbcf38888dad2815b126dd0a",
+      "version": "nose 0.18.0"
+    },
+    "selection_sha256": "419ab53ca32c9d33443c64dca03687220d2d92940e47bb8dd2df4b61e40d3712",
+    "source_artifact": {
+      "path": "bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json",
+      "sha256": "b3c3b8c6ba5581f5679bc6de685be52c63a40790640784f98c58597e002f57ac"
+    },
+    "working_tree_status_before_measurement": ""
+  },
+  "repository_runs": {
+    "alacritty": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/alacritty",
+      "counts": {
+        "accepted_pairs": 318,
+        "candidate_pairs": 1640,
+        "units": 2092
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "a35592b880034f309086498ecb074075bb25f110b1cfef0ffc1db60fb27d8136",
+          "size_bytes": 18016
+        },
+        "predictions.json": {
+          "sha256": "128d39d5868ec564bc02d9fab1793399b9fc0f77790ba4e85b93d6afdcb2c017",
+          "size_bytes": 95069
+        },
+        "units.json": {
+          "sha256": "ec9fe89d232ce04563c45c6d7240a00935bed1a642b92c2ee048f60d601abb75",
+          "size_bytes": 198453
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "21a7bf5e1c3de11558f15f204c6aa773a437cd153c6b4ab3dd92670a9812b42a",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "axios": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/axios",
+      "counts": {
+        "accepted_pairs": 675,
+        "candidate_pairs": 1488,
+        "units": 1119
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "f848601d2c27823b2179fc32d233a389062b2c76bc6ac45371b57a84dd75057a",
+          "size_bytes": 15225
+        },
+        "predictions.json": {
+          "sha256": "27e46fd9021b4d2a2f94e5854ff5cfd050ba3b5b8934a0e7c3ebf65a0095e76e",
+          "size_bytes": 201557
+        },
+        "units.json": {
+          "sha256": "048ba96ea04eb777636ade0258db79370e54d721845ca74a59a8c32204e91b5b",
+          "size_bytes": 99128
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "6603a2955736afc2b85e8a5de91af2f8b61e93bd71f58c8f4e3e7542bb74060f",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "bat": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/bat",
+      "counts": {
+        "accepted_pairs": 69,
+        "candidate_pairs": 668,
+        "units": 1053
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "1bcd8a7e8180fca0d03658933979df8ab7cd980f63414e56f42bab5f86ee980b",
+          "size_bytes": 6640
+        },
+        "predictions.json": {
+          "sha256": "52181300e6cd60c2bf7921397b5cd48dcdcd5b11b1c200ba94a283abc5df7261",
+          "size_bytes": 20275
+        },
+        "units.json": {
+          "sha256": "418c60aaedd427f29c0685c1ed794c3a02bef72f6cae1232cecd3ddc13a58d9c",
+          "size_bytes": 82510
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "6dd3e0d44931bf8f8b1a04b7115342df41ee4d56ccfce760a570268cc85e90c4",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "chi": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/chi",
+      "counts": {
+        "accepted_pairs": 112,
+        "candidate_pairs": 380,
+        "units": 508
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b4b85c6337c9d41881643d339234f8fc46b16c6a1a1d2a543aeb32cde926f5b1",
+          "size_bytes": 3497
+        },
+        "predictions.json": {
+          "sha256": "330acc272b76769663bc22c06eced77546d126677fe3d760bb49d169ed5364d5",
+          "size_bytes": 29121
+        },
+        "units.json": {
+          "sha256": "d045a02f1736e8237e82e0388c676a9282c57bb3a815ab2aa14d7da9d7a95af3",
+          "size_bytes": 39179
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "22505cc87ad8d1bb316e8b770fc2cbfa2e2f52db05bf8e9acb26d6662009a523",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "clap": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/clap",
+      "counts": {
+        "accepted_pairs": 2528,
+        "candidate_pairs": 8485,
+        "units": 4108
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "24075dd08176bf2a6362b4bb307c39e7542cd36fd11b5a664dfe526c9ea51e77",
+          "size_bytes": 96174
+        },
+        "predictions.json": {
+          "sha256": "9c63c8a42f87fec27563bcabf2969bf92e814a3f1d8f3abd5b4437cd9a834e67",
+          "size_bytes": 790144
+        },
+        "units.json": {
+          "sha256": "30270820f2d203d336d54bf841f310c56d7266e0d7c105410d4a8bcb6ef00a66",
+          "size_bytes": 368799
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "e31328bb07342c293361b199e6af264af55f06c73ef0daeabdf99d96e27be043",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "cobra": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/cobra",
+      "counts": {
+        "accepted_pairs": 233,
+        "candidate_pairs": 680,
+        "units": 581
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "0aeee82193268b5ecaffc180661ed4121a910695bc9468baa53a1aa481bdf0ba",
+          "size_bytes": 6205
+        },
+        "predictions.json": {
+          "sha256": "15679a3cb60a59e0d7cb32e6b9fd2dfcd67526213e9f11d6ada8f4198a3499ca",
+          "size_bytes": 67389
+        },
+        "units.json": {
+          "sha256": "d2d371b74023846338d89c2d46c80ccd55de2e8d7628d1946af6ee4602e77cbf",
+          "size_bytes": 42191
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "554b5ca0f498e5b7d17576eec81fb425f676f44043949bf42beb829802b39e6c",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "commons-lang": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/commons-lang",
+      "counts": {
+        "accepted_pairs": 9443,
+        "candidate_pairs": 37464,
+        "units": 11133
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "f5f5af6da380a97b148df59815b2ef460866d0253c03a3306aa73c17b151dd7d",
+          "size_bytes": 438940
+        },
+        "predictions.json": {
+          "sha256": "9818e27be917b7bc0a40b21628c07d621f2fa2e7a306f1e8238c737825e230d0",
+          "size_bytes": 3490858
+        },
+        "units.json": {
+          "sha256": "cf57ea1b9d0b5ab128f0f605427afac9e2356b15c4c8586f8af81b8efd53b11f",
+          "size_bytes": 1439551
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "7ff25a56b4e4a9b2e011e6b0638ae51c62298d134d8fdcf1f70cd841493be28c",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "curl": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/curl",
+      "counts": {
+        "accepted_pairs": 5701,
+        "candidate_pairs": 27907,
+        "units": 11983
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "800089d6c0df90d953669db19aee00603cbd407ff7037ddf2f923767470e65b6",
+          "size_bytes": 335249
+        },
+        "predictions.json": {
+          "sha256": "11dcda72aa5c1345a151fcbbaa7d9c2c226df61d30ea9e65cb60ae23d2f67b21",
+          "size_bytes": 1446790
+        },
+        "units.json": {
+          "sha256": "d304600c7874938b05fc72f4550891f7a2ff39f59c5c75b152677d8f717dbb5f",
+          "size_bytes": 916245
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "b29e289fbb3ec2b08a1eef9d9e3a94b96c31fa0791ae9de399f510633135f3b2",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "delve": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/delve",
+      "counts": {
+        "accepted_pairs": 2759,
+        "candidate_pairs": 9971,
+        "units": 5419
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "f4b024d035c215e359c0add775c49e4206e7a52a787ccffd6be3e26d6608ed85",
+          "size_bytes": 115601
+        },
+        "predictions.json": {
+          "sha256": "dadfce34c520afea0a991fb9c488805e892370f865470f61eba428cddf3a5695",
+          "size_bytes": 708097
+        },
+        "units.json": {
+          "sha256": "374f135120cfc3cf0c68f5c6e11788f1d9f95ebb03ab683ea8bf9da865e78670",
+          "size_bytes": 457665
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1ba9d7246014d6e67204cc1e299d852fabab6ddf25fd6eea104d51d436dfb531",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "devise": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/devise",
+      "counts": {
+        "accepted_pairs": 108,
+        "candidate_pairs": 1035,
+        "units": 1328
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "2f1de2a54041f91bda92542dc5033083f147cb7cbca2bab499cb2acb46507760",
+          "size_bytes": 10815
+        },
+        "predictions.json": {
+          "sha256": "fdf918a4cb081dc20a42ad52a7403a5162eca36c2a468f9fab170efcd0755401",
+          "size_bytes": 39698
+        },
+        "units.json": {
+          "sha256": "0e801c0360aa950f364a014cc77bb9839411db073d95fb69e144a27673b8375a",
+          "size_bytes": 123686
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "957c1d004d79345a5dfd95c77802675060e46e091c78e1063031d3a58788ed97",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "fastlane": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/fastlane",
+      "counts": {
+        "accepted_pairs": 7290,
+        "candidate_pairs": 26019,
+        "units": 13133
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "2dddbc82367c5e57e380eb5c721c1db2a02a4a6fdb9511ca31f5a3d55b61a9e4",
+          "size_bytes": 321885
+        },
+        "predictions.json": {
+          "sha256": "e0ccc3f05bb326ffa76f743f092b404314ce8c304ca7f8c6d90555729542be59",
+          "size_bytes": 2532428
+        },
+        "units.json": {
+          "sha256": "6a47a5190cc49f786a02c597315705dd2377f2e8751dad17285c52c07f1ea55e",
+          "size_bytes": 1389273
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "86f395fc869e183c8775078eb1c20aecc01e599e0d1f60361fea8a9a6b3f4fc6",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "fd": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/fd",
+      "counts": {
+        "accepted_pairs": 25,
+        "candidate_pairs": 158,
+        "units": 445
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "0dbde7da3bf0c359f15a2c0ffc5a213b417474b5d47c5d2226b8572c215477b0",
+          "size_bytes": 1484
+        },
+        "predictions.json": {
+          "sha256": "2df2dc80964ff07d1d4c7382e0172bb7a1655b78118cb73397a946ea5f5de818",
+          "size_bytes": 7115
+        },
+        "units.json": {
+          "sha256": "790fa7237d96bb794c5a30b14f1f878642b9e3529d1a1dc1ad5c649b238eb741",
+          "size_bytes": 31267
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "3b496ffb84002979d92701fe504d878d3797fcfa35e24df1823d2bb11441cc6d",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "git": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/git",
+      "counts": {
+        "accepted_pairs": 2127,
+        "candidate_pairs": 26560,
+        "units": 19299
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "6068fc410985ae8e9aeee6f6111ab7a0f3a98fa142da50c8515a8cf27b83ac73",
+          "size_bytes": 342026
+        },
+        "predictions.json": {
+          "sha256": "041651775df8e8a2b570601e00d5a838b4f251341ce7afbd8ae34bc927b61d36",
+          "size_bytes": 488193
+        },
+        "units.json": {
+          "sha256": "dc79adce904c2e25d1449ac288b06af567b2df06af4478decf40214849867c2d",
+          "size_bytes": 1386836
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "5949a9f371b75a19b9a7595a7c672d77232c79c45856b8ee2f75893f77ac9cd7",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gorm": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/gorm",
+      "counts": {
+        "accepted_pairs": 420,
+        "candidate_pairs": 2170,
+        "units": 2258
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b08d4bc5952d8c89b2d6559dedaba948f97bf1efa97c67b86db1b079d11ee758",
+          "size_bytes": 23820
+        },
+        "predictions.json": {
+          "sha256": "e472dd4a6767c4f889b946d1f298635ef6e3b52a5357821514ca7985f92745a8",
+          "size_bytes": 108580
+        },
+        "units.json": {
+          "sha256": "8bc97f26729ca6fde7f4bd925d269ea2d2e747f2b21b498f705876b2dd73b043",
+          "size_bytes": 171502
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "dafbf29d40c1ac656dd98a14bbc3e5240f69884268391cb570e554fc28c4104c",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "graphhopper": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/graphhopper",
+      "counts": {
+        "accepted_pairs": 4009,
+        "candidate_pairs": 37968,
+        "units": 12141
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b2c869e56e7cfbfef59e8d2156cd6085ed0a3668b14e43d201d96c5e98004687",
+          "size_bytes": 450747
+        },
+        "predictions.json": {
+          "sha256": "eca876307f430cc830722c4dbc8cc3dd892b340f5e79c31e080b44d2f922bbee",
+          "size_bytes": 1465692
+        },
+        "units.json": {
+          "sha256": "dee9548d3f6984b45e094ce8e037eec7e31b12d5ba8d29f507c39ab7e9425cc2",
+          "size_bytes": 1612064
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "0b81677946fdd74e0a9fac408e02908de467510af2fcb354b057decaff06c6e8",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gson": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/gson",
+      "counts": {
+        "accepted_pairs": 1613,
+        "candidate_pairs": 11043,
+        "units": 3984
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b091de7a77a1f99bc39edbfd5d4bc6982cf0f4b8cc7060d87fee6bb35a996fd8",
+          "size_bytes": 123796
+        },
+        "predictions.json": {
+          "sha256": "44413ef1b01d7c4f33c09af9e1f2a135ae5ca02bc89f19df6a15d5fad28e7e3d",
+          "size_bytes": 569494
+        },
+        "units.json": {
+          "sha256": "6b7673110a861d735f435dce8c1f5c92bd4ec38eed7b0b0d1d21243f1ff1ebcd",
+          "size_bytes": 496984
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1bf9f579cca34334960a102bef66fa4ae650f1eadcbeff7d8bf294df6b9c0c8e",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "image": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/image",
+      "counts": {
+        "accepted_pairs": 645,
+        "candidate_pairs": 3401,
+        "units": 2723
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "61c1079fc14ca6d6ae6647c0764ce4d8c7a5d58c6d3f21242da7818273f18d30",
+          "size_bytes": 38753
+        },
+        "predictions.json": {
+          "sha256": "e7edd512d681e163d395feaba111a898b4b01334da9da3b84b0365e785d2e0eb",
+          "size_bytes": 178766
+        },
+        "units.json": {
+          "sha256": "e1f8178d03fd0a4431b2dc65aa779b093481c4ed0617aecab1ed41ce3bdd4cbb",
+          "size_bytes": 218939
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "81f6fd630903b4b7c2317f5202e983b8aa77810e08c35e255cf4e44c795c9166",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jekyll": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jekyll",
+      "counts": {
+        "accepted_pairs": 166,
+        "candidate_pairs": 1161,
+        "units": 1896
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "6fccf4aede76c910b89b39a9a9cbcb40b819dd69b3efcc6fd3e81cc78b46e550",
+          "size_bytes": 12217
+        },
+        "predictions.json": {
+          "sha256": "15950b3c595e9dee7afc848a5a11f84d9f1701557627168986691325dcb6e804",
+          "size_bytes": 47868
+        },
+        "units.json": {
+          "sha256": "6fd1acaec6346624ae03c94dfb76d4788e9237058df81aa79b92deb959432d37",
+          "size_bytes": 161291
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a3abfe8afce2c4779c2e4ad258fa9c29ef8ad9e174f7b56b117e0c7c450829ee",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jest": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jest",
+      "counts": {
+        "accepted_pairs": 879,
+        "candidate_pairs": 5038,
+        "units": 4873
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "6c8c0ecf837533943d7b592d04a8e027fbcc20754541aded130b2399025f252d",
+          "size_bytes": 57060
+        },
+        "predictions.json": {
+          "sha256": "09b694a4e222b038fa4473cda7d70ee7f558379adc9b487af5f643f5020461af",
+          "size_bytes": 262411
+        },
+        "units.json": {
+          "sha256": "ce8a1412d3d01388c7c0ac40604b02ac69975feea56cc87cc47c8671506affe1",
+          "size_bytes": 485580
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "069d00ee2160261d3bb2469a45c960cc6b9e17eceeef78501156190ca145cf73",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jq": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jq",
+      "counts": {
+        "accepted_pairs": 28,
+        "candidate_pairs": 412,
+        "units": 1002
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "c841face0b6ddc17d6107f9b790bd6e706c2d66890afbe68ec19e0426cad8e3a",
+          "size_bytes": 4060
+        },
+        "predictions.json": {
+          "sha256": "97f60876228f4db91e84cd3be48470353f129a176b2081cecaa1512673b516f3",
+          "size_bytes": 6981
+        },
+        "units.json": {
+          "sha256": "bb073cec6e718992b22631fd7a7e518e757eff3f4716fa605f968318fa5ad47f",
+          "size_bytes": 69181
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "985e8ab1a400a190659eae0ed551e01a0fac498331e70647bd7f98a6a2c2fe69",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "lua": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/lua",
+      "counts": {
+        "accepted_pairs": 74,
+        "candidate_pairs": 1819,
+        "units": 1837
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "5432dbcf5e953e0bd4ddaccafc77bde4e06755d4d2e0b3141558eb171dfd97e9",
+          "size_bytes": 19523
+        },
+        "predictions.json": {
+          "sha256": "9e6d37cb2670dc5c96ece8527f1858e16ad058dd5fbcd93e9f0ecb6539e29274",
+          "size_bytes": 17919
+        },
+        "units.json": {
+          "sha256": "25e1a1467207f7c058e4edf136d2520690d023d8ca4d7da7ad9ddd1137721364",
+          "size_bytes": 119255
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "81be994e26254b3905e1ef030ca26a9dd525ce79b16dcaa9f8968fcd0eff06a5",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "mockito": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/mockito",
+      "counts": {
+        "accepted_pairs": 3224,
+        "candidate_pairs": 19252,
+        "units": 7322
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "78bbb8ffdef996a54f80b78a8f9c2449e334b707b3424bfb416bf63d58a83af0",
+          "size_bytes": 218302
+        },
+        "predictions.json": {
+          "sha256": "0f016e6a43292c69abf8a849cbd862f4bb2c3769bd082540646788a4109427ab",
+          "size_bytes": 1252490
+        },
+        "units.json": {
+          "sha256": "6c7c3eed534e7b613be27ce6cc5cfa930a54cc35079f672461d21d0dd19edbc7",
+          "size_bytes": 1067019
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "bbd318e03a182427879abc8f17b30e2733e1788c8ca8fae8ac3b7f1461e918df",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "nats-server": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/nats-server",
+      "counts": {
+        "accepted_pairs": 9347,
+        "candidate_pairs": 15661,
+        "units": 6048
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "8af3ca008bfa2a34b9dfc8471d0752e0b7cf9c373a5ba1e19a97d4281e39be17",
+          "size_bytes": 184933
+        },
+        "predictions.json": {
+          "sha256": "ec3ef35646a4c1bde3496e57cca41708984667f70b996cd4a0b3b9a2a4f46e7f",
+          "size_bytes": 3373685
+        },
+        "units.json": {
+          "sha256": "73506a5afa41f83268c10ff94bb3ff1e6223a51f404cc82ef29df43f80ab3a56",
+          "size_bytes": 520773
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "e14ae0e950c6dee0bbf5ed7cf2ff24ba638f66a97a85e6c9890646d4c4447257",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "netty": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/netty",
+      "counts": {
+        "accepted_pairs": 61418,
+        "candidate_pairs": 215880,
+        "units": 46248
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "6c4d40d8114ec5a204a65fca5c536591851696bb751dee6b5e3b5a1bae7da1a1",
+          "size_bytes": 2854756
+        },
+        "predictions.json": {
+          "sha256": "a0396f2de5efeabf7eca8e6f05f0b861d4321e7bf7f232b975476d412d97d458",
+          "size_bytes": 24195523
+        },
+        "units.json": {
+          "sha256": "cb7659692590bb862747bf65fe35d37d44a5e6e604e5e1795fb989950010b165",
+          "size_bytes": 6283803
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "c998c3001d16a52f08d5431a2a27e119f4bac2994b230b18ac79a4bac5dd67d8",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "nushell": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/nushell",
+      "counts": {
+        "accepted_pairs": 19483,
+        "candidate_pairs": 76370,
+        "units": 24341
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "06532d9357711dce2fe2671057d428831cd192e1d225c083c484ff6001c625ad",
+          "size_bytes": 995204
+        },
+        "predictions.json": {
+          "sha256": "3e8e3446c65d33efcda482aa1c7f04cc14045957e8f56c2fa4ce93345c98f2e2",
+          "size_bytes": 6438846
+        },
+        "units.json": {
+          "sha256": "4a844277979805a38cd83b8028350204c2d7aef617c943592b625fb3036e9002",
+          "size_bytes": 2471310
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "0d70d80236b551c5a9af653ddd2b3f1de29a04d474c5cc30a1045bf3a68652e6",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "packaging": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/packaging",
+      "counts": {
+        "accepted_pairs": 494,
+        "candidate_pairs": 4223,
+        "units": 1885
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "98fc599196b02820a0492a716e5724b46d11636fc34be12e6b50e2a419b37010",
+          "size_bytes": 47090
+        },
+        "predictions.json": {
+          "sha256": "f819a874bf112186d5fa115e629c9fd7e98a9cdedcc0e8d72c264db739260d13",
+          "size_bytes": 155725
+        },
+        "units.json": {
+          "sha256": "9bc3a28dc7b2ee9d9b382b89096364b1919e5de46dea8556c855a8ad2c25278d",
+          "size_bytes": 171164
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a1c21d522ca37aa6f03d45e714ac70ea6e4746d30ac0173e08f74c4259983b32",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "poetry": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/poetry",
+      "counts": {
+        "accepted_pairs": 2622,
+        "candidate_pairs": 9006,
+        "units": 5304
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "d059fb5b54db7a91c764206df18102703052369a20aabc386654007c3c40e2bf",
+          "size_bytes": 104700
+        },
+        "predictions.json": {
+          "sha256": "40fa173ef4518c003793cf7dd113be51ddaba93ef287b7818bbe773e29dcc02f",
+          "size_bytes": 732670
+        },
+        "units.json": {
+          "sha256": "2c5706aac97e3934e994af6b0577e696dbcde64fc9b49bf0723e7365230256f4",
+          "size_bytes": 504546
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "da0c2ef84bf9fac6d7a8c1a88b127f50aa090a0bd88b44e2e44d0b935af9015d",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "rack": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/rack",
+      "counts": {
+        "accepted_pairs": 69,
+        "candidate_pairs": 656,
+        "units": 1263
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "01a7dafdb35e485c2552e004edb4670bd253e8cc8180d4b8bd0f99e592a4aaa9",
+          "size_bytes": 6562
+        },
+        "predictions.json": {
+          "sha256": "f88848553d357f06d58b719760c8bcf57f42b3dcb550c53a99b5e37cd24da5fc",
+          "size_bytes": 19962
+        },
+        "units.json": {
+          "sha256": "4275ff7679b1549ced5e26b0204f5e4cdf2fbb70595edceec56472fb81bc722f",
+          "size_bytes": 98842
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "da1b7aea6b2242045455ac5031444325b72f2e227d7eedd574c2de76e1b82082",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "requests": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/requests",
+      "counts": {
+        "accepted_pairs": 78,
+        "candidate_pairs": 422,
+        "units": 663
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "ae195b9f0daa12250991c4c9c830c84c57d3ef248b11e7b4ce589ab01038e653",
+          "size_bytes": 4133
+        },
+        "predictions.json": {
+          "sha256": "c9cae26938e9f1244dc6704c0de4e759af0a16b4b1fafe9f4ee3e95fce2ce8d3",
+          "size_bytes": 20083
+        },
+        "units.json": {
+          "sha256": "cc664a273e4501fed6eb7a8c34db2c3605ad565793a79a0c5e98b49ff2749517",
+          "size_bytes": 55402
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "745d729e6f17d1ea5b22b54fd0595d0d496dd3fa5ae86f6ec7eb16d572dab736",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "retrofit": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/retrofit",
+      "counts": {
+        "accepted_pairs": 5963,
+        "candidate_pairs": 15369,
+        "units": 2585
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "defe51708b4c2f1dd2bd257286f35c84de5e7de29e7368a82df69406df8f5ac9",
+          "size_bytes": 164928
+        },
+        "predictions.json": {
+          "sha256": "6fb44d5a4673fe4af11d9d55e70ddc9f1a94f10724a746d0dccc3c5992d882ae",
+          "size_bytes": 2472816
+        },
+        "units.json": {
+          "sha256": "701c09dbbac5da04fd9158d19b0d8bb5bfe30e5d82c382392e0e6952dc4d098a",
+          "size_bytes": 355694
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "9d1e78d1a4555b939d33eb36d667b2a314f30ec7fa8637ccb4eca30ef9c7ca7e",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "rich": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/rich",
+      "counts": {
+        "accepted_pairs": 330,
+        "candidate_pairs": 2749,
+        "units": 2666
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "a46b00ce73474045e2b9910f18fe6cbc0403c20796f8543550c6d24d7d4b5c27",
+          "size_bytes": 30405
+        },
+        "predictions.json": {
+          "sha256": "16640b598846884dbe6c94dbb9c04c026d58d7b40e1d6fb299eeeff65203b5fd",
+          "size_bytes": 85345
+        },
+        "units.json": {
+          "sha256": "dc884629a8d61d672692d08b372bcde79bc7688e70ac838e0ad2d684b1585724",
+          "size_bytes": 199604
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "3434f0065535b807202fa146827e0c9c3b50d57c836049ac7303e6137a8e859a",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "ripgrep": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/ripgrep",
+      "counts": {
+        "accepted_pairs": 835,
+        "candidate_pairs": 7665,
+        "units": 3034
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "5a15c09137479dcfd45bd440b573d92f89e0516aa4612d13b04d984ea495c049",
+          "size_bytes": 86108
+        },
+        "predictions.json": {
+          "sha256": "557965f88791791e1ab670e3a317e4d9c51cd9d9d6ce7683e9ca086777b2b8be",
+          "size_bytes": 242820
+        },
+        "units.json": {
+          "sha256": "ced4c9a3ab5f5edf797890041e2e8d5cd92ec17eb4f1ee898a2afbcef50c60b5",
+          "size_bytes": 268514
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1545585db4819d99e5fe3365d58feacf063733176a859f94ecb2ae6e91f441fd",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "rspec-core": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/rspec-core",
+      "counts": {
+        "accepted_pairs": 176,
+        "candidate_pairs": 1379,
+        "units": 2852
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "ee21a9f5c8278c5b8b48ce14e6096d5960983afd70869fa78f0963999169b3c2",
+          "size_bytes": 15185
+        },
+        "predictions.json": {
+          "sha256": "6c7080cb60156484b663066198830eabd3bb762c0f78f1e0c3cc6bf0dce9d076",
+          "size_bytes": 64182
+        },
+        "units.json": {
+          "sha256": "25bcfc90fe4a87d033197f0f149d5af56ea77a53b5663783e690d75f6284580e",
+          "size_bytes": 286186
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "8c1cb64efd5415fab09d9e6748062d05729f2368428acd3730ed72c980a4a4c3",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "rubocop": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/rubocop",
+      "counts": {
+        "accepted_pairs": 3941,
+        "candidate_pairs": 25986,
+        "units": 16007
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "a6a4129f1a75c9fe2bd840e72ca695103aad54fca6bb7daf4c788799ace39d14",
+          "size_bytes": 321536
+        },
+        "predictions.json": {
+          "sha256": "9346a3f11abe2d91292d02de8577d94b6f6e313b14518c05ad76fd51d6b46c82",
+          "size_bytes": 1398606
+        },
+        "units.json": {
+          "sha256": "a17664b96384bc8c633ad91cd4d7800eb2e57a6faef940acdb29437d21ca6935",
+          "size_bytes": 1670627
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "9dbc06e6f6b142516c2f83f3fdf42db830aea266a9d42befe56814421c642bc8",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "scrapy": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/scrapy",
+      "counts": {
+        "accepted_pairs": 2468,
+        "candidate_pairs": 11208,
+        "units": 7291
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "9d425dad040beae65d5006a4630614594527faf52a56eae845b8334aa5ef872d",
+          "size_bytes": 131485
+        },
+        "predictions.json": {
+          "sha256": "ed2fd8a9b39429d760a74ebe708b09c39e1e672fc0d69e185e826ab5f60684b6",
+          "size_bytes": 691834
+        },
+        "units.json": {
+          "sha256": "a4a1c2c9626bf50b14e6ac76e0af3a2671247cc17a1891e43e212982c0ecb079",
+          "size_bytes": 643212
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "d6ff8998e7354320b619ed251c32cca23ccd8addbbfca667da32ae867b06e795",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "serde_json": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/serde_json",
+      "counts": {
+        "accepted_pairs": 1689,
+        "candidate_pairs": 3426,
+        "units": 1498
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "ed08b9d0ccc1b74a4cf948dd3508838ac608ab83a9c7faf07e11961ea46ccaaf",
+          "size_bytes": 36727
+        },
+        "predictions.json": {
+          "sha256": "1f6fba4029c5dd9386183eb162874ffc422c8a45cec5c20810c7cd96c6985dff",
+          "size_bytes": 477586
+        },
+        "units.json": {
+          "sha256": "66570897f817496cf5eccdc35e573e9594bdd574c055cd73ce2f8404b5fbae55",
+          "size_bytes": 117190
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "85f868e3dc18531955949fc06aa5492c6b0bc819cdc8a87fe373b7b2a0afa120",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "sinatra": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/sinatra",
+      "counts": {
+        "accepted_pairs": 292,
+        "candidate_pairs": 1594,
+        "units": 1612
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "09de21cf5081668ca5a4b4c8c40119bb2c23cbc39472dc1aabb09c6a22ced95f",
+          "size_bytes": 17872
+        },
+        "predictions.json": {
+          "sha256": "b48427868896024ea67b5a7bb322c12acf67b154d09f7471eecd1a4cf9c8b6cf",
+          "size_bytes": 94545
+        },
+        "units.json": {
+          "sha256": "3e3c3cc666f28f4ef173672ead263ad2e8eba65021a7fc4825f828ef7b4df2c7",
+          "size_bytes": 150671
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "04f42caa84b0893438ac2b169340ef911631cc57869a0c5bb76a7f6fbf9b225a",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "swr": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/swr",
+      "counts": {
+        "accepted_pairs": 2235,
+        "candidate_pairs": 3835,
+        "units": 1208
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "0b6710a005bbf342d5bc47dd34bca106ac18727940b1deb9320601baa3f977dc",
+          "size_bytes": 40100
+        },
+        "predictions.json": {
+          "sha256": "11003fba13bbf8552fe099f288865b6e506c249518d578e83ec4ee12797fe350",
+          "size_bytes": 612487
+        },
+        "units.json": {
+          "sha256": "ad85ca1d8a9d8d9082deed9ae4cbdd68f8273c60e36536bbc2c80417dab660bd",
+          "size_bytes": 107858
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "3daa94d1e20c12b71054af8cfb38564238a4cbf3aec32585186e842ee68fc363",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "thor": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/thor",
+      "counts": {
+        "accepted_pairs": 83,
+        "candidate_pairs": 433,
+        "units": 994
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "4b564f45e5109c3532af4396129ca056684c63796195e324fb8f4f7c438b0e34",
+          "size_bytes": 4265
+        },
+        "predictions.json": {
+          "sha256": "387351d08b14c1dba28024fe2763eb117ef493f8b706088447f811c1f8b38c76",
+          "size_bytes": 26339
+        },
+        "units.json": {
+          "sha256": "a50ce8b2180f5ad49fc4a6f097961ab8bbb4fcff4033adc31aa13d7d1c279ec0",
+          "size_bytes": 80811
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "ca8a3580ff9a4d52611bdf67b5b194579af705c7a520841ce1a4edcd69c40fcb",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "tmux": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/tmux",
+      "counts": {
+        "accepted_pairs": 708,
+        "candidate_pairs": 6318,
+        "units": 4245
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "d826c5f1a5a7d7ca6d7ecaf40a5efa16ad15701cd1e174accdedb3ec1d181352",
+          "size_bytes": 73701
+        },
+        "predictions.json": {
+          "sha256": "a644cf92430f8340826a2473afcc49ac25cc65888bf8ec8bf0fe0367a1b7fe0e",
+          "size_bytes": 183002
+        },
+        "units.json": {
+          "sha256": "2dca2c4fdbffc4de08ab31d425b0acb68c40d2d5d1280112d1474e25edcb288b",
+          "size_bytes": 295096
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "3c2d8da5d2c1b983823de5a17a2b230f68e4e19795c476dc51634aeca6b4b94f",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "zap": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/zap",
+      "counts": {
+        "accepted_pairs": 1026,
+        "candidate_pairs": 2318,
+        "units": 1384
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "955649bd750b30e34db65f1f481ee791419f8d96318a2503598d4722fa3a5389",
+          "size_bytes": 24012
+        },
+        "predictions.json": {
+          "sha256": "4c50aaf738e6f5483d42d7943c314ba3ec95705bde8fd29ce0f1f2685552bcd9",
+          "size_bytes": 263196
+        },
+        "units.json": {
+          "sha256": "e1c2d83e7688dad06a27d500f7cb3714d5e649bfc730168952419889408a5fcd",
+          "size_bytes": 103911
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "ea482c11bd1a7b6eeb7ebcf2605dfa90a2d18b48151c1feebc3ba598126c18f0",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "zod": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/zod",
+      "counts": {
+        "accepted_pairs": 4149,
+        "candidate_pairs": 8030,
+        "units": 2299
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "45621e343f6b43947f98cb27763edb9d613a9cddef54895e0b282fb1eae9ffd2",
+          "size_bytes": 93972
+        },
+        "predictions.json": {
+          "sha256": "2c3f0f7260763bb701583cb5c0d8f3238e23f5c881d97fedbaf03cf332dfb451",
+          "size_bytes": 1107973
+        },
+        "units.json": {
+          "sha256": "d63458ace0e346700c0e75115841e0ee3a0fff9f0eeca36d4fcbf949e8bbde36",
+          "size_bytes": 212763
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "fb7c34f2b837df4b112c04244084d5bffc4ead85ec297471a080072252d7b271",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "schema": "nose.missed_worthy_stage_audit.dev.v1",
+  "split": "dev",
+  "summary": {
+    "by_language": {
+      "C": {
+        "candidate-only": 2,
+        "extracted-no-candidate": 10
+      },
+      "Go": {
+        "candidate-only": 7,
+        "extracted-no-candidate": 10,
+        "missing-unit": 2
+      },
+      "Java": {
+        "candidate-only": 7,
+        "extracted-no-candidate": 21,
+        "missing-unit": 3
+      },
+      "Python": {
+        "candidate-only": 4,
+        "extracted-no-candidate": 5,
+        "missing-unit": 3
+      },
+      "Ruby": {
+        "candidate-only": 9,
+        "extracted-no-candidate": 14,
+        "missing-unit": 11
+      },
+      "Rust": {
+        "candidate-only": 9,
+        "extracted-no-candidate": 22,
+        "missing-unit": 12
+      },
+      "TypeScript": {
+        "candidate-only": 2,
+        "extracted-no-candidate": 3,
+        "missing-unit": 2
+      }
+    },
+    "by_probe_class": {
+      "inline-ceiling": {
+        "candidate-only": 2,
+        "extracted-no-candidate": 12,
+        "missing-unit": 2
+      },
+      "no-overlapping-unit": {
+        "missing-unit": 22
+      },
+      "same-unit-window": {
+        "candidate-only": 1,
+        "extracted-no-candidate": 15
+      },
+      "subdag-ceiling": {
+        "candidate-only": 27,
+        "extracted-no-candidate": 30,
+        "missing-unit": 3
+      },
+      "unrecovered": {
+        "candidate-only": 10,
+        "extracted-no-candidate": 28,
+        "missing-unit": 6
+      }
+    },
+    "states": {
+      "candidate-only": 40,
+      "extracted-no-candidate": 85,
+      "missing-unit": 33
+    },
+    "total": 158
+  }
+}

--- a/bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json
+++ b/bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json
@@ -1,0 +1,2123 @@
+{
+  "candidates": [
+    {
+      "candidate_key": "asciidoctor:11ce4268f0cf20de",
+      "candidate_sha256": "868b7b9da4e16fee70478312a8277a2dcac4cbc5a5c34050e3e460f1ec97a7a5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "same-unit-window",
+      "repo": "asciidoctor",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "asciidoctor:8699da327bd6ec73",
+      "candidate_sha256": "b99194c27ac1d485c39d9d52179aad7f5d0d41a754548d9607e1430a5f093bae",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "asciidoctor:8869aca250baf503",
+      "candidate_sha256": "45e54f5f621587a1e0deb6ce6758ec33d762dff7dbed49d13ab2b6542a15ccbe",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "asciidoctor:a1ecbd9860ff7d79",
+      "candidate_sha256": "b778f4ffaf24c74e2517fd7b8afd95dc7375f21c7d6cc44c645b12e93a12047b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "asciidoctor:e084a096af3db3ba",
+      "candidate_sha256": "a3db02990fad078f425fc420c11193b168b3dee07b44318459f930b18488465b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "asciidoctor:e3a775da989d15a2",
+      "candidate_sha256": "0ca829663f3b0c4d0c2b319300c0ac048baf9ba33f648d268dda131c03478ed9",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "asciidoctor:e9d7f17263b3ef9e",
+      "candidate_sha256": "d0ae9233925af2426bf24084d5dd95f25b05c92ce8739471f65739226fbab326",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "asciidoctor",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "asciidoctor:f49620c5fe1a5c28",
+      "candidate_sha256": "3c7d089b9fa0a3dbcb85b5e18492c2ac4feeafe563fc32087a0c12a787aee5c7",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "asciidoctor",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "boltons:ac3b57b1714437a6",
+      "candidate_sha256": "955f89a3e149fa1641a2ac99d16e3a58f6d7f80e44e97725858021310c1290df",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Python",
+      "probe_class": "subdag-ceiling",
+      "repo": "boltons",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "date-fns:2144f9d9bafc4adb",
+      "candidate_sha256": "3170c7eb87b0cf1bcd5691691ad10bd4194679a56695e80c7be32d62e7e437f4",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "date-fns",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "date-fns:486dcd2da0d41a72",
+      "candidate_sha256": "dce10df2169d28cafb41df423f800ec75ce7fc1a59956a3daeee5e0c79ead30a",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "date-fns",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "date-fns:959b04a23952dc9f",
+      "candidate_sha256": "362ad25f4f750c5c439a7999155882ab782c0e39efb2ceb5ab4e0d0d567f07b3",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "date-fns",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "date-fns:bdfb1a28bbbcdc44",
+      "candidate_sha256": "dabd2ea203830dfa94cae77abf0bdddda82fbb3738421315f1e28afa213d7115",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "date-fns",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "flask:f8a68d68a99d0686",
+      "candidate_sha256": "0d6afd61a3b0a13cc904e5edf612661bd1447fa5ac0f23e52c77e522e3333e7b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "flask",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fzf:2e8c305415b72ea1",
+      "candidate_sha256": "749bf0d5222be3358fd111f6ce08fab60f0818e1fe82aa4f024d23bfdb1d5d3e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "fzf",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "fzf:7a87eef6f427c345",
+      "candidate_sha256": "681dec1a0a9302954c0bb0a0583ad5e626c6ece5a3edd980f939dd2b4bd82d41",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "fzf",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fzf:7ad05a16966237d7",
+      "candidate_sha256": "430b57800ecd2fd673cb0c2f397514097bca5f9cdd216641ddedec17a7bb0a66",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "fzf",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fzf:b0fb439b03c8915a",
+      "candidate_sha256": "2b3afe34a8a31ee7c172f7824c8666e4cc9673169c1fef844b8525482eef5cd2",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "fzf",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fzf:b77e5403b856a74f",
+      "candidate_sha256": "168981c19209a3e872b6a9e9c541d5aa9d9aeec70619b0f358a8c51298d3fd3a",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "fzf",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "fzf:c90eca5c1c3a0f9c",
+      "candidate_sha256": "dc3b8332a0c1725b9f740f8b607d6ce18256ccc88a2ea8d2e6a2daeaa0573c83",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "fzf",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "fzf:edddd809d7e8e481",
+      "candidate_sha256": "c535beaf413531a7b47ec9a9d7a3f930e58469c0cbb830642fe71257f19602ec",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "fzf",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "gin:65f119e68db659dd",
+      "candidate_sha256": "e26db03f7848f3e54b4836ba7dbaecd19be8c6445a50d5d15f0ce8f7c8870525",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "gin",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gin:6bc4c8ba1738db57",
+      "candidate_sha256": "fc84d25d3b6e994db9d432545b54af47ef9cc8c4f7b97587eb5cc3db103105ea",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "gin",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "gin:e4a3c917303e7886",
+      "candidate_sha256": "37a42cf87f017a392bd251b1981c089b58e6ca07b63d51871f633ebf39ae9f9d",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "gin",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "hyperfine:8d17730736a3b397",
+      "candidate_sha256": "d1153f9481499d2cb1e28d36ea4a81681f281f21e293a103105a107534e18efb",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "same-unit-window",
+      "repo": "hyperfine",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jackson-core:b422f94f09cdb8af",
+      "candidate_sha256": "f3cdbabc17f7aed0305891cf1efcd83a52ed1260012e580f2e7158bbf1d9e542",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "jackson-core",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jedis:3bf2ce4ebf643e85",
+      "candidate_sha256": "505790d7960bc2825885859ae0d2093bee4685a192ca887fa85d9891a2d7cad1",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "jedis",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jedis:571c8822cc8713ae",
+      "candidate_sha256": "21e1a8d47d3bbc4970b12fca63691e123a04b1d06343a0cfb143fef582c867b1",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Java",
+      "probe_class": "same-unit-window",
+      "repo": "jedis",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "jedis:b349246419347b4e",
+      "candidate_sha256": "e456ca0cd1d2fc523253016c7678f38e8aaaadcd4efca54fc73a5e8a91156a6e",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "unrecovered",
+      "repo": "jedis",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "jsoup:07409b462c710a0a",
+      "candidate_sha256": "e88e3f42b31bc590e4ee742862b028a3a639ed396b702a40a7314df47721939a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "inline-ceiling",
+      "repo": "jsoup",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "jsoup:08ee491c1f4a7330",
+      "candidate_sha256": "82993e90b733cf98203a157b006b44bb2b5b7ebaf71df25ca236a36a8adccb9e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jsoup",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "jsoup:345ea47c67ac01ec",
+      "candidate_sha256": "952ece967150ea040199975b4e151d05e7a263ce7d58ca33658089e8718314b3",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jsoup",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "jsoup:9b909cd145cab0a1",
+      "candidate_sha256": "377e054c785942118f4aacc82132de41625248bae1c8c87db45e505bebdb182c",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "jsoup",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "jsoup:d7ddae2efb5f4a8e",
+      "candidate_sha256": "33d2bd0fe0fe934878573a9a87fabc1278d9e85bb27b606c28f3353baa9eb432",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jsoup",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "jsoup:de79fc0d2c8c8d34",
+      "candidate_sha256": "58344357302044e882bbd8fd476a20c8bdf7619ba0140267fee8ca5290c5ab7c",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Java",
+      "probe_class": "no-overlapping-unit",
+      "repo": "jsoup",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "ky:0525b9fef00e8153",
+      "candidate_sha256": "6a279fad7e9d76212ad3e2800c049e99fe4cae87628713b56e784688d6b3cbb9",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "ky",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "ky:65e620dd95442e39",
+      "candidate_sha256": "6f511d91bf66b2b9af8fe9c3eefb5b489a8c163ebb949389b5cdfd6812944b23",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "ky",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "libgdx:69cf536b3ec81f25",
+      "candidate_sha256": "0ae7b23eb90e3dca4aa3242370174d5687a6d903f83b493d1dfa99a512161019",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "libgdx",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "libgdx:8a6145e03a2ef0cb",
+      "candidate_sha256": "3a86f41de3897165dbd1974436a382b01d3e921d5bb35217f302e72b786c3f75",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Java",
+      "probe_class": "subdag-ceiling",
+      "repo": "libgdx",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "libuv:274a5f3b06e8f568",
+      "candidate_sha256": "d95982bc933cbde1ba4943f82a8a7c2672fd0bb1228e1dfb4a35ff0bec65469f",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "libuv",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "libuv:286758993f6dd08b",
+      "candidate_sha256": "ae9c095fc94957b84f527e13b309bd1882a88db09b931c271b207851a232bb3f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "C",
+      "probe_class": "no-overlapping-unit",
+      "repo": "libuv",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "libuv:3c29652abe2b1be6",
+      "candidate_sha256": "feff20b4c9a4c630e86481cef20fc083f406ca16f21b937c1240a8dbc53e9e2e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "C",
+      "probe_class": "no-overlapping-unit",
+      "repo": "libuv",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "libuv:b7eb674546159318",
+      "candidate_sha256": "9bd830b336a2f3d02704db6ad556f46bc16e0bbaba17b7db2c111ee569bf18db",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "libuv",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "libuv:d43581c5e3bc852f",
+      "candidate_sha256": "d5a73785a8e77aa8b2890393966fb714905faac01c9766bcf2408b144d2ea06d",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "libuv",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "libuv:ec23cb5ea6d0737e",
+      "candidate_sha256": "417c6c000a5f02f7d72967151da19ccb67cf96b12bb3f40d9a45afdde9aed990",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "libuv",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "libuv:fac251925ef52c9a",
+      "candidate_sha256": "c2d4b27e8b36d89ccb68e4561c9362077799c84c4a04827d52176d353c02f760",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        0
+      ],
+      "language": "C",
+      "probe_class": "no-overlapping-unit",
+      "repo": "libuv",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "liquid:2881fc0a22a0b8a4",
+      "candidate_sha256": "824fb1566ee2fe158b256e06b2cfc8e9ade5b257afd7a01c5c311788ed9d9721",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "same-unit-window",
+      "repo": "liquid",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "liquid:3c25695d8bcdaf05",
+      "candidate_sha256": "acf716dca88b2478905ee3ae3aec3c2fabc50496ed531ac0da3d7bf28bdd3a0d",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "liquid",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "liquid:4f4b572db8008f60",
+      "candidate_sha256": "775a4d1e959a88ef1cb677c958e11c4a859f1718427cb4fe3e83a8a23a114b59",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "liquid",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "liquid:53ac6cd76866936b",
+      "candidate_sha256": "657b47e691c3b68accea4212fa8c170d64635efd278f30dec5a1ceb39205529e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "liquid",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "liquid:887ab1f0cab75a90",
+      "candidate_sha256": "49e8ae9fb27ca96bdf8e2d1fe6bd5074ead38c113f03c13a2160d6c71df581c7",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "liquid",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "liquid:a5b873bd1d650af4",
+      "candidate_sha256": "7c303625a6f44e4075c75373eb6c212ca119c6ad02fd595aaedc238d6e9aeae4",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "liquid",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "liquid:d64d80cdbea35c4d",
+      "candidate_sha256": "b8c03535f1cab8c05584096be0d2c9317007d5262109fb0d688e57d19fc40dcd",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "liquid",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "liquid:ec0ea765982b749e",
+      "candidate_sha256": "8243042eda1718497e04dca1af95857ceaee27e0481f7d2d36b86feb030b0c7b",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "liquid",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "marshmallow:0f369456ae71dedc",
+      "candidate_sha256": "74acf6e4400f931a3d60244ed04c9080cca648d6db1518793c627fbe81e79a39",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "marshmallow",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "marshmallow:581d4caf7dc8178d",
+      "candidate_sha256": "d113fcec3fd765e2ff5ebf47e69fe6582052c3fc5d25001edc33953b6b875741",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "marshmallow",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "marshmallow:a8af960bf3a26e25",
+      "candidate_sha256": "a7a07126539da0342f6a436af451a25a3c913221bbfb3c423f5221afb5096f55",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Python",
+      "probe_class": "no-overlapping-unit",
+      "repo": "marshmallow",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "marshmallow:d3f1f8804b32ca0a",
+      "candidate_sha256": "6ae0c7022fe19aa5c04e8e77defb828a39e365c8b37f322babbb06b1c6aee2d5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "inline-ceiling",
+      "repo": "marshmallow",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "marshmallow:d5c9512eec776de0",
+      "candidate_sha256": "0401347fb6f86631219d3ab7358e30e5915e80c37f3b86ae72bdeca22536d2e4",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Python",
+      "probe_class": "inline-ceiling",
+      "repo": "marshmallow",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "minio:0162a4e5135745e2",
+      "candidate_sha256": "7254b4e77c2c88f28e4aeefda03aaa44490f0cd4501e3d35ae31dbeeb27c5950",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Go",
+      "probe_class": "same-unit-window",
+      "repo": "minio",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "minio:36c5d902a5772df3",
+      "candidate_sha256": "9435a96a8ae79a428033f6563a9d1f19c9859015d8b92f8a5ef59c5389dd4b45",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        4,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "subdag-ceiling",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "minio:43ad0a38b290c564",
+      "candidate_sha256": "63aee96973d675239a9d44a87ec4bd43b4c5967f45aed22042fc8ef4b43dcc92",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "minio:6df98f4de0a00d6b",
+      "candidate_sha256": "eec0803e33659b7a538f87886dc3b192ea55b1c234c7a1472858d3d95a83cf20",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "minio:76a7d6e4cc5527df",
+      "candidate_sha256": "05cd5ed7ac9938319cd5dd0831c93d455cfa8014062c44d411a17c2f61e611bd",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "minio:e02ba445f3a8f384",
+      "candidate_sha256": "8b265c346eb369a593bcfa1b4e5febd787ed6159cee6e4de495086f9360aff01",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "minio:e48d842d53a01d1e",
+      "candidate_sha256": "239301ed16f804fcd3db3dac8c4c4e47c6e0afd13700099e44485acf0238b1ae",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "minio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "pry:7a29d98ac73e8688",
+      "candidate_sha256": "7fc5e89a28d51c96d23d1f1442c85e590a364fd50a95bc086ab36745cb81e4ae",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        4
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "pry",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "pry:b464a888b12af0f1",
+      "candidate_sha256": "5839c1f353eac00dbed7fb15f0bb1a1141e5352fa72054fcdbc197b173783a76",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "pry",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "puma:0f39af5b364b1ffe",
+      "candidate_sha256": "84c16c367d184eeacdf694e0ea25cb6e61d54a7ce5e64fea53dd59cb44d07850",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "puma",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "puma:12acda2dd82390db",
+      "candidate_sha256": "6b558398a4a3714373800f56bbc5451fd0ecfc3469eb82b47a5fbd136484dd54",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        3,
+        3
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "puma",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "puma:16cbddbb2c42524c",
+      "candidate_sha256": "442fb3879cb41aae160e1de9564041cb03a10eced6e2af76be5fc3b25ffd9214",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        4,
+        4
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "puma",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "puma:4354e14716bd8dfb",
+      "candidate_sha256": "703fbf39c467bf80812bd60bd8683deacdbe5d71e02a971b3895df6a3bcd8360",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Ruby",
+      "probe_class": "unrecovered",
+      "repo": "puma",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "puma:93129e37c4504428",
+      "candidate_sha256": "d03f3f8cc86badfa3379af5fb5b351b5ea1f57438e2618058886387daa3d5b8d",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Ruby",
+      "probe_class": "subdag-ceiling",
+      "repo": "puma",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "regex:1f02b28389d3dd36",
+      "candidate_sha256": "5237bb8689ae087b24116ad61ac1e7a5df6861f31ed02d9d4a2de1635e60ecfa",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "regex",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "regex:4de609e3891fcfc5",
+      "candidate_sha256": "77ce059d8bd1826eb6564d372b7708f06b0db35cf94c0c6092d049924dce9ed8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "regex",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "regex:817e81c856c71f82",
+      "candidate_sha256": "c88c830d30af95a5537546ad2efe7f125d9ec3938405078160985bd940e1dd07",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        6,
+        5
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "regex",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "regex:fc8646004b5ef173",
+      "candidate_sha256": "19941b1c55f3926f719ae238d31850c479f7ed61c6b731b16d93f06bddb778d8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "regex",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "rustls:286cfa8283af3008",
+      "candidate_sha256": "aa890aa83a3968a1bccd909035107ae9a2a379e54f3850b82eea2776f44b0790",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "rustls",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "rustls:cb3ba04584140a2f",
+      "candidate_sha256": "8dc29069c2dd9172cf0778923a9b75a9a2f719b7dd9724b511b3648bad68f94c",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "subdag-ceiling",
+      "repo": "rustls",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "sidekiq:fe3c6be4a61ad4de",
+      "candidate_sha256": "1747fbcc8a9093d1343439dac6a8dccc41121959e2979b0fcc89c0be710bf08f",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Ruby",
+      "probe_class": "no-overlapping-unit",
+      "repo": "sidekiq",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "sled:a5e482f708ba7014",
+      "candidate_sha256": "499e4802a1ffc317554d445d024edb4e8e602dc113dfe5e669acaac278d7ff4a",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Rust",
+      "probe_class": "inline-ceiling",
+      "repo": "sled",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "tokio:1e05e06201182605",
+      "candidate_sha256": "a83eddb81211be8b44babb52167426536f601673e7b38dd358333b2366123993",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "tokio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "tokio:6189ced49439fb29",
+      "candidate_sha256": "7a46302885bf56a6a15d5003901f23d9e4e70a5f6cc5bff1047237c5bfb1ba57",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "tokio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "tokio:af17a49f38c801e2",
+      "candidate_sha256": "8eb2847b49b14f54baaaf5186db1f9bb85dbda5629987bd0d30ae64aec373927",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Rust",
+      "probe_class": "no-overlapping-unit",
+      "repo": "tokio",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "trpc:392570d60aac814e",
+      "candidate_sha256": "3f3d16cb29dd6a2807b28b31d25f4e8704e2751f99d9c39443b5c5521430d2ea",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "inline-ceiling",
+      "repo": "trpc",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "trpc:5c1809963c693d04",
+      "candidate_sha256": "f0e1b3d4784d26502e2b7b3da604be87f09036cdef0dfc61666a2e00e63efa9e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "trpc",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "trpc:8624bd4a921aa255",
+      "candidate_sha256": "ab3d70520fee248eee19afed661943c0a8e9d50efd1474b465d96e34953a9fe5",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "unrecovered",
+      "repo": "trpc",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "trpc:8eefa5a90b80ca48",
+      "candidate_sha256": "a2647e378ae750cbafcb8f5653a05aa7e19a41454fefe0e55d5ea2c4862b94b2",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "no-overlapping-unit",
+      "repo": "trpc",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "trpc:b6d295fc4fe003ac",
+      "candidate_sha256": "c81da1a7edb7ed2f310f8cc25ca3bbfc31b72111fc3ef1b7bfdb410a7526a57e",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        0
+      ],
+      "language": "TypeScript",
+      "probe_class": "subdag-ceiling",
+      "repo": "trpc",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "urfave-cli:8d16dc452f3936a2",
+      "candidate_sha256": "de5e7571b84a78c3f57aaabd4fde31f491602d8fdfcb6b857ecec36d8cd226e0",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        2,
+        2
+      ],
+      "language": "Go",
+      "probe_class": "unrecovered",
+      "repo": "urfave-cli",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "urfave-cli:ea93d66380eba837",
+      "candidate_sha256": "f2a8525acda8ea51727468df82fdc2421b99b106da9cbf04bf7b6d8f08d4edb2",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        0,
+        0
+      ],
+      "language": "Go",
+      "probe_class": "no-overlapping-unit",
+      "repo": "urfave-cli",
+      "stage": "missing-unit"
+    },
+    {
+      "candidate_key": "vim:0d979b4ba53dad74",
+      "candidate_sha256": "f00825015c571fff7d05ae2804f991a3ebf797e6d98f5519ded47dd2652e67d2",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "vim",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "vim:a309eef0f8cb0f71",
+      "candidate_sha256": "657502d03bc7564c1dd83c108bdc4fe17b892d3bcfa6b1f0cb49c8cb6319e0a8",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "vim",
+      "stage": "extracted-no-candidate"
+    },
+    {
+      "candidate_key": "vim:a3155684430a48be",
+      "candidate_sha256": "99961141559acfeafca2256eae4be93ee52e3bcad6b2dd67e45501be9a0e7e4a",
+      "direct_accepted": false,
+      "direct_candidate": true,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "subdag-ceiling",
+      "repo": "vim",
+      "stage": "candidate-only"
+    },
+    {
+      "candidate_key": "zstd:3ad45bf126ac090a",
+      "candidate_sha256": "f50b8c40f8d1ef34ec96829299a2bf19ba10b89f8d50b267bc29ef68360ffb13",
+      "direct_accepted": false,
+      "direct_candidate": false,
+      "extracted_unit_counts": [
+        1,
+        1
+      ],
+      "language": "C",
+      "probe_class": "same-unit-window",
+      "repo": "zstd",
+      "stage": "extracted-no-candidate"
+    }
+  ],
+  "confirmation_gate": {
+    "expected_accepted_pairs": 0,
+    "expected_candidate_only_subdag_ge20": 2,
+    "expected_candidate_only_subdag_ge20_languages": [
+      "C",
+      "Java"
+    ],
+    "observed_accepted_pairs": 0,
+    "observed_candidate_only_subdag_ge20": 2,
+    "observed_candidate_only_subdag_ge20_ids": [
+      "jsoup:9b909cd145cab0a1",
+      "vim:a3155684430a48be"
+    ],
+    "observed_candidate_only_subdag_ge20_languages": [
+      "C",
+      "Java"
+    ],
+    "passed": true
+  },
+  "failures": [],
+  "method": {
+    "reused_dev_method": "nose detect --candidates direct extracted/candidate/accepted stages",
+    "source_review": "none",
+    "threshold_tuning": "none"
+  },
+  "provenance": {
+    "command": "python3 bench/labels/missed_worthy_heldout_confirmation.py --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json --nose target/issue-820/release/nose --repos-root bench/repos --json-out bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json --check-binary",
+    "frozen_dev_decisions": {
+      "commit": "4e0b067f9349eeb0b16fe97595186ac818a92e25",
+      "path": "bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json",
+      "selected_tranche": "connected-candidate-subdag-witness",
+      "sha256": "33bbdbd3a3aebc9467d156f3472b54224b3875b60a97c3fa47f2762fb0ba95a2"
+    },
+    "git_sha": "a73f650cd76989fc0513879d7cd3dfd02193e139",
+    "nose": {
+      "path": "target/issue-820/release/nose",
+      "sha256": "5999e791c276a7d098099911b8252d35609d1ec7dbcf38888dad2815b126dd0a",
+      "version": "nose 0.18.0"
+    },
+    "source_artifact": {
+      "path": "bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json",
+      "sha256": "b3c3b8c6ba5581f5679bc6de685be52c63a40790640784f98c58597e002f57ac"
+    },
+    "working_tree_status_before_measurement": ""
+  },
+  "repository_runs": {
+    "asciidoctor": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/asciidoctor",
+      "counts": {
+        "accepted_pairs": 542,
+        "candidate_pairs": 3051,
+        "units": 2366
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "e7015feebd27c9b46ecc3ef69b4170261f042c055716ef583c343cc920d13135",
+          "size_bytes": 34686
+        },
+        "predictions.json": {
+          "sha256": "5f3776cd2e3a3a291055c69540deab96b720c2a520066ad4146797141c883ee2",
+          "size_bytes": 195643
+        },
+        "units.json": {
+          "sha256": "604dab7b94d42817758a882e294f53a54cd4c4c41fea3d33f7d10fedabc977bc",
+          "size_bytes": 222457
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "65a841ad6eca928aa599c4112343d261e8a3c60b5343e1bcac7d45c4b8d4b3e1",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "boltons": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/boltons",
+      "counts": {
+        "accepted_pairs": 687,
+        "candidate_pairs": 3421,
+        "units": 2142
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "99a0becde78fc8d5cf5fe049c26463122e8fd09458448bdf2d8f578a4227769b",
+          "size_bytes": 37131
+        },
+        "predictions.json": {
+          "sha256": "980648f455a9956f3ab45319c511c0037dd7c514420f3e368583843660be5676",
+          "size_bytes": 171825
+        },
+        "units.json": {
+          "sha256": "cfc80062566d99726c75c9c90f7b744cb090e5222f8faea8adea32209dc685df",
+          "size_bytes": 174953
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a5a1c309037781ee12778459432ea3bbe1188167ca50e76c4b6a6818fd1bcdbe",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "date-fns": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/date-fns",
+      "counts": {
+        "accepted_pairs": 4118,
+        "candidate_pairs": 7709,
+        "units": 1715
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "603a990449508effdd45a132eb68e15309a815bf8b15c6c113095db21a7b0eef",
+          "size_bytes": 81260
+        },
+        "predictions.json": {
+          "sha256": "b768f6c069fbe2e5dc0de9237148c8dc5619bcef810c773032d0a6c7d00ec3d7",
+          "size_bytes": 1278198
+        },
+        "units.json": {
+          "sha256": "9e77f67c0f310bc9a8b29f4d8d23517508eab3b97d3bb900873a25c2f88c79ac",
+          "size_bytes": 177740
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "8aa42e45d290326c5a0f3da4e7f9ad7867a63805aebf1ea87c096e1f71757846",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "flask": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/flask",
+      "counts": {
+        "accepted_pairs": 1270,
+        "candidate_pairs": 3134,
+        "units": 1656
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b7c3037cd164bed6f07677ca1696d585e6a16fd72e9c5470574266f82c51ef12",
+          "size_bytes": 33918
+        },
+        "predictions.json": {
+          "sha256": "b959623061cc92bd9cf649a33404073963b094e7238e907e4506f49b01fbca21",
+          "size_bytes": 340697
+        },
+        "units.json": {
+          "sha256": "66ab190c537dd5b50f4edbcfcc8397700113c82c4c70f3896652fc7f52d6dd19",
+          "size_bytes": 136363
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "9b1a86c766746d4951d6de9f705b9930c6918fd53303b650063141e1d7dd76bb",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "fzf": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/fzf",
+      "counts": {
+        "accepted_pairs": 301,
+        "candidate_pairs": 1248,
+        "units": 1574
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "10038572cc209855a3c3ce324973e4998bd6d3e6d2d22905788dd5f895a9edd5",
+          "size_bytes": 13871
+        },
+        "predictions.json": {
+          "sha256": "2afdaebe72a2eca1148f0d4a066627749509c402c3e6de84066721b4643c790e",
+          "size_bytes": 88303
+        },
+        "units.json": {
+          "sha256": "61fdaff3ff05f6975d212130e7088e8fc1edbb1ccb57089114dec6fab1143599",
+          "size_bytes": 115486
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "56f2d9d4089c7f8d329868741e90cac8adb68c1d4fdae57aa755c982bc1e532a",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "gin": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/gin",
+      "counts": {
+        "accepted_pairs": 392,
+        "candidate_pairs": 1424,
+        "units": 1230
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "cddc7d0ca87ab900d8bf865a8d344162aa94a5022ea28072943cea7b61361cba",
+          "size_bytes": 14488
+        },
+        "predictions.json": {
+          "sha256": "7fa377def09a624631a2940b41f010c1cd6f4e42711e38c809e7dca8e3a9d05d",
+          "size_bytes": 106145
+        },
+        "units.json": {
+          "sha256": "433a4ba733693dd093074274bcdeb0c1a672734b042551ddf12843f46af2aef7",
+          "size_bytes": 88650
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a6da2b95f52a1d3d40c1bf08c10788a1308ae686b6fecb9f6095ca05bce9bcd6",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "hyperfine": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/hyperfine",
+      "counts": {
+        "accepted_pairs": 21,
+        "candidate_pairs": 156,
+        "units": 366
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "ee85e02cd49a0b49f0fbbfe1f98b7a920f7b0909b8739b450d8e2e195e20b6c4",
+          "size_bytes": 1469
+        },
+        "predictions.json": {
+          "sha256": "242b64e6b1e0190153e4526e58f12c7eec06d7571cdbaa2b96b33180da28ee67",
+          "size_bytes": 6336
+        },
+        "units.json": {
+          "sha256": "14ee418c8c0336f1bbfa613828d3f3fc3ed70b0acdf0f804705d742f2aad244d",
+          "size_bytes": 30626
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "d5a61395c0e8f9de16e44dc254a2a96cb5c63bcf8f47923459a383628f7ef0e6",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jackson-core": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jackson-core",
+      "counts": {
+        "accepted_pairs": 2997,
+        "candidate_pairs": 16105,
+        "units": 6349
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "45fd044581ff037d2a146107e6adf6fe229c90149c5cdfd90ab8fb032c231e27",
+          "size_bytes": 185816
+        },
+        "predictions.json": {
+          "sha256": "3685bf918f5e6b87e883bacc3ac9a83616e26c09227b48dd066aefbb5fc4e325",
+          "size_bytes": 1128642
+        },
+        "units.json": {
+          "sha256": "266d4e06d18a9142b74caed62eb620dbab7e671e8b078e5439acb15a579f7538",
+          "size_bytes": 845276
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "5eaaab5f8f25f4f60ff7e930b8d1072e6f0e45b8f1d81cff154594e9ae934268",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jedis": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jedis",
+      "counts": {
+        "accepted_pairs": 20595,
+        "candidate_pairs": 106726,
+        "units": 16465
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "50542c6a9689c3ec09b1814efcca6d9def684c5e433389cf7e8d6140ac6b6e2f",
+          "size_bytes": 1319814
+        },
+        "predictions.json": {
+          "sha256": "2713f814d530cbf2b04705c96d16261168d3698b7b7eff64749389b168cb59f0",
+          "size_bytes": 7183129
+        },
+        "units.json": {
+          "sha256": "de85e5f1a7862646364326ba42338a98a1cb366d679eb7a717ee28bd323900da",
+          "size_bytes": 2029970
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "755cc47788c4faff7d1ee6b6dbd3da60687defc04085ad17f8fd91c34aeea3b3",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "jsoup": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/jsoup",
+      "counts": {
+        "accepted_pairs": 1808,
+        "candidate_pairs": 10737,
+        "units": 4953
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "4fdcbf944de87dae82a3b59472e2b9827c912dfb79db7910af7d0a616631a91e",
+          "size_bytes": 119608
+        },
+        "predictions.json": {
+          "sha256": "5be50046fa3c00d090ac71fa8cc6d2561bf3ca8125b8dddf64efd0ec2715dfae",
+          "size_bytes": 548213
+        },
+        "units.json": {
+          "sha256": "4fa1af9b9f54f27907643b1cd9c02c6bbf867551bce8ce01b3e5c1c70ca56ca5",
+          "size_bytes": 523321
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a30c2d69bb4aea6a5e28dd6db74f146487262343266e136b91939040e238354e",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "ky": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/ky",
+      "counts": {
+        "accepted_pairs": 40,
+        "candidate_pairs": 130,
+        "units": 250
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "1563fb7dd305aab778a26ee46cf3d3841fbaa55a4c954a07dfa5b33fb5c85877",
+          "size_bytes": 1252
+        },
+        "predictions.json": {
+          "sha256": "e4290a63113420df6ba2fe4d2931d9a28fc2a65ce4525db2c63786ca71dedfdd",
+          "size_bytes": 10291
+        },
+        "units.json": {
+          "sha256": "92c49592f9c118883f5f62cd1471713f8bb5a249f38d6b83f8972a64058a0c7f",
+          "size_bytes": 18654
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "9a62dae48f525ad58d5606969a297743b795d9a8bf2638b2bcd09aebb9a26fab",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "libgdx": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/libgdx",
+      "counts": {
+        "accepted_pairs": 89123,
+        "candidate_pairs": 327587,
+        "units": 46158
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "e0a96649245925c22ae54822182df3f0ef99fb7e1efbe5b06f462d252d740351",
+          "size_bytes": 4390716
+        },
+        "predictions.json": {
+          "sha256": "8bd183c1d11245c84fb2ed3e367267928f32a82e12368d8edf6d587af3438779",
+          "size_bytes": 36468120
+        },
+        "units.json": {
+          "sha256": "25ec5d177257fdde0d3ec378fcf7e35f57570285366858bdd1d11bf0fab4846e",
+          "size_bytes": 6575311
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "9fe8b717d2a98cad68985c823a23d065fe6ff21f400ca328854afd56fba88f79",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "libuv": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/libuv",
+      "counts": {
+        "accepted_pairs": 1451,
+        "candidate_pairs": 7795,
+        "units": 3995
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "95a885555ca676181e9f916b681a469e1143f13993efeccbe858e62ef786ba72",
+          "size_bytes": 89339
+        },
+        "predictions.json": {
+          "sha256": "8a32982b3f36afaed69b969d1bdbe859e808119aa5cb6a2f097097641dbdd282",
+          "size_bytes": 396168
+        },
+        "units.json": {
+          "sha256": "c628fe15c3f4da02973cfe4e4a40a68945def1c87246602cd2edbb5623beefee",
+          "size_bytes": 311569
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "aefb907b4ce000c32a314839c6481a90e56e8fe39e04f2a8b57e52cdd4171893",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "liquid": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/liquid",
+      "counts": {
+        "accepted_pairs": 529,
+        "candidate_pairs": 1386,
+        "units": 1897
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "83aa156f1bfdfee841c56620e3fbfa304c0fa8c60fa596a732ba00303392b893",
+          "size_bytes": 15226
+        },
+        "predictions.json": {
+          "sha256": "7aa855d36a8ddbb256542102db468bc70ce1fb6cdc28d45d766c7bf50048c118",
+          "size_bytes": 172409
+        },
+        "units.json": {
+          "sha256": "7fcfdb41d626949cc2250813135902f477874c7df57f514d5fbc1bbc9874e88a",
+          "size_bytes": 169702
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "e99f19184a87194fc7763a911b9be8f6f9bffbc1736f70c23396e660d9b077c3",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "marshmallow": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/marshmallow",
+      "counts": {
+        "accepted_pairs": 228,
+        "candidate_pairs": 1478,
+        "units": 1049
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "7fb1973a0892b974dea826248a285ed32674e965e461f22fc947c8e96e7c5c9d",
+          "size_bytes": 14525
+        },
+        "predictions.json": {
+          "sha256": "0c6d0cea73f0f209104fc6c56f6c076650c98a0913558c5c2396f7eabd9a33b1",
+          "size_bytes": 64477
+        },
+        "units.json": {
+          "sha256": "195019f9e01bbfd16ea2914e6397dcde4efbc8be10bb62c3b7bdcc49ddd22c09",
+          "size_bytes": 93046
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "e7e015f4a8766d8c64f67a436afd01ff64525bb8aa6f4f894f1e944622e043aa",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "minio": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/minio",
+      "counts": {
+        "accepted_pairs": 4801,
+        "candidate_pairs": 23802,
+        "units": 11559
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "36d84b6b03912a9ef53cc63e402b34ab63b420a21b2819c210ea493f3542a57e",
+          "size_bytes": 289837
+        },
+        "predictions.json": {
+          "sha256": "367f39927b97268d48b6e3ee6c523926bf9aea704daf5423ecaf4dfcbaf5f623",
+          "size_bytes": 1393819
+        },
+        "units.json": {
+          "sha256": "806abda1342998f7ccaec7e6cd83e88bc84303a929a07af66cc030b746efdbb7",
+          "size_bytes": 979477
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1baf6e0204b6e0053d86622c06d0459367035f11362d5c590585475b871bf1ff",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "pry": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/pry",
+      "counts": {
+        "accepted_pairs": 248,
+        "candidate_pairs": 1570,
+        "units": 2630
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "3951c9eecef83240a7c9e3736decc137d355ec1dc0ecd001a79c6bda8f41e11d",
+          "size_bytes": 17185
+        },
+        "predictions.json": {
+          "sha256": "3cf6afcd988b213cb6612960fe9ff65ff18f2068f47601150f203238fe98f0b4",
+          "size_bytes": 82801
+        },
+        "units.json": {
+          "sha256": "59783e2035e721d557203524cd92a079338827c62122d9d10b3c7fc3f4a62302",
+          "size_bytes": 212411
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "a0773505ee9869828e417cdd579ddc8e2f4a7271c63152f291faa307a9882832",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "puma": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/puma",
+      "counts": {
+        "accepted_pairs": 594,
+        "candidate_pairs": 1696,
+        "units": 2478
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "243a03e4e35f956ca3efed68e02254087b6daa7f4323d13b24e1219fb5333fc9",
+          "size_bytes": 18417
+        },
+        "predictions.json": {
+          "sha256": "55c21dde442a1207beaff1355cfd9bdb04fb2b6f90788969da83dc6c1dd4b418",
+          "size_bytes": 158857
+        },
+        "units.json": {
+          "sha256": "a4e1e446d92b343f75c6ab19be41c3ecad4c57c15a150a11206024d75a7c807e",
+          "size_bytes": 204888
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "18120e80638ec3189269cc34b28cb5a01529ab18165f08ce2d55e6f3f6351aca",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "regex": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/regex",
+      "counts": {
+        "accepted_pairs": 2585,
+        "candidate_pairs": 14007,
+        "units": 5800
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "0bd8e25b645c066b4e8028926389ef9e9d06762b6b99cbcb44a827d4d1497f2a",
+          "size_bytes": 163153
+        },
+        "predictions.json": {
+          "sha256": "79c3f98add51c625146125d23b6237e6537f7eb15a3ec8ecfd47f815eddacd15",
+          "size_bytes": 739121
+        },
+        "units.json": {
+          "sha256": "03de5d184f321316e270f23c505948c36711d21c1abcf8bf5af6aa36dde9fdbe",
+          "size_bytes": 524570
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "d3e825ac8ed9f92867461f18a3f84d79c51a7c0469ae5cb1a70ef4348049dc0e",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "rustls": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/rustls",
+      "counts": {
+        "accepted_pairs": 1301,
+        "candidate_pairs": 6364,
+        "units": 4582
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "ed2ead4f07938bdbb5d23f670bc9783cb3da31e039b1107c455bfae713c07c91",
+          "size_bytes": 73019
+        },
+        "predictions.json": {
+          "sha256": "4926e15e2ef5414d8091e650c0e040568f68d3f3e636f456ada2bec20c537484",
+          "size_bytes": 374446
+        },
+        "units.json": {
+          "sha256": "728fd7a0bcdff2475e07648085e7d0690a2cee93c4f3f85a13641b2d1b638701",
+          "size_bytes": 399568
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "f9931336df309a0c32dc367ed4a4603c512fcab92c71e627eccbf27e87d79e88",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "sidekiq": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/sidekiq",
+      "counts": {
+        "accepted_pairs": 168,
+        "candidate_pairs": 991,
+        "units": 1836
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "20bc2b0cd76bbe902794fceac96df680ef360641a9b6a86346a6d57aecf2b2c3",
+          "size_bytes": 10833
+        },
+        "predictions.json": {
+          "sha256": "67f6cd4a0772653fabb606e5d0ea056bc24661d7ed52fbb6413d9c600201c44f",
+          "size_bytes": 48714
+        },
+        "units.json": {
+          "sha256": "2beee0cd6b8b242c78437c3d7b655fb6027ee7cd4ebdeee287ec86d0d2e3f6f9",
+          "size_bytes": 156564
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "bc518acc179c6997bd567008d28c55bf000528a894546b6d4adf7362c754fad0",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "sled": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/sled",
+      "counts": {
+        "accepted_pairs": 57,
+        "candidate_pairs": 637,
+        "units": 808
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "36efba78628bfaeb4bd863105d41db8701b6805367828707bc213a29f490a7b5",
+          "size_bytes": 6269
+        },
+        "predictions.json": {
+          "sha256": "04d300693e95b13bce77a4cd010dd8914814f8f673bba64b018d5685ec83818c",
+          "size_bytes": 14162
+        },
+        "units.json": {
+          "sha256": "c4535376c4e214236d451533ba60139093fa4b3c83beb691ca0f1eace61cb6cd",
+          "size_bytes": 61844
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "466d06ed3c176eff2c2a991e887a4b0f6fbabb5aace97c5bb451c7e27b8b0546",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "tokio": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/tokio",
+      "counts": {
+        "accepted_pairs": 4102,
+        "candidate_pairs": 20754,
+        "units": 8793
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b572b0e05e9a73969b102371588d2464bcc1f97a053a9a8ecb454461acd73a46",
+          "size_bytes": 243780
+        },
+        "predictions.json": {
+          "sha256": "aa70fd75c4e2250c8ae7d255bba24b4fc08bcdfa8151b590a9e900ea26ecbe8a",
+          "size_bytes": 1177114
+        },
+        "units.json": {
+          "sha256": "949cd52afe7fc6f966d9318bc066af63abc4143005fcf3683c440ca78b7e19a2",
+          "size_bytes": 782121
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "bd6994083f67e1d098bb4e56d2e6970488a0b94561f50dee38154cd580c32d18",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "trpc": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/trpc",
+      "counts": {
+        "accepted_pairs": 11472,
+        "candidate_pairs": 15237,
+        "units": 4369
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "b774b3c8be0ef9d87c1c8c0ff52fe7f454d562b80c8aa067991fe315e4eac125",
+          "size_bytes": 179163
+        },
+        "predictions.json": {
+          "sha256": "0c278e90d09449b793d3fc73aac966aff18cc5c1c376acd996cab3eac5116ad1",
+          "size_bytes": 4071129
+        },
+        "units.json": {
+          "sha256": "0dd106137ba49341eb0c124495d915f22e683a9b6c7a8bedb0636b212537cdc8",
+          "size_bytes": 496875
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1e910641aa9d29e11b7fc138d6d04e051c0a1913e21a4a403d6f5432e8d91c89",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "urfave-cli": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/urfave-cli",
+      "counts": {
+        "accepted_pairs": 287,
+        "candidate_pairs": 842,
+        "units": 706
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "e12f613e8284743e6536c63dc0bb23e85c0eef159ea66440d09af68852a11b3c",
+          "size_bytes": 8265
+        },
+        "predictions.json": {
+          "sha256": "95eab0269316c3a84bacb29ef30ac2d8fe610c09a5c7dc61e659b8acaa1a9c44",
+          "size_bytes": 78877
+        },
+        "units.json": {
+          "sha256": "edaab72e16d99839d1cb35e591a78760935b4950280b12968569e2a76bbf4609",
+          "size_bytes": 54544
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "81ff5f4b880728f01ea2bdae5f5fd24ec2ee3cb432c38ea31fa2bdca90135b07",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "vim": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/vim",
+      "counts": {
+        "accepted_pairs": 1938,
+        "candidate_pairs": 18480,
+        "units": 13995
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "96b4109bbe616fd9af7b91ac761fc98024fb9a8e89014762955817def32c3ecc",
+          "size_bytes": 224419
+        },
+        "predictions.json": {
+          "sha256": "bbd3ab9e144595c7da33e2bc9146a78ca22aaef85be2ba8cebc0967f1d53827a",
+          "size_bytes": 545039
+        },
+        "units.json": {
+          "sha256": "ff5e40141160727d0795b2220a9247f37196ac9845869e151216e9f195235058",
+          "size_bytes": 1019135
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "86648fddcd59d9b13816ef82221e96ee7b2f96f1d23e96ef79bc5e8c7a8ad466",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "zstd": {
+      "command": "target/issue-820/release/nose detect --candidates --dump <temporary-dump> --repos-root bench/repos bench/repos/zstd",
+      "counts": {
+        "accepted_pairs": 2828,
+        "candidate_pairs": 11473,
+        "units": 4390
+      },
+      "dump": {
+        "candidates.json": {
+          "sha256": "a99c742832a0f3d0fcc626a54513834634759c1abb6d93a4d04426519b029d32",
+          "size_bytes": 131880
+        },
+        "predictions.json": {
+          "sha256": "b043def61bf9a315dd513c3a7a611135b8913daa9d024fd16adda9e9259cce68",
+          "size_bytes": 808425
+        },
+        "units.json": {
+          "sha256": "0cc30b82b51a95d3a4d48b107a968747cf274a4f7bf2471dccf2c05d8a1c38f7",
+          "size_bytes": 373042
+        }
+      },
+      "returncode": 0,
+      "stderr_sha256": "1b76a69cb28c94cddc73a5bc160ec95ae95f390258634abd73952e2671299874",
+      "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "schema": "nose.missed_worthy_stage_confirmation.heldout.v2",
+  "split": "heldout",
+  "summary": {
+    "by_language": {
+      "C": {
+        "candidate-only": 2,
+        "extracted-no-candidate": 6,
+        "missing-unit": 3
+      },
+      "Go": {
+        "extracted-no-candidate": 7,
+        "missing-unit": 12
+      },
+      "Java": {
+        "candidate-only": 3,
+        "extracted-no-candidate": 5,
+        "missing-unit": 4
+      },
+      "Python": {
+        "candidate-only": 1,
+        "extracted-no-candidate": 2,
+        "missing-unit": 4
+      },
+      "Ruby": {
+        "candidate-only": 8,
+        "extracted-no-candidate": 6,
+        "missing-unit": 10
+      },
+      "Rust": {
+        "extracted-no-candidate": 6,
+        "missing-unit": 5
+      },
+      "TypeScript": {
+        "extracted-no-candidate": 3,
+        "missing-unit": 8
+      }
+    },
+    "by_probe_class": {
+      "inline-ceiling": {
+        "candidate-only": 1,
+        "extracted-no-candidate": 3,
+        "missing-unit": 1
+      },
+      "no-overlapping-unit": {
+        "missing-unit": 41
+      },
+      "same-unit-window": {
+        "extracted-no-candidate": 10
+      },
+      "subdag-ceiling": {
+        "candidate-only": 9,
+        "extracted-no-candidate": 17,
+        "missing-unit": 3
+      },
+      "unrecovered": {
+        "candidate-only": 4,
+        "extracted-no-candidate": 5,
+        "missing-unit": 1
+      }
+    },
+    "states": {
+      "candidate-only": 14,
+      "extracted-no-candidate": 35,
+      "missing-unit": 46
+    },
+    "total": 95
+  }
+}

--- a/bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json
+++ b/bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json
@@ -1,0 +1,5500 @@
+{
+  "comparison": {
+    "direction": "current --nose minus --comparison-nose",
+    "provenance": {
+      "nose_binary": "/Users/ak/prjs/cc/nose/target/release/nose",
+      "nose_binary_sha256": "a0a210b9527353b65bbf253c1ee483f9a435e69e4b9587b432eefdcbdba52128",
+      "nose_version": "nose 0.18.0"
+    },
+    "worthy_recall": {
+      "by_repository": {
+        "alacritty": {
+          "comparison_hits": 32,
+          "current_hits": 35,
+          "delta": 3
+        },
+        "alamofire": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "antlr4": {
+          "comparison_hits": 16,
+          "current_hits": 16,
+          "delta": 0
+        },
+        "arrow": {
+          "comparison_hits": 7,
+          "current_hits": 7,
+          "delta": 0
+        },
+        "asciidoctor": {
+          "comparison_hits": 50,
+          "current_hits": 50,
+          "delta": 0
+        },
+        "axios": {
+          "comparison_hits": 57,
+          "current_hits": 60,
+          "delta": 3
+        },
+        "badger": {
+          "comparison_hits": 70,
+          "current_hits": 71,
+          "delta": 1
+        },
+        "bat": {
+          "comparison_hits": 17,
+          "current_hits": 18,
+          "delta": 1
+        },
+        "black": {
+          "comparison_hits": 12,
+          "current_hits": 12,
+          "delta": 0
+        },
+        "boltons": {
+          "comparison_hits": 21,
+          "current_hits": 22,
+          "delta": 1
+        },
+        "chi": {
+          "comparison_hits": 33,
+          "current_hits": 33,
+          "delta": 0
+        },
+        "clap": {
+          "comparison_hits": 103,
+          "current_hits": 105,
+          "delta": 2
+        },
+        "click": {
+          "comparison_hits": 20,
+          "current_hits": 20,
+          "delta": 0
+        },
+        "cmark": {
+          "comparison_hits": 1,
+          "current_hits": 1,
+          "delta": 0
+        },
+        "cobra": {
+          "comparison_hits": 42,
+          "current_hits": 42,
+          "delta": 0
+        },
+        "commons-lang": {
+          "comparison_hits": 89,
+          "current_hits": 89,
+          "delta": 0
+        },
+        "curl": {
+          "comparison_hits": 83,
+          "current_hits": 91,
+          "delta": 8
+        },
+        "date-fns": {
+          "comparison_hits": 17,
+          "current_hits": 17,
+          "delta": 0
+        },
+        "delve": {
+          "comparison_hits": 40,
+          "current_hits": 40,
+          "delta": 0
+        },
+        "devise": {
+          "comparison_hits": 14,
+          "current_hits": 14,
+          "delta": 0
+        },
+        "drizzle-orm": {
+          "comparison_hits": 37,
+          "current_hits": 37,
+          "delta": 0
+        },
+        "esbuild": {
+          "comparison_hits": 42,
+          "current_hits": 42,
+          "delta": 0
+        },
+        "etcd": {
+          "comparison_hits": 51,
+          "current_hits": 51,
+          "delta": 0
+        },
+        "execa": {
+          "comparison_hits": 25,
+          "current_hits": 25,
+          "delta": 0
+        },
+        "faraday": {
+          "comparison_hits": 14,
+          "current_hits": 14,
+          "delta": 0
+        },
+        "fastlane": {
+          "comparison_hits": 91,
+          "current_hits": 92,
+          "delta": 1
+        },
+        "fd": {
+          "comparison_hits": 3,
+          "current_hits": 3,
+          "delta": 0
+        },
+        "flask": {
+          "comparison_hits": 21,
+          "current_hits": 21,
+          "delta": 0
+        },
+        "fzf": {
+          "comparison_hits": 29,
+          "current_hits": 29,
+          "delta": 0
+        },
+        "gin": {
+          "comparison_hits": 77,
+          "current_hits": 77,
+          "delta": 0
+        },
+        "git": {
+          "comparison_hits": 46,
+          "current_hits": 48,
+          "delta": 2
+        },
+        "gorm": {
+          "comparison_hits": 100,
+          "current_hits": 100,
+          "delta": 0
+        },
+        "graphhopper": {
+          "comparison_hits": 43,
+          "current_hits": 44,
+          "delta": 1
+        },
+        "gson": {
+          "comparison_hits": 84,
+          "current_hits": 84,
+          "delta": 0
+        },
+        "guava": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "h2database": {
+          "comparison_hits": 64,
+          "current_hits": 65,
+          "delta": 1
+        },
+        "httpie": {
+          "comparison_hits": 11,
+          "current_hits": 11,
+          "delta": 0
+        },
+        "httpx": {
+          "comparison_hits": 44,
+          "current_hits": 45,
+          "delta": 1
+        },
+        "hugo": {
+          "comparison_hits": 63,
+          "current_hits": 63,
+          "delta": 0
+        },
+        "hyperfine": {
+          "comparison_hits": 9,
+          "current_hits": 9,
+          "delta": 0
+        },
+        "image": {
+          "comparison_hits": 51,
+          "current_hits": 51,
+          "delta": 0
+        },
+        "jackson-core": {
+          "comparison_hits": 91,
+          "current_hits": 101,
+          "delta": 10
+        },
+        "jedis": {
+          "comparison_hits": 70,
+          "current_hits": 72,
+          "delta": 2
+        },
+        "jekyll": {
+          "comparison_hits": 20,
+          "current_hits": 20,
+          "delta": 0
+        },
+        "jest": {
+          "comparison_hits": 60,
+          "current_hits": 60,
+          "delta": 0
+        },
+        "jq": {
+          "comparison_hits": 18,
+          "current_hits": 18,
+          "delta": 0
+        },
+        "jsoup": {
+          "comparison_hits": 76,
+          "current_hits": 76,
+          "delta": 0
+        },
+        "junit5": {
+          "comparison_hits": 35,
+          "current_hits": 35,
+          "delta": 0
+        },
+        "kingfisher": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "kramdown": {
+          "comparison_hits": 2,
+          "current_hits": 2,
+          "delta": 0
+        },
+        "ky": {
+          "comparison_hits": 18,
+          "current_hits": 18,
+          "delta": 0
+        },
+        "libgdx": {
+          "comparison_hits": 84,
+          "current_hits": 92,
+          "delta": 8
+        },
+        "libsodium": {
+          "comparison_hits": 55,
+          "current_hits": 63,
+          "delta": 8
+        },
+        "libuv": {
+          "comparison_hits": 101,
+          "current_hits": 106,
+          "delta": 5
+        },
+        "liquid": {
+          "comparison_hits": 52,
+          "current_hits": 52,
+          "delta": 0
+        },
+        "lua": {
+          "comparison_hits": 8,
+          "current_hits": 8,
+          "delta": 0
+        },
+        "marked": {
+          "comparison_hits": 17,
+          "current_hits": 19,
+          "delta": 2
+        },
+        "marshmallow": {
+          "comparison_hits": 24,
+          "current_hits": 24,
+          "delta": 0
+        },
+        "meilisearch": {
+          "comparison_hits": 19,
+          "current_hits": 19,
+          "delta": 0
+        },
+        "minio": {
+          "comparison_hits": 90,
+          "current_hits": 90,
+          "delta": 0
+        },
+        "mockito": {
+          "comparison_hits": 93,
+          "current_hits": 96,
+          "delta": 3
+        },
+        "nats-server": {
+          "comparison_hits": 61,
+          "current_hits": 61,
+          "delta": 0
+        },
+        "netty": {
+          "comparison_hits": 95,
+          "current_hits": 99,
+          "delta": 4
+        },
+        "nginx": {
+          "comparison_hits": 41,
+          "current_hits": 46,
+          "delta": 5
+        },
+        "nimble": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "nushell": {
+          "comparison_hits": 51,
+          "current_hits": 57,
+          "delta": 6
+        },
+        "packaging": {
+          "comparison_hits": 47,
+          "current_hits": 47,
+          "delta": 0
+        },
+        "pixijs": {
+          "comparison_hits": 89,
+          "current_hits": 89,
+          "delta": 0
+        },
+        "poetry": {
+          "comparison_hits": 104,
+          "current_hits": 104,
+          "delta": 0
+        },
+        "prettier": {
+          "comparison_hits": 15,
+          "current_hits": 15,
+          "delta": 0
+        },
+        "prometheus": {
+          "comparison_hits": 81,
+          "current_hits": 83,
+          "delta": 2
+        },
+        "pry": {
+          "comparison_hits": 18,
+          "current_hits": 18,
+          "delta": 0
+        },
+        "puma": {
+          "comparison_hits": 59,
+          "current_hits": 59,
+          "delta": 0
+        },
+        "quick": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "rack": {
+          "comparison_hits": 15,
+          "current_hits": 15,
+          "delta": 0
+        },
+        "radash": {
+          "comparison_hits": 9,
+          "current_hits": 9,
+          "delta": 0
+        },
+        "raylib": {
+          "comparison_hits": 14,
+          "current_hits": 14,
+          "delta": 0
+        },
+        "redis": {
+          "comparison_hits": 40,
+          "current_hits": 41,
+          "delta": 1
+        },
+        "regex": {
+          "comparison_hits": 64,
+          "current_hits": 65,
+          "delta": 1
+        },
+        "requests": {
+          "comparison_hits": 8,
+          "current_hits": 8,
+          "delta": 0
+        },
+        "retrofit": {
+          "comparison_hits": 40,
+          "current_hits": 41,
+          "delta": 1
+        },
+        "rich": {
+          "comparison_hits": 26,
+          "current_hits": 27,
+          "delta": 1
+        },
+        "ripgrep": {
+          "comparison_hits": 56,
+          "current_hits": 57,
+          "delta": 1
+        },
+        "rspec-core": {
+          "comparison_hits": 46,
+          "current_hits": 49,
+          "delta": 3
+        },
+        "rubocop": {
+          "comparison_hits": 85,
+          "current_hits": 88,
+          "delta": 3
+        },
+        "rustls": {
+          "comparison_hits": 46,
+          "current_hits": 50,
+          "delta": 4
+        },
+        "rxjava": {
+          "comparison_hits": 37,
+          "current_hits": 39,
+          "delta": 2
+        },
+        "rxjs": {
+          "comparison_hits": 19,
+          "current_hits": 19,
+          "delta": 0
+        },
+        "rxswift": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "scrapy": {
+          "comparison_hits": 69,
+          "current_hits": 69,
+          "delta": 0
+        },
+        "serde_json": {
+          "comparison_hits": 40,
+          "current_hits": 42,
+          "delta": 2
+        },
+        "sidekiq": {
+          "comparison_hits": 45,
+          "current_hits": 45,
+          "delta": 0
+        },
+        "sinatra": {
+          "comparison_hits": 35,
+          "current_hits": 37,
+          "delta": 2
+        },
+        "sled": {
+          "comparison_hits": 23,
+          "current_hits": 23,
+          "delta": 0
+        },
+        "sqlalchemy": {
+          "comparison_hits": 57,
+          "current_hits": 57,
+          "delta": 0
+        },
+        "sqlite": {
+          "comparison_hits": 49,
+          "current_hits": 50,
+          "delta": 1
+        },
+        "swift-algorithms": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-argument-parser": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-collections": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-composable-architecture": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-log": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-metrics": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-nio": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swift-service-lifecycle": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swiftlint": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "swr": {
+          "comparison_hits": 38,
+          "current_hits": 38,
+          "delta": 0
+        },
+        "sympy": {
+          "comparison_hits": 31,
+          "current_hits": 31,
+          "delta": 0
+        },
+        "thor": {
+          "comparison_hits": 17,
+          "current_hits": 17,
+          "delta": 0
+        },
+        "tmux": {
+          "comparison_hits": 98,
+          "current_hits": 100,
+          "delta": 2
+        },
+        "tokei": {
+          "comparison_hits": 5,
+          "current_hits": 5,
+          "delta": 0
+        },
+        "tokio": {
+          "comparison_hits": 72,
+          "current_hits": 73,
+          "delta": 1
+        },
+        "trpc": {
+          "comparison_hits": 62,
+          "current_hits": 65,
+          "delta": 3
+        },
+        "urfave-cli": {
+          "comparison_hits": 46,
+          "current_hits": 47,
+          "delta": 1
+        },
+        "vapor": {
+          "comparison_hits": 0,
+          "current_hits": 0,
+          "delta": 0
+        },
+        "vim": {
+          "comparison_hits": 44,
+          "current_hits": 44,
+          "delta": 0
+        },
+        "wrk": {
+          "comparison_hits": 1,
+          "current_hits": 1,
+          "delta": 0
+        },
+        "zap": {
+          "comparison_hits": 34,
+          "current_hits": 34,
+          "delta": 0
+        },
+        "zod": {
+          "comparison_hits": 52,
+          "current_hits": 52,
+          "delta": 0
+        },
+        "zstd": {
+          "comparison_hits": 24,
+          "current_hits": 27,
+          "delta": 3
+        },
+        "zustand": {
+          "comparison_hits": 5,
+          "current_hits": 5,
+          "delta": 0
+        }
+      },
+      "comparison_hits": 4575,
+      "current_hits": 4687,
+      "delta": 112,
+      "recovered": [
+        {
+          "candidate_key": "alacritty:4c6345613406b888",
+          "channel": "contiguous",
+          "family_id": "4c6345613406b888",
+          "language": "Rust",
+          "repo": "alacritty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "alacritty:c5b0dc1d87506916",
+          "channel": "structural",
+          "family_id": "c5b0dc1d87506916",
+          "language": "Rust",
+          "repo": "alacritty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "alacritty:c93b1e63f96d2a38",
+          "channel": "contiguous",
+          "family_id": "c93b1e63f96d2a38",
+          "language": "Rust",
+          "repo": "alacritty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "axios:70db87b821c19292",
+          "channel": "structural",
+          "family_id": "70db87b821c19292",
+          "language": "TypeScript",
+          "repo": "axios",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "axios:80e929ac1884dd5b",
+          "channel": "structural",
+          "family_id": "80e929ac1884dd5b",
+          "language": "TypeScript",
+          "repo": "axios",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "axios:9c60235300651f6f",
+          "channel": "structural",
+          "family_id": "9c60235300651f6f",
+          "language": "TypeScript",
+          "repo": "axios",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "badger:3fda2f8f131fc24a",
+          "channel": "structural",
+          "family_id": "3fda2f8f131fc24a",
+          "language": "Go",
+          "repo": "badger",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "bat:53a5234e49ea003a",
+          "channel": "contiguous",
+          "family_id": "53a5234e49ea003a",
+          "language": "Rust",
+          "repo": "bat",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "boltons:8d56606d9e012c03",
+          "channel": "structural",
+          "family_id": "8d56606d9e012c03",
+          "language": "Python",
+          "repo": "boltons",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "clap:67e4d3199dcb742a",
+          "channel": "contiguous",
+          "family_id": "67e4d3199dcb742a",
+          "language": "Rust",
+          "repo": "clap",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "clap:8314f42e205f4857",
+          "channel": "contiguous",
+          "family_id": "8314f42e205f4857",
+          "language": "Rust",
+          "repo": "clap",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "curl:07576398d3db15e6",
+          "channel": "structural",
+          "family_id": "07576398d3db15e6",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:1b0b0a2a78f4053e",
+          "channel": "structural",
+          "family_id": "1b0b0a2a78f4053e",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:438cb822fefd5174",
+          "channel": "structural",
+          "family_id": "438cb822fefd5174",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:688ec0f1c0146e0d",
+          "channel": "structural",
+          "family_id": "688ec0f1c0146e0d",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:79d633f8b5dc6977",
+          "channel": "structural",
+          "family_id": "79d633f8b5dc6977",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:add4f3e341202511",
+          "channel": "contiguous",
+          "family_id": "add4f3e341202511",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:af38d8d5c688322b",
+          "channel": "structural",
+          "family_id": "af38d8d5c688322b",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "curl:b6645e054f2f60ec",
+          "channel": "structural",
+          "family_id": "b6645e054f2f60ec",
+          "language": "C",
+          "repo": "curl",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "fastlane:cfbff7878814e3a7",
+          "channel": "structural",
+          "family_id": "cfbff7878814e3a7",
+          "language": "Ruby",
+          "repo": "fastlane",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "git:895d513507a19cf6",
+          "channel": "contiguous",
+          "family_id": "895d513507a19cf6",
+          "language": "C",
+          "repo": "git",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "git:d9d84da753e732ca",
+          "channel": "contiguous",
+          "family_id": "d9d84da753e732ca",
+          "language": "C",
+          "repo": "git",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "graphhopper:fb83868d7d451012",
+          "channel": "structural",
+          "family_id": "fb83868d7d451012",
+          "language": "Java",
+          "repo": "graphhopper",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "h2database:1a9aca871c0e706c",
+          "channel": "structural",
+          "family_id": "1a9aca871c0e706c",
+          "language": "Java",
+          "repo": "h2database",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "httpx:403e192d93e50365",
+          "channel": "contiguous",
+          "family_id": "403e192d93e50365",
+          "language": "Python",
+          "repo": "httpx",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "jackson-core:342212b29c461055",
+          "channel": "structural",
+          "family_id": "342212b29c461055",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:3b7bbc46ecda91fd",
+          "channel": "structural",
+          "family_id": "3b7bbc46ecda91fd",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:5ee172574837dc0c",
+          "channel": "structural",
+          "family_id": "5ee172574837dc0c",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:775a5f9f16c89d95",
+          "channel": "structural",
+          "family_id": "775a5f9f16c89d95",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:778106f7b108c992",
+          "channel": "structural",
+          "family_id": "778106f7b108c992",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:7b236caf2bab92fe",
+          "channel": "structural",
+          "family_id": "7b236caf2bab92fe",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:7c3f203b9752f881",
+          "channel": "structural",
+          "family_id": "7c3f203b9752f881",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:802599ebe9b1ef57",
+          "channel": "structural",
+          "family_id": "802599ebe9b1ef57",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:a29cf09848dc8864",
+          "channel": "structural",
+          "family_id": "a29cf09848dc8864",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jackson-core:f37d2a9bde46882e",
+          "channel": "structural",
+          "family_id": "f37d2a9bde46882e",
+          "language": "Java",
+          "repo": "jackson-core",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "jedis:3ebcee53c3f860ec",
+          "channel": "structural",
+          "family_id": "3ebcee53c3f860ec",
+          "language": "Java",
+          "repo": "jedis",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "jedis:5acc5abea88f00ec",
+          "channel": "contiguous",
+          "family_id": "5acc5abea88f00ec",
+          "language": "Java",
+          "repo": "jedis",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:09ec699248996d6b",
+          "channel": "structural",
+          "family_id": "09ec699248996d6b",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:1b380b3779b5c1e1",
+          "channel": "structural",
+          "family_id": "1b380b3779b5c1e1",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:4562f098b917f263",
+          "channel": "structural",
+          "family_id": "4562f098b917f263",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:90716198a3851eb8",
+          "channel": "structural",
+          "family_id": "90716198a3851eb8",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:939e0a48c9e83152",
+          "channel": "structural",
+          "family_id": "939e0a48c9e83152",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:aa17fd9c278f7a8b",
+          "channel": "structural",
+          "family_id": "aa17fd9c278f7a8b",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:da6bf9411a931fed",
+          "channel": "structural",
+          "family_id": "da6bf9411a931fed",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libgdx:fb2fb32d118d9ac3",
+          "channel": "structural",
+          "family_id": "fb2fb32d118d9ac3",
+          "language": "Java",
+          "repo": "libgdx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:37ebbd018de90717",
+          "channel": "structural",
+          "family_id": "37ebbd018de90717",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:442744c3d62eaa4a",
+          "channel": "structural",
+          "family_id": "442744c3d62eaa4a",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:4edecc65d87fe574",
+          "channel": "structural",
+          "family_id": "4edecc65d87fe574",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:79eeba5922837da4",
+          "channel": "structural",
+          "family_id": "79eeba5922837da4",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:863cbbeb598f2419",
+          "channel": "structural",
+          "family_id": "863cbbeb598f2419",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libsodium:8d6552152465a969",
+          "channel": "structural",
+          "family_id": "8d6552152465a969",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "libsodium:d141aa6e57d27742",
+          "channel": "contiguous",
+          "family_id": "d141aa6e57d27742",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libsodium:d8e13c5353153ccd",
+          "channel": "contiguous",
+          "family_id": "d8e13c5353153ccd",
+          "language": "C",
+          "repo": "libsodium",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libuv:2ae21bab34147fd7",
+          "channel": "contiguous",
+          "family_id": "2ae21bab34147fd7",
+          "language": "C",
+          "repo": "libuv",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libuv:6c5bd4c1a677d902",
+          "channel": "structural",
+          "family_id": "6c5bd4c1a677d902",
+          "language": "C",
+          "repo": "libuv",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libuv:728784083123064f",
+          "channel": "contiguous",
+          "family_id": "728784083123064f",
+          "language": "C",
+          "repo": "libuv",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libuv:d247bd8fb6aa7918",
+          "channel": "structural",
+          "family_id": "d247bd8fb6aa7918",
+          "language": "C",
+          "repo": "libuv",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "libuv:fdd26ef0cf1e4fbc",
+          "channel": "structural",
+          "family_id": "fdd26ef0cf1e4fbc",
+          "language": "C",
+          "repo": "libuv",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "marked:b5e9e74259791de2",
+          "channel": "contiguous",
+          "family_id": "b5e9e74259791de2",
+          "language": "TypeScript",
+          "repo": "marked",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "marked:fe11a12dcee5cd78",
+          "channel": "structural",
+          "family_id": "fe11a12dcee5cd78",
+          "language": "TypeScript",
+          "repo": "marked",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "mockito:67d372348d1d6446",
+          "channel": "structural",
+          "family_id": "67d372348d1d6446",
+          "language": "Java",
+          "repo": "mockito",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "mockito:9f967a3cfc10f3b8",
+          "channel": "structural",
+          "family_id": "9f967a3cfc10f3b8",
+          "language": "Java",
+          "repo": "mockito",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "mockito:faafc7cc04839b34",
+          "channel": "contiguous",
+          "family_id": "faafc7cc04839b34",
+          "language": "Java",
+          "repo": "mockito",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "netty:265776dc187e262c",
+          "channel": "contiguous",
+          "family_id": "265776dc187e262c",
+          "language": "Java",
+          "repo": "netty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "netty:5bd323713843fdad",
+          "channel": "structural",
+          "family_id": "5bd323713843fdad",
+          "language": "Java",
+          "repo": "netty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "netty:aaffd3da87f0f758",
+          "channel": "contiguous",
+          "family_id": "aaffd3da87f0f758",
+          "language": "Java",
+          "repo": "netty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "netty:de6611cbcf1671b4",
+          "channel": "structural",
+          "family_id": "de6611cbcf1671b4",
+          "language": "Java",
+          "repo": "netty",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nginx:04895d9a2eeb6131",
+          "channel": "structural",
+          "family_id": "04895d9a2eeb6131",
+          "language": "C",
+          "repo": "nginx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nginx:7ea165022a7e3302",
+          "channel": "contiguous",
+          "family_id": "7ea165022a7e3302",
+          "language": "C",
+          "repo": "nginx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nginx:7ee7007d5fc2a0d5",
+          "channel": "contiguous",
+          "family_id": "7ee7007d5fc2a0d5",
+          "language": "C",
+          "repo": "nginx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nginx:8fa530f40ce49c73",
+          "channel": "contiguous",
+          "family_id": "8fa530f40ce49c73",
+          "language": "C",
+          "repo": "nginx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nginx:d153a4f3802a42c5",
+          "channel": "contiguous",
+          "family_id": "d153a4f3802a42c5",
+          "language": "C",
+          "repo": "nginx",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:06abb0a4b9c069e2",
+          "channel": "structural",
+          "family_id": "06abb0a4b9c069e2",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:2637963422239bd3",
+          "channel": "structural",
+          "family_id": "2637963422239bd3",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:5717ee835ee37e72",
+          "channel": "contiguous",
+          "family_id": "5717ee835ee37e72",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:822da63ee38b1ab2",
+          "channel": "structural",
+          "family_id": "822da63ee38b1ab2",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:a5418a9b1b048516",
+          "channel": "contiguous",
+          "family_id": "a5418a9b1b048516",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "nushell:d6fb645fa2e28fdf",
+          "channel": "contiguous",
+          "family_id": "d6fb645fa2e28fdf",
+          "language": "Rust",
+          "repo": "nushell",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "prometheus:00732ff2a6289f00",
+          "channel": "structural",
+          "family_id": "00732ff2a6289f00",
+          "language": "Go",
+          "repo": "prometheus",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "prometheus:03e916354ac5c664",
+          "channel": "structural",
+          "family_id": "03e916354ac5c664",
+          "language": "Go",
+          "repo": "prometheus",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "redis:c2825c415199a3c0",
+          "channel": "structural",
+          "family_id": "c2825c415199a3c0",
+          "language": "C",
+          "repo": "redis",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "regex:5a11c4e183cbc3e4",
+          "channel": "structural",
+          "family_id": "5a11c4e183cbc3e4",
+          "language": "Rust",
+          "repo": "regex",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "retrofit:450a5844cce0c0bd",
+          "channel": "contiguous",
+          "family_id": "450a5844cce0c0bd",
+          "language": "Java",
+          "repo": "retrofit",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rich:cd216bafb0dfec7c",
+          "channel": "structural",
+          "family_id": "cd216bafb0dfec7c",
+          "language": "Python",
+          "repo": "rich",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "ripgrep:e6d81b48f46ce521",
+          "channel": "structural",
+          "family_id": "e6d81b48f46ce521",
+          "language": "Rust",
+          "repo": "ripgrep",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rspec-core:122d3349380489f2",
+          "channel": "contiguous",
+          "family_id": "122d3349380489f2",
+          "language": "Ruby",
+          "repo": "rspec-core",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "rspec-core:f1d562131fa8096a",
+          "channel": "contiguous",
+          "family_id": "f1d562131fa8096a",
+          "language": "Ruby",
+          "repo": "rspec-core",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "rspec-core:f90e040392961f73",
+          "channel": "contiguous",
+          "family_id": "f90e040392961f73",
+          "language": "Ruby",
+          "repo": "rspec-core",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "rubocop:24160f04580c3762",
+          "channel": "structural",
+          "family_id": "24160f04580c3762",
+          "language": "Ruby",
+          "repo": "rubocop",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rubocop:490869ad2d30695d",
+          "channel": "structural",
+          "family_id": "490869ad2d30695d",
+          "language": "Ruby",
+          "repo": "rubocop",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rubocop:9a3d18bd8a3ac7b6",
+          "channel": "structural",
+          "family_id": "9a3d18bd8a3ac7b6",
+          "language": "Ruby",
+          "repo": "rubocop",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rustls:048bb3ded39cea58",
+          "channel": "structural",
+          "family_id": "048bb3ded39cea58",
+          "language": "Rust",
+          "repo": "rustls",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "rustls:78320de9065fa5dd",
+          "channel": "structural",
+          "family_id": "78320de9065fa5dd",
+          "language": "Rust",
+          "repo": "rustls",
+          "scope": "mixed"
+        },
+        {
+          "candidate_key": "rustls:c48929f0bc472366",
+          "channel": "structural",
+          "family_id": "c48929f0bc472366",
+          "language": "Rust",
+          "repo": "rustls",
+          "scope": "mixed"
+        },
+        {
+          "candidate_key": "rustls:fb557ff961c221e7",
+          "channel": "structural",
+          "family_id": "fb557ff961c221e7",
+          "language": "Rust",
+          "repo": "rustls",
+          "scope": "mixed"
+        },
+        {
+          "candidate_key": "rxjava:3c288591c2be98b4",
+          "channel": "contiguous",
+          "family_id": "3c288591c2be98b4",
+          "language": "Java",
+          "repo": "rxjava",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "rxjava:e9e23c6a404cd218",
+          "channel": "contiguous",
+          "family_id": "e9e23c6a404cd218",
+          "language": "Java",
+          "repo": "rxjava",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "serde_json:5c3a440867f18f80",
+          "channel": "structural",
+          "family_id": "5c3a440867f18f80",
+          "language": "Rust",
+          "repo": "serde_json",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "serde_json:bec63f16f3ebd8fd",
+          "channel": "structural",
+          "family_id": "bec63f16f3ebd8fd",
+          "language": "Rust",
+          "repo": "serde_json",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "sinatra:30191d2f42a72a70",
+          "channel": "contiguous",
+          "family_id": "30191d2f42a72a70",
+          "language": "Ruby",
+          "repo": "sinatra",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "sinatra:6c0f20ce8939ef2f",
+          "channel": "contiguous",
+          "family_id": "6c0f20ce8939ef2f",
+          "language": "Ruby",
+          "repo": "sinatra",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "sqlite:409c1b9791d270e9",
+          "channel": "structural",
+          "family_id": "409c1b9791d270e9",
+          "language": "C",
+          "repo": "sqlite",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "tmux:3a515df5216b5259",
+          "channel": "contiguous",
+          "family_id": "3a515df5216b5259",
+          "language": "C",
+          "repo": "tmux",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "tmux:a0458bd522fd4095",
+          "channel": "structural",
+          "family_id": "a0458bd522fd4095",
+          "language": "C",
+          "repo": "tmux",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "tokio:88b4d4de5315663a",
+          "channel": "structural",
+          "family_id": "88b4d4de5315663a",
+          "language": "Rust",
+          "repo": "tokio",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "trpc:b91d241a9953e9d8",
+          "channel": "structural",
+          "family_id": "b91d241a9953e9d8",
+          "language": "TypeScript",
+          "repo": "trpc",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "trpc:d6db15b35bf59aab",
+          "channel": "structural",
+          "family_id": "d6db15b35bf59aab",
+          "language": "TypeScript",
+          "repo": "trpc",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "trpc:f3f2624fcf3514bc",
+          "channel": "structural",
+          "family_id": "f3f2624fcf3514bc",
+          "language": "TypeScript",
+          "repo": "trpc",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "urfave-cli:a0711b6deb1519bc",
+          "channel": "contiguous",
+          "family_id": "a0711b6deb1519bc",
+          "language": "Go",
+          "repo": "urfave-cli",
+          "scope": "test"
+        },
+        {
+          "candidate_key": "zstd:1067877d52f3f396",
+          "channel": "structural",
+          "family_id": "1067877d52f3f396",
+          "language": "C",
+          "repo": "zstd",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "zstd:2acbb5888bdfe4dc",
+          "channel": "structural",
+          "family_id": "2acbb5888bdfe4dc",
+          "language": "C",
+          "repo": "zstd",
+          "scope": "prod"
+        },
+        {
+          "candidate_key": "zstd:69bba34d7f63f5ba",
+          "channel": "structural",
+          "family_id": "69bba34d7f63f5ba",
+          "language": "C",
+          "repo": "zstd",
+          "scope": "prod"
+        }
+      ],
+      "recovered_count": 112,
+      "regressed": [],
+      "regressed_count": 0
+    }
+  },
+  "configuration": {
+    "bootstrap_resamples": 500,
+    "bootstrap_seed": 1,
+    "cache_dir": "target/issue-820/eval-cache",
+    "limit_repos": null,
+    "mode": "CLI default",
+    "precision_denominator": "reported top-10 families matching at least one active precision label",
+    "rank": "extractability",
+    "recall_denominator": "worthy labels eligible for unbiased worthy-recall",
+    "repos_root": "bench/repos",
+    "splits": [
+      "dev",
+      "heldout"
+    ],
+    "timeout_seconds_per_repo": 300,
+    "top": 1000000
+  },
+  "metrics": {
+    "dev": {
+      "C": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            41.6667,
+            63.8889
+          ],
+          "hits": 38,
+          "n": 72,
+          "pct": 52.7778
+        },
+        "label_match_coverage": {
+          "hits": 70,
+          "n": 90,
+          "pct": 77.7778
+        },
+        "labels": 1009,
+        "precision_at_10": {
+          "ci95": [
+            34.2857,
+            58.5714
+          ],
+          "hits": 32,
+          "n": 70,
+          "pct": 45.7143
+        },
+        "precision_labels": 1009,
+        "repositories": 9,
+        "worthy_labels": 450,
+        "worthy_recall": {
+          "ci95": [
+            95.7778,
+            98.6667
+          ],
+          "hits": 438,
+          "n": 450,
+          "pct": 97.3333
+        }
+      },
+      "Go": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            48.3871,
+            72.5806
+          ],
+          "hits": 37,
+          "n": 62,
+          "pct": 59.6774
+        },
+        "label_match_coverage": {
+          "hits": 59,
+          "n": 80,
+          "pct": 73.75
+        },
+        "labels": 804,
+        "precision_at_10": {
+          "ci95": [
+            47.4576,
+            71.1864
+          ],
+          "hits": 35,
+          "n": 59,
+          "pct": 59.322
+        },
+        "precision_labels": 804,
+        "repositories": 8,
+        "worthy_labels": 475,
+        "worthy_recall": {
+          "ci95": [
+            94.1053,
+            97.6842
+          ],
+          "hits": 456,
+          "n": 475,
+          "pct": 96.0
+        }
+      },
+      "Java": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            36.6197,
+            60.5634
+          ],
+          "hits": 35,
+          "n": 71,
+          "pct": 49.2958
+        },
+        "label_match_coverage": {
+          "hits": 74,
+          "n": 90,
+          "pct": 82.2222
+        },
+        "labels": 1174,
+        "precision_at_10": {
+          "ci95": [
+            24.3243,
+            45.9459
+          ],
+          "hits": 26,
+          "n": 74,
+          "pct": 35.1351
+        },
+        "precision_labels": 1174,
+        "repositories": 9,
+        "worthy_labels": 535,
+        "worthy_recall": {
+          "ci95": [
+            92.5234,
+            96.0748
+          ],
+          "hits": 504,
+          "n": 535,
+          "pct": 94.2056
+        }
+      },
+      "OVERALL": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            54.6318,
+            64.133
+          ],
+          "hits": 248,
+          "n": 421,
+          "pct": 58.9074
+        },
+        "label_match_coverage": {
+          "hits": 447,
+          "n": 660,
+          "pct": 67.7273
+        },
+        "labels": 5504,
+        "precision_at_10": {
+          "ci95": [
+            54.5861,
+            63.7584
+          ],
+          "hits": 264,
+          "n": 447,
+          "pct": 59.0604
+        },
+        "precision_labels": 5504,
+        "repositories": 66,
+        "worthy_labels": 2849,
+        "worthy_recall": {
+          "ci95": [
+            93.7171,
+            95.3668
+          ],
+          "hits": 2691,
+          "n": 2849,
+          "pct": 94.4542
+        }
+      },
+      "Python": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            48.1481,
+            74.0741
+          ],
+          "hits": 33,
+          "n": 54,
+          "pct": 61.1111
+        },
+        "label_match_coverage": {
+          "hits": 56,
+          "n": 70,
+          "pct": 80.0
+        },
+        "labels": 601,
+        "precision_at_10": {
+          "ci95": [
+            50.0,
+            75.0
+          ],
+          "hits": 35,
+          "n": 56,
+          "pct": 62.5
+        },
+        "precision_labels": 601,
+        "repositories": 7,
+        "worthy_labels": 299,
+        "worthy_recall": {
+          "ci95": [
+            93.6455,
+            97.9933
+          ],
+          "hits": 287,
+          "n": 299,
+          "pct": 95.9866
+        }
+      },
+      "Ruby": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            82.3529,
+            100.0
+          ],
+          "hits": 31,
+          "n": 34,
+          "pct": 91.1765
+        },
+        "label_match_coverage": {
+          "hits": 51,
+          "n": 90,
+          "pct": 56.6667
+        },
+        "labels": 483,
+        "precision_at_10": {
+          "ci95": [
+            86.2745,
+            100.0
+          ],
+          "hits": 48,
+          "n": 51,
+          "pct": 94.1176
+        },
+        "precision_labels": 483,
+        "repositories": 9,
+        "worthy_labels": 380,
+        "worthy_recall": {
+          "ci95": [
+            88.1579,
+            93.9474
+          ],
+          "hits": 346,
+          "n": 380,
+          "pct": 91.0526
+        }
+      },
+      "Rust": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            54.6875,
+            78.125
+          ],
+          "hits": 43,
+          "n": 64,
+          "pct": 67.1875
+        },
+        "label_match_coverage": {
+          "hits": 62,
+          "n": 80,
+          "pct": 77.5
+        },
+        "labels": 694,
+        "precision_at_10": {
+          "ci95": [
+            59.6774,
+            82.2581
+          ],
+          "hits": 44,
+          "n": 62,
+          "pct": 70.9677
+        },
+        "precision_labels": 694,
+        "repositories": 8,
+        "worthy_labels": 411,
+        "worthy_recall": {
+          "ci95": [
+            86.3747,
+            92.4574
+          ],
+          "hits": 368,
+          "n": 411,
+          "pct": 89.5377
+        }
+      },
+      "Swift": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            9.0909,
+            45.4545
+          ],
+          "hits": 6,
+          "n": 22,
+          "pct": 27.2727
+        },
+        "label_match_coverage": {
+          "hits": 27,
+          "n": 80,
+          "pct": 33.75
+        },
+        "labels": 24,
+        "precision_at_10": {
+          "ci95": [
+            22.2222,
+            59.2593
+          ],
+          "hits": 11,
+          "n": 27,
+          "pct": 40.7407
+        },
+        "precision_labels": 24,
+        "repositories": 8,
+        "worthy_labels": 0,
+        "worthy_recall": {
+          "ci95": [
+            0.0,
+            0.0
+          ],
+          "hits": 0,
+          "n": 0,
+          "pct": 0.0
+        }
+      },
+      "TypeScript": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            45.2381,
+            73.8095
+          ],
+          "hits": 25,
+          "n": 42,
+          "pct": 59.5238
+        },
+        "label_match_coverage": {
+          "hits": 48,
+          "n": 80,
+          "pct": 60.0
+        },
+        "labels": 715,
+        "precision_at_10": {
+          "ci95": [
+            54.1667,
+            81.25
+          ],
+          "hits": 33,
+          "n": 48,
+          "pct": 68.75
+        },
+        "precision_labels": 715,
+        "repositories": 8,
+        "worthy_labels": 299,
+        "worthy_recall": {
+          "ci95": [
+            95.6522,
+            99.3311
+          ],
+          "hits": 292,
+          "n": 299,
+          "pct": 97.6589
+        }
+      }
+    },
+    "heldout": {
+      "C": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            24.0,
+            52.0
+          ],
+          "hits": 19,
+          "n": 50,
+          "pct": 38.0
+        },
+        "label_match_coverage": {
+          "hits": 46,
+          "n": 60,
+          "pct": 76.6667
+        },
+        "labels": 539,
+        "precision_at_10": {
+          "ci95": [
+            30.4348,
+            58.6957
+          ],
+          "hits": 20,
+          "n": 46,
+          "pct": 43.4783
+        },
+        "precision_labels": 539,
+        "repositories": 6,
+        "worthy_labels": 231,
+        "worthy_recall": {
+          "ci95": [
+            92.2078,
+            97.8355
+          ],
+          "hits": 220,
+          "n": 231,
+          "pct": 95.2381
+        }
+      },
+      "Go": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            64.4068,
+            86.4407
+          ],
+          "hits": 45,
+          "n": 59,
+          "pct": 76.2712
+        },
+        "label_match_coverage": {
+          "hits": 61,
+          "n": 70,
+          "pct": 87.1429
+        },
+        "labels": 720,
+        "precision_at_10": {
+          "ci95": [
+            77.0492,
+            93.4426
+          ],
+          "hits": 52,
+          "n": 61,
+          "pct": 85.2459
+        },
+        "precision_labels": 720,
+        "repositories": 7,
+        "worthy_labels": 426,
+        "worthy_recall": {
+          "ci95": [
+            93.4272,
+            97.4178
+          ],
+          "hits": 407,
+          "n": 426,
+          "pct": 95.5399
+        }
+      },
+      "Java": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            36.1702,
+            63.8298
+          ],
+          "hits": 23,
+          "n": 47,
+          "pct": 48.9362
+        },
+        "label_match_coverage": {
+          "hits": 43,
+          "n": 60,
+          "pct": 71.6667
+        },
+        "labels": 742,
+        "precision_at_10": {
+          "ci95": [
+            34.8837,
+            65.1163
+          ],
+          "hits": 21,
+          "n": 43,
+          "pct": 48.8372
+        },
+        "precision_labels": 742,
+        "repositories": 6,
+        "worthy_labels": 457,
+        "worthy_recall": {
+          "ci95": [
+            95.8425,
+            98.6871
+          ],
+          "hits": 445,
+          "n": 457,
+          "pct": 97.3742
+        }
+      },
+      "OVERALL": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            47.7922,
+            57.4026
+          ],
+          "hits": 201,
+          "n": 385,
+          "pct": 52.2078
+        },
+        "label_match_coverage": {
+          "hits": 384,
+          "n": 540,
+          "pct": 71.1111
+        },
+        "labels": 4072,
+        "precision_at_10": {
+          "ci95": [
+            50.7812,
+            60.9375
+          ],
+          "hits": 214,
+          "n": 384,
+          "pct": 55.7292
+        },
+        "precision_labels": 4072,
+        "repositories": 54,
+        "worthy_labels": 2091,
+        "worthy_recall": {
+          "ci95": [
+            94.5481,
+            96.3176
+          ],
+          "hits": 1996,
+          "n": 2091,
+          "pct": 95.4567
+        }
+      },
+      "Python": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            35.0,
+            60.0
+          ],
+          "hits": 29,
+          "n": 60,
+          "pct": 48.3333
+        },
+        "label_match_coverage": {
+          "hits": 57,
+          "n": 80,
+          "pct": 71.25
+        },
+        "labels": 505,
+        "precision_at_10": {
+          "ci95": [
+            33.3333,
+            61.4035
+          ],
+          "hits": 27,
+          "n": 57,
+          "pct": 47.3684
+        },
+        "precision_labels": 505,
+        "repositories": 8,
+        "worthy_labels": 225,
+        "worthy_recall": {
+          "ci95": [
+            94.6667,
+            99.1111
+          ],
+          "hits": 218,
+          "n": 225,
+          "pct": 96.8889
+        }
+      },
+      "Ruby": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            71.875,
+            96.875
+          ],
+          "hits": 27,
+          "n": 32,
+          "pct": 84.375
+        },
+        "label_match_coverage": {
+          "hits": 29,
+          "n": 60,
+          "pct": 48.3333
+        },
+        "labels": 315,
+        "precision_at_10": {
+          "ci95": [
+            79.3103,
+            100.0
+          ],
+          "hits": 26,
+          "n": 29,
+          "pct": 89.6552
+        },
+        "precision_labels": 315,
+        "repositories": 6,
+        "worthy_labels": 250,
+        "worthy_recall": {
+          "ci95": [
+            86.8,
+            94.4
+          ],
+          "hits": 226,
+          "n": 250,
+          "pct": 90.4
+        }
+      },
+      "Rust": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            49.1525,
+            72.8814
+          ],
+          "hits": 36,
+          "n": 59,
+          "pct": 61.0169
+        },
+        "label_match_coverage": {
+          "hits": 65,
+          "n": 70,
+          "pct": 92.8571
+        },
+        "labels": 577,
+        "precision_at_10": {
+          "ci95": [
+            47.6923,
+            72.3077
+          ],
+          "hits": 39,
+          "n": 65,
+          "pct": 60.0
+        },
+        "precision_labels": 577,
+        "repositories": 7,
+        "worthy_labels": 255,
+        "worthy_recall": {
+          "ci95": [
+            92.9412,
+            98.0392
+          ],
+          "hits": 244,
+          "n": 255,
+          "pct": 95.6863
+        }
+      },
+      "Swift": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            9.0909,
+            45.4545
+          ],
+          "hits": 6,
+          "n": 22,
+          "pct": 27.2727
+        },
+        "label_match_coverage": {
+          "hits": 27,
+          "n": 70,
+          "pct": 38.5714
+        },
+        "labels": 21,
+        "precision_at_10": {
+          "ci95": [
+            29.6296,
+            62.963
+          ],
+          "hits": 13,
+          "n": 27,
+          "pct": 48.1481
+        },
+        "precision_labels": 21,
+        "repositories": 7,
+        "worthy_labels": 0,
+        "worthy_recall": {
+          "ci95": [
+            0.0,
+            0.0
+          ],
+          "hits": 0,
+          "n": 0,
+          "pct": 0.0
+        }
+      },
+      "TypeScript": {
+        "antiunification_rerank_precision_at_10": {
+          "ci95": [
+            16.0714,
+            41.0714
+          ],
+          "hits": 16,
+          "n": 56,
+          "pct": 28.5714
+        },
+        "label_match_coverage": {
+          "hits": 56,
+          "n": 70,
+          "pct": 80.0
+        },
+        "labels": 653,
+        "precision_at_10": {
+          "ci95": [
+            17.8571,
+            41.0714
+          ],
+          "hits": 16,
+          "n": 56,
+          "pct": 28.5714
+        },
+        "precision_labels": 653,
+        "repositories": 7,
+        "worthy_labels": 247,
+        "worthy_recall": {
+          "ci95": [
+            93.1174,
+            97.9757
+          ],
+          "hits": 236,
+          "n": 247,
+          "pct": 95.5466
+        }
+      }
+    }
+  },
+  "provenance": {
+    "command": "python3 bench/labels/eval_by_language.py --labelset bench/labels/refactoring_families.v6.json --nose target/issue-820/release/nose --comparison-nose target/release/nose --rank extractability --bootstrap 500 --cache-dir target/issue-820/eval-cache --json-out bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json",
+    "corpus_commit_digest": "366c977c096a91d50095253cce77a3ec8468d3147ecbd819353dc01196281083",
+    "corpus_manifest": "bench/goldens/corpus.json",
+    "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",
+    "git_sha": "a1cce3309eebde4e5d149a77950a710b8b962a96",
+    "labelset": "bench/labels/refactoring_families.v6.json",
+    "labelset_inputs": [
+      {
+        "path": "bench/labels/refactoring_families.v5.json",
+        "sha256": "e18b65543f4b6373d7eadbc93159adda69699eafe8f5f814d9ba53e245a6d9f9"
+      },
+      {
+        "path": "bench/labels/refactoring_families.v6.dev.json",
+        "sha256": "56ab02cf17f0fae2ef31155da92ca2e2d7cde70b0037363ca54768ccd6d98147"
+      },
+      {
+        "path": "bench/labels/refactoring_families.v6.heldout.json",
+        "sha256": "deff0c42d62a96a559f02f85fbe515cd366816821c10486294aed2a216b62ee9"
+      }
+    ],
+    "labelset_sha256": "6b72927d0e68e05406540016d3fa136029c52a406af0938b5a805d3fa199ac23",
+    "labelset_version": "v6",
+    "nose_binary": "/Users/ak/prjs/cc/nose/target/issue-820/release/nose",
+    "nose_binary_sha256": "5999e791c276a7d098099911b8252d35609d1ec7dbcf38888dad2815b126dd0a",
+    "nose_version": "nose 0.18.0",
+    "prune_manifest": "bench/labels/prune_manifest.json",
+    "prune_manifest_sha256": "c22f34d3ab4da9b89b5938140bbfdf7664178b3b7b57e5ea3937ba0bb47c2980",
+    "working_tree_status_before_measurement": ""
+  },
+  "query_schema_version": 7,
+  "repositories": {
+    "alacritty": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 10
+      },
+      "commit": "aaf3bd744a4f7608fe7d7168fb12b62a2155d311",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 81,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 10
+      },
+      "precision_labels": 81,
+      "reported_families": 113,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 37,
+      "worthy_recall": {
+        "hits": 35,
+        "n": 37
+      }
+    },
+    "alamofire": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 4
+      },
+      "commit": "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 1091,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "antlr4": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 5
+      },
+      "commit": "7d5770395bb7b02eb56e7c62662cb1d7c08f42a3",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 6
+      },
+      "precision_labels": 130,
+      "reported_families": 909,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 16,
+      "worthy_recall": {
+        "hits": 16,
+        "n": 16
+      }
+    },
+    "arrow": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "commit": "2224255c4acc594d734cef0bbc83360452a67983",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 40,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "precision_labels": 40,
+      "reported_families": 95,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 7,
+      "worthy_recall": {
+        "hits": 7,
+        "n": 7
+      }
+    },
+    "asciidoctor": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "07fbd12b0cb51cef76a4cf624436b0a241aaa397",
+      "label_match_coverage": {
+        "hits": 2,
+        "n": 10
+      },
+      "labels": 85,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "precision_labels": 85,
+      "reported_families": 505,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 8,
+      "worthy_labels": 58,
+      "worthy_recall": {
+        "hits": 50,
+        "n": 58
+      }
+    },
+    "axios": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "commit": "4306df21e84332fc576e98c2de549347c06bfb76",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 114,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 114,
+      "reported_families": 211,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 62,
+      "worthy_recall": {
+        "hits": 60,
+        "n": 62
+      }
+    },
+    "badger": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 9
+      },
+      "commit": "897f12fdb4631a9bf2aea347bde0a93d930d3001",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 118,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "precision_labels": 118,
+      "reported_families": 279,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 71,
+      "worthy_recall": {
+        "hits": 71,
+        "n": 71
+      }
+    },
+    "bat": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 4
+      },
+      "commit": "af1f53d9a977154216d01435991fe33631b74713",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 57,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 6
+      },
+      "precision_labels": 57,
+      "reported_families": 150,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 22,
+      "worthy_recall": {
+        "hits": 18,
+        "n": 22
+      }
+    },
+    "black": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 6
+      },
+      "commit": "d246367ab471cd56298407858661d475c33b3e36",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 124,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 7
+      },
+      "precision_labels": 124,
+      "reported_families": 248,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 12,
+      "worthy_recall": {
+        "hits": 12,
+        "n": 12
+      }
+    },
+    "boltons": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "commit": "207651ee6055aabd0d9cdeac2e00140cdc208d44",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 31,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "precision_labels": 31,
+      "reported_families": 127,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 23,
+      "worthy_recall": {
+        "hits": 22,
+        "n": 23
+      }
+    },
+    "chi": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "commit": "3b171578ca44dfd75ca3c5cbddc7b44c600a7b49",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 40,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "precision_labels": 40,
+      "reported_families": 78,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 35,
+      "worthy_recall": {
+        "hits": 33,
+        "n": 35
+      }
+    },
+    "clap": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "commit": "8387c812c4b9726474b8407f81ec97f0acf570ed",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 679,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 109,
+      "worthy_recall": {
+        "hits": 105,
+        "n": 109
+      }
+    },
+    "click": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "commit": "c48021040a50c659b74e24ac2b11c9c9c6620a21",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 33,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 33,
+      "reported_families": 125,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 20,
+      "worthy_recall": {
+        "hits": 20,
+        "n": 20
+      }
+    },
+    "cmark": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 7
+      },
+      "commit": "b6232e95c028eee78cdbc84a608815d6a945909c",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 45,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "precision_labels": 45,
+      "reported_families": 132,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 1,
+      "worthy_recall": {
+        "hits": 1,
+        "n": 1
+      }
+    },
+    "cobra": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 8
+      },
+      "commit": "ad460ea8f249db69c943a365fb84f3a59042d54e",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 53,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 6
+      },
+      "precision_labels": 53,
+      "reported_families": 197,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 43,
+      "worthy_recall": {
+        "hits": 42,
+        "n": 43
+      }
+    },
+    "commons-lang": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "commit": "62ea4b620be45462ace4247df34ca938aa29a4da",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 129,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 129,
+      "reported_families": 1304,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 93,
+      "worthy_recall": {
+        "hits": 89,
+        "n": 93
+      }
+    },
+    "curl": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "commit": "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 10
+      },
+      "precision_labels": 131,
+      "reported_families": 1217,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 96,
+      "worthy_recall": {
+        "hits": 91,
+        "n": 96
+      }
+    },
+    "date-fns": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 9
+      },
+      "commit": "cd53d2538cfa318404eff7ade6449b49bf34562e",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 112,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 9
+      },
+      "precision_labels": 112,
+      "reported_families": 451,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 21,
+      "worthy_recall": {
+        "hits": 17,
+        "n": 21
+      }
+    },
+    "delve": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 9
+      },
+      "commit": "b17af91dec79ddb2d1fcc08fa13c10d13de77b83",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 107,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "precision_labels": 107,
+      "reported_families": 697,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 41,
+      "worthy_recall": {
+        "hits": 40,
+        "n": 41
+      }
+    },
+    "devise": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 5
+      },
+      "commit": "9ea459de9aec5f1217ad738c58e0d23fb9f5beaa",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 27,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 4
+      },
+      "precision_labels": 27,
+      "reported_families": 105,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 15,
+      "worthy_recall": {
+        "hits": 14,
+        "n": 15
+      }
+    },
+    "drizzle-orm": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 3
+      },
+      "commit": "48e5406027103a9fca6eb66417187c4a8b5c6aa3",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "precision_labels": 130,
+      "reported_families": 3350,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 37,
+      "worthy_recall": {
+        "hits": 37,
+        "n": 37
+      }
+    },
+    "esbuild": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 10
+      },
+      "commit": "6a794dff68e6a43539f6da671e3080efdf11ca70",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 111,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 10
+      },
+      "precision_labels": 111,
+      "reported_families": 1101,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 42,
+      "worthy_recall": {
+        "hits": 42,
+        "n": 42
+      }
+    },
+    "etcd": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "commit": "9ed485d3e37bbdddff471f5c6d6d7f62048c07d1",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 131,
+      "reported_families": 1418,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 51,
+      "worthy_recall": {
+        "hits": 51,
+        "n": 51
+      }
+    },
+    "execa": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 5
+      },
+      "commit": "f3a2e8481a1e9138de3895827895c834078b9456",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 73,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 5
+      },
+      "precision_labels": 73,
+      "reported_families": 199,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 25,
+      "worthy_recall": {
+        "hits": 25,
+        "n": 25
+      }
+    },
+    "faraday": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 8
+      },
+      "commit": "59334e0e9b1918bd26b143f4a7bbc8c765de3ac4",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 15,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 15,
+      "reported_families": 74,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 14,
+      "worthy_recall": {
+        "hits": 14,
+        "n": 14
+      }
+    },
+    "fastlane": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "c30e449d26dc99fa3841f94f3a2a505a676aedbf",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "precision_labels": 131,
+      "reported_families": 1443,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 94,
+      "worthy_recall": {
+        "hits": 92,
+        "n": 94
+      }
+    },
+    "fd": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 4
+      },
+      "commit": "42b2ab8a84ddedf80eeed9079128c60161f64658",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 7,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 4
+      },
+      "precision_labels": 7,
+      "reported_families": 15,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 5,
+      "worthy_recall": {
+        "hits": 3,
+        "n": 5
+      }
+    },
+    "flask": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "commit": "36e4a824f340fdee7ed50937ba8e7f6bc7d17f81",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 28,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "precision_labels": 28,
+      "reported_families": 136,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 22,
+      "worthy_recall": {
+        "hits": 21,
+        "n": 22
+      }
+    },
+    "fzf": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 9
+      },
+      "commit": "7d647c70c286720c225ebb8ab75896e5dbee6af6",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 74,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 8
+      },
+      "precision_labels": 74,
+      "reported_families": 158,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 36,
+      "worthy_recall": {
+        "hits": 29,
+        "n": 36
+      }
+    },
+    "gin": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 10
+      },
+      "commit": "5f4f9643258dc2a65e684b63f12c8d543c936c67",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 93,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "precision_labels": 93,
+      "reported_families": 242,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 80,
+      "worthy_recall": {
+        "hits": 77,
+        "n": 80
+      }
+    },
+    "git": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 8
+      },
+      "commit": "9ac3f193c05c2237e2b14ebaa1149e9fc8a1abe0",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 8
+      },
+      "precision_labels": 130,
+      "reported_families": 1189,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 49,
+      "worthy_recall": {
+        "hits": 48,
+        "n": 49
+      }
+    },
+    "gorm": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "commit": "d0ee5e2296150d691364c5f4f7f2b32abde04545",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 129,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 129,
+      "reported_families": 369,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 112,
+      "worthy_recall": {
+        "hits": 100,
+        "n": 112
+      }
+    },
+    "graphhopper": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 7
+      },
+      "commit": "2d63716da2e1981fff64d52ee46a0a011202af02",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 8
+      },
+      "precision_labels": 130,
+      "reported_families": 1144,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 45,
+      "worthy_recall": {
+        "hits": 44,
+        "n": 45
+      }
+    },
+    "gson": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 8
+      },
+      "commit": "ed2397502708ebaba53643e5c3d60e0974d7045f",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 328,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 94,
+      "worthy_recall": {
+        "hits": 84,
+        "n": 94
+      }
+    },
+    "guava": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 4
+      },
+      "commit": "8ee72dc2b4f14a0d10ba434a2453262899a1ca0b",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 7
+      },
+      "precision_labels": 131,
+      "reported_families": 3241,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "h2database": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "commit": "c39970fff5fbda13cf3d16df88426c36d98e5c39",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 6
+      },
+      "precision_labels": 131,
+      "reported_families": 1929,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 65,
+      "worthy_recall": {
+        "hits": 65,
+        "n": 65
+      }
+    },
+    "httpie": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "commit": "5b604c37c6c67e18e7c3e9aee6c88a8c22b98345",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 14,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 6
+      },
+      "precision_labels": 14,
+      "reported_families": 106,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 11,
+      "worthy_recall": {
+        "hits": 11,
+        "n": 11
+      }
+    },
+    "httpx": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "commit": "b5addb64f0161ff6bfe94c124ef76f6a1fba5254",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 87,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 10
+      },
+      "precision_labels": 87,
+      "reported_families": 186,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 45,
+      "worthy_recall": {
+        "hits": 45,
+        "n": 45
+      }
+    },
+    "hugo": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 8
+      },
+      "commit": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 896,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 63,
+      "worthy_recall": {
+        "hits": 63,
+        "n": 63
+      }
+    },
+    "hyperfine": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "commit": "f12f3d9f86f3643b3b7deace5e160b1f0f44d2b7",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 14,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 14,
+      "reported_families": 30,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 10,
+      "worthy_recall": {
+        "hits": 9,
+        "n": 10
+      }
+    },
+    "image": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 10
+      },
+      "commit": "1063f55cef361fc55ab2e805030d07d11337dad3",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 112,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 9
+      },
+      "precision_labels": 112,
+      "reported_families": 260,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 56,
+      "worthy_recall": {
+        "hits": 51,
+        "n": 56
+      }
+    },
+    "jackson-core": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "commit": "7df7f1f24fdde585d6a35aa53f2b14d55cd8c734",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 855,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 102,
+      "worthy_recall": {
+        "hits": 101,
+        "n": 102
+      }
+    },
+    "jedis": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 9
+      },
+      "commit": "2ec0938d621aa324680490c7c20a09c27563d272",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 2649,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 75,
+      "worthy_recall": {
+        "hits": 72,
+        "n": 75
+      }
+    },
+    "jekyll": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "202df571314ba1d18e9fccd81d12aaad4a703c38",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 28,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 6
+      },
+      "precision_labels": 28,
+      "reported_families": 129,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 25,
+      "worthy_recall": {
+        "hits": 20,
+        "n": 25
+      }
+    },
+    "jest": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 4
+      },
+      "commit": "4c3091b4204d703f4ebe343b8ac9d8a28ac4388e",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 6
+      },
+      "precision_labels": 131,
+      "reported_families": 1049,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 61,
+      "worthy_recall": {
+        "hits": 60,
+        "n": 61
+      }
+    },
+    "jq": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "commit": "985abe534fdd48186015e169da7786c05fd7f868",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 73,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 73,
+      "reported_families": 71,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 19,
+      "worthy_recall": {
+        "hits": 18,
+        "n": 19
+      }
+    },
+    "jsoup": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 4
+      },
+      "commit": "8fb8eb5633901f535b8867a1c5a6fcc07df266c3",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 88,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 4
+      },
+      "precision_labels": 88,
+      "reported_families": 407,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 82,
+      "worthy_recall": {
+        "hits": 76,
+        "n": 82
+      }
+    },
+    "junit5": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "commit": "9a7a266fdd22cbe62d0d06e69fe8aab0dd2649cd",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 9
+      },
+      "precision_labels": 131,
+      "reported_families": 1689,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 35,
+      "worthy_recall": {
+        "hits": 35,
+        "n": 35
+      }
+    },
+    "kingfisher": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "commit": "072c31174e9f481882e6c3ec8ddc74384d395789",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 199,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "kramdown": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 0
+      },
+      "commit": "12b3d2e752793d4128b6355c338b23fefa674ee0",
+      "label_match_coverage": {
+        "hits": 1,
+        "n": 10
+      },
+      "labels": 6,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 1
+      },
+      "precision_labels": 6,
+      "reported_families": 128,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 9,
+      "worthy_labels": 2,
+      "worthy_recall": {
+        "hits": 2,
+        "n": 2
+      }
+    },
+    "ky": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 8
+      },
+      "commit": "61d6d66d27911001b9b4d57ab93139f9ad61384b",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 45,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 7
+      },
+      "precision_labels": 45,
+      "reported_families": 150,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 20,
+      "worthy_recall": {
+        "hits": 18,
+        "n": 20
+      }
+    },
+    "libgdx": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 8
+      },
+      "commit": "f9af1f6273e04da84eaffebbb782d083441634b0",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 7
+      },
+      "precision_labels": 131,
+      "reported_families": 2712,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 94,
+      "worthy_recall": {
+        "hits": 92,
+        "n": 94
+      }
+    },
+    "libsodium": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 9
+      },
+      "commit": "3591adef1c26061b3cce43366ec32e03f1df8a5e",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 129,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "precision_labels": 129,
+      "reported_families": 419,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 63,
+      "worthy_recall": {
+        "hits": 63,
+        "n": 63
+      }
+    },
+    "libuv": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 9
+      },
+      "commit": "ea493f19895bc0cc90b28b48a4e204bc139c48d3",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 656,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 113,
+      "worthy_recall": {
+        "hits": 106,
+        "n": 113
+      }
+    },
+    "liquid": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 10,
+        "n": 10
+      },
+      "commit": "742ac3dbf5432c6c2689ea00da604d7379f73799",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 61,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 10,
+        "n": 10
+      },
+      "precision_labels": 61,
+      "reported_families": 182,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 60,
+      "worthy_recall": {
+        "hits": 52,
+        "n": 60
+      }
+    },
+    "lua": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "commit": "53b41d0cddd80bf33fdc631bdd32e3ba53842b89",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 24,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 4
+      },
+      "precision_labels": 24,
+      "reported_families": 78,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 10,
+      "worthy_recall": {
+        "hits": 8,
+        "n": 10
+      }
+    },
+    "marked": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "commit": "c1a86f00ccd81144422f1a4194756bd48111c531",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 25,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 4
+      },
+      "precision_labels": 25,
+      "reported_families": 174,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 19,
+      "worthy_recall": {
+        "hits": 19,
+        "n": 19
+      }
+    },
+    "marshmallow": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 7
+      },
+      "commit": "db4aa4d00b0fa073e31c4d4ce2d05e4ea9e90d52",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 44,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 5
+      },
+      "precision_labels": 44,
+      "reported_families": 101,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 29,
+      "worthy_recall": {
+        "hits": 24,
+        "n": 29
+      }
+    },
+    "meilisearch": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 8
+      },
+      "commit": "ded427cf58d75f5da740297a7eb8581444cb7b30",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 1418,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 19,
+      "worthy_recall": {
+        "hits": 19,
+        "n": 19
+      }
+    },
+    "minio": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 8
+      },
+      "commit": "7aac2a2c5b7c882e68c1ce017d8256be2feea27f",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 9,
+        "n": 9
+      },
+      "precision_labels": 131,
+      "reported_families": 2001,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 97,
+      "worthy_recall": {
+        "hits": 90,
+        "n": 97
+      }
+    },
+    "mockito": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 10,
+        "n": 10
+      },
+      "commit": "70a97b057b36b4c0c165318826e3b12b49dbd970",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 10
+      },
+      "precision_labels": 131,
+      "reported_families": 630,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 106,
+      "worthy_recall": {
+        "hits": 96,
+        "n": 106
+      }
+    },
+    "nats-server": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 6
+      },
+      "commit": "050df88d3fb7e968ef8acf02b3ea092d439881c3",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "precision_labels": 131,
+      "reported_families": 4462,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 62,
+      "worthy_recall": {
+        "hits": 61,
+        "n": 62
+      }
+    },
+    "netty": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "commit": "e90eee9f556e3c770dda5ee171276e886266ae71",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 9
+      },
+      "precision_labels": 131,
+      "reported_families": 4874,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 100,
+      "worthy_recall": {
+        "hits": 99,
+        "n": 100
+      }
+    },
+    "nginx": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 8
+      },
+      "commit": "d44205284fa41662da803b796d6056fc1e59b1f3",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 1289,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 46,
+      "worthy_recall": {
+        "hits": 46,
+        "n": 46
+      }
+    },
+    "nimble": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 4
+      },
+      "commit": "727f75d91a0f7501d08d938966d17e6728b76a2a",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 5
+      },
+      "precision_labels": 3,
+      "reported_families": 210,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "nushell": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "commit": "779e2473aa28092760fe91ceefb288f36f0670e7",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "precision_labels": 131,
+      "reported_families": 1940,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 63,
+      "worthy_recall": {
+        "hits": 57,
+        "n": 63
+      }
+    },
+    "packaging": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "commit": "cf5dc921b4e1e85b50e3146f94e69d0268d5543d",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 78,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 78,
+      "reported_families": 161,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 51,
+      "worthy_recall": {
+        "hits": 47,
+        "n": 51
+      }
+    },
+    "pixijs": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "commit": "b2f8668c2c3c3d8b4aa7dcd1906424a9bbf75241",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 131,
+      "reported_families": 829,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 89,
+      "worthy_recall": {
+        "hits": 89,
+        "n": 89
+      }
+    },
+    "poetry": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 9
+      },
+      "commit": "aab3194f200e52198101d0f303b0f6423897829c",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 126,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "precision_labels": 126,
+      "reported_families": 612,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 107,
+      "worthy_recall": {
+        "hits": 104,
+        "n": 107
+      }
+    },
+    "prettier": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 3
+      },
+      "commit": "a5e7b7c3bd1e783ce33d8b0e335530317fe85bab",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 56,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "precision_labels": 56,
+      "reported_families": 685,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 15,
+      "worthy_recall": {
+        "hits": 15,
+        "n": 15
+      }
+    },
+    "prometheus": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "commit": "f3d653fb5cee5e503356eef531b5da7e578cf22f",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "precision_labels": 131,
+      "reported_families": 2623,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 83,
+      "worthy_recall": {
+        "hits": 83,
+        "n": 83
+      }
+    },
+    "pry": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 6
+      },
+      "commit": "135640262879544c6bfecbf3e78511289bfe956c",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 27,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "precision_labels": 27,
+      "reported_families": 147,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 20,
+      "worthy_recall": {
+        "hits": 18,
+        "n": 20
+      }
+    },
+    "puma": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 7
+      },
+      "commit": "c981c010f438596d958932c08d123d079033b7fa",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 78,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "precision_labels": 78,
+      "reported_families": 246,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 64,
+      "worthy_recall": {
+        "hits": 59,
+        "n": 64
+      }
+    },
+    "quick": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 6
+      },
+      "commit": "2b4547b230e94d84320724fd6df65e418b058be2",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 253,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "rack": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "commit": "1551230b9868c5981d8614e487646dd634a0eb41",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 20,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 6
+      },
+      "precision_labels": 20,
+      "reported_families": 167,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 16,
+      "worthy_recall": {
+        "hits": 15,
+        "n": 16
+      }
+    },
+    "radash": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "commit": "4cab1900d08e0997abc4f17aec3cbfe18958d766",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 89,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "precision_labels": 89,
+      "reported_families": 99,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 9,
+      "worthy_recall": {
+        "hits": 9,
+        "n": 9
+      }
+    },
+    "raylib": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 9
+      },
+      "commit": "895154bcb2c55540cee9e2aa2de95c0e5ba9b729",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 9
+      },
+      "precision_labels": 131,
+      "reported_families": 2203,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 14,
+      "worthy_recall": {
+        "hits": 14,
+        "n": 14
+      }
+    },
+    "redis": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 10
+      },
+      "commit": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 9
+      },
+      "precision_labels": 130,
+      "reported_families": 1123,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 41,
+      "worthy_recall": {
+        "hits": 41,
+        "n": 41
+      }
+    },
+    "regex": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 8,
+        "n": 10
+      },
+      "commit": "839d16bc65b60e2006d3599d20bfa6efc14049d8",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 631,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 69,
+      "worthy_recall": {
+        "hits": 65,
+        "n": 69
+      }
+    },
+    "requests": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 7
+      },
+      "commit": "cd90742ed94d901759e26766197d0ce7c7bd9c8e",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 13,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 8
+      },
+      "precision_labels": 13,
+      "reported_families": 52,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 9,
+      "worthy_recall": {
+        "hits": 8,
+        "n": 9
+      }
+    },
+    "retrofit": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "commit": "8e83a242eac1afc22a13c52098eddb27421353ff",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 348,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 46,
+      "worthy_recall": {
+        "hits": 41,
+        "n": 46
+      }
+    },
+    "rich": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "commit": "46cebbb032f920eb096efbaf23cdc6fe9dd541f7",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 97,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "precision_labels": 97,
+      "reported_families": 217,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 29,
+      "worthy_recall": {
+        "hits": 27,
+        "n": 29
+      }
+    },
+    "ripgrep": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "commit": "4857d6fa67db69a95cd4b6f2adda5d807d4d0119",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 107,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 9
+      },
+      "precision_labels": 107,
+      "reported_families": 268,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 69,
+      "worthy_recall": {
+        "hits": 57,
+        "n": 69
+      }
+    },
+    "rspec-core": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "aec5f49485d97908183dbe790a7fefb8baaa8091",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 68,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 6
+      },
+      "precision_labels": 68,
+      "reported_families": 246,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 52,
+      "worthy_recall": {
+        "hits": 49,
+        "n": 52
+      }
+    },
+    "rubocop": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "commit": "43942e260071e869bccc7497bbba82d5d458530e",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "precision_labels": 130,
+      "reported_families": 1231,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 106,
+      "worthy_recall": {
+        "hits": 88,
+        "n": 106
+      }
+    },
+    "rustls": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "commit": "22a546cfa1f24130514411be7c99295c093ec575",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 359,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 52,
+      "worthy_recall": {
+        "hits": 50,
+        "n": 52
+      }
+    },
+    "rxjava": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 9
+      },
+      "commit": "17e6f21c87f5d75b832b6f6fc0448603ae959b58",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Java",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 8
+      },
+      "precision_labels": 131,
+      "reported_families": 4083,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 39,
+      "worthy_recall": {
+        "hits": 39,
+        "n": 39
+      }
+    },
+    "rxjs": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 9
+      },
+      "commit": "c15b37f81ba5f5abea8c872b0189a70b150df4cb",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 121,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 9
+      },
+      "precision_labels": 121,
+      "reported_families": 998,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 19,
+      "worthy_recall": {
+        "hits": 19,
+        "n": 19
+      }
+    },
+    "rxswift": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "commit": "132aea4f236ccadc51590b38af0357a331d51fa2",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 4
+      },
+      "precision_labels": 3,
+      "reported_families": 1097,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "scrapy": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "commit": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 7
+      },
+      "precision_labels": 130,
+      "reported_families": 756,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 71,
+      "worthy_recall": {
+        "hits": 69,
+        "n": 71
+      }
+    },
+    "serde_json": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 8
+      },
+      "commit": "a1ae73ac6a6940a4a57c673aebaa13ed4dfe3e8c",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 68,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 6
+      },
+      "precision_labels": 68,
+      "reported_families": 148,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 50,
+      "worthy_recall": {
+        "hits": 42,
+        "n": 50
+      }
+    },
+    "sidekiq": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 7
+      },
+      "commit": "ae2fcadb06147fc23e70ce8085443c845c737186",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 58,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 6
+      },
+      "precision_labels": 58,
+      "reported_families": 164,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 46,
+      "worthy_recall": {
+        "hits": 45,
+        "n": 46
+      }
+    },
+    "sinatra": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 4
+      },
+      "commit": "5236d3459b8b9015e5ce21ddd0c6beb0db4081d4",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 41,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "precision_labels": 41,
+      "reported_families": 186,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 39,
+      "worthy_recall": {
+        "hits": 37,
+        "n": 39
+      }
+    },
+    "sled": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "commit": "e449d17111f4a097e1c66b6db241962ccb6a4136",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 32,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 9,
+        "n": 9
+      },
+      "precision_labels": 32,
+      "reported_families": 46,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 24,
+      "worthy_recall": {
+        "hits": 23,
+        "n": 24
+      }
+    },
+    "sqlalchemy": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "commit": "4fb459aaf05dd9c31ce3ece57c1bbf81ca9855de",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 8
+      },
+      "precision_labels": 130,
+      "reported_families": 4559,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 57,
+      "worthy_recall": {
+        "hits": 57,
+        "n": 57
+      }
+    },
+    "sqlite": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 6
+      },
+      "commit": "2acb57c1be48b34129b2d91b33d7b5fdbaac7d07",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 5
+      },
+      "precision_labels": 131,
+      "reported_families": 1548,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 50,
+      "worthy_recall": {
+        "hits": 50,
+        "n": 50
+      }
+    },
+    "swift-algorithms": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 3
+      },
+      "commit": "0b4376902cfc3901c496a79f2cb70f1ffd583fff",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 4
+      },
+      "precision_labels": 3,
+      "reported_families": 91,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-argument-parser": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 1
+      },
+      "commit": "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 104,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-collections": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 2
+      },
+      "commit": "f5b320c29f5af4087bc8f527ed52e0930f4f9fb4",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 1049,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-composable-architecture": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 4
+      },
+      "commit": "a28ddfada0ec31d726e5c8e525318c3745ad97d9",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 5
+      },
+      "precision_labels": 3,
+      "reported_families": 619,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-log": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "commit": "ca6118469893201380f29a4d67feb68bcb44fa25",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 72,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-metrics": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 0
+      },
+      "commit": "4d99a2ec9735d7738c642189a09a77ccbb117aeb",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 5
+      },
+      "precision_labels": 3,
+      "reported_families": 67,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-nio": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 1,
+        "n": 3
+      },
+      "commit": "eb8ac41afd91195d1095de61803402c27ecde293",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 1628,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swift-service-lifecycle": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "commit": "2fd7a348e9d0333979108c2da83642a64df6cb2c",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 4,
+        "n": 4
+      },
+      "precision_labels": 3,
+      "reported_families": 52,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swiftlint": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "64b731e35cda419025868a9c5248a3bdf1b57631",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 322,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "swr": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "commit": "e384af7f0d3e8620e4ec10c5b7c2b0e9bb9466be",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 73,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 7
+      },
+      "precision_labels": 73,
+      "reported_families": 204,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 39,
+      "worthy_recall": {
+        "hits": 38,
+        "n": 39
+      }
+    },
+    "sympy": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 5
+      },
+      "commit": "da4a5fa52418ae593a941d4ba585cfef87a31870",
+      "label_match_coverage": {
+        "hits": 5,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "Python",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 5
+      },
+      "precision_labels": 131,
+      "reported_families": 4975,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 5,
+      "worthy_labels": 31,
+      "worthy_recall": {
+        "hits": 31,
+        "n": 31
+      }
+    },
+    "thor": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 5
+      },
+      "commit": "036cb4ddd5ccecc3a61c16186d2810addb7d42f3",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 23,
+      "language": "Ruby",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 8
+      },
+      "precision_labels": 23,
+      "reported_families": 97,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 19,
+      "worthy_recall": {
+        "hits": 17,
+        "n": 19
+      }
+    },
+    "tmux": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 9,
+        "n": 10
+      },
+      "commit": "0759030ee8c44def03158bcbeac33338fd2b719e",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 129,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 8,
+        "n": 9
+      },
+      "precision_labels": 129,
+      "reported_families": 519,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 103,
+      "worthy_recall": {
+        "hits": 100,
+        "n": 103
+      }
+    },
+    "tokei": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 5,
+        "n": 8
+      },
+      "commit": "fa44e5194060305576514d59b850353643afbfc8",
+      "label_match_coverage": {
+        "hits": 8,
+        "n": 10
+      },
+      "labels": 9,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 5,
+        "n": 8
+      },
+      "precision_labels": 9,
+      "reported_families": 10,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 2,
+      "worthy_labels": 5,
+      "worthy_recall": {
+        "hits": 5,
+        "n": 5
+      }
+    },
+    "tokio": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 132,
+      "language": "Rust",
+      "precision_at_10": {
+        "hits": 7,
+        "n": 10
+      },
+      "precision_labels": 132,
+      "reported_families": 1076,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 76,
+      "worthy_recall": {
+        "hits": 73,
+        "n": 76
+      }
+    },
+    "trpc": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "commit": "c7360d4eb3c89c336468809a293e5cda4b302d4b",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 130,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "precision_labels": 130,
+      "reported_families": 689,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 70,
+      "worthy_recall": {
+        "hits": 65,
+        "n": 70
+      }
+    },
+    "urfave-cli": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 7,
+        "n": 8
+      },
+      "commit": "be8b79d0c8de1a03812914c9c511c961e5ed6ecc",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 62,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 62,
+      "reported_families": 152,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 49,
+      "worthy_recall": {
+        "hits": 47,
+        "n": 49
+      }
+    },
+    "vapor": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "commit": "fff4892930e69b49ea2612699bed9583721723dc",
+      "label_match_coverage": {
+        "hits": 3,
+        "n": 10
+      },
+      "labels": 3,
+      "language": "Swift",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 3
+      },
+      "precision_labels": 3,
+      "reported_families": 171,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 7,
+      "worthy_labels": 0,
+      "worthy_recall": {
+        "hits": 0,
+        "n": 0
+      }
+    },
+    "vim": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 9
+      },
+      "commit": "f1ed84158ab80240c42c9f2356767cad448ca151",
+      "label_match_coverage": {
+        "hits": 4,
+        "n": 10
+      },
+      "labels": 95,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 4
+      },
+      "precision_labels": 95,
+      "reported_families": 1400,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 6,
+      "worthy_labels": 47,
+      "worthy_recall": {
+        "hits": 44,
+        "n": 47
+      }
+    },
+    "wrk": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 5
+      },
+      "commit": "a211dd5a7050b1f9e8a9870b95513060e72ac4a0",
+      "label_match_coverage": {
+        "hits": 6,
+        "n": 10
+      },
+      "labels": 7,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 2,
+        "n": 6
+      },
+      "precision_labels": 7,
+      "reported_families": 19,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 4,
+      "worthy_labels": 1,
+      "worthy_recall": {
+        "hits": 1,
+        "n": 1
+      }
+    },
+    "zap": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 4,
+        "n": 10
+      },
+      "commit": "5b81b37b81b8e2ed447a6f57991e372ee4fa5c8f",
+      "label_match_coverage": {
+        "hits": 7,
+        "n": 10
+      },
+      "labels": 83,
+      "language": "Go",
+      "precision_at_10": {
+        "hits": 6,
+        "n": 7
+      },
+      "precision_labels": 83,
+      "reported_families": 160,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 3,
+      "worthy_labels": 36,
+      "worthy_recall": {
+        "hits": 34,
+        "n": 36
+      }
+    },
+    "zod": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "commit": "bbc68f990c7e6a5e3f506c56fb04bd0279b9c9b5",
+      "label_match_coverage": {
+        "hits": 10,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 10
+      },
+      "precision_labels": 131,
+      "reported_families": 628,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 0,
+      "worthy_labels": 55,
+      "worthy_recall": {
+        "hits": 52,
+        "n": 55
+      }
+    },
+    "zstd": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 0,
+        "n": 10
+      },
+      "commit": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc",
+      "label_match_coverage": {
+        "hits": 9,
+        "n": 10
+      },
+      "labels": 131,
+      "language": "C",
+      "precision_at_10": {
+        "hits": 3,
+        "n": 9
+      },
+      "precision_labels": 131,
+      "reported_families": 782,
+      "split": "heldout",
+      "top_10_reported": 10,
+      "unmatched_top_10": 1,
+      "worthy_labels": 28,
+      "worthy_recall": {
+        "hits": 27,
+        "n": 28
+      }
+    },
+    "zustand": {
+      "antiunification_rerank_precision_at_10": {
+        "hits": 2,
+        "n": 2
+      },
+      "commit": "04a8487aea075b13e71a327cc99b16fb68352c1a",
+      "label_match_coverage": {
+        "hits": 2,
+        "n": 10
+      },
+      "labels": 7,
+      "language": "TypeScript",
+      "precision_at_10": {
+        "hits": 1,
+        "n": 2
+      },
+      "precision_labels": 7,
+      "reported_families": 116,
+      "split": "dev",
+      "top_10_reported": 10,
+      "unmatched_top_10": 8,
+      "worthy_labels": 5,
+      "worthy_recall": {
+        "hits": 5,
+        "n": 5
+      }
+    }
+  },
+  "repository_count": 120,
+  "schema": "nose.product_quality_evaluation.v2"
+}

--- a/bench/labels/recall_ceiling_probe.py
+++ b/bench/labels/recall_ceiling_probe.py
@@ -25,7 +25,6 @@ from typing import Any
 from labelset import RECALL_METRIC, load_labelset, metric_eligible, sha256_file
 from missed_worthy_frontier import (
     ARTIFACT_SCHEMA,
-    EXPECTED_CURRENT_RECALL,
     INLINE_FLOOR,
     REQUIRED_RESIDUAL_LANES,
     ROOT,
@@ -39,6 +38,7 @@ from missed_worthy_frontier import (
     load_and_validate_closeout,
     load_and_validate_decisions,
     relative_path,
+    registered_recall_profile,
     render_dev_context,
     run_self_test,
     select_dev_audit,
@@ -463,6 +463,11 @@ def collect(args: argparse.Namespace) -> dict[str, Any]:
     if not args.nose.is_file():
         raise SystemExit(f"release binary is missing: {args.nose}")
 
+    evaluation_input = tracked_input(args.evaluation_report)
+    evaluation_input["expected_worthy_recall"] = registered_recall_profile(
+        evaluation_input["sha256"]
+    )
+
     recall_labelset = load_labelset(args.recall_labelset)
     if recall_labelset.version != "v5":
         raise SystemExit("--recall-labelset must be the source-independent v5 pool")
@@ -632,10 +637,7 @@ def collect(args: argparse.Namespace) -> dict[str, Any]:
                     version="v6",
                     role="precision-only-current-output-overlay",
                 ),
-                "evaluation_report": tracked_input(
-                    args.evaluation_report,
-                    expected_worthy_recall=EXPECTED_CURRENT_RECALL,
-                ),
+                "evaluation_report": evaluation_input,
                 "corpus_manifest": tracked_input(args.corpus_manifest),
                 "prune_manifest": tracked_input(args.prune_manifest),
                 "query_schema": tracked_input(QUERY_SCHEMA_PATH),

--- a/bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+++ b/bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
@@ -1,0 +1,20628 @@
+{
+  "configuration": {
+    "arm0": [
+      "--mode",
+      "syntax,semantic"
+    ],
+    "arm1": [
+      "--mode",
+      "syntax,semantic,near",
+      "--min-value",
+      "0",
+      "--min-members",
+      "2"
+    ],
+    "inline_floor": 20,
+    "limit_repositories": null,
+    "query_timeout_seconds": 600,
+    "subdag_floors": [
+      8,
+      12,
+      20
+    ]
+  },
+  "dev_audit_selection": {
+    "candidates": [
+      {
+        "candidate_key": "mockito:db2a627e3c414165",
+        "candidate_sha256": "6f54e260b213a96cf5cb6661fe9c6aad46bdc484cbbd587c818993e953b2de41",
+        "lane": "inline-ceiling",
+        "language": "Java",
+        "order": 1,
+        "phase": "required-residual:inline-ceiling",
+        "repo": "mockito"
+      },
+      {
+        "candidate_key": "gorm:b2cd9c61ce98289a",
+        "candidate_sha256": "89cbc2c55eac3f4c6c36d7bbf97711fe5602fd0b863de4b3190a4ee7991043c7",
+        "lane": "same-unit-window",
+        "language": "Go",
+        "order": 2,
+        "phase": "required-residual:same-unit-window",
+        "repo": "gorm"
+      },
+      {
+        "candidate_key": "packaging:aea1981ddc32dcf4",
+        "candidate_sha256": "47c95e3d4deac0f49167dd6cfcc855c1112af180394060c15aff79c19e4a5037",
+        "lane": "unrecovered",
+        "language": "Python",
+        "order": 3,
+        "phase": "required-residual:unrecovered",
+        "repo": "packaging"
+      },
+      {
+        "candidate_key": "serde_json:3f1d50e522be29ae",
+        "candidate_sha256": "e9c065ca3ff8bf83c2678ffe174e2b3a4740238cd7be16d38ba3c39a5bee4464",
+        "lane": "extraction-other",
+        "language": "Rust",
+        "order": 4,
+        "phase": "required-residual:extraction-other",
+        "repo": "serde_json"
+      },
+      {
+        "candidate_key": "curl:08e1435f8564adf7",
+        "candidate_sha256": "b5aeb2fa7a54e29886f9554ab06d42bb95879127b8b3cc627f14d655e545dbaf",
+        "lane": "subdag-ge20",
+        "language": "C",
+        "order": 5,
+        "phase": "language-fill",
+        "repo": "curl"
+      },
+      {
+        "candidate_key": "curl:2a436119a08187ba",
+        "candidate_sha256": "82a67204587605f18a10cfcea9666a15e6fd1a6b525a40dae287cc61435a208b",
+        "lane": "subdag-ge20",
+        "language": "C",
+        "order": 6,
+        "phase": "language-fill",
+        "repo": "curl"
+      },
+      {
+        "candidate_key": "git:1d9b1c7f444d15d0",
+        "candidate_sha256": "0605378cce63ec592aafd62b787673acbb7a2b9697afbc18db849313fcfcfb29",
+        "lane": "same-unit-window",
+        "language": "C",
+        "order": 7,
+        "phase": "language-fill",
+        "repo": "git"
+      },
+      {
+        "candidate_key": "tmux:6c7a09c2a9c5c2b2",
+        "candidate_sha256": "9b3c61ac9465a247ebfabfcf4a955aea2f93934b44a7d72bcef627ebe5964c06",
+        "lane": "same-unit-window",
+        "language": "C",
+        "order": 8,
+        "phase": "language-fill",
+        "repo": "tmux"
+      },
+      {
+        "candidate_key": "jq:c0adad57af0c4d06",
+        "candidate_sha256": "1072745a4b89b9daa9e056d5c50764034ea9a080206ea407b514c8f60d843dd4",
+        "lane": "unrecovered",
+        "language": "C",
+        "order": 9,
+        "phase": "language-fill",
+        "repo": "jq"
+      },
+      {
+        "candidate_key": "delve:de84b1952aa09a8e",
+        "candidate_sha256": "9129174bbac4023a963efac616e7f35a52b736b11e1904ba1f0dfde0faab507f",
+        "lane": "subdag-ge20",
+        "language": "Go",
+        "order": 10,
+        "phase": "language-fill",
+        "repo": "delve"
+      },
+      {
+        "candidate_key": "zap:23de1a83b5d5ff94",
+        "candidate_sha256": "5bc3f8cfe16e43bce128a9d5cff8cfa5b85e5930a321e16ac2e25e3da81771dd",
+        "lane": "unrecovered",
+        "language": "Go",
+        "order": 11,
+        "phase": "language-fill",
+        "repo": "zap"
+      },
+      {
+        "candidate_key": "chi:154bd73cf15a6de5",
+        "candidate_sha256": "818c4cdb58b65284187992985c8c892352bf2def26eacc7b2b2d88a813984d10",
+        "lane": "same-unit-window",
+        "language": "Go",
+        "order": 12,
+        "phase": "language-fill",
+        "repo": "chi"
+      },
+      {
+        "candidate_key": "cobra:db88c9b581c2c760",
+        "candidate_sha256": "3c255fd3352ee4dc071afc43147cd945d0a7353eda757f4898cbd85bfcf5ff11",
+        "lane": "extraction-other",
+        "language": "Go",
+        "order": 13,
+        "phase": "language-fill",
+        "repo": "cobra"
+      },
+      {
+        "candidate_key": "graphhopper:2acc71582f85cc79",
+        "candidate_sha256": "a4d67823c8ec861ddf2b850b5744598119502832a5bb8a9af5cac9f2c45f5a51",
+        "lane": "subdag-ge20",
+        "language": "Java",
+        "order": 14,
+        "phase": "language-fill",
+        "repo": "graphhopper"
+      },
+      {
+        "candidate_key": "gson:4014d594ab6a8e54",
+        "candidate_sha256": "4703ef0be15ca03e40b43336f7e8fefc53dd90edbf1a81d19ed170939c7047c3",
+        "lane": "subdag-ge20",
+        "language": "Java",
+        "order": 15,
+        "phase": "language-fill",
+        "repo": "gson"
+      },
+      {
+        "candidate_key": "mockito:d82f6e75097748da",
+        "candidate_sha256": "ffce9aa676545670fa722b6aac6c466679b9ecab9a930776e524c8bf20752790",
+        "lane": "subdag-ge20",
+        "language": "Java",
+        "order": 16,
+        "phase": "language-fill",
+        "repo": "mockito"
+      },
+      {
+        "candidate_key": "commons-lang:7deea4aa415c6197",
+        "candidate_sha256": "e7d43c53204c6d5cc2532e8deac1d82bb99ce8646354117a395ef6eecd14d2aa",
+        "lane": "extraction-other",
+        "language": "Java",
+        "order": 17,
+        "phase": "language-fill",
+        "repo": "commons-lang"
+      },
+      {
+        "candidate_key": "poetry:08556e25e7ab80e4",
+        "candidate_sha256": "e2363e766aa4eec9fde3402b25b7638df17c4112fe28ed78fb42a4d4638f7d2e",
+        "lane": "subdag-ge20",
+        "language": "Python",
+        "order": 18,
+        "phase": "language-fill",
+        "repo": "poetry"
+      },
+      {
+        "candidate_key": "scrapy:be72d6b46ad8eaf1",
+        "candidate_sha256": "6963b79dc8e4de4ceecd58c6b4c029e31dfd9ff7de15f4a4d3dd6faa92274441",
+        "lane": "subdag-ge20",
+        "language": "Python",
+        "order": 19,
+        "phase": "language-fill",
+        "repo": "scrapy"
+      },
+      {
+        "candidate_key": "poetry:053a58bae5b5c441",
+        "candidate_sha256": "9e6f3d7b7cb1dd263a5146e3a3df310dc43024b44997023d6b8ee0f016abf688",
+        "lane": "subdag-ge20",
+        "language": "Python",
+        "order": 20,
+        "phase": "language-fill",
+        "repo": "poetry"
+      },
+      {
+        "candidate_key": "requests:8465ccbf517afa52",
+        "candidate_sha256": "214b609709c65f27e46ed4d9cfc080ae9a0686a1a7922de797bf0ab9c0cc537e",
+        "lane": "extraction-other",
+        "language": "Python",
+        "order": 21,
+        "phase": "language-fill",
+        "repo": "requests"
+      },
+      {
+        "candidate_key": "thor:07e233ddffad07f0",
+        "candidate_sha256": "c3607b8739203183114dff0787b5aa08759c4fb42acca06dbd7fb183d1e90149",
+        "lane": "subdag-ge20",
+        "language": "Ruby",
+        "order": 22,
+        "phase": "language-fill",
+        "repo": "thor"
+      },
+      {
+        "candidate_key": "rspec-core:a1957f9937b645c3",
+        "candidate_sha256": "4b5c0e4ef02ef4adb85997167c46a25c3d219c181b06a45dc684b53d917153f8",
+        "lane": "inline-ceiling",
+        "language": "Ruby",
+        "order": 23,
+        "phase": "language-fill",
+        "repo": "rspec-core"
+      },
+      {
+        "candidate_key": "rubocop:1eead1acc41e3d0d",
+        "candidate_sha256": "b9fe0551e7f284c68a940eae1203bc687056637aa0ecfff6c80435de3ac434ae",
+        "lane": "inline-ceiling",
+        "language": "Ruby",
+        "order": 24,
+        "phase": "language-fill",
+        "repo": "rubocop"
+      },
+      {
+        "candidate_key": "jekyll:2791928407ad302c",
+        "candidate_sha256": "83fed4df03ca9b53775245f533e6f4c4d841d5c20bac934c03948545976e4934",
+        "lane": "unrecovered",
+        "language": "Ruby",
+        "order": 25,
+        "phase": "language-fill",
+        "repo": "jekyll"
+      },
+      {
+        "candidate_key": "rack:b7b0b53fbcbab71c",
+        "candidate_sha256": "a28b9f78fb129b1e8c865743008ea1b9c245bb756a16eb93b5a7169e35284956",
+        "lane": "inline-ceiling",
+        "language": "Ruby",
+        "order": 26,
+        "phase": "language-fill",
+        "repo": "rack"
+      },
+      {
+        "candidate_key": "ripgrep:519afdcaed73af0d",
+        "candidate_sha256": "8cc801b76980e41c492850a8eb29d633df91772439d70a1e8022ff40c3830d00",
+        "lane": "subdag-ge20",
+        "language": "Rust",
+        "order": 27,
+        "phase": "language-fill",
+        "repo": "ripgrep"
+      },
+      {
+        "candidate_key": "serde_json:946bfa61cb71d562",
+        "candidate_sha256": "d9014a0c4450f8a1a2798507d4ccce4c51d43e7720bf3cb98d64d39ffa5b5756",
+        "lane": "subdag-ge20",
+        "language": "Rust",
+        "order": 28,
+        "phase": "language-fill",
+        "repo": "serde_json"
+      },
+      {
+        "candidate_key": "serde_json:2515a9bc2af59ece",
+        "candidate_sha256": "62c870bf522611ae0c96dac81e5c421eab766b1e7bd25c2f84319fe7b8d2e427",
+        "lane": "subdag-ge20",
+        "language": "Rust",
+        "order": 29,
+        "phase": "language-fill",
+        "repo": "serde_json"
+      },
+      {
+        "candidate_key": "serde_json:8dc63e0bf59dff86",
+        "candidate_sha256": "403bd910e440a367948b99a06941c25603cb84bbdf0205b255c951760a1f360e",
+        "lane": "subdag-ge20",
+        "language": "Rust",
+        "order": 30,
+        "phase": "language-fill",
+        "repo": "serde_json"
+      },
+      {
+        "candidate_key": "swr:9b7a03feec3a4cce",
+        "candidate_sha256": "e2c696c8e4ae43729bbd7ed107be9b9fab9fa3238563adbba9db3581eba6e1a7",
+        "lane": "extraction-other",
+        "language": "TypeScript",
+        "order": 31,
+        "phase": "language-fill",
+        "repo": "swr"
+      },
+      {
+        "candidate_key": "axios:2169018b8e46a6b6",
+        "candidate_sha256": "7c053d4386e72b2a87fa6c19877b813c6e4c195e4d5bb916bdf49728b7356e01",
+        "lane": "extraction-other",
+        "language": "TypeScript",
+        "order": 32,
+        "phase": "language-fill",
+        "repo": "axios"
+      },
+      {
+        "candidate_key": "zod:e6c204c8d398e185",
+        "candidate_sha256": "82c6cd02f99bcee27a22f0ce51b8179097a191ccc81e7cc26fb29e62e74413e8",
+        "lane": "subdag-below-20",
+        "language": "TypeScript",
+        "order": 33,
+        "phase": "language-fill",
+        "repo": "zod"
+      },
+      {
+        "candidate_key": "jest:4c55eff3b52a86ff",
+        "candidate_sha256": "9679975d447841d1d453dac826bd359d78fd5adc300ee1d3ae6b19b29672f6cc",
+        "lane": "subdag-below-20",
+        "language": "TypeScript",
+        "order": 34,
+        "phase": "language-fill",
+        "repo": "jest"
+      },
+      {
+        "candidate_key": "axios:e4b2c19f4886a989",
+        "candidate_sha256": "250df6c0c2a309504c84e4f57ebcf127f92e4a1e04650aee84af6c1a364d352e",
+        "lane": "subdag-below-20",
+        "language": "TypeScript",
+        "order": 35,
+        "phase": "language-fill",
+        "repo": "axios"
+      }
+    ],
+    "per_language": 5,
+    "policy": "Reserve one deterministic dev family from each residual lane, then fill every language to five families, preferring weight-20 sub-DAG ceilings and distinct repositories. Selection uses metadata and probe measurements only; no candidate source text is consulted.",
+    "required_residual_lanes": [
+      "inline-ceiling",
+      "same-unit-window",
+      "unrecovered",
+      "extraction-other"
+    ],
+    "seed": "nose-issue-816-dev-audit-v1",
+    "sha256": "419ab53ca32c9d33443c64dca03687220d2d92940e47bb8dd2df4b61e40d3712"
+  },
+  "failures": [],
+  "feature_runs": {
+    "00369a0d615be50b4ab2": {
+      "command": "target/issue-820/release/nose features bench/repos/image/src/math/utils.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/image/src/math/utils.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f4db93a88af7215bcc5f5ee5ad6be177fa981384ee407c95a5f471eebc25c308",
+      "units": 13
+    },
+    "00c0d5c2ebaca781dc99": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "c6aa6cdb0dae548096a6f0edf6495bf8bcbb4b991ec3d6b55b22bd8c46ba59c4",
+      "units": 36
+    },
+    "0110ad8cd10b3679a5ae": {
+      "command": "target/issue-820/release/nose features bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d98349823db636ce20d3fc3f9e0c0c4e3c1128c710d9d5d47fb3bf350e5619b5",
+      "units": 13
+    },
+    "01e939d46f7249857653": {
+      "command": "target/issue-820/release/nose features bench/repos/image/src/codecs/pnm/header.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/image/src/codecs/pnm/header.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "06318f8ff00b6273e3c419f50c1c96a4cf1ac7f59b509a9724e1a78e1a1603f8",
+      "units": 45
+    },
+    "027c6c9b8c071393994d": {
+      "command": "target/issue-820/release/nose features bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "03ce9cfb01edd7f6d63c": {
+      "command": "target/issue-820/release/nose features bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "0438ebb7ac4712fdf5f6": {
+      "command": "target/issue-820/release/nose features bench/repos/ky/test/stream.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ky/test/stream.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "c0e226da1583538e8acab78ff3463eadbdb00b21e171755a4e4d608013537254",
+      "units": 51
+    },
+    "0445800b191e6bec7b37": {
+      "command": "target/issue-820/release/nose features bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java",
+        "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "149ec151ffa7de990cd6f6d3741039b333582addaedd646b28889a74b99fe0bd",
+      "units": 4
+    },
+    "0543d70d91a72a8e0be5": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java",
+        "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ecf7d216759f808d5595b6751b9c4e8d6eb26b6a82594cd25d283ff316456f60",
+      "units": 71
+    },
+    "054806247a97103e9f3c": {
+      "command": "target/issue-820/release/nose features bench/repos/sled/examples/bench_large.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/sled/examples/bench_large.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "76d494c6e761a4c3547830b929d914701ca805e41f07262deb90a69628ab7c72",
+      "units": 14
+    },
+    "06cab112eb61fe18b96b": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "fdc6e27efba429aa5e38741545ef1a90e0f00393b5255a926dadaf9f012afd97",
+      "units": 39
+    },
+    "0a76b109597dca6038f5": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9b12c369e9f780cc81ddb498c3775c485914c4be83503f2fb0c24ee87151db9e",
+      "units": 36
+    },
+    "0ae76d6c5f24427ae4a5": {
+      "command": "target/issue-820/release/nose features bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8fbd832edc436762fbdd3318602fcddf7452f3da1c96373f7e0f3e4b1bb570c3",
+      "units": 40
+    },
+    "0bd8daeffe09e90ba193": {
+      "command": "target/issue-820/release/nose features bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts",
+        "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "e92a8d32049b1ff8cd94c882079bd860584447fbe465f14516fb5f181c508f99",
+      "units": 4
+    },
+    "0c4393d57e1f7acba8c9": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "63be2a3c0dc7d0376167aa43e6755980a87c9eed332997446b96ffcb2c922de6",
+      "units": 24
+    },
+    "0e95f20223f201c709fd": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4f7b1b4ade3affb2de8b2a3055fd5109c98e649a4f102335427b019a067dc49a",
+      "units": 18
+    },
+    "106f8c496fdc9575e077": {
+      "command": "target/issue-820/release/nose features bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts bench/repos/date-fns/pkgs/core/src/setWeek/index.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/setWeek/index.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "21e3093bbca5045e5dee568066c5ceb60f5aa25f78603f52be6d3543025bcc35",
+      "units": 4
+    },
+    "12d259c597975e499ef5": {
+      "command": "target/issue-820/release/nose features bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6d9e83adfb4318343de3590204c80d48a98be787bdedbb2be52c48dff56a3d06",
+      "units": 82
+    },
+    "13ead1049fac50b64d0a": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/printer/src/macros.rs bench/repos/ripgrep/tests/macros.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/printer/src/macros.rs",
+        "bench/repos/ripgrep/tests/macros.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8b84712e0475680bf10c0b5fc405e5b6d02bd1ff0db0af2ca7c902f4fe766943",
+      "units": 4
+    },
+    "1531784369f196976dd8": {
+      "command": "target/issue-820/release/nose features bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs bench/repos/rustls/examples/src/bin/tlsclient-mio.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs",
+        "bench/repos/rustls/examples/src/bin/tlsclient-mio.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "fd29845f045fe8e9ea29a430d8bf7a8a5fdf54887e274c5ffffc045cde22145d",
+      "units": 74
+    },
+    "158d32852b8548b45c40": {
+      "command": "target/issue-820/release/nose features bench/repos/jq/src/compile.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jq/src/compile.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "182a38b0d10635a625c8cf6424e9e08b1192b5cad2dbeb022a186be64a8452b8",
+      "units": 84
+    },
+    "16522c8bb081deab76d4": {
+      "command": "target/issue-820/release/nose features bench/repos/jest/packages/jest-resolve/src/resolver.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jest/packages/jest-resolve/src/resolver.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "7a7ede5dc2cb1659199509d3789b8f3f9b5f2e661926f8b897028b80255d95a5",
+      "units": 107
+    },
+    "167b96f8162a69ea05fe": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "397fc464388ea13376f861383a375d5e8a89da4f8d48cd5f0a25155e0c4e5111",
+      "units": 101
+    },
+    "185b977cd442963d882f": {
+      "command": "target/issue-820/release/nose features bench/repos/serde_json/src/number.rs bench/repos/serde_json/src/raw.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/serde_json/src/number.rs",
+        "bench/repos/serde_json/src/raw.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "681275d53c874c602ace96692fb5f1ea7540d1694acc22c8f2e378227a0c3e77",
+      "units": 216
+    },
+    "19cf6b752d6516d0d819": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8cb708f7a65a7a937955b092b07530d17a568fc989a83074092ce9e3fc1e5336",
+      "units": 34
+    },
+    "1b484fea8bffd9f61763": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/insert.go bench/repos/gorm/clause/update.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/insert.go",
+        "bench/repos/gorm/clause/update.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "3435a538953f388a9cebb9246f265801c24f3651222990c6d31de9bc11e8b71c",
+      "units": 15
+    },
+    "1c126a35ca8a29398605": {
+      "command": "target/issue-820/release/nose features bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "03183cf952f47d5a9295c8e758bbdf0dd111b0d8be354a7f3c42fb30252d0df4",
+      "units": 26
+    },
+    "1e69e4ae4ccf3b10c46a": {
+      "command": "target/issue-820/release/nose features bench/repos/jekyll/lib/jekyll/document.rb bench/repos/jekyll/lib/jekyll/page.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jekyll/lib/jekyll/document.rb",
+        "bench/repos/jekyll/lib/jekyll/page.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "5bfadf626c18ad706f5a4771d2e539c192be6848e6caa398a320572c4f4d051a",
+      "units": 113
+    },
+    "20dfa695b6ff47bd4410": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/ignore/src/types.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/ignore/src/types.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "81e7d32bf3a16c73e7e9ed16ce0de458942920bd5b906b1d1f1600babc69e8f5",
+      "units": 69
+    },
+    "214de89d475e776f44a3": {
+      "command": "target/issue-820/release/nose features bench/repos/zstd/build/meson/tests/valgrindTest.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/zstd/build/meson/tests/valgrindTest.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "1cadaf290efd84a13179a9c530622b7e938a2548abcf84f4b9d9750c74266db7",
+      "units": 2
+    },
+    "2197d095059435b29de9": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/globset/src/lib.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/globset/src/lib.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "502c5ca4f73ffbbfaee4880b351efebce5d689364443a18e49bee4d2e9f8ba1b",
+      "units": 170
+    },
+    "2221d8241f91b307e416": {
+      "command": "target/issue-820/release/nose features bench/repos/regex/regex-capi/src/rure.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/regex/regex-capi/src/rure.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "67bb9905e485aad2edb8be93c70d0b38b438db611714a41618683ea7a885062b",
+      "units": 14
+    },
+    "24e9205a3dfa567cb672": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "96e5a6fd458dcd2d3a12d30bb4f89787e3dbe540929c394d9dcccdc5ed0e0310",
+      "units": 102
+    },
+    "24ec04a617e47091fe50": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java",
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "27c00c5f86fbcdb7026f6ea22239ad03321812c60c4697aefb6db132ef072dd6",
+      "units": 10
+    },
+    "253ffadee6f432c35c88": {
+      "command": "target/issue-820/release/nose features bench/repos/axios/sandbox/client.html --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/axios/sandbox/client.html"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f3d94e0517ea42600c100bdbb2750550057a5106040172c71ae90e3ad943fa52",
+      "units": 101
+    },
+    "281aad53609cd00dda58": {
+      "command": "target/issue-820/release/nose features bench/repos/hyperfine/src/export/csv.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/hyperfine/src/export/csv.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "606627a68b9add677db47a1befaefde9b7013329a3403c18dc00bc14b2686f98",
+      "units": 8
+    },
+    "2a9db24de0201e0e9288": {
+      "command": "target/issue-820/release/nose features bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "c72b0bd2b48d5fd5fddfb1afca6572a1f370c9220e6cdfb90b8ba02e12b33356",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "2c854e0b1159d783268e": {
+      "command": "target/issue-820/release/nose features bench/repos/bat/src/assets.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/bat/src/assets.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b154e6d8af89c515b4aebc99495832511e75cb40e31fc53c1ade4cacc6337f12",
+      "units": 69
+    },
+    "2d597f18c47bfaaa7f4b": {
+      "command": "target/issue-820/release/nose features bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6672c3c68cad45cb3a74ce92a21c7766da9e5efd58bf25f9c583c72a75349a0a",
+      "units": 33
+    },
+    "2d855f50038477dfa6a5": {
+      "command": "target/issue-820/release/nose features bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "130e909676da9355c83cef4f96d55691773c3329dc76bfa48e9e93299c8cdc5c",
+      "units": 22
+    },
+    "2eea9086449901a1bd0d": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/from_test.go bench/repos/gorm/clause/select_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/from_test.go",
+        "bench/repos/gorm/clause/select_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "05bb760b0b36554182bed2ac79f99f026372751bf8abc72b691142472b61e289",
+      "units": 4
+    },
+    "2fe40b7e62c8fa39535a": {
+      "command": "target/issue-820/release/nose features bench/repos/puma/lib/puma/thread_pool.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/puma/lib/puma/thread_pool.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "84d0284e66cec7c59b2a8c4f191f45904cd4f35f10713265d48f4a88caf04a8f",
+      "units": 67
+    },
+    "3111b3d0de34d67d5235": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/printer/src/color.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/printer/src/color.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "26e20b3fc663d999a6ef9450912089a1ebdbdebca7ca1aaa3b7f15d52227c3d8",
+      "units": 54
+    },
+    "32bd50619cd69dccebeb": {
+      "command": "target/issue-820/release/nose features bench/repos/boltons/tests/test_strutils.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/boltons/tests/test_strutils.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "466ae8533da15547315bd3093b50903d1857338ccf4525ed7e37c24e9a664c14",
+      "units": 66
+    },
+    "336808270fa5b254e151": {
+      "command": "target/issue-820/release/nose features bench/repos/regex/regex-automata/src/dfa/search.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/regex/regex-automata/src/dfa/search.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "3dc951abe2e9a076fcda2cf725161f5e724adea37773ee2799993131ccf65787",
+      "units": 91
+    },
+    "35e91f59f2e6b5c3b141": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ccf1adc29ac39555464a0d776cbc9598b34b79e9bf67e9cd6dc0ad771ad148e9",
+      "units": 15
+    },
+    "35faaa38d7b06eae733a": {
+      "command": "target/issue-820/release/nose features bench/repos/tokio/tokio/src/io/poll_evented.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tokio/tokio/src/io/poll_evented.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "746c1d9d1be9cf9c63e6df18027438f056107f3269547cef35193ffc98b492fd",
+      "units": 16
+    },
+    "382b25c322c0d82da5c0": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f9a56bfee4126086552bdc70d2e05dc138e80e70cdeddf16adc9a081648605f0",
+      "units": 65
+    },
+    "395b5e92f6e14714a361": {
+      "command": "target/issue-820/release/nose features bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts bench/repos/trpc/examples/next-big-router/scripts/codegen.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts",
+        "bench/repos/trpc/examples/next-big-router/scripts/codegen.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "1f42722747ff9f7d5962c3bb909e1c54ba7776e626a58cd0f5cdaa06979f1f96",
+      "units": 6
+    },
+    "3addce1524893be73182": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/src/unix/udp.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/src/unix/udp.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "920ffa82752f7084c5d1191acb5d7cd86d9a93c73475e83c19dcc19d382e2fdf",
+      "units": 199
+    },
+    "3c7f294c220792716b52": {
+      "command": "target/issue-820/release/nose features bench/repos/packaging/tests/test_utils.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/packaging/tests/test_utils.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "dac648323043cbb60d5cefdff66fea3c1cbfd3a3a9ade49ed79f29be3b89a04c",
+      "units": 23
+    },
+    "3d1be6c9b8b778c6c12b": {
+      "command": "target/issue-820/release/nose features bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "cee11f3a813b5e3aa72e51714a06139eacbbfc7e80aae140a86ce10ebc573f8a",
+      "units": 9
+    },
+    "3d3e969eec7221efd482": {
+      "command": "target/issue-820/release/nose features bench/repos/curl/tests/libtest/lib1525.c bench/repos/curl/tests/libtest/lib1526.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/curl/tests/libtest/lib1525.c",
+        "bench/repos/curl/tests/libtest/lib1526.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "da0e420f7ef1c6c4d22bef9d80b2dedb427ff7a3d393ac67590c1c8287fa4e37",
+      "units": 13
+    },
+    "3d98cfe57d37b578be7e": {
+      "command": "target/issue-820/release/nose features bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "76a56c59e90639f2b5e982a32e209dcef1836b162cc64c5334a389e131fa349f",
+      "units": 48
+    },
+    "3df9e62d112692390ac9": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9dd440ed87ace95e5c560eb8ec047a797ae7813584646e077dfa92d2fb4631d3",
+      "units": 21
+    },
+    "3e66f80b25d6bb4fe86d": {
+      "command": "target/issue-820/release/nose features bench/repos/rustls/rustls-test/tests/api/crypto.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rustls/rustls-test/tests/api/crypto.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d86071e56a7828b3c2cf30230079ca53cb80d4f8ef142872ca6c9383c9191d6a",
+      "units": 31
+    },
+    "3e751d49a52c657be621": {
+      "command": "target/issue-820/release/nose features bench/repos/poetry/tests/utils/test_cache.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/poetry/tests/utils/test_cache.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "0851ec6072cf6bf6f255303ea8ab0a1b09f4f2cbbab397792ff209e5bdc6db43",
+      "units": 34
+    },
+    "4045df1fb5f4db673e46": {
+      "command": "target/issue-820/release/nose features bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "75ee0ffee5091ab0d462e3a8558dddf053546b0ac2ddb6e84cd1204f4dde771f",
+      "units": 2
+    },
+    "4080f1abd3b2d288e465": {
+      "command": "target/issue-820/release/nose features bench/repos/zap/benchmarks/zap_test.go bench/repos/zap/sugar.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/zap/benchmarks/zap_test.go",
+        "bench/repos/zap/sugar.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "746b9965c20b766ce9cc6d305f1c424f57af89682424fd721d6c2b11049189e8",
+      "units": 73
+    },
+    "408d8053c7e101fbea99": {
+      "command": "target/issue-820/release/nose features bench/repos/alacritty/alacritty/src/daemon.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/alacritty/alacritty/src/daemon.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4122acb4f669c1fcaa0bf090bea1fc000fc3832282a40e71db843539e792805c",
+      "units": 9
+    },
+    "40f2496ece87d6a21cb7": {
+      "command": "target/issue-820/release/nose features bench/repos/asciidoctor/test/lists_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/asciidoctor/test/lists_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "42ddad0914cc9adb67a8": {
+      "command": "target/issue-820/release/nose features bench/repos/fzf/test/test_core.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fzf/test/test_core.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "4324b4cc350a20553898": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "2f391ebb72efb296ccee973b50ba46b681a86deaf8c2f5d8beaa6400f620aa27",
+      "units": 7
+    },
+    "43bd3d6f421a288edd77": {
+      "command": "target/issue-820/release/nose features bench/repos/rich/tests/test_tools.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rich/tests/test_tools.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6b72b5e8e2226bbb506fb4a1480e464b9e20942a3438678193551e09e46bb8b8",
+      "units": 10
+    },
+    "450a75c020d154401c99": {
+      "command": "target/issue-820/release/nose features bench/repos/urfave-cli/flag_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/urfave-cli/flag_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "47091dcff176e545471b": {
+      "command": "target/issue-820/release/nose features bench/repos/image/src/traits.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/image/src/traits.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "744b55f2b39cde8f38d3239459d5a7fafc9b6b3e4bae0074cfcdd89303c89436",
+      "units": 101
+    },
+    "48bac71af49f3e7cf0ee": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/src/unix/fs.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/src/unix/fs.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8bcb7f003c6afa276157d0acb683dc812247b6e3edea7ddb71c246532643fc25",
+      "units": 83
+    },
+    "49d5c1e32c3b1379eb7d": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/lib/liquid/parser_switching.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/lib/liquid/parser_switching.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "42697245791d8b695cac53a3c05e3e136959707a7d270cf220ec6977f689f157",
+      "units": 24
+    },
+    "4a185da9475e8b16fa9c": {
+      "command": "target/issue-820/release/nose features bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8ba2e18f46caa2914088ea124e6d0c4d2675f8571bdbf18a7e8079f40e683590",
+      "units": 121
+    },
+    "4ad65b30539580049df4": {
+      "command": "target/issue-820/release/nose features bench/repos/serde_json/tests/test.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/serde_json/tests/test.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "4af90955fe3608edd9f7": {
+      "command": "target/issue-820/release/nose features bench/repos/git/remote-curl.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/git/remote-curl.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f394652013d3d8fc933e332dbe23c9f9092ed767e0eacd3f61cb8b7023567fa5",
+      "units": 31
+    },
+    "4c47c7871d3bee2af308": {
+      "command": "target/issue-820/release/nose features bench/repos/serde_json/src/de.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/serde_json/src/de.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "c64f4083c509795ef48ba438eb3f526a0b059ce87ce5348398cc83eee636b75b",
+      "units": 140
+    },
+    "4fe7afaae305adfa2784": {
+      "command": "target/issue-820/release/nose features bench/repos/tmux/layout-custom.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tmux/layout-custom.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "430cc35fcade72ff5b0b7ebbbdf7898b871c6ddedd852323a8cc8199b3e7fdf4",
+      "units": 81
+    },
+    "50322461d5dab7594bd6": {
+      "command": "target/issue-820/release/nose features bench/repos/packaging/tests/test_markers.py bench/repos/packaging/tests/test_requirements.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/packaging/tests/test_markers.py",
+        "bench/repos/packaging/tests/test_requirements.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f43a9ffd73225d3654b3765f648da23341d1aefe6d7f9a249afa859f09ccc81e",
+      "units": 116
+    },
+    "50b2416cd8ec3a22e00f": {
+      "command": "target/issue-820/release/nose features bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f71cd8cf2b292ca71c286f7af27c1cdd29858b950d375c1b868dd79e685a6949",
+      "units": 16
+    },
+    "50d0a104700c1d2927b1": {
+      "command": "target/issue-820/release/nose features bench/repos/sinatra/test/indifferent_hash_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/sinatra/test/indifferent_hash_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "7163d303cfa73fb6ff463d1d3341a01125ad9e385c8885137a8df7c53ae72012",
+      "units": 38
+    },
+    "51cc2384f0438ce357c5": {
+      "command": "target/issue-820/release/nose features bench/repos/puma/test/test_puma_server.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/puma/test/test_puma_server.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "522c598786f1b5a6b7ea": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "19b12abc53095320f511368665a29f85c1d2da35ac4c30d64c99c5091c2b086a",
+      "units": 8
+    },
+    "5254be9017b1161e54b5": {
+      "command": "target/issue-820/release/nose features bench/repos/curl/lib/curlx/warnless.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/curl/lib/curlx/warnless.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "570c8249d04f866ce05ea46b2f5e05574fbcc9daf22a2a622fb698f0b4f9ea77",
+      "units": 23
+    },
+    "554244141348864a7683": {
+      "command": "target/issue-820/release/nose features bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "58eb05b795b2e5948fff3f034f61d076f546e8f14f9f0c1e83f71c9b2145569e",
+      "units": 24
+    },
+    "55f51d4f1c58a60d28b6": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/test/integration/context_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/test/integration/context_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "241e511659981c1f85e72c0dde135b3d8cd74701eff7b6c3bb6ef5eb808e3403",
+      "units": 97
+    },
+    "57477ef717688315dc81": {
+      "command": "target/issue-820/release/nose features bench/repos/minio/internal/logger/config.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/minio/internal/logger/config.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "412f2a561b6e4e07f8022a7d5a4689b15bd82adef375b4be37c4ff4d5d8836f2",
+      "units": 62
+    },
+    "577a5f350ae9bcc92abe": {
+      "command": "target/issue-820/release/nose features bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "30a84f89a330f0b889c9194c02723f34ca82d6c0827e52a10103299dbcfba9c8",
+      "units": 12
+    },
+    "583999e157a3ba6fe30c": {
+      "command": "target/issue-820/release/nose features bench/repos/asciidoctor/test/api_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/asciidoctor/test/api_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "58ca68af19f53af130da": {
+      "command": "target/issue-820/release/nose features bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java",
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "a02ecc2f981716d6ee03537061f053301af93b7a5a2a09bfe4f25cf3bedb10c3",
+      "units": 50
+    },
+    "59bcd032acba7c4096e2": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/migrator/migrator.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/migrator/migrator.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "fbd7feaa406c21a19ac32e005c906161e69dbe090bf7ac5514e35f62cd0090f0",
+      "units": 195
+    },
+    "61c8b51ef23bd6d2cbac": {
+      "command": "target/issue-820/release/nose features bench/repos/bat/tests/integration_tests.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/bat/tests/integration_tests.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "62d1a51df6902b825238": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b5dc02502cea047d42ab5a94c3a134c8fa2b9c75ea5f04989d55f58d746e8073",
+      "units": 6
+    },
+    "63b3f9a1191a6543ab6f": {
+      "command": "target/issue-820/release/nose features bench/repos/vim/src/if_py_both.h --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/vim/src/if_py_both.h"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "62b7bf87cf7efba9a508054b58417004db9e249199c67e0400b1d7ba2269b2fa",
+      "units": 230
+    },
+    "64973265314a02c6583b": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d4d471b6f0decb581e5f56291cae7eea732563b80990ede053cb102b61f0d488",
+      "units": 104
+    },
+    "652dbc432184a0634647": {
+      "command": "target/issue-820/release/nose features bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "78efaf98450ba18d94450ff01a05bf525e3f2edf612318c0f59e7095a41da3c9",
+      "units": 133
+    },
+    "656e5bc6976e29f01d47": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/joins_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/joins_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "005f63935092214f7cfb7d008fb5390599e4c21cea89b22e3ddccb1dbed6038f",
+      "units": 3
+    },
+    "676f616c9eb2015c8859": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/tests/preload_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/tests/preload_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ce69a918291843cb888009187935b8d98ccf9b38e949746d8c63ad58c5d2ea1f",
+      "units": 61
+    },
+    "69134373c04bbef74d48": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/searcher/src/lines.rs bench/repos/ripgrep/tests/hay.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/searcher/src/lines.rs",
+        "bench/repos/ripgrep/tests/hay.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b8d48df1c60fed39ab66029d8d5e1ac6f0d9350a51245d77538842f4126bfe09",
+      "units": 44
+    },
+    "6a0a5ebcbf5acea301c1": {
+      "command": "target/issue-820/release/nose features bench/repos/jekyll/test/test_win_tz.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jekyll/test/test_win_tz.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "878961e90ae05105a9e7f1db1cfff7460bbec255ab53e6da1bcb9d93bcb7464d",
+      "units": 1
+    },
+    "6a47c8eab9f9297a4233": {
+      "command": "target/issue-820/release/nose features bench/repos/nats-server/server/monitor_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nats-server/server/monitor_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "6c73e1e05b28502eb21d": {
+      "command": "target/issue-820/release/nose features bench/repos/fd/src/exec/mod.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fd/src/exec/mod.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f1ebe1f200d7b593225a946d1ffdb87616576fa13087df868ebfdf4dd92f9145",
+      "units": 52
+    },
+    "6d84992a05bfa77e98ff": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/ignore/src/gitignore.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/ignore/src/gitignore.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4d630689a68a2f0142e82894bb2fafc882bd3939408d83af5bbca24ab49f9a6b",
+      "units": 93
+    },
+    "6e1987d1b27e3eccf1f6": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ee60d6d2b6e311256d62b46f587fa9669f940d93250d7cceaaecf2cf7773bb99",
+      "units": 319
+    },
+    "72c3aeccc28ac8074dfd": {
+      "command": "target/issue-820/release/nose features bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "73f6f56015eadf307750": {
+      "command": "target/issue-820/release/nose features bench/repos/minio/internal/logger/help.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/minio/internal/logger/help.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "74334ccc304a16d34295": {
+      "command": "target/issue-820/release/nose features bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java",
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "e381bce478bc4e8ffc7cea9ec4dd574d4dd6dc255705ad99210e37b4a80ecfaa",
+      "units": 46
+    },
+    "74d9481c3d71bdcdb216": {
+      "command": "target/issue-820/release/nose features bench/repos/serde_json/src/read.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/serde_json/src/read.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9912199328b4d0e3143538908e377df39e7f9e12a378db9640737e1164d6c513",
+      "units": 167
+    },
+    "7b585d2275b35af8419b": {
+      "command": "target/issue-820/release/nose features bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "51bf421b1c1c5c78d81200fb857444d7ec501ed6b76d54ca8447b6686874e9a3",
+      "units": 18
+    },
+    "7d48090b5db26515c38b": {
+      "command": "target/issue-820/release/nose features bench/repos/minio/internal/config/notify/parse.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/minio/internal/config/notify/parse.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ccfc3efbf15d56811cb4ab8c4b6de6740208585d48ddba28b1fa7499344740ac",
+      "units": 15
+    },
+    "7ff6571825f63bd33df7": {
+      "command": "target/issue-820/release/nose features bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d20671440e5ac56530a8e48ad5392b3736b759c9ab11b4f22294567c8ed2b64a",
+      "units": 122
+    },
+    "8158e58a07d52a483a07": {
+      "command": "target/issue-820/release/nose features bench/repos/thor/spec/line_editor_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/thor/spec/line_editor_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "89efe68475ed9d9006d8087ae61199927fab1c6d1a0d43614e260f6db2b47d2e",
+      "units": 10
+    },
+    "82d069343e8374f542a7": {
+      "command": "target/issue-820/release/nose features bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "64b660266a934648f401201bcb0a2e43dcb832e19366e2c268ab16b585c1cb3f",
+      "units": 21
+    },
+    "840c5785a562882442de": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/lib/liquid/standardfilters.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/lib/liquid/standardfilters.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "815c351a313d5c05bc2b3e8f0e0fa3baa5ec9dfdb7cb7a8679beef6a6525b221",
+      "units": 150
+    },
+    "84fb6e8591995beb7858": {
+      "command": "target/issue-820/release/nose features bench/repos/marshmallow/tests/test_schema.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/marshmallow/tests/test_schema.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "87bec6b27a18ffd8a3bb": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "268f8a7a5088bc8339c6ce065f2f70699799cf68a54ad9d90a1be9599792f6b1",
+      "units": 20
+    },
+    "88db6c2c479b254e5ad6": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ef7a274aa6b96a7ead41d368fc9cb3f04e7b3b0a0fae788129b63e8ec2a0fbb2",
+      "units": 43
+    },
+    "89c13001160da9ac2306": {
+      "command": "target/issue-820/release/nose features bench/repos/minio/internal/config/lambda/help.go bench/repos/minio/internal/config/notify/help.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/minio/internal/config/lambda/help.go",
+        "bench/repos/minio/internal/config/notify/help.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "8b7712a70abd7d4e48ed": {
+      "command": "target/issue-820/release/nose features bench/repos/asciidoctor/test/tables_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/asciidoctor/test/tables_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "8d4604da20f8ae7de3e0": {
+      "command": "target/issue-820/release/nose features bench/repos/flask/tests/test_basic.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/flask/tests/test_basic.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "8e381d0d42dbb88f347c": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ab0ac0febefe80a4db42de01729deaaa96aae8dd17799f87a1845ab096210eae",
+      "units": 32
+    },
+    "8ee52644558ec9288530": {
+      "command": "target/issue-820/release/nose features bench/repos/trpc/packages/react-query/tsdown.config.ts bench/repos/trpc/packages/server/tsdown.config.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/trpc/packages/react-query/tsdown.config.ts",
+        "bench/repos/trpc/packages/server/tsdown.config.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "8f83811708f0df3e82f2": {
+      "command": "target/issue-820/release/nose features bench/repos/vim/src/autocmd.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/vim/src/autocmd.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "393805b89efdb9717149d0ad8c22c05455b05d49710cee837a8119776b7d19d6",
+      "units": 68
+    },
+    "8ff1315068d88c20a774": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/from_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/from_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "38f9c94277befa784718b0e5031ac82e04cdb01c7e35cb05a5f4f7e9e2e03913",
+      "units": 2
+    },
+    "9050213e424a65811e3a": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/test/integration/tag/disableable_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/test/integration/tag/disableable_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "77413c65b4a30845bff93383c83a459befc9b2aebb0ad1d596563ddb98b3e2d7",
+      "units": 10
+    },
+    "91b30592408a36de9a47": {
+      "command": "target/issue-820/release/nose features bench/repos/marshmallow/tests/test_validate.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/marshmallow/tests/test_validate.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "04c915518a1c7ffcfd8fe6e684f0dccaa976891973ff2388c4ee93014850d2bd",
+      "units": 78
+    },
+    "9242ad049432e3ea9858": {
+      "command": "target/issue-820/release/nose features bench/repos/urfave-cli/flag_bool_with_inverse.go bench/repos/urfave-cli/flag_impl.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/urfave-cli/flag_bool_with_inverse.go",
+        "bench/repos/urfave-cli/flag_impl.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "106ba086058938f49e701bb9b5199b0cbee7b9fb249e880db3649df828c79f63",
+      "units": 86
+    },
+    "92f742a1c346bce85577": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9c5cbf1babf3da1d13552fb1bc00ee0ec84d0f61b819fac29bc3a8878d20d8e0",
+      "units": 57
+    },
+    "93505a19df1066c3cf43": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/where.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/where.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "eacaad7e0a157cb836548f67b447f2a255e904de6b64a8d386f5e1c6993e95f1",
+      "units": 55
+    },
+    "93844c8428c8d71854a2": {
+      "command": "target/issue-820/release/nose features bench/repos/image/src/codecs/jpeg/encoder.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/image/src/codecs/jpeg/encoder.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "1b9e399b8c46927b348571cd140da447c104eeb2ba43056cbb996cc16ec193a8",
+      "units": 43
+    },
+    "93b081de2249028d2718": {
+      "command": "target/issue-820/release/nose features bench/repos/fzf/src/terminal.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fzf/src/terminal.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9820fbdaf50194b857187676e47ef31515c26aef74c557c4a700e47753c5fc12",
+      "units": 165
+    },
+    "93b231711ac31e228c69": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/logger/logger.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/logger/logger.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "81b85dec52eba6a1ad9b13875aafe3c732f1373fd7cfd4169e36a1f18a139baa",
+      "units": 18
+    },
+    "93daf51105fd13b0f7e7": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/clause/returning.go bench/repos/gorm/clause/select.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/clause/returning.go",
+        "bench/repos/gorm/clause/select.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "e9057143bc302e8ccc8cfae4a378a1d0d5d5d8663545dc965e403d1d98110f47",
+      "units": 21
+    },
+    "95715abcba13fb58a9ec": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/test/integration/drop_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/test/integration/drop_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "92bae88299c41aaebb2df5c6b4ffc1b5b7d8bdb18e724733e96f432292eb50b9",
+      "units": 54
+    },
+    "95c2bfceca5b285769c5": {
+      "command": "target/issue-820/release/nose features bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "c4f8df533a3f8c62a6d981d169754520c3c96b2b0afca411239ced70bf59bbfa",
+      "units": 23
+    },
+    "983cda346a17a9e63253": {
+      "command": "target/issue-820/release/nose features bench/repos/tokio/tokio/tests/rt_handle_block_on.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "cb861c0cdcbe97b5fab19ef5eda96428e6d761a04da35c9a1ef635479d23fdae",
+      "units": 9
+    },
+    "9b3f5aa2b8eb454f7d63": {
+      "command": "target/issue-820/release/nose features bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "9e82f29edac625f02224": {
+      "command": "target/issue-820/release/nose features bench/repos/ky/test/retry.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ky/test/retry.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "9ed44ed16e8f42d9bea1": {
+      "command": "target/issue-820/release/nose features bench/repos/scrapy/tests/test_pipelines.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/scrapy/tests/test_pipelines.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "77cec2cd977d11884ce85fbf8fc9bcd8bb3410b68ede0d82c5847db2f3fb1002",
+      "units": 75
+    },
+    "9fd9c0d1dcef00e775d3": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/test/test-fs-readdir.c bench/repos/libuv/test/test-fs.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/test/test-fs-readdir.c",
+        "bench/repos/libuv/test/test-fs.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "94a9c09a3e1877de28f77c723d49c5ccea70047c06e7750031b87984347f008d",
+      "units": 23
+    },
+    "9ffe96467a8156cec536": {
+      "command": "target/issue-820/release/nose features bench/repos/asciidoctor/test/links_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/asciidoctor/test/links_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4dcc9a527ae4a62e32b02f95e6ce65a056355efd276138c6bb2ae639dafffe22",
+      "units": 173
+    },
+    "a05848e5ee66b5ff58f3": {
+      "command": "target/issue-820/release/nose features bench/repos/gin/routes_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gin/routes_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9fcea2d4dff5dac1c59dd1fa3eaf60aafc418b8ec8d32638bd44fd1ab4f2795d",
+      "units": 43
+    },
+    "a125be0d4f7522b0a2e5": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/test/test-fs.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/test/test-fs.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "a3a5867df5ed74c0dc8a": {
+      "command": "target/issue-820/release/nose features bench/repos/chi/middleware/client_ip_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/chi/middleware/client_ip_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "1888745de3d260c0218039ddf50878b6906b0e4a9aa99714b11f936c3cae931e",
+      "units": 70
+    },
+    "a41d7e018e9b831212a8": {
+      "command": "target/issue-820/release/nose features bench/repos/rich/tests/test_win32_console.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rich/tests/test_win32_console.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "e90faaf5b2be3a8d8d8a5a70d8fb8ca975d2209be8b5c1c9399017b196b29c26",
+      "units": 34
+    },
+    "a55524cbd63654e1f618": {
+      "command": "target/issue-820/release/nose features bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d786b695f9c1adf5f7d83d6a5ad369045234213a793c76a3f4f057c8de4c6bf3",
+      "units": 20
+    },
+    "a628e51310606e901aa9": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "68e6bdbe48d2f35a06b5c902e3c5d7109354223abfc616de5b8586c0317dead0",
+      "units": 29
+    },
+    "a6879713e7b9c9d32f8e": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "aaac538fae31f459e184": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/searcher/src/testutil.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/searcher/src/testutil.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "e1da130e0b13fc96965048f7afa1012edc0d3d7d64754b09eff53fcc4eaeb1e4",
+      "units": 80
+    },
+    "ab3ac7395feb766ff897": {
+      "command": "target/issue-820/release/nose features bench/repos/thor/lib/thor/group.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/thor/lib/thor/group.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "49dd0d7752b36332ad4cd501bf7b09690386972bb7af9805b21fe040631c388b",
+      "units": 39
+    },
+    "ad9f67808d7de8fba4c7": {
+      "command": "target/issue-820/release/nose features bench/repos/chi/middleware/route_headers_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/chi/middleware/route_headers_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6d9de72b7d48bbd9febb3f96ae7c92a6382b907d21652e537b3de5cff9d92522",
+      "units": 11
+    },
+    "ae141805ca30bdf65cd1": {
+      "command": "target/issue-820/release/nose features bench/repos/fzf/test/test_shell_integration.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fzf/test/test_shell_integration.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "aeb0fb56f2cb79b68dd0": {
+      "command": "target/issue-820/release/nose features bench/repos/swr/test/use-swr-local-mutation.test.tsx --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/swr/test/use-swr-local-mutation.test.tsx"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "af55ea8cbfaf4ac8fdb9": {
+      "command": "target/issue-820/release/nose features bench/repos/marshmallow/tests/test_deserialization.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/marshmallow/tests/test_deserialization.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "b1002553bd6e3b417700": {
+      "command": "target/issue-820/release/nose features bench/repos/gin/auth.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gin/auth.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "a491bf8aa0db82a1a6de1f666215218840af71d083e44fd9507159248dbce381",
+      "units": 14
+    },
+    "b1032b28fbdd7a7b9c49": {
+      "command": "target/issue-820/release/nose features bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4cfb9354d7ca79abd7f7828246e8e8a34d7fc1b04303c6219c109ff672c69a15",
+      "units": 23
+    },
+    "b10b96346a6225aa38c7": {
+      "command": "target/issue-820/release/nose features bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "851d4edcf32712c74767aa61039154ec54550dc1a3f46d9118b339d9bd56f904",
+      "units": 4
+    },
+    "b15db51a731ec5b18533": {
+      "command": "target/issue-820/release/nose features bench/repos/puma/test/test_rack_handler.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/puma/test/test_rack_handler.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "96d24dbe9ee2b0e20905e5f64128f365ab2a7f4d5bf6ce71ad0f517206c00ec5",
+      "units": 52
+    },
+    "b1fbdb0743ade95185a5": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/tests/json.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/tests/json.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4ee027cd5b3d21bcecec682cbeacb3d2c59460e25e29217ffd60b595b6dbf187",
+      "units": 22
+    },
+    "b363aeb29931fef86676": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "5e774b183ccaf9954af2fb4d808a161aaf83d08340c91c4ede665fa555199ad0",
+      "units": 43
+    },
+    "b3d260441dbb3bb35bf8": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "fd1f8b061c6b3888cf80433ec44ab398e9f3f6504998a4e383a9bbb16d6c1e6d",
+      "units": 15
+    },
+    "b4482bff0c047212f57a": {
+      "command": "target/issue-820/release/nose features bench/repos/requests/tests/test_requests.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/requests/tests/test_requests.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "b489127c3697e3a6075f": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/test/runner.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/test/runner.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "c7f6c33bdcdc71b1446185200f0a72b84446423278bf4ba345450a6b04eb58b8",
+      "units": 67
+    },
+    "b807b3b50355e5c14e75": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6af44215c84e850fdff446bcae927014b3687d24f2baf15c3e43c662fea8bf0b",
+      "units": 9
+    },
+    "ba47ff4dd05189d8f83f": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f5d658b16089c340eea02644da356a3c1bdec4e3e238c8aff51ed802a9069d87",
+      "units": 30
+    },
+    "bdfcb85da8b7fae87346": {
+      "command": "target/issue-820/release/nose features bench/repos/packaging/tests/test_tags.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/packaging/tests/test_tags.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "bfb2e14ea116aa691167": {
+      "command": "target/issue-820/release/nose features bench/repos/tmux/notify.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tmux/notify.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ab50ebd1683cfa9c548463e2e8e4e2d997287242979c37183c2575d206001443",
+      "units": 52
+    },
+    "c45f5895e395a488aba6": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/lib/liquid/resource_limits.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/lib/liquid/resource_limits.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "13735db97061dd888492653cf36c57608de8f498785ef2cd5a7714cc34dd9724",
+      "units": 19
+    },
+    "c4c0e932b6ab3d8567b2": {
+      "command": "target/issue-820/release/nose features bench/repos/fzf/src/result.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fzf/src/result.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b8e9c69209e44ae7f1e002c9939b6c69e756b787f47dee25d0853362c5710312",
+      "units": 78
+    },
+    "c5770322194a668734a7": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "d4b0ccef41fe08ebf6b47fe468108396e690ea65bba0d596e5f7ac57f16a1e59",
+      "units": 19
+    },
+    "c70e29b42ab324f65503": {
+      "command": "target/issue-820/release/nose features bench/repos/liquid/test/integration/standard_filter_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/liquid/test/integration/standard_filter_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "cc0417d78e5e8ad603b6": {
+      "command": "target/issue-820/release/nose features bench/repos/puma/test/test_fiber_local_application.rb bench/repos/puma/test/test_fiber_storage_application.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/puma/test/test_fiber_local_application.rb",
+        "bench/repos/puma/test/test_fiber_storage_application.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ade24bd371baf9f58c4a48c130d92eda44438a0450b4cadb90f45c7b0de43071",
+      "units": 12
+    },
+    "ce455b0bb06c773ab692": {
+      "command": "target/issue-820/release/nose features bench/repos/sinatra/test/contest.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/sinatra/test/contest.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "11ae99c989e845ab84d39ccbe03f3ccb0c220bb0f533ead2fff0eef43ae19112",
+      "units": 17
+    },
+    "cf03cb81c5b37a979c74": {
+      "command": "target/issue-820/release/nose features bench/repos/cobra/completions_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/cobra/completions_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "cf40837fcd2bc2c77cec": {
+      "command": "target/issue-820/release/nose features bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b019233c7bd7dcb53107d12ea38fe231fa0682acde67d3ced44c53372439c27b",
+      "units": 4
+    },
+    "cfac957836efcb0c6e52": {
+      "command": "target/issue-820/release/nose features bench/repos/delve/pkg/dwarf/op/op.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/delve/pkg/dwarf/op/op.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ca278f6eb4b336a3778f8ee9413bce7fd21ffcd5040769f08411cfa396b398bf",
+      "units": 101
+    },
+    "d0288ec6a9a3938f6749": {
+      "command": "target/issue-820/release/nose features bench/repos/fastlane/spaceship/spec/client_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fastlane/spaceship/spec/client_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "87f005f04b87261432956af25dcb30b0214b0486caf10f95a65095ea267066d9",
+      "units": 48
+    },
+    "d181b3a8588ad9e17e85": {
+      "command": "target/issue-820/release/nose features bench/repos/regex/regex-lite/src/hir/parse.rs bench/repos/regex/regex-syntax/src/hir/translate.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/regex/regex-lite/src/hir/parse.rs",
+        "bench/repos/regex/regex-syntax/src/hir/translate.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "62c7a2daec1fe1735ca1706d15cf7348ee5a1a85ee1b6c44baf01e176d4fe424",
+      "units": 238
+    },
+    "d192ffea872de7e52589": {
+      "command": "target/issue-820/release/nose features bench/repos/image/src/imageops/colorops.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/image/src/imageops/colorops.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "258d629c411e1c63e426fbc32d60dc59ff53b414f1c09e279c5421f352870640",
+      "units": 64
+    },
+    "d2a4e73bf81658f132cd": {
+      "command": "target/issue-820/release/nose features bench/repos/alacritty/alacritty/src/display/window.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/alacritty/alacritty/src/display/window.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "1d1f02dcf568e9144c9d40d5e2d6fbbfc17646409b0821fb435c79b8fb2c9b2a",
+      "units": 69
+    },
+    "d3cf4f7527db4885cfa6": {
+      "command": "target/issue-820/release/nose features bench/repos/puma/ext/puma_http11/puma_http11.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/puma/ext/puma_http11/puma_http11.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "196d1042f34835a07c9af124b5d4a43786854e8ac6cbed2a9221d7373b728ac8",
+      "units": 38
+    },
+    "d7e8db7be9e75806d8b9": {
+      "command": "target/issue-820/release/nose features bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6c345ed7daec3173cca33053e7e69fea6f800e97f9fc499e3a7858f1de1e9c77",
+      "units": 78
+    },
+    "d8828d60f95eadba6587": {
+      "command": "target/issue-820/release/nose features bench/repos/minio/cmd/erasure-metadata-utils.go bench/repos/minio/docs/debugging/hash-set/main.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/minio/cmd/erasure-metadata-utils.go",
+        "bench/repos/minio/docs/debugging/hash-set/main.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "2fffa57914c011245a9894f11e76ee0582cea267c7268e36c465023f144c1cfe",
+      "units": 80
+    },
+    "d8f96a7aeec47ad26d7c": {
+      "command": "target/issue-820/release/nose features bench/repos/lua/lvm.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/lua/lvm.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "71595362bf5227b46f3d3bbf2fea9f282952834446a0908ff0d6288ea20ab451",
+      "units": 118
+    },
+    "d9b45afa30ca9b61697d": {
+      "command": "target/issue-820/release/nose features bench/repos/scrapy/scrapy/http/response/text.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/scrapy/scrapy/http/response/text.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "35b8854a843cfcea36b3c7473b68674a3dfb74b019ca437387b04e4319ce59f5",
+      "units": 46
+    },
+    "da317a8835db15e84c54": {
+      "command": "target/issue-820/release/nose features bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8e7c4fb1d64dde5464bd80435c5b9fa3bc15dc8305401574fdb479c07e46f5f2",
+      "units": 31
+    },
+    "dacb76cc8d21ea555fed": {
+      "command": "target/issue-820/release/nose features bench/repos/clap/tests/builder/help.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/clap/tests/builder/help.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "dd9b12da28b16e7c6c46": {
+      "command": "target/issue-820/release/nose features bench/repos/poetry/tests/installation/test_chef.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/poetry/tests/installation/test_chef.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "391c51e0c0c77ea56b107acb1af2f7c95036377b336e80836567930dc2a5592a",
+      "units": 10
+    },
+    "e000f083c244b99a7346": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/ignore/src/walk.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/ignore/src/walk.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "31becd74cc22bd212e4453937550f8d2b5cbc420bafad22008d2f218c280a3ac",
+      "units": 164
+    },
+    "e01afb34ffe576da56ff": {
+      "command": "target/issue-820/release/nose features bench/repos/gorm/logger/slog.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gorm/logger/slog.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b7b886e4dcc0d6862fc2176b0f90fe1273cbcdd1256ddf00cbcc2a92e4e8d465",
+      "units": 15
+    },
+    "e0b0d0eaddb74ca5bb99": {
+      "command": "target/issue-820/release/nose features bench/repos/zod/packages/zod/src/v3/types.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/zod/packages/zod/src/v3/types.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8ad62756d30eaf78b030c3b2d7aec038616a715456d1debde9bfd7f181e271fd",
+      "units": 397
+    },
+    "e0f606364bf8a0741cc7": {
+      "command": "target/issue-820/release/nose features bench/repos/pry/lib/pry/method/weird_method_locator.rb bench/repos/pry/lib/pry/wrapped_module.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/pry/lib/pry/method/weird_method_locator.rb",
+        "bench/repos/pry/lib/pry/wrapped_module.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "ca53df8ff5131c9661000001ad738af7f38e9d4ccf6c6c1f61172172475f5214",
+      "units": 93
+    },
+    "e8ad489feb4411ce1ae9": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "f4405a87e55b3aa192f9b3a0d82f707ca65aeb06a95db8f97f86db81a0592b38",
+      "units": 53
+    },
+    "e9368315355b50b806eb": {
+      "command": "target/issue-820/release/nose features bench/repos/curl/lib/curl_share.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/curl/lib/curl_share.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "5953cb2a4fb803321861ad10cf1cb9d09f523322451b6f27fab5dece309590b9",
+      "units": 62
+    },
+    "e9a8d3eecafdbcc4bf02": {
+      "command": "target/issue-820/release/nose features bench/repos/poetry/tests/utils/test_password_manager.py --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/poetry/tests/utils/test_password_manager.py"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "af26225e553d391de6736a39e4206a1e6ad8c061d6325f6d86c69507c86efbc3",
+      "units": 58
+    },
+    "ea28272bcf894d89317b": {
+      "command": "target/issue-820/release/nose features bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "ea6fc403b5914267ec6b": {
+      "command": "target/issue-820/release/nose features bench/repos/libuv/src/win/fs.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/libuv/src/win/fs.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9d9d889aac05414845dd5b28aabdd8fa8547482f55bdf6a85f800c7bcd1b52d2",
+      "units": 104
+    },
+    "eb62d971ae1302e44534": {
+      "command": "target/issue-820/release/nose features bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "207be8ba974383edc9c19d2213b13e1edbb0dd6a7c850c85eb981e1d3a0bdd44",
+      "units": 4
+    },
+    "ee766c13ffcbb3b7321a": {
+      "command": "target/issue-820/release/nose features bench/repos/bat/src/assets/lazy_theme_set.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/bat/src/assets/lazy_theme_set.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "38d480874d44d53f001b66e23f9898c36fad6e3d6b60ab527a866175a8f5db09",
+      "units": 11
+    },
+    "eece54d6a3537293ff2f": {
+      "command": "target/issue-820/release/nose features bench/repos/pry/lib/pry/method.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/pry/lib/pry/method.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "8bb6a94452947927d2978c9eceef663ca58b6863fcecb13319bdca27f7ba9a9e",
+      "units": 103
+    },
+    "f0499addcf4b27e3300a": {
+      "command": "target/issue-820/release/nose features bench/repos/curl/tests/unit/unit1607.c bench/repos/curl/tests/unit/unit1609.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/curl/tests/unit/unit1607.c",
+        "bench/repos/curl/tests/unit/unit1609.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "5d20c5db2edfb4d6571bccbe62d4e91a978d7c9924a25cecfbfce33bfc15f391",
+      "units": 32
+    },
+    "f05b9e274c9c3ff3759b": {
+      "command": "target/issue-820/release/nose features bench/repos/devise/lib/devise/orm.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/devise/lib/devise/orm.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b947c27d5eaed972b4a4c25bfc96d056aab5baf550cc8e0671d510529b155e16",
+      "units": 20
+    },
+    "f2f8570e20fd579c917f": {
+      "command": "target/issue-820/release/nose features bench/repos/asciidoctor/test/reader_test.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/asciidoctor/test/reader_test.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "f4207b66d16d5a571e40": {
+      "command": "target/issue-820/release/nose features bench/repos/rack/lib/rack/lint.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rack/lib/rack/lint.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "3a8b1351328653fa21be219e2eb07de6fd515e10edaeb899bbcf35aecf5c223b",
+      "units": 142
+    },
+    "f43a5fddd36c19ca1fc8": {
+      "command": "target/issue-820/release/nose features bench/repos/zap/writer_test.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/zap/writer_test.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "9d74d77868cbac9fa73095d7a721f7db3b694d55c8a9195117cd571f61570f00",
+      "units": 20
+    },
+    "f4600d9cc727f7cf5fad": {
+      "command": "target/issue-820/release/nose features bench/repos/serde_json/tests/lexical/float.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/serde_json/tests/lexical/float.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "47cc2387e3e0a9f6b3e9c447933f994c9434be0693cef6a198c457beeb253c47",
+      "units": 20
+    },
+    "f49c73d3c95cc5054160": {
+      "command": "target/issue-820/release/nose features bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen-base.ts bench/repos/trpc/examples/next-big-router/scripts/codegen-base.ts --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen-base.ts",
+        "bench/repos/trpc/examples/next-big-router/scripts/codegen-base.ts"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "f4b48f81a5a7702fc399": {
+      "command": "target/issue-820/release/nose features bench/repos/tokio/tokio-stream/tests/async_send_sync.rs bench/repos/tokio/tokio/tests/async_send_sync.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tokio/tokio-stream/tests/async_send_sync.rs",
+        "bench/repos/tokio/tokio/tests/async_send_sync.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "62ef03b3629e426ee7e79265b4d8ebe84047bfb4670a3295c112061073d1ff0c",
+      "units": 22
+    },
+    "f6a72a06295fe4f90918": {
+      "command": "target/issue-820/release/nose features bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "b71ac96332da6324f1fc66ef4c766aed4d16ff4584f52dae5da6fb29ec21d544",
+      "units": 38
+    },
+    "f778ab3848f7cabe8b45": {
+      "command": "target/issue-820/release/nose features bench/repos/rspec-core/spec/support/formatter_support.rb --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/rspec-core/spec/support/formatter_support.rb"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "645f3eeed435fcb3fb5f940592b0b76d242c89bb8fd00dd22475528d0762ce3e",
+      "units": 39
+    },
+    "f849fa41f7df81093b7f": {
+      "command": "target/issue-820/release/nose features bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "183930d39d44cdfa749ab7514d005092195a6648a36ee0d4cc5261c13d459d4f",
+      "units": 22
+    },
+    "f92f71d46a497be5eab5": {
+      "command": "target/issue-820/release/nose features bench/repos/clap/tests/derive/non_literal_attributes.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/clap/tests/derive/non_literal_attributes.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "4a000bc56c11b9f3b6e523f00a36e39fcc7d205b0d3bd49a58ecfc39b0b9d5ce",
+      "units": 7
+    },
+    "f9b17c0c331639ad74d4": {
+      "command": "target/issue-820/release/nose features bench/repos/tmux/tty.c --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/tmux/tty.c"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "6241579717d9ac7f0d3b30e355528e5770db74b6de89cc9ff78a17c568ed04a3",
+      "units": 115
+    },
+    "fa4e807a35e997e30b83": {
+      "command": "target/issue-820/release/nose features bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "dcc4875cc225c84e6a2b6b9ac483eaca5645a1c31c2ebbf0f52f38d2f9f58e03",
+      "units": 13
+    },
+    "fb03ea40370bc641770c": {
+      "command": "target/issue-820/release/nose features bench/repos/sidekiq/bin/multi_queue_bench bench/repos/sidekiq/bin/sidekiqload --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/sidekiq/bin/multi_queue_bench",
+        "bench/repos/sidekiq/bin/sidekiqload"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "26918a6ebc7aed34f8bc3fa729ea8a7cc206b30cc824ec6b1d748e81a3454431",
+      "stdout_sha256": "daf70bbdcf9949ee0a522a5f9ae724497a075a4b78e9a3072ca72c1761139728",
+      "units": 0
+    },
+    "fc38e9846bc30cf8f138": {
+      "command": "target/issue-820/release/nose features bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "a8e19901b20b8987b8940bf2e3b09860f7bb0d0476776151380a7297186dfb23",
+      "units": 14
+    },
+    "fc4d0b82c8332da22295": {
+      "command": "target/issue-820/release/nose features bench/repos/gin/binding/toml.go bench/repos/gin/binding/xml.go --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/gin/binding/toml.go",
+        "bench/repos/gin/binding/xml.go"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "04105ad00b330afde18cf3fb14d052996b1877d2d5e31516d97c269ae4261833",
+      "units": 10
+    },
+    "fc942826add48d7f0682": {
+      "command": "target/issue-820/release/nose features bench/repos/ripgrep/crates/core/flags/doc/version.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/ripgrep/crates/core/flags/doc/version.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "0ac507994c3d4b682f6337cb669fc64bcd78ef4d65e175bdb422a4a11228634a",
+      "units": 14
+    },
+    "ff99257a2da82da4dabb": {
+      "command": "target/issue-820/release/nose features bench/repos/clap/clap_builder/src/error/mod.rs --min-lines 1 --min-tokens 1",
+      "files": [
+        "bench/repos/clap/clap_builder/src/error/mod.rs"
+      ],
+      "returncode": 0,
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stdout_sha256": "591eaee51a3010ee7f7fba381762170a352088dd8ca0fa003374513252e1cc65",
+      "units": 102
+    }
+  },
+  "metrics": {
+    "dev": {
+      "hit_arm0": 2442,
+      "hit_arm1": 2691,
+      "inline-ceiling": 16,
+      "missed_arm1": 158,
+      "no-overlapping-unit": 22,
+      "repositories": 57,
+      "same-unit-window": 16,
+      "subdag-ceiling": 60,
+      "subdag_ge_12": 32,
+      "subdag_ge_20": 14,
+      "subdag_ge_8": 60,
+      "unrecovered": 44,
+      "worthy": 2849
+    },
+    "heldout": {
+      "hit_arm0": 1829,
+      "hit_arm1": 1996,
+      "inline-ceiling": 5,
+      "missed_arm1": 95,
+      "no-overlapping-unit": 41,
+      "repositories": 47,
+      "same-unit-window": 10,
+      "subdag-ceiling": 29,
+      "subdag_ge_12": 19,
+      "subdag_ge_20": 8,
+      "subdag_ge_8": 29,
+      "unrecovered": 10,
+      "worthy": 2091
+    }
+  },
+  "metrics_by_language": {
+    "dev": {
+      "C": {
+        "hit_arm0": 408,
+        "hit_arm1": 438,
+        "missed_arm1": 12,
+        "repositories": 9,
+        "same-unit-window": 3,
+        "subdag-ceiling": 4,
+        "subdag_ge_12": 2,
+        "subdag_ge_20": 2,
+        "subdag_ge_8": 4,
+        "unrecovered": 5,
+        "worthy": 450
+      },
+      "Go": {
+        "hit_arm0": 431,
+        "hit_arm1": 456,
+        "missed_arm1": 19,
+        "no-overlapping-unit": 2,
+        "repositories": 8,
+        "same-unit-window": 6,
+        "subdag-ceiling": 6,
+        "subdag_ge_12": 3,
+        "subdag_ge_20": 1,
+        "subdag_ge_8": 6,
+        "unrecovered": 5,
+        "worthy": 475
+      },
+      "Java": {
+        "hit_arm0": 481,
+        "hit_arm1": 504,
+        "inline-ceiling": 5,
+        "missed_arm1": 31,
+        "no-overlapping-unit": 2,
+        "repositories": 8,
+        "same-unit-window": 4,
+        "subdag-ceiling": 14,
+        "subdag_ge_12": 9,
+        "subdag_ge_20": 3,
+        "subdag_ge_8": 14,
+        "unrecovered": 6,
+        "worthy": 535
+      },
+      "Python": {
+        "hit_arm0": 252,
+        "hit_arm1": 287,
+        "inline-ceiling": 1,
+        "missed_arm1": 12,
+        "no-overlapping-unit": 3,
+        "repositories": 7,
+        "subdag-ceiling": 6,
+        "subdag_ge_12": 6,
+        "subdag_ge_20": 3,
+        "subdag_ge_8": 6,
+        "unrecovered": 2,
+        "worthy": 299
+      },
+      "Ruby": {
+        "hit_arm0": 288,
+        "hit_arm1": 346,
+        "inline-ceiling": 7,
+        "missed_arm1": 34,
+        "no-overlapping-unit": 2,
+        "repositories": 9,
+        "same-unit-window": 1,
+        "subdag-ceiling": 11,
+        "subdag_ge_12": 3,
+        "subdag_ge_20": 1,
+        "subdag_ge_8": 11,
+        "unrecovered": 13,
+        "worthy": 380
+      },
+      "Rust": {
+        "hit_arm0": 314,
+        "hit_arm1": 368,
+        "inline-ceiling": 3,
+        "missed_arm1": 43,
+        "no-overlapping-unit": 11,
+        "repositories": 8,
+        "same-unit-window": 2,
+        "subdag-ceiling": 14,
+        "subdag_ge_12": 6,
+        "subdag_ge_20": 4,
+        "subdag_ge_8": 14,
+        "unrecovered": 13,
+        "worthy": 411
+      },
+      "TypeScript": {
+        "hit_arm0": 268,
+        "hit_arm1": 292,
+        "missed_arm1": 7,
+        "no-overlapping-unit": 2,
+        "repositories": 8,
+        "subdag-ceiling": 5,
+        "subdag_ge_12": 3,
+        "subdag_ge_20": 0,
+        "subdag_ge_8": 5,
+        "worthy": 299
+      }
+    },
+    "heldout": {
+      "C": {
+        "hit_arm0": 211,
+        "hit_arm1": 220,
+        "missed_arm1": 11,
+        "no-overlapping-unit": 3,
+        "repositories": 6,
+        "same-unit-window": 3,
+        "subdag-ceiling": 5,
+        "subdag_ge_12": 3,
+        "subdag_ge_20": 1,
+        "subdag_ge_8": 5,
+        "worthy": 231
+      },
+      "Go": {
+        "hit_arm0": 373,
+        "hit_arm1": 407,
+        "missed_arm1": 19,
+        "no-overlapping-unit": 11,
+        "repositories": 7,
+        "same-unit-window": 2,
+        "subdag-ceiling": 3,
+        "subdag_ge_12": 2,
+        "subdag_ge_20": 1,
+        "subdag_ge_8": 3,
+        "unrecovered": 3,
+        "worthy": 426
+      },
+      "Java": {
+        "hit_arm0": 426,
+        "hit_arm1": 445,
+        "inline-ceiling": 1,
+        "missed_arm1": 12,
+        "no-overlapping-unit": 4,
+        "repositories": 6,
+        "same-unit-window": 2,
+        "subdag-ceiling": 4,
+        "subdag_ge_12": 3,
+        "subdag_ge_20": 3,
+        "subdag_ge_8": 4,
+        "unrecovered": 1,
+        "worthy": 457
+      },
+      "Python": {
+        "hit_arm0": 204,
+        "hit_arm1": 218,
+        "inline-ceiling": 2,
+        "missed_arm1": 7,
+        "no-overlapping-unit": 4,
+        "repositories": 8,
+        "subdag-ceiling": 1,
+        "subdag_ge_12": 1,
+        "subdag_ge_20": 0,
+        "subdag_ge_8": 1,
+        "worthy": 225
+      },
+      "Ruby": {
+        "hit_arm0": 173,
+        "hit_arm1": 226,
+        "missed_arm1": 24,
+        "no-overlapping-unit": 10,
+        "repositories": 6,
+        "same-unit-window": 2,
+        "subdag-ceiling": 7,
+        "subdag_ge_12": 4,
+        "subdag_ge_20": 0,
+        "subdag_ge_8": 7,
+        "unrecovered": 5,
+        "worthy": 250
+      },
+      "Rust": {
+        "hit_arm0": 224,
+        "hit_arm1": 244,
+        "inline-ceiling": 1,
+        "missed_arm1": 11,
+        "no-overlapping-unit": 5,
+        "repositories": 7,
+        "same-unit-window": 1,
+        "subdag-ceiling": 4,
+        "subdag_ge_12": 4,
+        "subdag_ge_20": 2,
+        "subdag_ge_8": 4,
+        "worthy": 255
+      },
+      "TypeScript": {
+        "hit_arm0": 218,
+        "hit_arm1": 236,
+        "inline-ceiling": 1,
+        "missed_arm1": 11,
+        "no-overlapping-unit": 4,
+        "repositories": 7,
+        "subdag-ceiling": 5,
+        "subdag_ge_12": 2,
+        "subdag_ge_20": 1,
+        "subdag_ge_8": 5,
+        "unrecovered": 1,
+        "worthy": 247
+      }
+    }
+  },
+  "missed_worthy": [
+    {
+      "candidate_key": "alacritty:9c6effe5d34be3b4",
+      "candidate_sha256": "451b8eb4b29c7aa3e718b144461bc554bb8900fde8dbdaca35cb8e90c4162cb4",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "9c6effe5d34be3b4",
+      "feature_run": "408d8053c7e101fbea99",
+      "inline_aug_mass": 19,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 167,
+          "file": "bench/repos/alacritty/alacritty/src/daemon.rs",
+          "kind": "Function",
+          "name": "foreground_process_path",
+          "pure_single_return": false,
+          "start_line": 141,
+          "token_count": 82,
+          "value_size": 19
+        }
+      },
+      "intersection_mass": 1,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 167,
+          "file": "bench/repos/alacritty/alacritty/src/daemon.rs",
+          "kind": "Function",
+          "name": "foreground_process_path",
+          "pure_single_return": false,
+          "start_line": 141,
+          "token_count": 82,
+          "value_size": 19
+        },
+        {
+          "end_line": 138,
+          "file": "bench/repos/alacritty/alacritty/src/daemon.rs",
+          "kind": "Function",
+          "name": "foreground_process_path",
+          "pure_single_return": true,
+          "start_line": 117,
+          "token_count": 46,
+          "value_size": 4
+        }
+      ],
+      "members": [
+        {
+          "end_line": 149,
+          "file": "bench/repos/alacritty/alacritty/src/daemon.rs",
+          "start_line": 141
+        },
+        {
+          "end_line": 126,
+          "file": "bench/repos/alacritty/alacritty/src/daemon.rs",
+          "start_line": 117
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "alacritty",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/alacritty/alacritty/src/daemon.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        19,
+        4
+      ]
+    },
+    {
+      "candidate_key": "alacritty:f4fee9de42105372",
+      "candidate_sha256": "e06eb5a07a0425e8c706523e30ec74eafa3a2593a08d714778bd99516a939662",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "f4fee9de42105372",
+      "feature_run": "d2a4e73bf81658f132cd",
+      "intersection_mass": 9,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 534,
+          "file": "bench/repos/alacritty/alacritty/src/display/window.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 528,
+          "token_count": 36,
+          "value_size": 24
+        },
+        {
+          "end_line": 481,
+          "file": "bench/repos/alacritty/alacritty/src/display/window.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 475,
+          "token_count": 28,
+          "value_size": 20
+        }
+      ],
+      "members": [
+        {
+          "end_line": 536,
+          "file": "bench/repos/alacritty/alacritty/src/display/window.rs",
+          "start_line": 528
+        },
+        {
+          "end_line": 483,
+          "file": "bench/repos/alacritty/alacritty/src/display/window.rs",
+          "start_line": 475
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "alacritty",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/alacritty/alacritty/src/display/window.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        24,
+        20
+      ]
+    },
+    {
+      "candidate_key": "asciidoctor:11ce4268f0cf20de",
+      "candidate_sha256": "868b7b9da4e16fee70478312a8277a2dcac4cbc5a5c34050e3e460f1ec97a7a5",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        654,
+        666
+      ],
+      "family_id": "11ce4268f0cf20de",
+      "feature_run": "9ffe96467a8156cec536",
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 666,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "kind": "Block",
+          "name": "test:xref macro with implicit inter-document target should preserve path with file extension",
+          "pure_single_return": false,
+          "start_line": 654,
+          "token_count": 80,
+          "value_size": 19
+        },
+        {
+          "end_line": 666,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "kind": "Block",
+          "name": "test:xref macro with implicit inter-document target should preserve path with file extension",
+          "pure_single_return": false,
+          "start_line": 654,
+          "token_count": 80,
+          "value_size": 19
+        }
+      ],
+      "members": [
+        {
+          "end_line": 660,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "start_line": 654
+        },
+        {
+          "end_line": 666,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "start_line": 661
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/links_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:8699da327bd6ec73",
+      "candidate_sha256": "b99194c27ac1d485c39d9d52179aad7f5d0d41a754548d9607e1430a5f093bae",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "8699da327bd6ec73",
+      "feature_run": "40f2496ece87d6a21cb7",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 3428,
+          "file": "bench/repos/asciidoctor/test/lists_test.rb",
+          "start_line": 3421
+        },
+        {
+          "end_line": 3404,
+          "file": "bench/repos/asciidoctor/test/lists_test.rb",
+          "start_line": 3398
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/lists_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:8869aca250baf503",
+      "candidate_sha256": "45e54f5f621587a1e0deb6ce6758ec33d762dff7dbed49d13ab2b6542a15ccbe",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "8869aca250baf503",
+      "feature_run": "583999e157a3ba6fe30c",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1592,
+          "file": "bench/repos/asciidoctor/test/api_test.rb",
+          "start_line": 1587
+        },
+        {
+          "end_line": 1603,
+          "file": "bench/repos/asciidoctor/test/api_test.rb",
+          "start_line": 1598
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/api_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:a1ecbd9860ff7d79",
+      "candidate_sha256": "b778f4ffaf24c74e2517fd7b8afd95dc7375f21c7d6cc44c645b12e93a12047b",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "a1ecbd9860ff7d79",
+      "feature_run": "f2f8570e20fd579c917f",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 845,
+          "file": "bench/repos/asciidoctor/test/reader_test.rb",
+          "start_line": 838
+        },
+        {
+          "end_line": 859,
+          "file": "bench/repos/asciidoctor/test/reader_test.rb",
+          "start_line": 852
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/reader_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:e084a096af3db3ba",
+      "candidate_sha256": "a3db02990fad078f425fc420c11193b168b3dee07b44318459f930b18488465b",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "e084a096af3db3ba",
+      "feature_run": "40f2496ece87d6a21cb7",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1703,
+          "file": "bench/repos/asciidoctor/test/lists_test.rb",
+          "start_line": 1699
+        },
+        {
+          "end_line": 1736,
+          "file": "bench/repos/asciidoctor/test/lists_test.rb",
+          "start_line": 1732
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/lists_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:e3a775da989d15a2",
+      "candidate_sha256": "0ca829663f3b0c4d0c2b319300c0ac048baf9ba33f648d268dda131c03478ed9",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "e3a775da989d15a2",
+      "feature_run": "8b7712a70abd7d4e48ed",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1578,
+          "file": "bench/repos/asciidoctor/test/tables_test.rb",
+          "start_line": 1561
+        },
+        {
+          "end_line": 1619,
+          "file": "bench/repos/asciidoctor/test/tables_test.rb",
+          "start_line": 1602
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/tables_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "asciidoctor:e9d7f17263b3ef9e",
+      "candidate_sha256": "d0ae9233925af2426bf24084d5dd95f25b05c92ce8739471f65739226fbab326",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "e9d7f17263b3ef9e",
+      "feature_run": "9ffe96467a8156cec536",
+      "intersection_mass": 9,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 632,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "kind": "Block",
+          "name": "test:inter-document xref shorthand syntax should assume AsciiDoc extension if AsciiDoc extension not present",
+          "pure_single_return": false,
+          "start_line": 625,
+          "token_count": 47,
+          "value_size": 14
+        },
+        {
+          "end_line": 650,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "kind": "Block",
+          "name": "test:xref macro with explicit inter-document target should assume implicit AsciiDoc file extension if no file extension is present",
+          "pure_single_return": false,
+          "start_line": 636,
+          "token_count": 90,
+          "value_size": 23
+        }
+      ],
+      "members": [
+        {
+          "end_line": 632,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "start_line": 625
+        },
+        {
+          "end_line": 650,
+          "file": "bench/repos/asciidoctor/test/links_test.rb",
+          "start_line": 643
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/links_test.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        23
+      ]
+    },
+    {
+      "candidate_key": "asciidoctor:f49620c5fe1a5c28",
+      "candidate_sha256": "3c7d089b9fa0a3dbcb85b5e18492c2ac4feeafe563fc32087a0c12a787aee5c7",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "f49620c5fe1a5c28",
+      "feature_run": "583999e157a3ba6fe30c",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1642,
+          "file": "bench/repos/asciidoctor/test/api_test.rb",
+          "start_line": 1636
+        },
+        {
+          "end_line": 1681,
+          "file": "bench/repos/asciidoctor/test/api_test.rb",
+          "start_line": 1675
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "asciidoctor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/asciidoctor/test/api_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "axios:2169018b8e46a6b6",
+      "candidate_sha256": "7c053d4386e72b2a87fa6c19877b813c6e4c195e4d5bb916bdf49728b7356e01",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "2169018b8e46a6b6",
+      "feature_run": "4045df1fb5f4db673e46",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 70,
+          "file": "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js",
+          "start_line": 60
+        },
+        {
+          "end_line": 55,
+          "file": "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js",
+          "start_line": 45
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "axios",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "axios:e4b2c19f4886a989",
+      "candidate_sha256": "250df6c0c2a309504c84e4f57ebcf127f92e4a1e04650aee84af6c1a364d352e",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "e4b2c19f4886a989",
+      "feature_run": "253ffadee6f432c35c88",
+      "intersection_mass": 10,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 405,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 400,
+          "token_count": 22,
+          "value_size": 23
+        },
+        {
+          "end_line": 414,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 409,
+          "token_count": 22,
+          "value_size": 24
+        }
+      ],
+      "members": [
+        {
+          "end_line": 406,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "start_line": 399
+        },
+        {
+          "end_line": 415,
+          "file": "bench/repos/axios/sandbox/client.html",
+          "start_line": 408
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "axios",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/axios/sandbox/client.html"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        23,
+        24
+      ]
+    },
+    {
+      "candidate_key": "bat:05ca8156de2d3b25",
+      "candidate_sha256": "528e229525fd01172d03e3df2417bfa917d2a7dee9ae0e11554f8e23e5b40f60",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "low",
+      "family_id": "05ca8156de2d3b25",
+      "feature_run": "ee766c13ffcbb3b7321a",
+      "inline_aug_mass": 13,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 73,
+          "file": "bench/repos/bat/src/assets/lazy_theme_set.rs",
+          "kind": "Class",
+          "name": "ThemeSet",
+          "pure_single_return": false,
+          "start_line": 57,
+          "token_count": 27,
+          "value_size": 13
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 99,
+          "file": "bench/repos/bat/src/assets/lazy_theme_set.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 86,
+          "token_count": 25,
+          "value_size": 12
+        },
+        {
+          "end_line": 72,
+          "file": "bench/repos/bat/src/assets/lazy_theme_set.rs",
+          "kind": "Function",
+          "name": "try_from",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 26,
+          "value_size": 13
+        }
+      ],
+      "members": [
+        {
+          "end_line": 103,
+          "file": "bench/repos/bat/src/assets/lazy_theme_set.rs",
+          "start_line": 76
+        },
+        {
+          "end_line": 73,
+          "file": "bench/repos/bat/src/assets/lazy_theme_set.rs",
+          "start_line": 57
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "bat",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/bat/src/assets/lazy_theme_set.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        12,
+        13
+      ]
+    },
+    {
+      "candidate_key": "bat:3da3e13d270dcbb0",
+      "candidate_sha256": "ba8f1da69b0c67ea4e564906d185986e2a74124db71fed210f20ff9f1b38fe18",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "3da3e13d270dcbb0",
+      "feature_run": "61c8b51ef23bd6d2cbac",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1861,
+          "file": "bench/repos/bat/tests/integration_tests.rs",
+          "start_line": 1852
+        },
+        {
+          "end_line": 1873,
+          "file": "bench/repos/bat/tests/integration_tests.rs",
+          "start_line": 1864
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "bat",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/bat/tests/integration_tests.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "bat:6a12988f697482b6",
+      "candidate_sha256": "108703c7be53dd72626686364cff5b6acff7ae1f8dc1ffe49408fff93e775f1f",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "6a12988f697482b6",
+      "feature_run": "2c854e0b1159d783268e",
+      "intersection_mass": 14,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 822,
+          "file": "bench/repos/bat/src/assets.rs",
+          "kind": "Function",
+          "name": "syntax_detection_for_symlinked_file_by_target_extension",
+          "pure_single_return": false,
+          "start_line": 799,
+          "token_count": 88,
+          "value_size": 49
+        },
+        {
+          "end_line": 795,
+          "file": "bench/repos/bat/src/assets.rs",
+          "kind": "Function",
+          "name": "syntax_detection_for_symlinked_file",
+          "pure_single_return": false,
+          "start_line": 773,
+          "token_count": 83,
+          "value_size": 41
+        }
+      ],
+      "members": [
+        {
+          "end_line": 820,
+          "file": "bench/repos/bat/src/assets.rs",
+          "start_line": 814
+        },
+        {
+          "end_line": 793,
+          "file": "bench/repos/bat/src/assets.rs",
+          "start_line": 787
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "bat",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/bat/src/assets.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        49,
+        41
+      ]
+    },
+    {
+      "candidate_key": "bat:7836101146be0e22",
+      "candidate_sha256": "1c073d7003d68460eca24d5c5e7380a7bc05ab222ac18b59a1c6230a68ee43b6",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        690,
+        707
+      ],
+      "family_id": "7836101146be0e22",
+      "feature_run": "2c854e0b1159d783268e",
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 707,
+          "file": "bench/repos/bat/src/assets.rs",
+          "kind": "Function",
+          "name": "syntax_detection_is_case_insensitive",
+          "pure_single_return": false,
+          "start_line": 690,
+          "token_count": 73,
+          "value_size": 30
+        },
+        {
+          "end_line": 707,
+          "file": "bench/repos/bat/src/assets.rs",
+          "kind": "Function",
+          "name": "syntax_detection_is_case_insensitive",
+          "pure_single_return": false,
+          "start_line": 690,
+          "token_count": 73,
+          "value_size": 30
+        }
+      ],
+      "members": [
+        {
+          "end_line": 707,
+          "file": "bench/repos/bat/src/assets.rs",
+          "start_line": 701
+        },
+        {
+          "end_line": 699,
+          "file": "bench/repos/bat/src/assets.rs",
+          "start_line": 691
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "bat",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/bat/src/assets.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "boltons:ac3b57b1714437a6",
+      "candidate_sha256": "955f89a3e149fa1641a2ac99d16e3a58f6d7f80e44e97725858021310c1290df",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "ac3b57b1714437a6",
+      "feature_run": "32bd50619cd69dccebeb",
+      "intersection_mass": 14,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 112,
+          "file": "bench/repos/boltons/tests/test_strutils.py",
+          "kind": "Method",
+          "name": "test_sub_with_regex",
+          "pure_single_return": false,
+          "start_line": 102,
+          "token_count": 29,
+          "value_size": 23
+        },
+        {
+          "end_line": 124,
+          "file": "bench/repos/boltons/tests/test_strutils.py",
+          "kind": "Method",
+          "name": "test_sub_with_list",
+          "pure_single_return": false,
+          "start_line": 114,
+          "token_count": 29,
+          "value_size": 23
+        }
+      ],
+      "members": [
+        {
+          "end_line": 112,
+          "file": "bench/repos/boltons/tests/test_strutils.py",
+          "start_line": 102
+        },
+        {
+          "end_line": 124,
+          "file": "bench/repos/boltons/tests/test_strutils.py",
+          "start_line": 114
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "boltons",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/boltons/tests/test_strutils.py"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        23,
+        23
+      ]
+    },
+    {
+      "candidate_key": "chi:154bd73cf15a6de5",
+      "candidate_sha256": "818c4cdb58b65284187992985c8c892352bf2def26eacc7b2b2d88a813984d10",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        10,
+        185
+      ],
+      "family_id": "154bd73cf15a6de5",
+      "feature_run": "ad9f67808d7de8fba4c7",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 185,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "kind": "Function",
+          "name": "TestRouteHeaders",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 624,
+          "value_size": 26
+        },
+        {
+          "end_line": 185,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "kind": "Function",
+          "name": "TestRouteHeaders",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 624,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 170,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "start_line": 161
+        },
+        {
+          "end_line": 98,
+          "file": "bench/repos/chi/middleware/route_headers_test.go",
+          "start_line": 91
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "chi",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/chi/middleware/route_headers_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "chi:8aa3c17d2ce27099",
+      "candidate_sha256": "beeefa55d64f8783cc6be859424fc022b3b6736b0e199416497de3ba755b93ad",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        276,
+        320
+      ],
+      "family_id": "8aa3c17d2ce27099",
+      "feature_run": "a3a5867df5ed74c0dc8a",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 320,
+          "file": "bench/repos/chi/middleware/client_ip_test.go",
+          "kind": "Function",
+          "name": "TestClientIPLastWriteWins",
+          "pure_single_return": false,
+          "start_line": 276,
+          "token_count": 133,
+          "value_size": 14
+        },
+        {
+          "end_line": 320,
+          "file": "bench/repos/chi/middleware/client_ip_test.go",
+          "kind": "Function",
+          "name": "TestClientIPLastWriteWins",
+          "pure_single_return": false,
+          "start_line": 276,
+          "token_count": 133,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 299,
+          "file": "bench/repos/chi/middleware/client_ip_test.go",
+          "start_line": 292
+        },
+        {
+          "end_line": 284,
+          "file": "bench/repos/chi/middleware/client_ip_test.go",
+          "start_line": 277
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "chi",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/chi/middleware/client_ip_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "clap:26db8890dd78e8ec",
+      "candidate_sha256": "239f8fcc5e5e818a5f1d23098141cca0dd07dcb50a56f38b018554ff180456dd",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "26db8890dd78e8ec",
+      "feature_run": "ff99257a2da82da4dabb",
+      "inline_aug_mass": 9,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 550,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "unrecognized_subcommand",
+          "pure_single_return": false,
+          "start_line": 530,
+          "token_count": 42,
+          "value_size": 9
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 550,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "unrecognized_subcommand",
+          "pure_single_return": false,
+          "start_line": 530,
+          "token_count": 42,
+          "value_size": 9
+        },
+        {
+          "end_line": 572,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "missing_required_argument",
+          "pure_single_return": false,
+          "start_line": 552,
+          "token_count": 42,
+          "value_size": 9
+        }
+      ],
+      "members": [
+        {
+          "end_line": 550,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "start_line": 530
+        },
+        {
+          "end_line": 572,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "start_line": 552
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "clap",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/clap/clap_builder/src/error/mod.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        9,
+        9
+      ]
+    },
+    {
+      "candidate_key": "clap:74091cb7bc4194da",
+      "candidate_sha256": "bd4a73247380b7e92dc5b8a9919ae044ccee42057b20b86689b81e082b013a06",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        49,
+        86
+      ],
+      "family_id": "74091cb7bc4194da",
+      "feature_run": "f92f71d46a497be5eab5",
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 86,
+          "file": "bench/repos/clap/tests/derive/non_literal_attributes.rs",
+          "kind": "Function",
+          "name": "test_slice",
+          "pure_single_return": false,
+          "start_line": 49,
+          "token_count": 82,
+          "value_size": 27
+        },
+        {
+          "end_line": 86,
+          "file": "bench/repos/clap/tests/derive/non_literal_attributes.rs",
+          "kind": "Function",
+          "name": "test_slice",
+          "pure_single_return": false,
+          "start_line": 49,
+          "token_count": 82,
+          "value_size": 27
+        }
+      ],
+      "members": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/clap/tests/derive/non_literal_attributes.rs",
+          "start_line": 66
+        },
+        {
+          "end_line": 66,
+          "file": "bench/repos/clap/tests/derive/non_literal_attributes.rs",
+          "start_line": 57
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "clap",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/clap/tests/derive/non_literal_attributes.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "clap:bb9832e72fa8ae15",
+      "candidate_sha256": "ad4d59be35c9cf519f0a171730079701dbd3ababf614bfee66976371f5cc2f8b",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "bb9832e72fa8ae15",
+      "feature_run": "ff99257a2da82da4dabb",
+      "inline_aug_mass": 9,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 666,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "too_few_values",
+          "pure_single_return": false,
+          "start_line": 637,
+          "token_count": 54,
+          "value_size": 9
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 666,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "too_few_values",
+          "pure_single_return": false,
+          "start_line": 637,
+          "token_count": 54,
+          "value_size": 9
+        },
+        {
+          "end_line": 715,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "kind": "Function",
+          "name": "wrong_number_of_values",
+          "pure_single_return": false,
+          "start_line": 686,
+          "token_count": 54,
+          "value_size": 9
+        }
+      ],
+      "members": [
+        {
+          "end_line": 666,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "start_line": 637
+        },
+        {
+          "end_line": 715,
+          "file": "bench/repos/clap/clap_builder/src/error/mod.rs",
+          "start_line": 686
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "clap",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/clap/clap_builder/src/error/mod.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        9,
+        9
+      ]
+    },
+    {
+      "candidate_key": "clap:f54bde1dd7bb3151",
+      "candidate_sha256": "2aae16d76e8a03c2122ce24d180bf806e958e4c61d74c784fb41647d359cd9cb",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "f54bde1dd7bb3151",
+      "feature_run": "dacb76cc8d21ea555fed",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1133,
+          "file": "bench/repos/clap/tests/builder/help.rs",
+          "start_line": 1107
+        },
+        {
+          "end_line": 1163,
+          "file": "bench/repos/clap/tests/builder/help.rs",
+          "start_line": 1137
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "clap",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/clap/tests/builder/help.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "cobra:db88c9b581c2c760",
+      "candidate_sha256": "3c255fd3352ee4dc071afc43147cd945d0a7353eda757f4898cbd85bfcf5ff11",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "db88c9b581c2c760",
+      "feature_run": "cf03cb81c5b37a979c74",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/cobra/completions_test.go",
+          "start_line": 27
+        },
+        {
+          "end_line": 53,
+          "file": "bench/repos/cobra/completions_test.go",
+          "start_line": 41
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "cobra",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/cobra/completions_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "commons-lang:1ae611d010ed2053",
+      "candidate_sha256": "a20bb130b5336d401a5161cd8283440b4457fa08c2b34972bf468233bd9cf98b",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        143,
+        224
+      ],
+      "family_id": "1ae611d010ed2053",
+      "feature_run": "95c2bfceca5b285769c5",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 224,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java",
+          "kind": "Method",
+          "name": "testEqualsAnonynous",
+          "pure_single_return": false,
+          "start_line": 143,
+          "token_count": 105,
+          "value_size": 29
+        },
+        {
+          "end_line": 224,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java",
+          "kind": "Method",
+          "name": "testEqualsAnonynous",
+          "pure_single_return": false,
+          "start_line": 143,
+          "token_count": 105,
+          "value_size": 29
+        }
+      ],
+      "members": [
+        {
+          "end_line": 211,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java",
+          "start_line": 180
+        },
+        {
+          "end_line": 180,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java",
+          "start_line": 148
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "commons-lang",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "commons-lang:2eceec2b9e4c1883",
+      "candidate_sha256": "a13880ddf164e97255331605780b7e776a98b054aee1be5207b3db97285cc707",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "2eceec2b9e4c1883",
+      "feature_run": "7ff6571825f63bd33df7",
+      "intersection_mass": 17,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 323,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+          "kind": "Method",
+          "name": "testLang100",
+          "pure_single_return": false,
+          "start_line": 303,
+          "token_count": 105,
+          "value_size": 52
+        },
+        {
+          "end_line": 295,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+          "kind": "Method",
+          "name": "testLang100",
+          "pure_single_return": false,
+          "start_line": 276,
+          "token_count": 104,
+          "value_size": 52
+        }
+      ],
+      "members": [
+        {
+          "end_line": 325,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+          "start_line": 308
+        },
+        {
+          "end_line": 303,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+          "start_line": 280
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "commons-lang",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        52,
+        52
+      ]
+    },
+    {
+      "candidate_key": "commons-lang:7deea4aa415c6197",
+      "candidate_sha256": "e7d43c53204c6d5cc2532e8deac1d82bb99ce8646354117a395ef6eecd14d2aa",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "7deea4aa415c6197",
+      "feature_run": "03ce9cfb01edd7f6d63c",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 294,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+          "start_line": 211
+        },
+        {
+          "end_line": 379,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+          "start_line": 296
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "commons-lang",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "commons-lang:81a43aee2b3a31d7",
+      "candidate_sha256": "2621636f3998200d888dd37284e4b9d7c285267bb662606dd3553602c28a29f5",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        42,
+        522
+      ],
+      "family_id": "81a43aee2b3a31d7",
+      "feature_run": "f849fa41f7df81093b7f",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 522,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java",
+          "kind": "Class",
+          "name": "AnnotationUtilsTest",
+          "pure_single_return": false,
+          "start_line": 42,
+          "token_count": 729,
+          "value_size": 159
+        },
+        {
+          "end_line": 522,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java",
+          "kind": "Class",
+          "name": "AnnotationUtilsTest",
+          "pure_single_return": false,
+          "start_line": 42,
+          "token_count": 729,
+          "value_size": 159
+        }
+      ],
+      "members": [
+        {
+          "end_line": 265,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java",
+          "start_line": 191
+        },
+        {
+          "end_line": 189,
+          "file": "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java",
+          "start_line": 115
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "commons-lang",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "curl:08e1435f8564adf7",
+      "candidate_sha256": "b5aeb2fa7a54e29886f9554ab06d42bb95879127b8b3cc627f14d655e545dbaf",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "08e1435f8564adf7",
+      "feature_run": "f0499addcf4b27e3300a",
+      "intersection_mass": 57,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 233,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "kind": "Function",
+          "name": "test_unit1607",
+          "pure_single_return": false,
+          "start_line": 36,
+          "token_count": 564,
+          "value_size": 289
+        },
+        {
+          "end_line": 216,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "kind": "Function",
+          "name": "test_unit1609",
+          "pure_single_return": false,
+          "start_line": 68,
+          "token_count": 432,
+          "value_size": 238
+        }
+      ],
+      "members": [
+        {
+          "end_line": 227,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "start_line": 204
+        },
+        {
+          "end_line": 209,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "start_line": 186
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "curl",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/curl/tests/unit/unit1607.c",
+        "bench/repos/curl/tests/unit/unit1609.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        289,
+        238
+      ]
+    },
+    {
+      "candidate_key": "curl:2a436119a08187ba",
+      "candidate_sha256": "82a67204587605f18a10cfcea9666a15e6fd1a6b525a40dae287cc61435a208b",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "2a436119a08187ba",
+      "feature_run": "f0499addcf4b27e3300a",
+      "intersection_mass": 57,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 233,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "kind": "Function",
+          "name": "test_unit1607",
+          "pure_single_return": false,
+          "start_line": 36,
+          "token_count": 564,
+          "value_size": 289
+        },
+        {
+          "end_line": 216,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "kind": "Function",
+          "name": "test_unit1609",
+          "pure_single_return": false,
+          "start_line": 68,
+          "token_count": 432,
+          "value_size": 238
+        }
+      ],
+      "members": [
+        {
+          "end_line": 192,
+          "file": "bench/repos/curl/tests/unit/unit1607.c",
+          "start_line": 152
+        },
+        {
+          "end_line": 191,
+          "file": "bench/repos/curl/tests/unit/unit1609.c",
+          "start_line": 151
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "curl",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/curl/tests/unit/unit1607.c",
+        "bench/repos/curl/tests/unit/unit1609.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        289,
+        238
+      ]
+    },
+    {
+      "candidate_key": "curl:4240a5f55e0db83b",
+      "candidate_sha256": "61f6b4e3adc68eccafe60af286eab02f8046d7d8bea7d80175b67227fe611006",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "4240a5f55e0db83b",
+      "feature_run": "5254be9017b1161e54b5",
+      "inline_aug_mass": 12,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 186,
+          "file": "bench/repos/curl/lib/curlx/warnless.c",
+          "kind": "Function",
+          "name": "curlx_sltous",
+          "pure_single_return": false,
+          "start_line": 172,
+          "token_count": 19,
+          "value_size": 12
+        }
+      },
+      "intersection_mass": 2,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 186,
+          "file": "bench/repos/curl/lib/curlx/warnless.c",
+          "kind": "Function",
+          "name": "curlx_sltous",
+          "pure_single_return": false,
+          "start_line": 172,
+          "token_count": 19,
+          "value_size": 12
+        },
+        {
+          "end_line": 67,
+          "file": "bench/repos/curl/lib/curlx/warnless.c",
+          "kind": "Function",
+          "name": "curlx_ultouc",
+          "pure_single_return": false,
+          "start_line": 54,
+          "token_count": 13,
+          "value_size": 8
+        }
+      ],
+      "members": [
+        {
+          "end_line": 186,
+          "file": "bench/repos/curl/lib/curlx/warnless.c",
+          "start_line": 172
+        },
+        {
+          "end_line": 67,
+          "file": "bench/repos/curl/lib/curlx/warnless.c",
+          "start_line": 54
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "curl",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/curl/lib/curlx/warnless.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        12,
+        8
+      ]
+    },
+    {
+      "candidate_key": "curl:b4ce193dda870c7b",
+      "candidate_sha256": "5cfe053f885fb5d1aa87b41d238f043bd9520eafb687fb66284101f8dde60d84",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "b4ce193dda870c7b",
+      "feature_run": "3d3e969eec7221efd482",
+      "inline_aug_mass": 7,
+      "intersection_mass": 7,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 45,
+          "file": "bench/repos/curl/tests/libtest/lib1525.c",
+          "kind": "Function",
+          "name": "t1525_read_cb",
+          "pure_single_return": false,
+          "start_line": 36,
+          "token_count": 25,
+          "value_size": 20
+        },
+        {
+          "end_line": 44,
+          "file": "bench/repos/curl/tests/libtest/lib1526.c",
+          "kind": "Function",
+          "name": "t1526_read_cb",
+          "pure_single_return": false,
+          "start_line": 35,
+          "token_count": 25,
+          "value_size": 20
+        }
+      ],
+      "members": [
+        {
+          "end_line": 45,
+          "file": "bench/repos/curl/tests/libtest/lib1525.c",
+          "start_line": 36
+        },
+        {
+          "end_line": 44,
+          "file": "bench/repos/curl/tests/libtest/lib1526.c",
+          "start_line": 35
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "curl",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/curl/tests/libtest/lib1525.c",
+        "bench/repos/curl/tests/libtest/lib1526.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        20,
+        20
+      ]
+    },
+    {
+      "candidate_key": "curl:c06c2711b53dbd66",
+      "candidate_sha256": "a198b6ee87b0b44ae0121815e0e026651bb6a9b279c3467f9505159a46067605",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c06c2711b53dbd66",
+      "feature_run": "e9368315355b50b806eb",
+      "inline_aug_mass": 18,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 173,
+          "file": "bench/repos/curl/lib/curl_share.c",
+          "kind": "Function",
+          "name": "share_in_use",
+          "pure_single_return": false,
+          "start_line": 160,
+          "token_count": 42,
+          "value_size": 18
+        }
+      },
+      "intersection_mass": 7,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 108,
+          "file": "bench/repos/curl/lib/curl_share.c",
+          "kind": "Function",
+          "name": "share_ref_inc",
+          "pure_single_return": false,
+          "start_line": 95,
+          "token_count": 44,
+          "value_size": 15
+        },
+        {
+          "end_line": 173,
+          "file": "bench/repos/curl/lib/curl_share.c",
+          "kind": "Function",
+          "name": "share_in_use",
+          "pure_single_return": false,
+          "start_line": 160,
+          "token_count": 42,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 108,
+          "file": "bench/repos/curl/lib/curl_share.c",
+          "start_line": 95
+        },
+        {
+          "end_line": 173,
+          "file": "bench/repos/curl/lib/curl_share.c",
+          "start_line": 160
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "curl",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/curl/lib/curl_share.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        15,
+        18
+      ]
+    },
+    {
+      "candidate_key": "date-fns:2144f9d9bafc4adb",
+      "candidate_sha256": "3170c7eb87b0cf1bcd5691691ad10bd4194679a56695e80c7be32d62e7e437f4",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "2144f9d9bafc4adb",
+      "feature_run": "cf40837fcd2bc2c77cec",
+      "intersection_mass": 11,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 50,
+          "file": "bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts",
+          "kind": "Function",
+          "name": "isSameDay",
+          "pure_single_return": false,
+          "start_line": 39,
+          "token_count": 25,
+          "value_size": 18
+        },
+        {
+          "end_line": 45,
+          "file": "bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts",
+          "kind": "Function",
+          "name": "isSameHour",
+          "pure_single_return": false,
+          "start_line": 34,
+          "token_count": 25,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 50,
+          "file": "bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts",
+          "start_line": 39
+        },
+        {
+          "end_line": 45,
+          "file": "bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts",
+          "start_line": 34
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "date-fns",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        18
+      ]
+    },
+    {
+      "candidate_key": "date-fns:486dcd2da0d41a72",
+      "candidate_sha256": "dce10df2169d28cafb41df423f800ec75ce7fc1a59956a3daeee5e0c79ead30a",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "486dcd2da0d41a72",
+      "feature_run": "106f8c496fdc9575e077",
+      "intersection_mass": 10,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 48,
+          "file": "bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts",
+          "kind": "Function",
+          "name": "setISOWeek",
+          "pure_single_return": false,
+          "start_line": 36,
+          "token_count": 33,
+          "value_size": 18
+        },
+        {
+          "end_line": 71,
+          "file": "bench/repos/date-fns/pkgs/core/src/setWeek/index.ts",
+          "kind": "Function",
+          "name": "setWeek",
+          "pure_single_return": false,
+          "start_line": 59,
+          "token_count": 37,
+          "value_size": 19
+        }
+      ],
+      "members": [
+        {
+          "end_line": 48,
+          "file": "bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts",
+          "start_line": 36
+        },
+        {
+          "end_line": 71,
+          "file": "bench/repos/date-fns/pkgs/core/src/setWeek/index.ts",
+          "start_line": 59
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "date-fns",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/setWeek/index.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        19
+      ]
+    },
+    {
+      "candidate_key": "date-fns:959b04a23952dc9f",
+      "candidate_sha256": "362ad25f4f750c5c439a7999155882ab782c0e39efb2ceb5ab4e0d0d567f07b3",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "959b04a23952dc9f",
+      "feature_run": "eb62d971ae1302e44534",
+      "intersection_mass": 14,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 66,
+          "file": "bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts",
+          "kind": "Function",
+          "name": "differenceInCalendarDays",
+          "pure_single_return": false,
+          "start_line": 43,
+          "token_count": 50,
+          "value_size": 32
+        },
+        {
+          "end_line": 59,
+          "file": "bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts",
+          "kind": "Function",
+          "name": "differenceInCalendarISOWeeks",
+          "pure_single_return": false,
+          "start_line": 36,
+          "token_count": 50,
+          "value_size": 32
+        }
+      ],
+      "members": [
+        {
+          "end_line": 66,
+          "file": "bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts",
+          "start_line": 43
+        },
+        {
+          "end_line": 59,
+          "file": "bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts",
+          "start_line": 36
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "date-fns",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts",
+        "bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        32,
+        32
+      ]
+    },
+    {
+      "candidate_key": "date-fns:bdfb1a28bbbcdc44",
+      "candidate_sha256": "dabd2ea203830dfa94cae77abf0bdddda82fbb3738421315f1e28afa213d7115",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "bdfb1a28bbbcdc44",
+      "feature_run": "12d259c597975e499ef5",
+      "intersection_mass": 8,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 737,
+          "file": "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 727,
+          "token_count": 20,
+          "value_size": 15
+        },
+        {
+          "end_line": 754,
+          "file": "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 744,
+          "token_count": 20,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 737,
+          "file": "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts",
+          "start_line": 727
+        },
+        {
+          "end_line": 754,
+          "file": "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts",
+          "start_line": 744
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "date-fns",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        15,
+        15
+      ]
+    },
+    {
+      "candidate_key": "delve:de84b1952aa09a8e",
+      "candidate_sha256": "9129174bbac4023a963efac616e7f35a52b736b11e1904ba1f0dfde0faab507f",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "de84b1952aa09a8e",
+      "feature_run": "cfac957836efcb0c6e52",
+      "intersection_mass": 30,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 342,
+          "file": "bench/repos/delve/pkg/dwarf/op/op.go",
+          "kind": "Function",
+          "name": "constns",
+          "pure_single_return": false,
+          "start_line": 316,
+          "token_count": 125,
+          "value_size": 63
+        },
+        {
+          "end_line": 314,
+          "file": "bench/repos/delve/pkg/dwarf/op/op.go",
+          "kind": "Function",
+          "name": "constnu",
+          "pure_single_return": false,
+          "start_line": 290,
+          "token_count": 103,
+          "value_size": 53
+        }
+      ],
+      "members": [
+        {
+          "end_line": 344,
+          "file": "bench/repos/delve/pkg/dwarf/op/op.go",
+          "start_line": 332
+        },
+        {
+          "end_line": 316,
+          "file": "bench/repos/delve/pkg/dwarf/op/op.go",
+          "start_line": 304
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "delve",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/delve/pkg/dwarf/op/op.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        63,
+        53
+      ]
+    },
+    {
+      "candidate_key": "devise:458679b19d6bcbfa",
+      "candidate_sha256": "4d23e77ce5493b3f4a9d48ee3b3e6aaed595b0a4ee18144c4e1b01229668b1ac",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "458679b19d6bcbfa",
+      "feature_run": "f05b9e274c9c3ff3759b",
+      "inline_aug_mass": 15,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 79,
+          "file": "bench/repos/devise/lib/devise/orm.rb",
+          "kind": "Class",
+          "name": "Devise",
+          "pure_single_return": false,
+          "start_line": 4,
+          "token_count": 147,
+          "value_size": 98
+        }
+      },
+      "intersection_mass": 4,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/devise/lib/devise/orm.rb",
+          "kind": "Method",
+          "name": "devise_respond_to_and_will_save_change_to_attribute?",
+          "pure_single_return": false,
+          "start_line": 42,
+          "token_count": 19,
+          "value_size": 15
+        },
+        {
+          "end_line": 77,
+          "file": "bench/repos/devise/lib/devise/orm.rb",
+          "kind": "Method",
+          "name": "devise_respond_to_and_will_save_change_to_attribute?",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 15,
+          "value_size": 13
+        }
+      ],
+      "members": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/devise/lib/devise/orm.rb",
+          "start_line": 42
+        },
+        {
+          "end_line": 77,
+          "file": "bench/repos/devise/lib/devise/orm.rb",
+          "start_line": 75
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "devise",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/devise/lib/devise/orm.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        15,
+        13
+      ]
+    },
+    {
+      "candidate_key": "fastlane:37ed5651c32ff32a",
+      "candidate_sha256": "8bcfbd306aa9a7f3af1477744ba2078db2cadab88d9d8049dd921ed534369c2a",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "37ed5651c32ff32a",
+      "feature_run": "da317a8835db15e84c54",
+      "intersection_mass": 9,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 19,
+          "file": "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 16,
+          "token_count": 12,
+          "value_size": 12
+        },
+        {
+          "end_line": 26,
+          "file": "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 23,
+          "token_count": 12,
+          "value_size": 12
+        }
+      ],
+      "members": [
+        {
+          "end_line": 20,
+          "file": "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb",
+          "start_line": 15
+        },
+        {
+          "end_line": 27,
+          "file": "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb",
+          "start_line": 22
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "fastlane",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        12,
+        12
+      ]
+    },
+    {
+      "candidate_key": "fastlane:65e68827e870dbe0",
+      "candidate_sha256": "4f5bf9de13d6cfc527ac499767a7f9328484476a7498b02d1d7676386fe28dcd",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "65e68827e870dbe0",
+      "feature_run": "d0288ec6a9a3938f6749",
+      "inline_aug_mass": 21,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 215,
+          "file": "bench/repos/fastlane/spaceship/spec/client_spec.rb",
+          "kind": "Block",
+          "name": "describe:retry",
+          "pure_single_return": false,
+          "start_line": 148,
+          "token_count": 130,
+          "value_size": 21
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 215,
+          "file": "bench/repos/fastlane/spaceship/spec/client_spec.rb",
+          "kind": "Block",
+          "name": "describe:retry",
+          "pure_single_return": false,
+          "start_line": 148,
+          "token_count": 130,
+          "value_size": 21
+        },
+        {
+          "end_line": 233,
+          "file": "bench/repos/fastlane/spaceship/spec/client_spec.rb",
+          "kind": "Block",
+          "name": "it:re-raises when retry limit reached throwing #{thrown}",
+          "pure_single_return": false,
+          "start_line": 229,
+          "token_count": 22,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 170,
+          "file": "bench/repos/fastlane/spaceship/spec/client_spec.rb",
+          "start_line": 148
+        },
+        {
+          "end_line": 241,
+          "file": "bench/repos/fastlane/spaceship/spec/client_spec.rb",
+          "start_line": 219
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fastlane",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fastlane/spaceship/spec/client_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        21,
+        15
+      ]
+    },
+    {
+      "candidate_key": "fd:5f935c3d9e9dd8fd",
+      "candidate_sha256": "3512441f56023053fe8cbf3feafced3fa28d4187ea337a7d5bfe6b89d8218203",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "5f935c3d9e9dd8fd",
+      "feature_run": "6c73e1e05b28502eb21d",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 124,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Class",
+          "name": "CommandSet",
+          "pure_single_return": false,
+          "start_line": 35,
+          "token_count": 205,
+          "value_size": 52
+        }
+      },
+      "intersection_mass": 1,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 73,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Function",
+          "name": "new_batch",
+          "pure_single_return": true,
+          "start_line": 51,
+          "token_count": 51,
+          "value_size": 6
+        },
+        {
+          "end_line": 49,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Function",
+          "name": "new",
+          "pure_single_return": true,
+          "start_line": 36,
+          "token_count": 17,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 58,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "start_line": 51
+        },
+        {
+          "end_line": 43,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "start_line": 36
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "fd",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/fd/src/exec/mod.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        6,
+        6
+      ]
+    },
+    {
+      "candidate_key": "fd:a46e9200da364aff",
+      "candidate_sha256": "b032b4c288b83f07f7a6d7aca3121cf4134bfe25c658c1c96bc3c7aa4d077bfb",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "a46e9200da364aff",
+      "feature_run": "6c73e1e05b28502eb21d",
+      "inline_aug_mass": 21,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 472,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Function",
+          "name": "generate_custom_path_separator_windows",
+          "pure_single_return": false,
+          "start_line": 448,
+          "token_count": 44,
+          "value_size": 21
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 472,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Function",
+          "name": "generate_custom_path_separator_windows",
+          "pure_single_return": false,
+          "start_line": 448,
+          "token_count": 44,
+          "value_size": 21
+        },
+        {
+          "end_line": 444,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "kind": "Function",
+          "name": "generate_custom_path_separator",
+          "pure_single_return": false,
+          "start_line": 433,
+          "token_count": 34,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 457,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "start_line": 448
+        },
+        {
+          "end_line": 441,
+          "file": "bench/repos/fd/src/exec/mod.rs",
+          "start_line": 433
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fd",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/fd/src/exec/mod.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        21,
+        14
+      ]
+    },
+    {
+      "candidate_key": "flask:f8a68d68a99d0686",
+      "candidate_sha256": "0d6afd61a3b0a13cc904e5edf612661bd1447fa5ac0f23e52c77e522e3333e7b",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "f8a68d68a99d0686",
+      "feature_run": "8d4604da20f8ae7de3e0",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1440,
+          "file": "bench/repos/flask/tests/test_basic.py",
+          "start_line": 1432
+        },
+        {
+          "end_line": 1451,
+          "file": "bench/repos/flask/tests/test_basic.py",
+          "start_line": 1443
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "flask",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/flask/tests/test_basic.py"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:2e8c305415b72ea1",
+      "candidate_sha256": "749bf0d5222be3358fd111f6ce08fab60f0818e1fe82aa4f024d23bfdb1d5d3e",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "2e8c305415b72ea1",
+      "feature_run": "c4c0e932b6ab3d8567b2",
+      "intersection_mass": 14,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 182,
+          "file": "bench/repos/fzf/src/result.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 180,
+          "token_count": 18,
+          "value_size": 18
+        },
+        {
+          "end_line": 188,
+          "file": "bench/repos/fzf/src/result.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 186,
+          "token_count": 18,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 183,
+          "file": "bench/repos/fzf/src/result.go",
+          "start_line": 179
+        },
+        {
+          "end_line": 189,
+          "file": "bench/repos/fzf/src/result.go",
+          "start_line": 185
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "fzf",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/fzf/src/result.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        18
+      ]
+    },
+    {
+      "candidate_key": "fzf:7a87eef6f427c345",
+      "candidate_sha256": "681dec1a0a9302954c0bb0a0583ad5e626c6ece5a3edd980f939dd2b4bd82d41",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "7a87eef6f427c345",
+      "feature_run": "42ddad0914cc9adb67a8",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2429,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2422
+        },
+        {
+          "end_line": 2438,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2431
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fzf",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fzf/test/test_core.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:7ad05a16966237d7",
+      "candidate_sha256": "430b57800ecd2fd673cb0c2f397514097bca5f9cdd216641ddedec17a7bb0a66",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "7ad05a16966237d7",
+      "feature_run": "42ddad0914cc9adb67a8",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2552,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2539
+        },
+        {
+          "end_line": 2567,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2554
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fzf",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fzf/test/test_core.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:b0fb439b03c8915a",
+      "candidate_sha256": "2b3afe34a8a31ee7c172f7824c8666e4cc9673169c1fef844b8525482eef5cd2",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "b0fb439b03c8915a",
+      "feature_run": "ae141805ca30bdf65cd1",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 632,
+          "file": "bench/repos/fzf/test/test_shell_integration.rb",
+          "start_line": 614
+        },
+        {
+          "end_line": 652,
+          "file": "bench/repos/fzf/test/test_shell_integration.rb",
+          "start_line": 634
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fzf",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fzf/test/test_shell_integration.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:b77e5403b856a74f",
+      "candidate_sha256": "168981c19209a3e872b6a9e9c541d5aa9d9aeec70619b0f358a8c51298d3fd3a",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        5921,
+        8142
+      ],
+      "family_id": "b77e5403b856a74f",
+      "feature_run": "93b081de2249028d2718",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 8142,
+          "file": "bench/repos/fzf/src/terminal.go",
+          "kind": "Method",
+          "name": "Loop",
+          "pure_single_return": false,
+          "start_line": 5921,
+          "token_count": 10285,
+          "value_size": 387
+        },
+        {
+          "end_line": 8142,
+          "file": "bench/repos/fzf/src/terminal.go",
+          "kind": "Method",
+          "name": "Loop",
+          "pure_single_return": false,
+          "start_line": 5921,
+          "token_count": 10285,
+          "value_size": 387
+        }
+      ],
+      "members": [
+        {
+          "end_line": 7424,
+          "file": "bench/repos/fzf/src/terminal.go",
+          "start_line": 7420
+        },
+        {
+          "end_line": 7430,
+          "file": "bench/repos/fzf/src/terminal.go",
+          "start_line": 7426
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "fzf",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/fzf/src/terminal.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:c90eca5c1c3a0f9c",
+      "candidate_sha256": "dc3b8332a0c1725b9f740f8b607d6ce18256ccc88a2ea8d2e6a2daeaa0573c83",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "c90eca5c1c3a0f9c",
+      "feature_run": "42ddad0914cc9adb67a8",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2139,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2124
+        },
+        {
+          "end_line": 2189,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 2174
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fzf",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fzf/test/test_core.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "fzf:edddd809d7e8e481",
+      "candidate_sha256": "c535beaf413531a7b47ec9a9d7a3f930e58469c0cbb830642fe71257f19602ec",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "edddd809d7e8e481",
+      "feature_run": "42ddad0914cc9adb67a8",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1111,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 1104
+        },
+        {
+          "end_line": 1120,
+          "file": "bench/repos/fzf/test/test_core.rb",
+          "start_line": 1113
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "fzf",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/fzf/test/test_core.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "gin:65f119e68db659dd",
+      "candidate_sha256": "e26db03f7848f3e54b4836ba7dbaecd19be8c6445a50d5d15f0ce8f7c8870525",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "65f119e68db659dd",
+      "feature_run": "fc4d0b82c8332da22295",
+      "inline_aug_mass": 4,
+      "intersection_mass": 4,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 35,
+          "file": "bench/repos/gin/binding/toml.go",
+          "kind": "Function",
+          "name": "decodeToml",
+          "pure_single_return": true,
+          "start_line": 29,
+          "token_count": 27,
+          "value_size": 11
+        },
+        {
+          "end_line": 34,
+          "file": "bench/repos/gin/binding/xml.go",
+          "kind": "Function",
+          "name": "decodeXML",
+          "pure_single_return": true,
+          "start_line": 28,
+          "token_count": 27,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 35,
+          "file": "bench/repos/gin/binding/toml.go",
+          "start_line": 29
+        },
+        {
+          "end_line": 34,
+          "file": "bench/repos/gin/binding/xml.go",
+          "start_line": 28
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gin",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gin/binding/toml.go",
+        "bench/repos/gin/binding/xml.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "gin:6bc4c8ba1738db57",
+      "candidate_sha256": "fc84d25d3b6e994db9d432545b54af47ef9cc8c4f7b97587eb5cc3db103105ea",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "6bc4c8ba1738db57",
+      "feature_run": "b1002553bd6e3b417700",
+      "inline_aug_mass": 2,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 68,
+          "file": "bench/repos/gin/auth.go",
+          "kind": "Function",
+          "name": "BasicAuthForRealm",
+          "pure_single_return": true,
+          "start_line": 48,
+          "token_count": 61,
+          "value_size": 2
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 68,
+          "file": "bench/repos/gin/auth.go",
+          "kind": "Function",
+          "name": "BasicAuthForRealm",
+          "pure_single_return": true,
+          "start_line": 48,
+          "token_count": 61,
+          "value_size": 2
+        },
+        {
+          "end_line": 116,
+          "file": "bench/repos/gin/auth.go",
+          "kind": "Function",
+          "name": "BasicAuthForProxy",
+          "pure_single_return": true,
+          "start_line": 98,
+          "token_count": 61,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 68,
+          "file": "bench/repos/gin/auth.go",
+          "start_line": 48
+        },
+        {
+          "end_line": 116,
+          "file": "bench/repos/gin/auth.go",
+          "start_line": 98
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gin",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gin/auth.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "gin:e4a3c917303e7886",
+      "candidate_sha256": "37a42cf87f017a392bd251b1981c089b58e6ca07b63d51871f633ebf39ae9f9d",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "e4a3c917303e7886",
+      "feature_run": "a05848e5ee66b5ff58f3",
+      "intersection_mass": 11,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 119,
+          "file": "bench/repos/gin/routes_test.go",
+          "kind": "Function",
+          "name": "TestRouterGroupRouteOK",
+          "pure_single_return": false,
+          "start_line": 109,
+          "token_count": 57,
+          "value_size": 30
+        },
+        {
+          "end_line": 131,
+          "file": "bench/repos/gin/routes_test.go",
+          "kind": "Function",
+          "name": "TestRouteNotOK",
+          "pure_single_return": false,
+          "start_line": 121,
+          "token_count": 57,
+          "value_size": 30
+        }
+      ],
+      "members": [
+        {
+          "end_line": 119,
+          "file": "bench/repos/gin/routes_test.go",
+          "start_line": 109
+        },
+        {
+          "end_line": 131,
+          "file": "bench/repos/gin/routes_test.go",
+          "start_line": 121
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gin",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gin/routes_test.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        30,
+        30
+      ]
+    },
+    {
+      "candidate_key": "git:1d9b1c7f444d15d0",
+      "candidate_sha256": "0605378cce63ec592aafd62b787673acbb7a2b9697afbc18db849313fcfcfb29",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        64,
+        225
+      ],
+      "family_id": "1d9b1c7f444d15d0",
+      "feature_run": "4af90955fe3608edd9f7",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 225,
+          "file": "bench/repos/git/remote-curl.c",
+          "kind": "Function",
+          "name": "set_option",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 697,
+          "value_size": 806
+        },
+        {
+          "end_line": 225,
+          "file": "bench/repos/git/remote-curl.c",
+          "kind": "Function",
+          "name": "set_option",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 697,
+          "value_size": 806
+        }
+      ],
+      "members": [
+        {
+          "end_line": 80,
+          "file": "bench/repos/git/remote-curl.c",
+          "start_line": 75
+        },
+        {
+          "end_line": 105,
+          "file": "bench/repos/git/remote-curl.c",
+          "start_line": 100
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "git",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/git/remote-curl.c"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gorm:06b22e78705e5939",
+      "candidate_sha256": "aa83c19eca8526082e862bc635525321d62a6642af5711591b3181722bcf570c",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "06b22e78705e5939",
+      "feature_run": "93b231711ac31e228c69",
+      "intersection_mass": 11,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 142,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "kind": "Method",
+          "name": "Info",
+          "pure_single_return": false,
+          "start_line": 138,
+          "token_count": 25,
+          "value_size": 18
+        },
+        {
+          "end_line": 149,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "kind": "Method",
+          "name": "Warn",
+          "pure_single_return": false,
+          "start_line": 145,
+          "token_count": 25,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 142,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "start_line": 138
+        },
+        {
+          "end_line": 149,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "start_line": 145
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/logger/logger.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        18
+      ]
+    },
+    {
+      "candidate_key": "gorm:07b0262946c3716d",
+      "candidate_sha256": "6e5d4b465b0515c217b45f8cfafdd587a3b3adc23c90d9f073d3a7535ab8f9ee",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "07b0262946c3716d",
+      "feature_run": "93daf51105fd13b0f7e7",
+      "inline_aug_mass": 9,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 25,
+          "file": "bench/repos/gorm/clause/returning.go",
+          "kind": "Method",
+          "name": "Build",
+          "pure_single_return": false,
+          "start_line": 13,
+          "token_count": 39,
+          "value_size": 26
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 28,
+          "file": "bench/repos/gorm/clause/select.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 15,
+          "token_count": 45,
+          "value_size": 33
+        },
+        {
+          "end_line": 21,
+          "file": "bench/repos/gorm/clause/returning.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 15,
+          "token_count": 23,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 29,
+          "file": "bench/repos/gorm/clause/select.go",
+          "start_line": 14
+        },
+        {
+          "end_line": 25,
+          "file": "bench/repos/gorm/clause/returning.go",
+          "start_line": 13
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/clause/returning.go",
+        "bench/repos/gorm/clause/select.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        33,
+        17
+      ]
+    },
+    {
+      "candidate_key": "gorm:768d763acc7c5c60",
+      "candidate_sha256": "92c1f5a1b229f9a4d164eb1cd54b7962bcee9793050bcbd2f161e2c5e0210edc",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "768d763acc7c5c60",
+      "feature_run": "e01afb34ffe576da56ff",
+      "intersection_mass": 11,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/gorm/logger/slog.go",
+          "kind": "Method",
+          "name": "Info",
+          "pure_single_return": false,
+          "start_line": 40,
+          "token_count": 24,
+          "value_size": 17
+        },
+        {
+          "end_line": 50,
+          "file": "bench/repos/gorm/logger/slog.go",
+          "kind": "Method",
+          "name": "Warn",
+          "pure_single_return": false,
+          "start_line": 46,
+          "token_count": 24,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/gorm/logger/slog.go",
+          "start_line": 40
+        },
+        {
+          "end_line": 50,
+          "file": "bench/repos/gorm/logger/slog.go",
+          "start_line": 46
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/logger/slog.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "gorm:8478e206de15b28a",
+      "candidate_sha256": "cb90639932557afcb199f716b0bebd5a2cbe4cd9336c2ac4c7b631c16bdda739",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "8478e206de15b28a",
+      "feature_run": "1b484fea8bffd9f61763",
+      "inline_aug_mass": 6,
+      "intersection_mass": 6,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 37,
+          "file": "bench/repos/gorm/clause/insert.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 30,
+          "token_count": 26,
+          "value_size": 20
+        },
+        {
+          "end_line": 36,
+          "file": "bench/repos/gorm/clause/update.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 26,
+          "value_size": 20
+        }
+      ],
+      "members": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/gorm/clause/insert.go",
+          "start_line": 29
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/gorm/clause/update.go",
+          "start_line": 28
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/clause/insert.go",
+        "bench/repos/gorm/clause/update.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        20,
+        20
+      ]
+    },
+    {
+      "candidate_key": "gorm:85171013eba5ae62",
+      "candidate_sha256": "9968b486a51ccf4c49515b2bed50294b8941a2c61c94f642b800b87186759f64",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "85171013eba5ae62",
+      "feature_run": "2eea9086449901a1bd0d",
+      "intersection_mass": 17,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "kind": "Function",
+          "name": "TestFrom",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 173,
+          "value_size": 90
+        },
+        {
+          "end_line": 72,
+          "file": "bench/repos/gorm/clause/select_test.go",
+          "kind": "Function",
+          "name": "TestSelect",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 134,
+          "value_size": 85
+        }
+      ],
+      "members": [
+        {
+          "end_line": 22,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "start_line": 10
+        },
+        {
+          "end_line": 22,
+          "file": "bench/repos/gorm/clause/select_test.go",
+          "start_line": 10
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gorm",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gorm/clause/from_test.go",
+        "bench/repos/gorm/clause/select_test.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        90,
+        85
+      ]
+    },
+    {
+      "candidate_key": "gorm:9696bb6606c9a9ab",
+      "candidate_sha256": "88eb1b79919cb27cfc188983adc06e40fdb81cdf203f42237f3e0c5bd6d13f90",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9696bb6606c9a9ab",
+      "feature_run": "93505a19df1066c3cf43",
+      "intersection_mass": 9,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 128,
+          "file": "bench/repos/gorm/clause/where.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 122,
+          "token_count": 32,
+          "value_size": 24
+        },
+        {
+          "end_line": 149,
+          "file": "bench/repos/gorm/clause/where.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 143,
+          "token_count": 32,
+          "value_size": 24
+        }
+      ],
+      "members": [
+        {
+          "end_line": 129,
+          "file": "bench/repos/gorm/clause/where.go",
+          "start_line": 121
+        },
+        {
+          "end_line": 150,
+          "file": "bench/repos/gorm/clause/where.go",
+          "start_line": 142
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/clause/where.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        24,
+        24
+      ]
+    },
+    {
+      "candidate_key": "gorm:96d46442b02433a5",
+      "candidate_sha256": "0fdadd6599fa1fbd35d100e278c3bc42ac48ffec014512b65bbf73e525c3e221",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        13,
+        101
+      ],
+      "family_id": "96d46442b02433a5",
+      "feature_run": "656e5bc6976e29f01d47",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 101,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "kind": "Function",
+          "name": "TestJoin",
+          "pure_single_return": false,
+          "start_line": 13,
+          "token_count": 294,
+          "value_size": 86
+        },
+        {
+          "end_line": 101,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "kind": "Function",
+          "name": "TestJoin",
+          "pure_single_return": false,
+          "start_line": 13,
+          "token_count": 294,
+          "value_size": 86
+        }
+      ],
+      "members": [
+        {
+          "end_line": 82,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "start_line": 73
+        },
+        {
+          "end_line": 27,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "start_line": 20
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gorm",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gorm/clause/joins_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gorm:9aec931ab49f2c6e",
+      "candidate_sha256": "c90aa10f70f5c9f6ebb2521fb86a11b6b01df7f60bc806e4ea0c94527ebc6424",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        495,
+        630
+      ],
+      "family_id": "9aec931ab49f2c6e",
+      "feature_run": "676f616c9eb2015c8859",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 630,
+          "file": "bench/repos/gorm/tests/preload_test.go",
+          "kind": "Function",
+          "name": "TestEmbedPreload",
+          "pure_single_return": false,
+          "start_line": 495,
+          "token_count": 408,
+          "value_size": 151
+        },
+        {
+          "end_line": 630,
+          "file": "bench/repos/gorm/tests/preload_test.go",
+          "kind": "Function",
+          "name": "TestEmbedPreload",
+          "pure_single_return": false,
+          "start_line": 495,
+          "token_count": 408,
+          "value_size": 151
+        }
+      ],
+      "members": [
+        {
+          "end_line": 603,
+          "file": "bench/repos/gorm/tests/preload_test.go",
+          "start_line": 587
+        },
+        {
+          "end_line": 556,
+          "file": "bench/repos/gorm/tests/preload_test.go",
+          "start_line": 540
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gorm",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gorm/tests/preload_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gorm:a12cc73e717d5c78",
+      "candidate_sha256": "58cd262fe0b0783d69ce26d18920566995f740489f5b25d8e42c28b93225abe4",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "a12cc73e717d5c78",
+      "feature_run": "59bcd032acba7c4096e2",
+      "inline_aug_mass": 6,
+      "intersection_mass": 6,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 356,
+          "file": "bench/repos/gorm/migrator/migrator.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 352,
+          "token_count": 14,
+          "value_size": 6
+        },
+        {
+          "end_line": 367,
+          "file": "bench/repos/gorm/migrator/migrator.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 363,
+          "token_count": 14,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 357,
+          "file": "bench/repos/gorm/migrator/migrator.go",
+          "start_line": 348
+        },
+        {
+          "end_line": 368,
+          "file": "bench/repos/gorm/migrator/migrator.go",
+          "start_line": 359
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/migrator/migrator.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        6,
+        6
+      ]
+    },
+    {
+      "candidate_key": "gorm:b2cd9c61ce98289a",
+      "candidate_sha256": "89cbc2c55eac3f4c6c36d7bbf97711fe5602fd0b863de4b3190a4ee7991043c7",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        13,
+        101
+      ],
+      "family_id": "b2cd9c61ce98289a",
+      "feature_run": "656e5bc6976e29f01d47",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 101,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "kind": "Function",
+          "name": "TestJoin",
+          "pure_single_return": false,
+          "start_line": 13,
+          "token_count": 294,
+          "value_size": 86
+        },
+        {
+          "end_line": 101,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "kind": "Function",
+          "name": "TestJoin",
+          "pure_single_return": false,
+          "start_line": 13,
+          "token_count": 294,
+          "value_size": 86
+        }
+      ],
+      "members": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "start_line": 33
+        },
+        {
+          "end_line": 28,
+          "file": "bench/repos/gorm/clause/joins_test.go",
+          "start_line": 22
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gorm",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gorm/clause/joins_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gorm:b47a856846cdf8fc",
+      "candidate_sha256": "6bdba2333e7272624c8cd1e6723962b2cdddfd6a5db9ad57c325b2143454d992",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        10,
+        75
+      ],
+      "family_id": "b47a856846cdf8fc",
+      "feature_run": "8ff1315068d88c20a774",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "kind": "Function",
+          "name": "TestFrom",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 173,
+          "value_size": 90
+        },
+        {
+          "end_line": 75,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "kind": "Function",
+          "name": "TestFrom",
+          "pure_single_return": false,
+          "start_line": 10,
+          "token_count": 173,
+          "value_size": 90
+        }
+      ],
+      "members": [
+        {
+          "end_line": 43,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "start_line": 35
+        },
+        {
+          "end_line": 26,
+          "file": "bench/repos/gorm/clause/from_test.go",
+          "start_line": 18
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "gorm",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gorm/clause/from_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gorm:fdc399645a7b3dfd",
+      "candidate_sha256": "82230bea90c26a350f067dd27b69406ad327b1dfe9cd5adf6992eb29097ae06f",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "fdc399645a7b3dfd",
+      "feature_run": "93b231711ac31e228c69",
+      "intersection_mass": 19,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 174,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 170,
+          "token_count": 45,
+          "value_size": 28
+        },
+        {
+          "end_line": 182,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 178,
+          "token_count": 45,
+          "value_size": 27
+        }
+      ],
+      "members": [
+        {
+          "end_line": 174,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "start_line": 170
+        },
+        {
+          "end_line": 182,
+          "file": "bench/repos/gorm/logger/logger.go",
+          "start_line": 178
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gorm",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gorm/logger/logger.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        28,
+        27
+      ]
+    },
+    {
+      "candidate_key": "graphhopper:2acc71582f85cc79",
+      "candidate_sha256": "a4d67823c8ec861ddf2b850b5744598119502832a5bb8a9af5cac9f2c45f5a51",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "2acc71582f85cc79",
+      "feature_run": "b10b96346a6225aa38c7",
+      "intersection_mass": 23,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 112,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "kind": "Method",
+          "name": "testBFS2",
+          "pure_single_return": false,
+          "start_line": 82,
+          "token_count": 68,
+          "value_size": 41
+        },
+        {
+          "end_line": 80,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "kind": "Method",
+          "name": "testBFS",
+          "pure_single_return": false,
+          "start_line": 43,
+          "token_count": 111,
+          "value_size": 61
+        }
+      ],
+      "members": [
+        {
+          "end_line": 101,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "start_line": 83
+        },
+        {
+          "end_line": 62,
+          "file": "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java",
+          "start_line": 44
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "graphhopper",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        41,
+        61
+      ]
+    },
+    {
+      "candidate_key": "gson:259a137cfe6cf7fd",
+      "candidate_sha256": "2f15d3120984cd0b1fb97885fc480760d97dc8d11ddc161bc43dd9e732fb8046",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "259a137cfe6cf7fd",
+      "feature_run": "92f742a1c346bce85577",
+      "intersection_mass": 8,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 608,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "kind": "Method",
+          "name": "testNewBuilderModification",
+          "pure_single_return": false,
+          "start_line": 542,
+          "token_count": 127,
+          "value_size": 57
+        },
+        {
+          "end_line": 522,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "kind": "Method",
+          "name": "testDefaultGsonNewBuilderModification",
+          "pure_single_return": false,
+          "start_line": 487,
+          "token_count": 57,
+          "value_size": 29
+        }
+      ],
+      "members": [
+        {
+          "end_line": 582,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "start_line": 568
+        },
+        {
+          "end_line": 503,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "start_line": 489
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        57,
+        29
+      ]
+    },
+    {
+      "candidate_key": "gson:3f4ccba9d70e07f7",
+      "candidate_sha256": "b1ce1831ce91fc372f0727bf80cb99d35e5371e2ae2ec600c3a2f6126e3c7cc0",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "3f4ccba9d70e07f7",
+      "feature_run": "0543d70d91a72a8e0be5",
+      "intersection_mass": 8,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 181,
+          "file": "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java",
+          "kind": "Method",
+          "name": "testCustomAdapter",
+          "pure_single_return": false,
+          "start_line": 157,
+          "token_count": 39,
+          "value_size": 26
+        },
+        {
+          "end_line": 253,
+          "file": "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java",
+          "kind": "Method",
+          "name": "testCustomAdapter",
+          "pure_single_return": false,
+          "start_line": 229,
+          "token_count": 39,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 181,
+          "file": "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java",
+          "start_line": 157
+        },
+        {
+          "end_line": 253,
+          "file": "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java",
+          "start_line": 229
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java",
+        "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        26,
+        26
+      ]
+    },
+    {
+      "candidate_key": "gson:4014d594ab6a8e54",
+      "candidate_sha256": "4703ef0be15ca03e40b43336f7e8fefc53dd90edbf1a81d19ed170939c7047c3",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "4014d594ab6a8e54",
+      "feature_run": "4324b4cc350a20553898",
+      "intersection_mass": 22,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "kind": "Method",
+          "name": "wrap",
+          "pure_single_return": false,
+          "start_line": 63,
+          "token_count": 86,
+          "value_size": 45
+        },
+        {
+          "end_line": 99,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "kind": "Method",
+          "name": "unwrap",
+          "pure_single_return": false,
+          "start_line": 87,
+          "token_count": 86,
+          "value_size": 104
+        }
+      ],
+      "members": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "start_line": 63
+        },
+        {
+          "end_line": 99,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java",
+          "start_line": 87
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "gson",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        45,
+        104
+      ]
+    },
+    {
+      "candidate_key": "gson:579c5efb7564b4c6",
+      "candidate_sha256": "b108fc43ef8f64953f6db6f7b8ab6792f20028e43be9d790695875182a5d8494",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "579c5efb7564b4c6",
+      "feature_run": "167b96f8162a69ea05fe",
+      "intersection_mass": 13,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 639,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java",
+          "kind": "Method",
+          "name": "testDelegating_SameFactoryInstance_OnClassAndField",
+          "pure_single_return": false,
+          "start_line": 601,
+          "token_count": 52,
+          "value_size": 33
+        },
+        {
+          "end_line": 589,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java",
+          "kind": "Method",
+          "name": "testDelegating_SameFactoryClass_OnClassAndField",
+          "pure_single_return": false,
+          "start_line": 560,
+          "token_count": 42,
+          "value_size": 28
+        }
+      ],
+      "members": [
+        {
+          "end_line": 622,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java",
+          "start_line": 606
+        },
+        {
+          "end_line": 577,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java",
+          "start_line": 562
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        33,
+        28
+      ]
+    },
+    {
+      "candidate_key": "gson:68efa18d00d17764",
+      "candidate_sha256": "0a6205c27c0217b70691265c0cdf5d09dfccbcc26868b5d11f1c53d8701ebed3",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "68efa18d00d17764",
+      "feature_run": "b807b3b50355e5c14e75",
+      "inline_aug_mass": 19,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 114,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java",
+          "kind": "Class",
+          "name": "FieldNamingTest",
+          "pure_single_return": false,
+          "start_line": 33,
+          "token_count": 189,
+          "value_size": 118
+        }
+      },
+      "intersection_mass": 4,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 42,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java",
+          "kind": "Method",
+          "name": "testIdentity",
+          "pure_single_return": false,
+          "start_line": 34,
+          "token_count": 25,
+          "value_size": 19
+        },
+        {
+          "end_line": 52,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java",
+          "kind": "Method",
+          "name": "testUpperCamelCase",
+          "pure_single_return": false,
+          "start_line": 44,
+          "token_count": 25,
+          "value_size": 19
+        }
+      ],
+      "members": [
+        {
+          "end_line": 42,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java",
+          "start_line": 34
+        },
+        {
+          "end_line": 52,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java",
+          "start_line": 44
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        19,
+        19
+      ]
+    },
+    {
+      "candidate_key": "gson:9c7aefa30722a8cc",
+      "candidate_sha256": "e0b921da3781b44374761fb0187ded3c168f4607fef67f185bc12270bd916660",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9c7aefa30722a8cc",
+      "feature_run": "92f742a1c346bce85577",
+      "intersection_mass": 8,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 608,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "kind": "Method",
+          "name": "testNewBuilderModification",
+          "pure_single_return": false,
+          "start_line": 542,
+          "token_count": 127,
+          "value_size": 57
+        },
+        {
+          "end_line": 522,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "kind": "Method",
+          "name": "testDefaultGsonNewBuilderModification",
+          "pure_single_return": false,
+          "start_line": 487,
+          "token_count": 57,
+          "value_size": 29
+        }
+      ],
+      "members": [
+        {
+          "end_line": 559,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "start_line": 546
+        },
+        {
+          "end_line": 505,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java",
+          "start_line": 493
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        57,
+        29
+      ]
+    },
+    {
+      "candidate_key": "gson:c83b927017bfa33d",
+      "candidate_sha256": "188ba2421d1b7b7da361b325cff041e9b4e3d01ccd8fb6cb5aaf83f7420240a0",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "c83b927017bfa33d",
+      "feature_run": "a6879713e7b9c9d32f8e",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1290,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java",
+          "start_line": 1284
+        },
+        {
+          "end_line": 1306,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java",
+          "start_line": 1300
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "gson:eab1115974df3594",
+      "candidate_sha256": "50ba7432a9498d6fe63e2ed3d58a908b2f2e516e9ca1ed3ccf0b6ccdce1881d6",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "eab1115974df3594",
+      "feature_run": "6e1987d1b27e3eccf1f6",
+      "inline_aug_mass": 7,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 599,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 589,
+          "token_count": 10,
+          "value_size": 7
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 599,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 589,
+          "token_count": 10,
+          "value_size": 7
+        },
+        {
+          "end_line": 615,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 605,
+          "token_count": 10,
+          "value_size": 7
+        }
+      ],
+      "members": [
+        {
+          "end_line": 599,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java",
+          "start_line": 589
+        },
+        {
+          "end_line": 615,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java",
+          "start_line": 605
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gson",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        7,
+        7
+      ]
+    },
+    {
+      "candidate_key": "gson:f46d73b4e0ed55a9",
+      "candidate_sha256": "071dedfeb8cbc89eb44a3c57055c8a5af640e26689b4e9ef8306b5f952ccaeaa",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "f46d73b4e0ed55a9",
+      "feature_run": "d7e8db7be9e75806d8b9",
+      "intersection_mass": 17,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 586,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java",
+          "kind": "Method",
+          "name": "value",
+          "pure_single_return": false,
+          "start_line": 577,
+          "token_count": 40,
+          "value_size": 37
+        },
+        {
+          "end_line": 606,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java",
+          "kind": "Method",
+          "name": "value",
+          "pure_single_return": false,
+          "start_line": 597,
+          "token_count": 40,
+          "value_size": 36
+        }
+      ],
+      "members": [
+        {
+          "end_line": 586,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java",
+          "start_line": 577
+        },
+        {
+          "end_line": 606,
+          "file": "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java",
+          "start_line": 597
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "gson",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        37,
+        36
+      ]
+    },
+    {
+      "candidate_key": "gson:f7385770c6e8a429",
+      "candidate_sha256": "57a8fe1011e16c02e530406802d87586bcf3f2159a0477110a4a78702811c0e6",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "f7385770c6e8a429",
+      "feature_run": "64973265314a02c6583b",
+      "inline_aug_mass": 2,
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 368,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java",
+          "kind": "Method",
+          "name": "create",
+          "pure_single_return": true,
+          "start_line": 353,
+          "token_count": 6,
+          "value_size": 2
+        },
+        {
+          "end_line": 163,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java",
+          "kind": "Method",
+          "name": "create",
+          "pure_single_return": true,
+          "start_line": 148,
+          "token_count": 6,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 365,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java",
+          "start_line": 352
+        },
+        {
+          "end_line": 160,
+          "file": "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java",
+          "start_line": 147
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "gson",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "hyperfine:8d17730736a3b397",
+      "candidate_sha256": "d1153f9481499d2cb1e28d36ea4a81681f281f21e293a103105a107534e18efb",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        64,
+        123
+      ],
+      "family_id": "8d17730736a3b397",
+      "feature_run": "281aad53609cd00dda58",
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 123,
+          "file": "bench/repos/hyperfine/src/export/csv.rs",
+          "kind": "Function",
+          "name": "test_csv",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 150,
+          "value_size": 68
+        },
+        {
+          "end_line": 123,
+          "file": "bench/repos/hyperfine/src/export/csv.rs",
+          "kind": "Function",
+          "name": "test_csv",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 150,
+          "value_size": 68
+        }
+      ],
+      "members": [
+        {
+          "end_line": 105,
+          "file": "bench/repos/hyperfine/src/export/csv.rs",
+          "start_line": 99
+        },
+        {
+          "end_line": 85,
+          "file": "bench/repos/hyperfine/src/export/csv.rs",
+          "start_line": 79
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "hyperfine",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/hyperfine/src/export/csv.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "image:09688c2c17ddd091",
+      "candidate_sha256": "2f938edee451f0efe7d7e7abdc8db62abe9f9a8f401c83090babdc614afe9735",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "09688c2c17ddd091",
+      "feature_run": "93844c8428c8d71854a2",
+      "inline_aug_mass": 4,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 358,
+          "file": "bench/repos/image/src/codecs/jpeg/encoder.rs",
+          "kind": "Function",
+          "name": "roundtrip_sanity_check",
+          "pure_single_return": false,
+          "start_line": 335,
+          "token_count": 59,
+          "value_size": 4
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 385,
+          "file": "bench/repos/image/src/codecs/jpeg/encoder.rs",
+          "kind": "Function",
+          "name": "grayscale_roundtrip_sanity_check",
+          "pure_single_return": false,
+          "start_line": 361,
+          "token_count": 71,
+          "value_size": 4
+        },
+        {
+          "end_line": 358,
+          "file": "bench/repos/image/src/codecs/jpeg/encoder.rs",
+          "kind": "Function",
+          "name": "roundtrip_sanity_check",
+          "pure_single_return": false,
+          "start_line": 335,
+          "token_count": 59,
+          "value_size": 4
+        }
+      ],
+      "members": [
+        {
+          "end_line": 385,
+          "file": "bench/repos/image/src/codecs/jpeg/encoder.rs",
+          "start_line": 361
+        },
+        {
+          "end_line": 358,
+          "file": "bench/repos/image/src/codecs/jpeg/encoder.rs",
+          "start_line": 335
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "image",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/image/src/codecs/jpeg/encoder.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        4,
+        4
+      ]
+    },
+    {
+      "candidate_key": "image:37f494cca9a333c3",
+      "candidate_sha256": "d314a68ffcab3f5607e5439bf2c20364eb4c1d7f6d23c5a2eef6a3d04ff445e1",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "37f494cca9a333c3",
+      "feature_run": "d192ffea872de7e52589",
+      "intersection_mass": 10,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 181,
+          "file": "bench/repos/image/src/imageops/colorops.rs",
+          "kind": "Function",
+          "name": "brighten",
+          "pure_single_return": false,
+          "start_line": 156,
+          "token_count": 66,
+          "value_size": 16
+        },
+        {
+          "end_line": 116,
+          "file": "bench/repos/image/src/imageops/colorops.rs",
+          "kind": "Function",
+          "name": "contrast",
+          "pure_single_return": false,
+          "start_line": 90,
+          "token_count": 81,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 165,
+          "file": "bench/repos/image/src/imageops/colorops.rs",
+          "start_line": 156
+        },
+        {
+          "end_line": 99,
+          "file": "bench/repos/image/src/imageops/colorops.rs",
+          "start_line": 90
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "image",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/image/src/imageops/colorops.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        16,
+        15
+      ]
+    },
+    {
+      "candidate_key": "image:3bb7b58ae7adf7d9",
+      "candidate_sha256": "e46f5ef3dc20c1e3e213d9f263515a46d784e69f91aec18a4b33cd2f9eeed7a0",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "3bb7b58ae7adf7d9",
+      "feature_run": "47091dcff176e545471b",
+      "inline_aug_mass": 5,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 404,
+          "file": "bench/repos/image/src/traits.rs",
+          "kind": "Class",
+          "name": "HelpDispatchTransform",
+          "pure_single_return": true,
+          "start_line": 397,
+          "token_count": 10,
+          "value_size": 5
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 412,
+          "file": "bench/repos/image/src/traits.rs",
+          "kind": "Function",
+          "name": "transform_on",
+          "pure_single_return": true,
+          "start_line": 407,
+          "token_count": 9,
+          "value_size": 5
+        },
+        {
+          "end_line": 403,
+          "file": "bench/repos/image/src/traits.rs",
+          "kind": "Function",
+          "name": "transform_on",
+          "pure_single_return": true,
+          "start_line": 398,
+          "token_count": 9,
+          "value_size": 5
+        }
+      ],
+      "members": [
+        {
+          "end_line": 411,
+          "file": "bench/repos/image/src/traits.rs",
+          "start_line": 406
+        },
+        {
+          "end_line": 402,
+          "file": "bench/repos/image/src/traits.rs",
+          "start_line": 397
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "image",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/image/src/traits.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        5,
+        5
+      ]
+    },
+    {
+      "candidate_key": "image:4a8e4387c0a05967",
+      "candidate_sha256": "6fe72a667b1b8cf64a710456d5573a48eafe24ebc846cd03a42aa2be4e8a5b9e",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "4a8e4387c0a05967",
+      "feature_run": "00369a0d615be50b4ab2",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 29,
+          "file": "bench/repos/image/src/math/utils.rs",
+          "kind": "Function",
+          "name": "multiply_accumulate",
+          "pure_single_return": true,
+          "start_line": 21,
+          "token_count": 11,
+          "value_size": 6
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 47,
+          "file": "bench/repos/image/src/math/utils.rs",
+          "kind": "Function",
+          "name": "multiply_accumulate",
+          "pure_single_return": true,
+          "start_line": 39,
+          "token_count": 11,
+          "value_size": 6
+        },
+        {
+          "end_line": 29,
+          "file": "bench/repos/image/src/math/utils.rs",
+          "kind": "Function",
+          "name": "multiply_accumulate",
+          "pure_single_return": true,
+          "start_line": 21,
+          "token_count": 11,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 46,
+          "file": "bench/repos/image/src/math/utils.rs",
+          "start_line": 39
+        },
+        {
+          "end_line": 28,
+          "file": "bench/repos/image/src/math/utils.rs",
+          "start_line": 21
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "image",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/image/src/math/utils.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        6,
+        6
+      ]
+    },
+    {
+      "candidate_key": "image:98f7b2d07afc459a",
+      "candidate_sha256": "d6b293a5058880ce7f0bc6bce0ee3fb7bd0e3224fab8ac398aeb4718ba994fdd",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "98f7b2d07afc459a",
+      "feature_run": "01e939d46f7249857653",
+      "inline_aug_mass": 14,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 239,
+          "file": "bench/repos/image/src/codecs/pnm/header.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 236,
+          "token_count": 12,
+          "value_size": 14
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 239,
+          "file": "bench/repos/image/src/codecs/pnm/header.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 236,
+          "token_count": 12,
+          "value_size": 14
+        },
+        {
+          "end_line": 248,
+          "file": "bench/repos/image/src/codecs/pnm/header.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 245,
+          "token_count": 12,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 240,
+          "file": "bench/repos/image/src/codecs/pnm/header.rs",
+          "start_line": 235
+        },
+        {
+          "end_line": 249,
+          "file": "bench/repos/image/src/codecs/pnm/header.rs",
+          "start_line": 244
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "image",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/image/src/codecs/pnm/header.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        14,
+        14
+      ]
+    },
+    {
+      "candidate_key": "jackson-core:b422f94f09cdb8af",
+      "candidate_sha256": "f3cdbabc17f7aed0305891cf1efcd83a52ed1260012e580f2e7158bbf1d9e542",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "b422f94f09cdb8af",
+      "feature_run": "0ae76d6c5f24427ae4a5",
+      "intersection_mass": 10,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 83,
+          "file": "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java",
+          "kind": "Method",
+          "name": "_testIntArray",
+          "pure_single_return": false,
+          "start_line": 66,
+          "token_count": 87,
+          "value_size": 35
+        },
+        {
+          "end_line": 102,
+          "file": "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java",
+          "kind": "Method",
+          "name": "_testLongArray",
+          "pure_single_return": false,
+          "start_line": 85,
+          "token_count": 87,
+          "value_size": 35
+        }
+      ],
+      "members": [
+        {
+          "end_line": 83,
+          "file": "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java",
+          "start_line": 66
+        },
+        {
+          "end_line": 102,
+          "file": "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java",
+          "start_line": 85
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jackson-core",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        35,
+        35
+      ]
+    },
+    {
+      "candidate_key": "jedis:3bf2ce4ebf643e85",
+      "candidate_sha256": "505790d7960bc2825885859ae0d2093bee4685a192ca887fa85d9891a2d7cad1",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        18,
+        373
+      ],
+      "family_id": "3bf2ce4ebf643e85",
+      "feature_run": "3d98cfe57d37b578be7e",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 373,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java",
+          "kind": "Class",
+          "name": "HotkeysInfo",
+          "pure_single_return": false,
+          "start_line": 18,
+          "token_count": 449,
+          "value_size": 195
+        },
+        {
+          "end_line": 373,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java",
+          "kind": "Class",
+          "name": "HotkeysInfo",
+          "pure_single_return": false,
+          "start_line": 18,
+          "token_count": 449,
+          "value_size": 195
+        }
+      ],
+      "members": [
+        {
+          "end_line": 366,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java",
+          "start_line": 312
+        },
+        {
+          "end_line": 308,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java",
+          "start_line": 256
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jedis",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "jedis:571c8822cc8713ae",
+      "candidate_sha256": "21e1a8d47d3bbc4970b12fca63691e123a04b1d06343a0cfb143fef582c867b1",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        20,
+        185
+      ],
+      "family_id": "571c8822cc8713ae",
+      "feature_run": "50b2416cd8ec3a22e00f",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 185,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java",
+          "kind": "Class",
+          "name": "HybridResult",
+          "pure_single_return": false,
+          "start_line": 20,
+          "token_count": 191,
+          "value_size": 91
+        },
+        {
+          "end_line": 185,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java",
+          "kind": "Class",
+          "name": "HybridResult",
+          "pure_single_return": false,
+          "start_line": 20,
+          "token_count": 191,
+          "value_size": 91
+        }
+      ],
+      "members": [
+        {
+          "end_line": 184,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java",
+          "start_line": 159
+        },
+        {
+          "end_line": 150,
+          "file": "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java",
+          "start_line": 125
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jedis",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "jedis:b349246419347b4e",
+      "candidate_sha256": "e456ca0cd1d2fc523253016c7678f38e8aaaadcd4efca54fc73a5e8a91156a6e",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "b349246419347b4e",
+      "feature_run": "fc38e9846bc30cf8f138",
+      "inline_aug_mass": 2,
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 289,
+          "file": "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java",
+          "kind": "Method",
+          "name": "containsArguments",
+          "pure_single_return": true,
+          "start_line": 248,
+          "token_count": 5,
+          "value_size": 2
+        },
+        {
+          "end_line": 230,
+          "file": "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java",
+          "kind": "Method",
+          "name": "hasArguments",
+          "pure_single_return": true,
+          "start_line": 195,
+          "token_count": 5,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 291,
+          "file": "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java",
+          "start_line": 274
+        },
+        {
+          "end_line": 237,
+          "file": "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java",
+          "start_line": 216
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jedis",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "jekyll:1d13d09079bfb05e",
+      "candidate_sha256": "c88be8cf4242b31bef8b3b2c80d7fdc97c2f12820faebd781476e8502aa18ec0",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "1d13d09079bfb05e",
+      "feature_run": "1e69e4ae4ccf3b10c46a",
+      "intersection_mass": 9,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 269,
+          "file": "bench/repos/jekyll/lib/jekyll/document.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 261,
+          "token_count": 39,
+          "value_size": 27
+        },
+        {
+          "end_line": 160,
+          "file": "bench/repos/jekyll/lib/jekyll/page.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 155,
+          "token_count": 38,
+          "value_size": 25
+        }
+      ],
+      "members": [
+        {
+          "end_line": 270,
+          "file": "bench/repos/jekyll/lib/jekyll/document.rb",
+          "start_line": 259
+        },
+        {
+          "end_line": 161,
+          "file": "bench/repos/jekyll/lib/jekyll/page.rb",
+          "start_line": 153
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jekyll",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jekyll/lib/jekyll/document.rb",
+        "bench/repos/jekyll/lib/jekyll/page.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        27,
+        25
+      ]
+    },
+    {
+      "candidate_key": "jekyll:25f8eeacf08b1049",
+      "candidate_sha256": "451debc6020cbe6166fd2f82d6c4e83882a5e6617d00bc9f418c4732c0f88226",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "25f8eeacf08b1049",
+      "feature_run": "2a9db24de0201e0e9288",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 49,
+          "file": "bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash",
+          "start_line": 41
+        },
+        {
+          "end_line": 40,
+          "file": "bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash",
+          "start_line": 32
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jekyll",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "jekyll:2791928407ad302c",
+      "candidate_sha256": "83fed4df03ca9b53775245f533e6f4c4d841d5c20bac934c03948545976e4934",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "2791928407ad302c",
+      "feature_run": "82d069343e8374f542a7",
+      "inline_aug_mass": 13,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 149,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "kind": "Class",
+          "name": "RuboCop",
+          "pure_single_return": false,
+          "start_line": 4,
+          "token_count": 282,
+          "value_size": 162
+        }
+      },
+      "intersection_mass": 5,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 134,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "kind": "Method",
+          "name": "replace_hash_with_variable",
+          "pure_single_return": false,
+          "start_line": 124,
+          "token_count": 27,
+          "value_size": 13
+        },
+        {
+          "end_line": 146,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "kind": "Method",
+          "name": "replace_array_with_variable",
+          "pure_single_return": false,
+          "start_line": 136,
+          "token_count": 25,
+          "value_size": 12
+        }
+      ],
+      "members": [
+        {
+          "end_line": 134,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "start_line": 124
+        },
+        {
+          "end_line": 146,
+          "file": "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb",
+          "start_line": 136
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jekyll",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        13,
+        12
+      ]
+    },
+    {
+      "candidate_key": "jekyll:4acc42e4917235f2",
+      "candidate_sha256": "409db47e223da0dc0b545721f7a6652732af3d43980f30c6aa6b9b8be4d3bbc5",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        6,
+        30
+      ],
+      "family_id": "4acc42e4917235f2",
+      "feature_run": "6a0a5ebcbf5acea301c1",
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 30,
+          "file": "bench/repos/jekyll/test/test_win_tz.rb",
+          "kind": "Class",
+          "name": "TestWinTz",
+          "pure_single_return": false,
+          "start_line": 6,
+          "token_count": 135,
+          "value_size": 36
+        },
+        {
+          "end_line": 30,
+          "file": "bench/repos/jekyll/test/test_win_tz.rb",
+          "kind": "Class",
+          "name": "TestWinTz",
+          "pure_single_return": false,
+          "start_line": 6,
+          "token_count": 135,
+          "value_size": 36
+        }
+      ],
+      "members": [
+        {
+          "end_line": 11,
+          "file": "bench/repos/jekyll/test/test_win_tz.rb",
+          "start_line": 6
+        },
+        {
+          "end_line": 18,
+          "file": "bench/repos/jekyll/test/test_win_tz.rb",
+          "start_line": 13
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jekyll",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jekyll/test/test_win_tz.rb"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "jekyll:69d8954d1b741b57",
+      "candidate_sha256": "80818b8e8b860ec4b749d3bb3d0d566e952ce13e47bc5ea72e44afca58f981b8",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "69d8954d1b741b57",
+      "feature_run": "3d1be6c9b8b778c6c12b",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 655,
+          "file": "bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js",
+          "start_line": 650
+        },
+        {
+          "end_line": 661,
+          "file": "bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js",
+          "start_line": 656
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jekyll",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "jest:4c55eff3b52a86ff",
+      "candidate_sha256": "9679975d447841d1d453dac826bd359d78fd5adc300ee1d3ae6b19b29672f6cc",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "4c55eff3b52a86ff",
+      "feature_run": "16522c8bb081deab76d4",
+      "intersection_mass": 10,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 410,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "kind": "Method",
+          "name": "resolveModuleAsync",
+          "pure_single_return": false,
+          "start_line": 390,
+          "token_count": 40,
+          "value_size": 25
+        },
+        {
+          "end_line": 388,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "kind": "Method",
+          "name": "resolveModule",
+          "pure_single_return": false,
+          "start_line": 373,
+          "token_count": 37,
+          "value_size": 25
+        }
+      ],
+      "members": [
+        {
+          "end_line": 410,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "start_line": 390
+        },
+        {
+          "end_line": 388,
+          "file": "bench/repos/jest/packages/jest-resolve/src/resolver.ts",
+          "start_line": 373
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jest",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jest/packages/jest-resolve/src/resolver.ts"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        25
+      ]
+    },
+    {
+      "candidate_key": "jq:c0adad57af0c4d06",
+      "candidate_sha256": "1072745a4b89b9daa9e056d5c50764034ea9a080206ea407b514c8f60d843dd4",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c0adad57af0c4d06",
+      "feature_run": "158d32852b8548b45c40",
+      "inline_aug_mass": 18,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 151,
+          "file": "bench/repos/jq/src/compile.c",
+          "kind": "Function",
+          "name": "gen_error",
+          "pure_single_return": false,
+          "start_line": 146,
+          "token_count": 29,
+          "value_size": 18
+        }
+      },
+      "intersection_mass": 5,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 151,
+          "file": "bench/repos/jq/src/compile.c",
+          "kind": "Function",
+          "name": "gen_error",
+          "pure_single_return": false,
+          "start_line": 146,
+          "token_count": 29,
+          "value_size": 18
+        },
+        {
+          "end_line": 158,
+          "file": "bench/repos/jq/src/compile.c",
+          "kind": "Function",
+          "name": "gen_const",
+          "pure_single_return": false,
+          "start_line": 153,
+          "token_count": 29,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 151,
+          "file": "bench/repos/jq/src/compile.c",
+          "start_line": 146
+        },
+        {
+          "end_line": 158,
+          "file": "bench/repos/jq/src/compile.c",
+          "start_line": 153
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jq",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jq/src/compile.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        18,
+        18
+      ]
+    },
+    {
+      "candidate_key": "jsoup:07409b462c710a0a",
+      "candidate_sha256": "e88e3f42b31bc590e4ee742862b028a3a639ed396b702a40a7314df47721939a",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "medium",
+      "family_id": "07409b462c710a0a",
+      "feature_run": "4a185da9475e8b16fa9c",
+      "inline_aug_mass": 20,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 414,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java",
+          "kind": "Method",
+          "name": "size",
+          "pure_single_return": false,
+          "start_line": 407,
+          "token_count": 40,
+          "value_size": 20
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 109,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 106,
+          "token_count": 23,
+          "value_size": 5
+        },
+        {
+          "end_line": 414,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java",
+          "kind": "Method",
+          "name": "size",
+          "pure_single_return": false,
+          "start_line": 407,
+          "token_count": 40,
+          "value_size": 20
+        }
+      ],
+      "members": [
+        {
+          "end_line": 111,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java",
+          "start_line": 104
+        },
+        {
+          "end_line": 414,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java",
+          "start_line": 407
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jsoup",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        5,
+        20
+      ]
+    },
+    {
+      "candidate_key": "jsoup:08ee491c1f4a7330",
+      "candidate_sha256": "82993e90b733cf98203a157b006b44bb2b5b7ebaf71df25ca236a36a8adccb9e",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "08ee491c1f4a7330",
+      "feature_run": "9b3f5aa2b8eb454f7d63",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1518,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java",
+          "start_line": 1502
+        },
+        {
+          "end_line": 1536,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java",
+          "start_line": 1520
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jsoup",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "jsoup:345ea47c67ac01ec",
+      "candidate_sha256": "952ece967150ea040199975b4e151d05e7a263ce7d58ca33658089e8718314b3",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "345ea47c67ac01ec",
+      "feature_run": "ea28272bcf894d89317b",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 38,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java",
+          "start_line": 32
+        },
+        {
+          "end_line": 46,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java",
+          "start_line": 40
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jsoup",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "jsoup:9b909cd145cab0a1",
+      "candidate_sha256": "377e054c785942118f4aacc82132de41625248bae1c8c87db45e505bebdb182c",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9b909cd145cab0a1",
+      "feature_run": "652dbc432184a0634647",
+      "intersection_mass": 23,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 472,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java",
+          "kind": "Method",
+          "name": "consumeToAny",
+          "pure_single_return": false,
+          "start_line": 458,
+          "token_count": 54,
+          "value_size": 29
+        },
+        {
+          "end_line": 453,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java",
+          "kind": "Method",
+          "name": "consumeToAny",
+          "pure_single_return": false,
+          "start_line": 438,
+          "token_count": 49,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 467,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java",
+          "start_line": 458
+        },
+        {
+          "end_line": 448,
+          "file": "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java",
+          "start_line": 438
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jsoup",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        29,
+        26
+      ]
+    },
+    {
+      "candidate_key": "jsoup:d7ddae2efb5f4a8e",
+      "candidate_sha256": "33d2bd0fe0fe934878573a9a87fabc1278d9e85bb27b606c28f3353baa9eb432",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "d7ddae2efb5f4a8e",
+      "feature_run": "9b3f5aa2b8eb454f7d63",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1999,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java",
+          "start_line": 1984
+        },
+        {
+          "end_line": 2016,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java",
+          "start_line": 2001
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "jsoup",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "jsoup:de79fc0d2c8c8d34",
+      "candidate_sha256": "58344357302044e882bbd8fd476a20c8bdf7619ba0140267fee8ca5290c5ab7c",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "de79fc0d2c8c8d34",
+      "feature_run": "72c3aeccc28ac8074dfd",
+      "language": "Java",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1177,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java",
+          "start_line": 1168
+        },
+        {
+          "end_line": 1188,
+          "file": "bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java",
+          "start_line": 1179
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "jsoup",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "ky:0525b9fef00e8153",
+      "candidate_sha256": "6a279fad7e9d76212ad3e2800c049e99fe4cae87628713b56e784688d6b3cbb9",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "0525b9fef00e8153",
+      "feature_run": "9e82f29edac625f02224",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 108,
+          "file": "bench/repos/ky/test/retry.ts",
+          "start_line": 100
+        },
+        {
+          "end_line": 351,
+          "file": "bench/repos/ky/test/retry.ts",
+          "start_line": 343
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "ky",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/ky/test/retry.ts"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "ky:65e620dd95442e39",
+      "candidate_sha256": "6f511d91bf66b2b9af8fe9c3eefb5b489a8c163ebb949389b5cdfd6812944b23",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "65e620dd95442e39",
+      "feature_run": "0438ebb7ac4712fdf5f6",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 793,
+          "file": "bench/repos/ky/test/stream.ts",
+          "start_line": 775
+        },
+        {
+          "end_line": 718,
+          "file": "bench/repos/ky/test/stream.ts",
+          "start_line": 700
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ky",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/ky/test/stream.ts"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "libgdx:69cf536b3ec81f25",
+      "candidate_sha256": "0ae7b23eb90e3dca4aa3242370174d5687a6d903f83b493d1dfa99a512161019",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "69cf536b3ec81f25",
+      "feature_run": "74334ccc304a16d34295",
+      "intersection_mass": 29,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 127,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java",
+          "kind": "Class",
+          "name": "ETC1TextureData",
+          "pure_single_return": false,
+          "start_line": 28,
+          "token_count": 247,
+          "value_size": 116
+        },
+        {
+          "end_line": 115,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java",
+          "kind": "Class",
+          "name": "GLOnlyTextureData",
+          "pure_single_return": false,
+          "start_line": 28,
+          "token_count": 122,
+          "value_size": 50
+        }
+      ],
+      "members": [
+        {
+          "end_line": 115,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java",
+          "start_line": 90
+        },
+        {
+          "end_line": 103,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java",
+          "start_line": 78
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "libgdx",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java",
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        116,
+        50
+      ]
+    },
+    {
+      "candidate_key": "libgdx:8a6145e03a2ef0cb",
+      "candidate_sha256": "3a86f41de3897165dbd1974436a382b01d3e921d5bb35217f302e72b786c3f75",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "8a6145e03a2ef0cb",
+      "feature_run": "58ca68af19f53af130da",
+      "intersection_mass": 39,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 142,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java",
+          "kind": "Class",
+          "name": "FloatTextureData",
+          "pure_single_return": false,
+          "start_line": 32,
+          "token_count": 294,
+          "value_size": 144
+        },
+        {
+          "end_line": 115,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java",
+          "kind": "Class",
+          "name": "GLOnlyTextureData",
+          "pure_single_return": false,
+          "start_line": 28,
+          "token_count": 122,
+          "value_size": 50
+        }
+      ],
+      "members": [
+        {
+          "end_line": 136,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java",
+          "start_line": 102
+        },
+        {
+          "end_line": 113,
+          "file": "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java",
+          "start_line": 79
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "libgdx",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java",
+        "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        144,
+        50
+      ]
+    },
+    {
+      "candidate_key": "libuv:274a5f3b06e8f568",
+      "candidate_sha256": "d95982bc933cbde1ba4943f82a8a7c2672fd0bb1228e1dfb4a35ff0bec65469f",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "274a5f3b06e8f568",
+      "feature_run": "3addce1524893be73182",
+      "intersection_mass": 10,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 1216,
+          "file": "bench/repos/libuv/src/unix/udp.c",
+          "kind": "Function",
+          "name": "uv_udp_set_multicast_ttl",
+          "pure_single_return": false,
+          "start_line": 1194,
+          "token_count": 25,
+          "value_size": 18
+        },
+        {
+          "end_line": 1241,
+          "file": "bench/repos/libuv/src/unix/udp.c",
+          "kind": "Function",
+          "name": "uv_udp_set_multicast_loop",
+          "pure_single_return": false,
+          "start_line": 1219,
+          "token_count": 25,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 1216,
+          "file": "bench/repos/libuv/src/unix/udp.c",
+          "start_line": 1194
+        },
+        {
+          "end_line": 1241,
+          "file": "bench/repos/libuv/src/unix/udp.c",
+          "start_line": 1219
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "libuv",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/libuv/src/unix/udp.c"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        18
+      ]
+    },
+    {
+      "candidate_key": "libuv:286758993f6dd08b",
+      "candidate_sha256": "ae9c095fc94957b84f527e13b309bd1882a88db09b931c271b207851a232bb3f",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "286758993f6dd08b",
+      "feature_run": "a125be0d4f7522b0a2e5",
+      "language": "C",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 427,
+          "file": "bench/repos/libuv/test/test-fs.c",
+          "start_line": 418
+        },
+        {
+          "end_line": 493,
+          "file": "bench/repos/libuv/test/test-fs.c",
+          "start_line": 484
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "libuv",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/libuv/test/test-fs.c"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "libuv:3c29652abe2b1be6",
+      "candidate_sha256": "feff20b4c9a4c630e86481cef20fc083f406ca16f21b937c1240a8dbc53e9e2e",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "3c29652abe2b1be6",
+      "feature_run": "a125be0d4f7522b0a2e5",
+      "language": "C",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 947,
+          "file": "bench/repos/libuv/test/test-fs.c",
+          "start_line": 935
+        },
+        {
+          "end_line": 962,
+          "file": "bench/repos/libuv/test/test-fs.c",
+          "start_line": 950
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "libuv",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/libuv/test/test-fs.c"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "libuv:b7eb674546159318",
+      "candidate_sha256": "9bd830b336a2f3d02704db6ad556f46bc16e0bbaba17b7db2c111ee569bf18db",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "b7eb674546159318",
+      "feature_run": "ea6fc403b5914267ec6b",
+      "intersection_mass": 12,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 2268,
+          "file": "bench/repos/libuv/src/win/fs.c",
+          "kind": "Function",
+          "name": "fs__stat_impl",
+          "pure_single_return": false,
+          "start_line": 2248,
+          "token_count": 58,
+          "value_size": 39
+        },
+        {
+          "end_line": 2737,
+          "file": "bench/repos/libuv/src/win/fs.c",
+          "kind": "Function",
+          "name": "fs__utime_impl",
+          "pure_single_return": false,
+          "start_line": 2714,
+          "token_count": 59,
+          "value_size": 38
+        }
+      ],
+      "members": [
+        {
+          "end_line": 2264,
+          "file": "bench/repos/libuv/src/win/fs.c",
+          "start_line": 2252
+        },
+        {
+          "end_line": 2734,
+          "file": "bench/repos/libuv/src/win/fs.c",
+          "start_line": 2722
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "libuv",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/libuv/src/win/fs.c"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        39,
+        38
+      ]
+    },
+    {
+      "candidate_key": "libuv:d43581c5e3bc852f",
+      "candidate_sha256": "d5a73785a8e77aa8b2890393966fb714905faac01c9766bcf2408b144d2ea06d",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "d43581c5e3bc852f",
+      "feature_run": "b489127c3697e3a6075f",
+      "intersection_mass": 15,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 242,
+          "file": "bench/repos/libuv/test/runner.c",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 219,
+          "token_count": 57,
+          "value_size": 38
+        },
+        {
+          "end_line": 216,
+          "file": "bench/repos/libuv/test/runner.c",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 194,
+          "token_count": 52,
+          "value_size": 35
+        }
+      ],
+      "members": [
+        {
+          "end_line": 242,
+          "file": "bench/repos/libuv/test/runner.c",
+          "start_line": 219
+        },
+        {
+          "end_line": 216,
+          "file": "bench/repos/libuv/test/runner.c",
+          "start_line": 194
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "libuv",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/libuv/test/runner.c"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        38,
+        35
+      ]
+    },
+    {
+      "candidate_key": "libuv:ec23cb5ea6d0737e",
+      "candidate_sha256": "417c6c000a5f02f7d72967151da19ccb67cf96b12bb3f40d9a45afdde9aed990",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "ec23cb5ea6d0737e",
+      "feature_run": "48bac71af49f3e7cf0ee",
+      "intersection_mass": 9,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 1990,
+          "file": "bench/repos/libuv/src/unix/fs.c",
+          "kind": "Function",
+          "name": "uv_fs_mkdir",
+          "pure_single_return": false,
+          "start_line": 1978,
+          "token_count": 31,
+          "value_size": 26
+        },
+        {
+          "end_line": 1975,
+          "file": "bench/repos/libuv/src/unix/fs.c",
+          "kind": "Function",
+          "name": "uv_fs_link",
+          "pure_single_return": false,
+          "start_line": 1964,
+          "token_count": 27,
+          "value_size": 22
+        }
+      ],
+      "members": [
+        {
+          "end_line": 1990,
+          "file": "bench/repos/libuv/src/unix/fs.c",
+          "start_line": 1978
+        },
+        {
+          "end_line": 1975,
+          "file": "bench/repos/libuv/src/unix/fs.c",
+          "start_line": 1964
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "libuv",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/libuv/src/unix/fs.c"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        26,
+        22
+      ]
+    },
+    {
+      "candidate_key": "libuv:fac251925ef52c9a",
+      "candidate_sha256": "c2d4b27e8b36d89ccb68e4561c9362077799c84c4a04827d52176d353c02f760",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "fac251925ef52c9a",
+      "feature_run": "9fd9c0d1dcef00e775d3",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 56,
+          "file": "bench/repos/libuv/test/test-fs-readdir.c",
+          "kind": "Function",
+          "name": "empty_closedir_cb",
+          "pure_single_return": false,
+          "start_line": 50,
+          "token_count": 28,
+          "value_size": 17
+        },
+        null
+      ],
+      "members": [
+        {
+          "end_line": 56,
+          "file": "bench/repos/libuv/test/test-fs-readdir.c",
+          "start_line": 50
+        },
+        {
+          "end_line": 358,
+          "file": "bench/repos/libuv/test/test-fs.c",
+          "start_line": 352
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "libuv",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/libuv/test/test-fs-readdir.c",
+        "bench/repos/libuv/test/test-fs.c"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "liquid:2881fc0a22a0b8a4",
+      "candidate_sha256": "824fb1566ee2fe158b256e06b2cfc8e9ade5b257afd7a01c5c311788ed9d9721",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        220,
+        236
+      ],
+      "family_id": "2881fc0a22a0b8a4",
+      "feature_run": "95715abcba13fb58a9ec",
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 236,
+          "file": "bench/repos/liquid/test/integration/drop_test.rb",
+          "kind": "Method",
+          "name": "test_some_enumerable_methods_still_get_invoked",
+          "pure_single_return": false,
+          "start_line": 220,
+          "token_count": 187,
+          "value_size": 29
+        },
+        {
+          "end_line": 236,
+          "file": "bench/repos/liquid/test/integration/drop_test.rb",
+          "kind": "Method",
+          "name": "test_some_enumerable_methods_still_get_invoked",
+          "pure_single_return": false,
+          "start_line": 220,
+          "token_count": 187,
+          "value_size": 29
+        }
+      ],
+      "members": [
+        {
+          "end_line": 226,
+          "file": "bench/repos/liquid/test/integration/drop_test.rb",
+          "start_line": 221
+        },
+        {
+          "end_line": 235,
+          "file": "bench/repos/liquid/test/integration/drop_test.rb",
+          "start_line": 230
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "liquid",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/liquid/test/integration/drop_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "liquid:3c25695d8bcdaf05",
+      "candidate_sha256": "acf716dca88b2478905ee3ae3aec3c2fabc50496ed531ac0da3d7bf28bdd3a0d",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "3c25695d8bcdaf05",
+      "feature_run": "c45f5895e395a488aba6",
+      "inline_aug_mass": 17,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 31,
+          "file": "bench/repos/liquid/lib/liquid/resource_limits.rb",
+          "kind": "Method",
+          "name": "increment_render_score",
+          "pure_single_return": false,
+          "start_line": 26,
+          "token_count": 31,
+          "value_size": 17
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 31,
+          "file": "bench/repos/liquid/lib/liquid/resource_limits.rb",
+          "kind": "Method",
+          "name": "increment_render_score",
+          "pure_single_return": false,
+          "start_line": 26,
+          "token_count": 31,
+          "value_size": 17
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/liquid/lib/liquid/resource_limits.rb",
+          "kind": "Method",
+          "name": "increment_assign_score",
+          "pure_single_return": false,
+          "start_line": 33,
+          "token_count": 31,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 31,
+          "file": "bench/repos/liquid/lib/liquid/resource_limits.rb",
+          "start_line": 26
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/liquid/lib/liquid/resource_limits.rb",
+          "start_line": 33
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "liquid",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/liquid/lib/liquid/resource_limits.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "liquid:4f4b572db8008f60",
+      "candidate_sha256": "775a4d1e959a88ef1cb677c958e11c4a859f1718427cb4fe3e83a8a23a114b59",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "4f4b572db8008f60",
+      "feature_run": "49d5c1e32c3b1379eb7d",
+      "intersection_mass": 14,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 63,
+          "file": "bench/repos/liquid/lib/liquid/parser_switching.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 59,
+          "token_count": 21,
+          "value_size": 17
+        },
+        {
+          "end_line": 71,
+          "file": "bench/repos/liquid/lib/liquid/parser_switching.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 67,
+          "token_count": 21,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 64,
+          "file": "bench/repos/liquid/lib/liquid/parser_switching.rb",
+          "start_line": 58
+        },
+        {
+          "end_line": 72,
+          "file": "bench/repos/liquid/lib/liquid/parser_switching.rb",
+          "start_line": 66
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "liquid",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/liquid/lib/liquid/parser_switching.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "liquid:53ac6cd76866936b",
+      "candidate_sha256": "657b47e691c3b68accea4212fa8c170d64635efd278f30dec5a1ceb39205529e",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "53ac6cd76866936b",
+      "feature_run": "c70e29b42ab324f65503",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 525,
+          "file": "bench/repos/liquid/test/integration/standard_filter_test.rb",
+          "start_line": 521
+        },
+        {
+          "end_line": 1292,
+          "file": "bench/repos/liquid/test/integration/standard_filter_test.rb",
+          "start_line": 1288
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "liquid",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/liquid/test/integration/standard_filter_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "liquid:887ab1f0cab75a90",
+      "candidate_sha256": "49e8ae9fb27ca96bdf8e2d1fe6bd5074ead38c113f03c13a2160d6c71df581c7",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "887ab1f0cab75a90",
+      "feature_run": "c70e29b42ab324f65503",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 809,
+          "file": "bench/repos/liquid/test/integration/standard_filter_test.rb",
+          "start_line": 801
+        },
+        {
+          "end_line": 819,
+          "file": "bench/repos/liquid/test/integration/standard_filter_test.rb",
+          "start_line": 811
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "liquid",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/liquid/test/integration/standard_filter_test.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "liquid:a5b873bd1d650af4",
+      "candidate_sha256": "7c303625a6f44e4075c75373eb6c212ca119c6ad02fd595aaedc238d6e9aeae4",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "a5b873bd1d650af4",
+      "feature_run": "840c5785a562882442de",
+      "intersection_mass": 12,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 177,
+          "file": "bench/repos/liquid/lib/liquid/standardfilters.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 174,
+          "token_count": 26,
+          "value_size": 19
+        },
+        {
+          "end_line": 202,
+          "file": "bench/repos/liquid/lib/liquid/standardfilters.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 199,
+          "token_count": 26,
+          "value_size": 19
+        }
+      ],
+      "members": [
+        {
+          "end_line": 178,
+          "file": "bench/repos/liquid/lib/liquid/standardfilters.rb",
+          "start_line": 173
+        },
+        {
+          "end_line": 203,
+          "file": "bench/repos/liquid/lib/liquid/standardfilters.rb",
+          "start_line": 198
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "liquid",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/liquid/lib/liquid/standardfilters.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        19,
+        19
+      ]
+    },
+    {
+      "candidate_key": "liquid:d64d80cdbea35c4d",
+      "candidate_sha256": "b8c03535f1cab8c05584096be0d2c9317007d5262109fb0d688e57d19fc40dcd",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "d64d80cdbea35c4d",
+      "feature_run": "55f51d4f1c58a60d28b6",
+      "intersection_mass": 10,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 203,
+          "file": "bench/repos/liquid/test/integration/context_test.rb",
+          "kind": "Method",
+          "name": "test_add_item_in_outer_scope",
+          "pure_single_return": false,
+          "start_line": 197,
+          "token_count": 29,
+          "value_size": 15
+        },
+        {
+          "end_line": 211,
+          "file": "bench/repos/liquid/test/integration/context_test.rb",
+          "kind": "Method",
+          "name": "test_add_item_in_inner_scope",
+          "pure_single_return": false,
+          "start_line": 205,
+          "token_count": 28,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 203,
+          "file": "bench/repos/liquid/test/integration/context_test.rb",
+          "start_line": 197
+        },
+        {
+          "end_line": 211,
+          "file": "bench/repos/liquid/test/integration/context_test.rb",
+          "start_line": 205
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "liquid",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/liquid/test/integration/context_test.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        15,
+        17
+      ]
+    },
+    {
+      "candidate_key": "liquid:ec0ea765982b749e",
+      "candidate_sha256": "8243042eda1718497e04dca1af95857ceaee27e0481f7d2d36b86feb030b0c7b",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "ec0ea765982b749e",
+      "feature_run": "9050213e424a65811e3a",
+      "inline_aug_mass": 4,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 58,
+          "file": "bench/repos/liquid/test/integration/tag/disableable_test.rb",
+          "kind": "Class",
+          "name": "TagDisableableTest",
+          "pure_single_return": false,
+          "start_line": 6,
+          "token_count": 114,
+          "value_size": 36
+        }
+      },
+      "intersection_mass": 1,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/liquid/test/integration/tag/disableable_test.rb",
+          "kind": "Method",
+          "name": "test_block_tag_disabling_nested_tag",
+          "pure_single_return": true,
+          "start_line": 32,
+          "token_count": 27,
+          "value_size": 4
+        },
+        {
+          "end_line": 48,
+          "file": "bench/repos/liquid/test/integration/tag/disableable_test.rb",
+          "kind": "Method",
+          "name": "test_block_tag_disabling_multiple_nested_tags",
+          "pure_single_return": true,
+          "start_line": 41,
+          "token_count": 27,
+          "value_size": 4
+        }
+      ],
+      "members": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/liquid/test/integration/tag/disableable_test.rb",
+          "start_line": 32
+        },
+        {
+          "end_line": 48,
+          "file": "bench/repos/liquid/test/integration/tag/disableable_test.rb",
+          "start_line": 41
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "liquid",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/liquid/test/integration/tag/disableable_test.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        4,
+        4
+      ]
+    },
+    {
+      "candidate_key": "lua:6b8e0cef12881b68",
+      "candidate_sha256": "950159e99f06cd51d02cdf8966db074d302a29c869b61a3d8f10d8d4a84b0c6d",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "6b8e0cef12881b68",
+      "feature_run": "d8f96a7aeec47ad26d7c",
+      "intersection_mass": 10,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 436,
+          "file": "bench/repos/lua/lvm.c",
+          "kind": "Function",
+          "name": "LTintfloat",
+          "pure_single_return": false,
+          "start_line": 426,
+          "token_count": 33,
+          "value_size": 20
+        },
+        {
+          "end_line": 453,
+          "file": "bench/repos/lua/lvm.c",
+          "kind": "Function",
+          "name": "LEintfloat",
+          "pure_single_return": false,
+          "start_line": 443,
+          "token_count": 33,
+          "value_size": 20
+        }
+      ],
+      "members": [
+        {
+          "end_line": 436,
+          "file": "bench/repos/lua/lvm.c",
+          "start_line": 426
+        },
+        {
+          "end_line": 453,
+          "file": "bench/repos/lua/lvm.c",
+          "start_line": 443
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "lua",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/lua/lvm.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        20,
+        20
+      ]
+    },
+    {
+      "candidate_key": "lua:bc0ae7caf5d8bfbb",
+      "candidate_sha256": "decfb45ed5046c4d00b07165ac575a9e5a07521c9533b12c8f4ef2867bf1795d",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "bc0ae7caf5d8bfbb",
+      "feature_run": "d8f96a7aeec47ad26d7c",
+      "intersection_mass": 9,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 553,
+          "file": "bench/repos/lua/lvm.c",
+          "kind": "Function",
+          "name": "luaV_lessthan",
+          "pure_single_return": false,
+          "start_line": 549,
+          "token_count": 25,
+          "value_size": 17
+        },
+        {
+          "end_line": 575,
+          "file": "bench/repos/lua/lvm.c",
+          "kind": "Function",
+          "name": "luaV_lessequal",
+          "pure_single_return": false,
+          "start_line": 571,
+          "token_count": 25,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 553,
+          "file": "bench/repos/lua/lvm.c",
+          "start_line": 549
+        },
+        {
+          "end_line": 575,
+          "file": "bench/repos/lua/lvm.c",
+          "start_line": 571
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "lua",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/lua/lvm.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "marshmallow:0f369456ae71dedc",
+      "candidate_sha256": "74acf6e4400f931a3d60244ed04c9080cca648d6db1518793c627fbe81e79a39",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "0f369456ae71dedc",
+      "feature_run": "84fb6e8591995beb7858",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1282,
+          "file": "bench/repos/marshmallow/tests/test_schema.py",
+          "start_line": 1271
+        },
+        {
+          "end_line": 1297,
+          "file": "bench/repos/marshmallow/tests/test_schema.py",
+          "start_line": 1286
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "marshmallow",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/marshmallow/tests/test_schema.py"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "marshmallow:581d4caf7dc8178d",
+      "candidate_sha256": "d113fcec3fd765e2ff5ebf47e69fe6582052c3fc5d25001edc33953b6b875741",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "581d4caf7dc8178d",
+      "feature_run": "84fb6e8591995beb7858",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 238,
+          "file": "bench/repos/marshmallow/tests/test_schema.py",
+          "start_line": 231
+        },
+        {
+          "end_line": 250,
+          "file": "bench/repos/marshmallow/tests/test_schema.py",
+          "start_line": 243
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "marshmallow",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/marshmallow/tests/test_schema.py"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "marshmallow:a8af960bf3a26e25",
+      "candidate_sha256": "a7a07126539da0342f6a436af451a25a3c913221bbfb3c423f5221afb5096f55",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "a8af960bf3a26e25",
+      "feature_run": "af55ea8cbfaf4ac8fdb9",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1430,
+          "file": "bench/repos/marshmallow/tests/test_deserialization.py",
+          "start_line": 1424
+        },
+        {
+          "end_line": 1447,
+          "file": "bench/repos/marshmallow/tests/test_deserialization.py",
+          "start_line": 1441
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "marshmallow",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/marshmallow/tests/test_deserialization.py"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "marshmallow:d3f1f8804b32ca0a",
+      "candidate_sha256": "6ae0c7022fe19aa5c04e8e77defb828a39e365c8b37f322babbb06b1c6aee2d5",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "d3f1f8804b32ca0a",
+      "feature_run": "91b30592408a36de9a47",
+      "inline_aug_mass": 48,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 985,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsnoneof_in_list",
+          "pure_single_return": false,
+          "start_line": 967,
+          "token_count": 137,
+          "value_size": 48
+        }
+      },
+      "intersection_mass": 6,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 985,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsnoneof_in_list",
+          "pure_single_return": false,
+          "start_line": 967,
+          "token_count": 137,
+          "value_size": 48
+        },
+        {
+          "end_line": 1031,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsnoneof_in_tuple",
+          "pure_single_return": false,
+          "start_line": 1013,
+          "token_count": 137,
+          "value_size": 48
+        }
+      ],
+      "members": [
+        {
+          "end_line": 985,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "start_line": 967
+        },
+        {
+          "end_line": 1031,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "start_line": 1013
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "marshmallow",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/marshmallow/tests/test_validate.py"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        48,
+        48
+      ]
+    },
+    {
+      "candidate_key": "marshmallow:d5c9512eec776de0",
+      "candidate_sha256": "0401347fb6f86631219d3ab7358e30e5915e80c37f3b86ae72bdeca22536d2e4",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "d5c9512eec776de0",
+      "feature_run": "91b30592408a36de9a47",
+      "inline_aug_mass": 54,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 862,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsonly_in_list",
+          "pure_single_return": false,
+          "start_line": 844,
+          "token_count": 178,
+          "value_size": 54
+        }
+      },
+      "intersection_mass": 6,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 862,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsonly_in_list",
+          "pure_single_return": false,
+          "start_line": 844,
+          "token_count": 178,
+          "value_size": 54
+        },
+        {
+          "end_line": 894,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "kind": "Function",
+          "name": "test_containsonly_in_tuple",
+          "pure_single_return": false,
+          "start_line": 881,
+          "token_count": 159,
+          "value_size": 52
+        }
+      ],
+      "members": [
+        {
+          "end_line": 862,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "start_line": 844
+        },
+        {
+          "end_line": 894,
+          "file": "bench/repos/marshmallow/tests/test_validate.py",
+          "start_line": 881
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "marshmallow",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/marshmallow/tests/test_validate.py"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        54,
+        52
+      ]
+    },
+    {
+      "candidate_key": "minio:0162a4e5135745e2",
+      "candidate_sha256": "7254b4e77c2c88f28e4aeefda03aaa44490f0cd4501e3d35ae31dbeeb27c5950",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        94,
+        255
+      ],
+      "family_id": "0162a4e5135745e2",
+      "feature_run": "7d48090b5db26515c38b",
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 255,
+          "file": "bench/repos/minio/internal/config/notify/parse.go",
+          "kind": "Function",
+          "name": "fetchSubSysTargets",
+          "pure_single_return": false,
+          "start_line": 94,
+          "token_count": 668,
+          "value_size": 497
+        },
+        {
+          "end_line": 255,
+          "file": "bench/repos/minio/internal/config/notify/parse.go",
+          "kind": "Function",
+          "name": "fetchSubSysTargets",
+          "pure_single_return": false,
+          "start_line": 94,
+          "token_count": 668,
+          "value_size": 497
+        }
+      ],
+      "members": [
+        {
+          "end_line": 114,
+          "file": "bench/repos/minio/internal/config/notify/parse.go",
+          "start_line": 105
+        },
+        {
+          "end_line": 129,
+          "file": "bench/repos/minio/internal/config/notify/parse.go",
+          "start_line": 120
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/config/notify/parse.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "minio:36c5d902a5772df3",
+      "candidate_sha256": "9435a96a8ae79a428033f6563a9d1f19c9859015d8b92f8a5ef59c5389dd4b45",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "36c5d902a5772df3",
+      "feature_run": "d8828d60f95eadba6587",
+      "intersection_mass": 36,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 192,
+          "file": "bench/repos/minio/cmd/erasure-metadata-utils.go",
+          "kind": "Function",
+          "name": "hashOrder",
+          "pure_single_return": false,
+          "start_line": 178,
+          "token_count": 62,
+          "value_size": 36
+        },
+        {
+          "end_line": 68,
+          "file": "bench/repos/minio/docs/debugging/hash-set/main.go",
+          "kind": "Function",
+          "name": "hashOrder",
+          "pure_single_return": false,
+          "start_line": 54,
+          "token_count": 62,
+          "value_size": 36
+        }
+      ],
+      "members": [
+        {
+          "end_line": 196,
+          "file": "bench/repos/minio/cmd/erasure-metadata-utils.go",
+          "start_line": 171
+        },
+        {
+          "end_line": 70,
+          "file": "bench/repos/minio/docs/debugging/hash-set/main.go",
+          "start_line": 47
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/cmd/erasure-metadata-utils.go",
+        "bench/repos/minio/docs/debugging/hash-set/main.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        36,
+        36
+      ]
+    },
+    {
+      "candidate_key": "minio:43ad0a38b290c564",
+      "candidate_sha256": "63aee96973d675239a9d44a87ec4bd43b4c5967f45aed22042fc8ef4b43dcc92",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "43ad0a38b290c564",
+      "feature_run": "73f6f56015eadf307750",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 148,
+          "file": "bench/repos/minio/internal/logger/help.go",
+          "start_line": 108
+        },
+        {
+          "end_line": 69,
+          "file": "bench/repos/minio/internal/logger/help.go",
+          "start_line": 29
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/logger/help.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "minio:6df98f4de0a00d6b",
+      "candidate_sha256": "eec0803e33659b7a538f87886dc3b192ea55b1c234c7a1472858d3d95a83cf20",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "6df98f4de0a00d6b",
+      "feature_run": "57477ef717688315dc81",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 221,
+          "file": "bench/repos/minio/internal/logger/config.go",
+          "start_line": 192
+        },
+        {
+          "end_line": 174,
+          "file": "bench/repos/minio/internal/logger/config.go",
+          "start_line": 145
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/logger/config.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "minio:76a7d6e4cc5527df",
+      "candidate_sha256": "05cd5ed7ac9938319cd5dd0831c93d455cfa8014062c44d411a17c2f61e611bd",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "76a7d6e4cc5527df",
+      "feature_run": "73f6f56015eadf307750",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 178,
+          "file": "bench/repos/minio/internal/logger/help.go",
+          "start_line": 154
+        },
+        {
+          "end_line": 105,
+          "file": "bench/repos/minio/internal/logger/help.go",
+          "start_line": 81
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/logger/help.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "minio:e02ba445f3a8f384",
+      "candidate_sha256": "8b265c346eb369a593bcfa1b4e5febd787ed6159cee6e4de495086f9360aff01",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "e02ba445f3a8f384",
+      "feature_run": "57477ef717688315dc81",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 196,
+          "file": "bench/repos/minio/internal/logger/config.go",
+          "start_line": 174
+        },
+        {
+          "end_line": 145,
+          "file": "bench/repos/minio/internal/logger/config.go",
+          "start_line": 123
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/logger/config.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "minio:e48d842d53a01d1e",
+      "candidate_sha256": "239301ed16f804fcd3db3dac8c4c4e47c6e0afd13700099e44485acf0238b1ae",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "e48d842d53a01d1e",
+      "feature_run": "89c13001160da9ac2306",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 63,
+          "file": "bench/repos/minio/internal/config/lambda/help.go",
+          "start_line": 40
+        },
+        {
+          "end_line": 82,
+          "file": "bench/repos/minio/internal/config/notify/help.go",
+          "start_line": 58
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "minio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/minio/internal/config/lambda/help.go",
+        "bench/repos/minio/internal/config/notify/help.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "mockito:1fa8be0a8e1c9121",
+      "candidate_sha256": "42d4422c9de45752d7ce62357ae5abf40c5bbb9779aa9d53b91330d2d481cf6b",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "1fa8be0a8e1c9121",
+      "feature_run": "a628e51310606e901aa9",
+      "intersection_mass": 16,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 204,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java",
+          "kind": "Method",
+          "name": "transformer_suppresses_class_matched_by_package_predicate",
+          "pure_single_return": false,
+          "start_line": 187,
+          "token_count": 63,
+          "value_size": 27
+        },
+        {
+          "end_line": 185,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java",
+          "kind": "Method",
+          "name": "transformer_suppresses_matching_class_on_initial_load",
+          "pure_single_return": false,
+          "start_line": 169,
+          "token_count": 45,
+          "value_size": 27
+        }
+      ],
+      "members": [
+        {
+          "end_line": 206,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java",
+          "start_line": 190
+        },
+        {
+          "end_line": 187,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java",
+          "start_line": 171
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "mockito",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        27,
+        27
+      ]
+    },
+    {
+      "candidate_key": "mockito:290e05f149bee68c",
+      "candidate_sha256": "65dcd34289de25e2464c1b799f5af0e2b458efc7caf470f72d647ac74e66d3a7",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "290e05f149bee68c",
+      "feature_run": "87bec6b27a18ffd8a3bb",
+      "inline_aug_mass": 71,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 230,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Method",
+          "name": "toAnswer",
+          "pure_single_return": true,
+          "start_line": 216,
+          "token_count": 13,
+          "value_size": 2
+        },
+        {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      ],
+      "members": [
+        {
+          "end_line": 226,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 217
+        },
+        {
+          "end_line": 175,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 119
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        71
+      ]
+    },
+    {
+      "candidate_key": "mockito:46e9a5d46cce9beb",
+      "candidate_sha256": "aa540a5c54e74cb05bf995ce9bd1039f078ecdae91bfa95f85b5ce3af42ce089",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "46e9a5d46cce9beb",
+      "feature_run": "87bec6b27a18ffd8a3bb",
+      "inline_aug_mass": 71,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 257,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Method",
+          "name": "toAnswer",
+          "pure_single_return": true,
+          "start_line": 242,
+          "token_count": 13,
+          "value_size": 2
+        },
+        {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      ],
+      "members": [
+        {
+          "end_line": 252,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 243
+        },
+        {
+          "end_line": 199,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 141
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        71
+      ]
+    },
+    {
+      "candidate_key": "mockito:5b64ce572e3c94e1",
+      "candidate_sha256": "202520aae20a7550476016cb53241adde944990c93ecec5ae94f3bcea1b7d1a3",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "5b64ce572e3c94e1",
+      "feature_run": "24e9205a3dfa567cb672",
+      "inline_aug_mass": 0,
+      "intersection_mass": 0,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 764,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "kind": "Method",
+          "name": "exit",
+          "pure_single_return": false,
+          "start_line": 755,
+          "token_count": 14,
+          "value_size": 0
+        },
+        {
+          "end_line": 125,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "kind": "Method",
+          "name": "exit",
+          "pure_single_return": false,
+          "start_line": 116,
+          "token_count": 14,
+          "value_size": 0
+        }
+      ],
+      "members": [
+        {
+          "end_line": 765,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "start_line": 751
+        },
+        {
+          "end_line": 127,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "start_line": 112
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        0,
+        0
+      ]
+    },
+    {
+      "candidate_key": "mockito:706f73f0e5fd1978",
+      "candidate_sha256": "41ef2d25be10a843f49a15a4485fcd5e59f97dca1255710f59cf35846df4bc46",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        435,
+        659
+      ],
+      "family_id": "706f73f0e5fd1978",
+      "feature_run": "24e9205a3dfa567cb672",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 659,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 435,
+          "token_count": 13,
+          "value_size": 10
+        },
+        {
+          "end_line": 659,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 435,
+          "token_count": 13,
+          "value_size": 10
+        }
+      ],
+      "members": [
+        {
+          "end_line": 529,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "start_line": 512
+        },
+        {
+          "end_line": 477,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java",
+          "start_line": 460
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "mockito:79be91c925ed1869",
+      "candidate_sha256": "23befe06dd4fe660db7d8dd01bede971bc7888540b78923a2f431e2a776ebc2a",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "79be91c925ed1869",
+      "feature_run": "b3d260441dbb3bb35bf8",
+      "intersection_mass": 16,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 82,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java",
+          "kind": "Method",
+          "name": "should_get_results_for_methods",
+          "pure_single_return": false,
+          "start_line": 64,
+          "token_count": 54,
+          "value_size": 33
+        },
+        {
+          "end_line": 102,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java",
+          "kind": "Method",
+          "name": "should_get_results_for_methods_stub_only",
+          "pure_single_return": false,
+          "start_line": 84,
+          "token_count": 54,
+          "value_size": 33
+        }
+      ],
+      "members": [
+        {
+          "end_line": 82,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java",
+          "start_line": 64
+        },
+        {
+          "end_line": 102,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java",
+          "start_line": 84
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "mockito",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        33,
+        33
+      ]
+    },
+    {
+      "candidate_key": "mockito:baf4c3da359dfc3d",
+      "candidate_sha256": "574b2fa645f4bf9f76e7772cf5960575f0be8b9292645f70d852f77eb2f4c92e",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "baf4c3da359dfc3d",
+      "feature_run": "87bec6b27a18ffd8a3bb",
+      "inline_aug_mass": 71,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 319,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Method",
+          "name": "toAnswer",
+          "pure_single_return": true,
+          "start_line": 302,
+          "token_count": 13,
+          "value_size": 2
+        },
+        {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      ],
+      "members": [
+        {
+          "end_line": 314,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 304
+        },
+        {
+          "end_line": 253,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 141
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        71
+      ]
+    },
+    {
+      "candidate_key": "mockito:d82f6e75097748da",
+      "candidate_sha256": "ffce9aa676545670fa722b6aac6c466679b9ecab9a930776e524c8bf20752790",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "d82f6e75097748da",
+      "feature_run": "fa4e807a35e997e30b83",
+      "intersection_mass": 20,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 60,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "kind": "Method",
+          "name": "should_call_listener_when_mock_return_normally_with_stubbed_answer",
+          "pure_single_return": false,
+          "start_line": 32,
+          "token_count": 36,
+          "value_size": 30
+        },
+        {
+          "end_line": 89,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "kind": "Method",
+          "name": "should_call_listener_when_mock_return_normally_with_default_answer",
+          "pure_single_return": false,
+          "start_line": 62,
+          "token_count": 26,
+          "value_size": 23
+        }
+      ],
+      "members": [
+        {
+          "end_line": 60,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "start_line": 32
+        },
+        {
+          "end_line": 89,
+          "file": "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java",
+          "start_line": 62
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "mockito",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        30,
+        23
+      ]
+    },
+    {
+      "candidate_key": "mockito:db2a627e3c414165",
+      "candidate_sha256": "6f54e260b213a96cf5cb6661fe9c6aad46bdc484cbbd587c818993e953b2de41",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "db2a627e3c414165",
+      "feature_run": "87bec6b27a18ffd8a3bb",
+      "inline_aug_mass": 71,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 288,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Method",
+          "name": "toAnswer",
+          "pure_single_return": true,
+          "start_line": 272,
+          "token_count": 13,
+          "value_size": 2
+        },
+        {
+          "end_line": 353,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "kind": "Class",
+          "name": "AnswerFunctionalInterfaces",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 257,
+          "value_size": 71
+        }
+      ],
+      "members": [
+        {
+          "end_line": 284,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 274
+        },
+        {
+          "end_line": 227,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java",
+          "start_line": 119
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        71
+      ]
+    },
+    {
+      "candidate_key": "mockito:e1ce9eafd54a610f",
+      "candidate_sha256": "18111f9faebf51418c2efa15ba273df9ad2740f7d28da304008b01603cff9e59",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "e1ce9eafd54a610f",
+      "feature_run": "24ec04a617e47091fe50",
+      "inline_aug_mass": 6,
+      "intersection_mass": 6,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 28,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java",
+          "kind": "Class",
+          "name": "Contains",
+          "pure_single_return": false,
+          "start_line": 11,
+          "token_count": 31,
+          "value_size": 19
+        },
+        {
+          "end_line": 28,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java",
+          "kind": "Class",
+          "name": "EndsWith",
+          "pure_single_return": false,
+          "start_line": 11,
+          "token_count": 30,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 28,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java",
+          "start_line": 11
+        },
+        {
+          "end_line": 28,
+          "file": "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java",
+          "start_line": 11
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "mockito",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java",
+        "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        19,
+        15
+      ]
+    },
+    {
+      "candidate_key": "nats-server:5771783a43038bcb",
+      "candidate_sha256": "3f662100dce06ae51bf10c2426532fad29ab5ef12487e11f3f62103a5eb90dcd",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "5771783a43038bcb",
+      "feature_run": "6a47c8eab9f9297a4233",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 256,
+          "file": "bench/repos/nats-server/server/monitor_test.go",
+          "start_line": 241
+        },
+        {
+          "end_line": 380,
+          "file": "bench/repos/nats-server/server/monitor_test.go",
+          "start_line": 365
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nats-server",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/nats-server/server/monitor_test.go"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "netty:43870dd59c2be294",
+      "candidate_sha256": "65ef1dc1ed9449357fca6df1c46a572f991299108fc348b4371e919d7db2657f",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "medium",
+      "enclosing_unit_lines": [
+        136,
+        281
+      ],
+      "family_id": "43870dd59c2be294",
+      "feature_run": "a55524cbd63654e1f618",
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 281,
+          "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java",
+          "kind": "Method",
+          "name": "testInEventLoopAfterReschedulingFailure",
+          "pure_single_return": false,
+          "start_line": 136,
+          "token_count": 77,
+          "value_size": 36
+        },
+        {
+          "end_line": 281,
+          "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java",
+          "kind": "Method",
+          "name": "testInEventLoopAfterReschedulingFailure",
+          "pure_single_return": false,
+          "start_line": 136,
+          "token_count": 77,
+          "value_size": 36
+        }
+      ],
+      "members": [
+        {
+          "end_line": 242,
+          "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java",
+          "start_line": 207
+        },
+        {
+          "end_line": 200,
+          "file": "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java",
+          "start_line": 166
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "netty",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "nushell:46fd2ef00c8d9e98",
+      "candidate_sha256": "8127cff718c923f4c4a5a709effe980dbd9460858e14a41666d9f6fb320f262d",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "46fd2ef00c8d9e98",
+      "feature_run": "027c6c9b8c071393994d",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 321,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 307
+        },
+        {
+          "end_line": 257,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 243
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "nushell:5e0a811d5b711a35",
+      "candidate_sha256": "c1cd3e5b51fbfae434975172db05f5fe9f87fd50abefd39d3a9e5bcea23cdba5",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "5e0a811d5b711a35",
+      "feature_run": "027c6c9b8c071393994d",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 151,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 138
+        },
+        {
+          "end_line": 101,
+          "file": "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs",
+          "start_line": 88
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "nushell:5ed48a642e38d987",
+      "candidate_sha256": "0889bf08b1cf9dc62e6e61524cc405ed7876f62fde25754cdc4885c4d66ddf20",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "5ed48a642e38d987",
+      "feature_run": "1c126a35ca8a29398605",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 18,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs",
+          "start_line": 1
+        },
+        {
+          "end_line": 18,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs",
+          "start_line": 1
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "nushell:88118551cbcdb7f3",
+      "candidate_sha256": "7c46cb62826396e29ad10cad83e02209fcda151c92f0fd42cc7f08e03d5c0f52",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "88118551cbcdb7f3",
+      "feature_run": "2d597f18c47bfaaa7f4b",
+      "intersection_mass": 11,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 212,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs",
+          "kind": "Function",
+          "name": "command_lazy",
+          "pure_single_return": true,
+          "start_line": 192,
+          "token_count": 73,
+          "value_size": 32
+        },
+        {
+          "end_line": 261,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs",
+          "kind": "Function",
+          "name": "command_lazy",
+          "pure_single_return": true,
+          "start_line": 233,
+          "token_count": 90,
+          "value_size": 35
+        }
+      ],
+      "members": [
+        {
+          "end_line": 221,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs",
+          "start_line": 209
+        },
+        {
+          "end_line": 354,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs",
+          "start_line": 259
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        32,
+        35
+      ]
+    },
+    {
+      "candidate_key": "nushell:b950a3c8f074b925",
+      "candidate_sha256": "7671f790119886fc9204cc53c05e2f851fd683acd3f2df8b9911465f487aeaa8",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "b950a3c8f074b925",
+      "feature_run": "7b585d2275b35af8419b",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 13,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs",
+          "start_line": 1
+        },
+        {
+          "end_line": 13,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs",
+          "start_line": 1
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "nushell:c6f90bd8a5eb11d7",
+      "candidate_sha256": "7ee961d084bbb96fa3f01886ec71dc0d340dd50649d5523071a8e42291190f74",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "c6f90bd8a5eb11d7",
+      "feature_run": "2d855f50038477dfa6a5",
+      "intersection_mass": 10,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 150,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs",
+          "kind": "Function",
+          "name": "command",
+          "pure_single_return": true,
+          "start_line": 136,
+          "token_count": 31,
+          "value_size": 20
+        },
+        {
+          "end_line": 199,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs",
+          "kind": "Function",
+          "name": "command",
+          "pure_single_return": true,
+          "start_line": 187,
+          "token_count": 29,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 159,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs",
+          "start_line": 146
+        },
+        {
+          "end_line": 354,
+          "file": "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs",
+          "start_line": 196
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "nushell",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs",
+        "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        20,
+        18
+      ]
+    },
+    {
+      "candidate_key": "packaging:227533476889cd6e",
+      "candidate_sha256": "6595d48f121cb7492b8cd7382b9c5e8060c4028ccccf75059f8e44660ec22dfd",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "227533476889cd6e",
+      "feature_run": "bdfcb85da8b7fae87346",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1187,
+          "file": "bench/repos/packaging/tests/test_tags.py",
+          "start_line": 1180
+        },
+        {
+          "end_line": 1178,
+          "file": "bench/repos/packaging/tests/test_tags.py",
+          "start_line": 1173
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "packaging",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/packaging/tests/test_tags.py"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "packaging:9c308f351b219364",
+      "candidate_sha256": "1e0a0f5c4d7f7fec156b0f37adc2afd85121ea3a80ace737084c498202adfd33",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "9c308f351b219364",
+      "feature_run": "bdfcb85da8b7fae87346",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1963,
+          "file": "bench/repos/packaging/tests/test_tags.py",
+          "start_line": 1956
+        },
+        {
+          "end_line": 1973,
+          "file": "bench/repos/packaging/tests/test_tags.py",
+          "start_line": 1966
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "packaging",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/packaging/tests/test_tags.py"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "packaging:aea1981ddc32dcf4",
+      "candidate_sha256": "47c95e3d4deac0f49167dd6cfcc855c1112af180394060c15aff79c19e4a5037",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "aea1981ddc32dcf4",
+      "feature_run": "3c7f294c220792716b52",
+      "inline_aug_mass": 13,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 78,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "kind": "Function",
+          "name": "test_is_normalized_name",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 18,
+          "value_size": 13
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 78,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "kind": "Function",
+          "name": "test_is_normalized_name",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 18,
+          "value_size": 13
+        },
+        {
+          "end_line": 39,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "kind": "Function",
+          "name": "test_canonicalize_name",
+          "pure_single_return": false,
+          "start_line": 38,
+          "token_count": 10,
+          "value_size": 8
+        }
+      ],
+      "members": [
+        {
+          "end_line": 75,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "start_line": 60
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/packaging/tests/test_utils.py",
+          "start_line": 23
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "packaging",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/packaging/tests/test_utils.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        13,
+        8
+      ]
+    },
+    {
+      "candidate_key": "packaging:dff2a8be57aadc2d",
+      "candidate_sha256": "af3f9f0d1d642dafb77f7a4dea8475185fb564bdfb79775d2c97feca93992a7f",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "dff2a8be57aadc2d",
+      "feature_run": "50322461d5dab7594bd6",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 147,
+          "file": "bench/repos/packaging/tests/test_requirements.py",
+          "kind": "Function",
+          "name": "test_basic_valid_requirement_parsing",
+          "pure_single_return": false,
+          "start_line": 111,
+          "token_count": 143,
+          "value_size": 90
+        }
+      },
+      "intersection_mass": 5,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 584,
+          "file": "bench/repos/packaging/tests/test_markers.py",
+          "kind": "Function",
+          "name": "test_pickle_marker_roundtrip",
+          "pure_single_return": false,
+          "start_line": 579,
+          "token_count": 29,
+          "value_size": 15
+        },
+        {
+          "end_line": 729,
+          "file": "bench/repos/packaging/tests/test_requirements.py",
+          "kind": "Function",
+          "name": "test_pickle_requirement_roundtrip",
+          "pure_single_return": false,
+          "start_line": 724,
+          "token_count": 29,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 584,
+          "file": "bench/repos/packaging/tests/test_markers.py",
+          "start_line": 579
+        },
+        {
+          "end_line": 729,
+          "file": "bench/repos/packaging/tests/test_requirements.py",
+          "start_line": 724
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "packaging",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/packaging/tests/test_markers.py",
+        "bench/repos/packaging/tests/test_requirements.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        15,
+        15
+      ]
+    },
+    {
+      "candidate_key": "poetry:053a58bae5b5c441",
+      "candidate_sha256": "9e6f3d7b7cb1dd263a5146e3a3df310dc43024b44997023d6b8ee0f016abf688",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "053a58bae5b5c441",
+      "feature_run": "e9a8d3eecafdbcc4bf02",
+      "intersection_mass": 28,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 164,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "kind": "Function",
+          "name": "test_get_http_auth_with_unavailable_backend",
+          "pure_single_return": false,
+          "start_line": 144,
+          "token_count": 69,
+          "value_size": 45
+        },
+        {
+          "end_line": 70,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "kind": "Function",
+          "name": "test_get_http_auth",
+          "pure_single_return": false,
+          "start_line": 49,
+          "token_count": 73,
+          "value_size": 46
+        }
+      ],
+      "members": [
+        {
+          "end_line": 144,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "start_line": 135
+        },
+        {
+          "end_line": 49,
+          "file": "bench/repos/poetry/tests/utils/test_password_manager.py",
+          "start_line": 40
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "poetry",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/poetry/tests/utils/test_password_manager.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        45,
+        46
+      ]
+    },
+    {
+      "candidate_key": "poetry:08556e25e7ab80e4",
+      "candidate_sha256": "e2363e766aa4eec9fde3402b25b7638df17c4112fe28ed78fb42a4d4638f7d2e",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "08556e25e7ab80e4",
+      "feature_run": "dd9b12da28b16e7c6c46",
+      "intersection_mass": 23,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 125,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "kind": "Function",
+          "name": "test_prepare_directory_editable",
+          "pure_single_return": false,
+          "start_line": 105,
+          "token_count": 59,
+          "value_size": 41
+        },
+        {
+          "end_line": 80,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "kind": "Function",
+          "name": "test_prepare_directory",
+          "pure_single_return": false,
+          "start_line": 63,
+          "token_count": 51,
+          "value_size": 33
+        }
+      ],
+      "members": [
+        {
+          "end_line": 116,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "start_line": 105
+        },
+        {
+          "end_line": 74,
+          "file": "bench/repos/poetry/tests/installation/test_chef.py",
+          "start_line": 63
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "poetry",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/poetry/tests/installation/test_chef.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        41,
+        33
+      ]
+    },
+    {
+      "candidate_key": "poetry:e672109edfa67a72",
+      "candidate_sha256": "fe906c17c89e3f1855619d8e1fe56c7d5fdbd7428042f1117b8df46327b33686",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "e672109edfa67a72",
+      "feature_run": "3e751d49a52c657be621",
+      "intersection_mass": 13,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 72,
+          "file": "bench/repos/poetry/tests/utils/test_cache.py",
+          "kind": "Function",
+          "name": "test_cache_forget",
+          "pure_single_return": false,
+          "start_line": 61,
+          "token_count": 48,
+          "value_size": 25
+        },
+        {
+          "end_line": 86,
+          "file": "bench/repos/poetry/tests/utils/test_cache.py",
+          "kind": "Function",
+          "name": "test_cache_flush",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 48,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 72,
+          "file": "bench/repos/poetry/tests/utils/test_cache.py",
+          "start_line": 61
+        },
+        {
+          "end_line": 86,
+          "file": "bench/repos/poetry/tests/utils/test_cache.py",
+          "start_line": 75
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "poetry",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/poetry/tests/utils/test_cache.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        26
+      ]
+    },
+    {
+      "candidate_key": "pry:7a29d98ac73e8688",
+      "candidate_sha256": "7fc5e89a28d51c96d23d1f1442c85e590a364fd50a95bc086ab36745cb81e4ae",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "7a29d98ac73e8688",
+      "feature_run": "e0f606364bf8a0741cc7",
+      "intersection_mass": 13,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 379,
+          "file": "bench/repos/pry/lib/pry/wrapped_module.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 375,
+          "token_count": 20,
+          "value_size": 18
+        },
+        {
+          "end_line": 212,
+          "file": "bench/repos/pry/lib/pry/method/weird_method_locator.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 208,
+          "token_count": 17,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 380,
+          "file": "bench/repos/pry/lib/pry/wrapped_module.rb",
+          "start_line": 371
+        },
+        {
+          "end_line": 213,
+          "file": "bench/repos/pry/lib/pry/method/weird_method_locator.rb",
+          "start_line": 206
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "pry",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/pry/lib/pry/method/weird_method_locator.rb",
+        "bench/repos/pry/lib/pry/wrapped_module.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        18,
+        15
+      ]
+    },
+    {
+      "candidate_key": "pry:b464a888b12af0f1",
+      "candidate_sha256": "5839c1f353eac00dbed7fb15f0bb1a1141e5352fa72054fcdbc197b173783a76",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "b464a888b12af0f1",
+      "feature_run": "eece54d6a3537293ff2f",
+      "inline_aug_mass": 11,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 139,
+          "file": "bench/repos/pry/lib/pry/method.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 137,
+          "token_count": 14,
+          "value_size": 11
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 139,
+          "file": "bench/repos/pry/lib/pry/method.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 137,
+          "token_count": 14,
+          "value_size": 11
+        },
+        {
+          "end_line": 154,
+          "file": "bench/repos/pry/lib/pry/method.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 152,
+          "token_count": 14,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 140,
+          "file": "bench/repos/pry/lib/pry/method.rb",
+          "start_line": 136
+        },
+        {
+          "end_line": 155,
+          "file": "bench/repos/pry/lib/pry/method.rb",
+          "start_line": 151
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "pry",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/pry/lib/pry/method.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "puma:0f39af5b364b1ffe",
+      "candidate_sha256": "84c16c367d184eeacdf694e0ea25cb6e61d54a7ce5e64fea53dd59cb44d07850",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "0f39af5b364b1ffe",
+      "feature_run": "51cc2384f0438ce357c5",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 68,
+          "file": "bench/repos/puma/test/test_puma_server.rb",
+          "start_line": 61
+        },
+        {
+          "end_line": 77,
+          "file": "bench/repos/puma/test/test_puma_server.rb",
+          "start_line": 70
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "puma",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/puma/test/test_puma_server.rb"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "puma:12acda2dd82390db",
+      "candidate_sha256": "6b558398a4a3714373800f56bbc5451fd0ecfc3469eb82b47a5fbd136484dd54",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "12acda2dd82390db",
+      "feature_run": "b15db51a731ec5b18533",
+      "intersection_mass": 17,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 338,
+          "file": "bench/repos/puma/test/test_rack_handler.rb",
+          "kind": "Method",
+          "name": "test_user_log_requests_wins_over_file_config",
+          "pure_single_return": false,
+          "start_line": 326,
+          "token_count": 37,
+          "value_size": 25
+        },
+        {
+          "end_line": 324,
+          "file": "bench/repos/puma/test/test_rack_handler.rb",
+          "kind": "Method",
+          "name": "test_file_log_requests_wins_over_default_config",
+          "pure_single_return": false,
+          "start_line": 313,
+          "token_count": 29,
+          "value_size": 22
+        }
+      ],
+      "members": [
+        {
+          "end_line": 338,
+          "file": "bench/repos/puma/test/test_rack_handler.rb",
+          "start_line": 326
+        },
+        {
+          "end_line": 324,
+          "file": "bench/repos/puma/test/test_rack_handler.rb",
+          "start_line": 313
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "puma",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/puma/test/test_rack_handler.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        22
+      ]
+    },
+    {
+      "candidate_key": "puma:16cbddbb2c42524c",
+      "candidate_sha256": "442fb3879cb41aae160e1de9564041cb03a10eced6e2af76be5fc3b25ffd9214",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "16cbddbb2c42524c",
+      "feature_run": "2fe40b7e62c8fa39535a",
+      "inline_aug_mass": 17,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 271,
+          "file": "bench/repos/puma/lib/puma/thread_pool.rb",
+          "kind": "Method",
+          "name": "trigger_before_thread_start_hooks",
+          "pure_single_return": false,
+          "start_line": 260,
+          "token_count": 46,
+          "value_size": 17
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 271,
+          "file": "bench/repos/puma/lib/puma/thread_pool.rb",
+          "kind": "Method",
+          "name": "trigger_before_thread_start_hooks",
+          "pure_single_return": false,
+          "start_line": 260,
+          "token_count": 46,
+          "value_size": 17
+        },
+        {
+          "end_line": 286,
+          "file": "bench/repos/puma/lib/puma/thread_pool.rb",
+          "kind": "Method",
+          "name": "trigger_before_thread_exit_hooks",
+          "pure_single_return": false,
+          "start_line": 275,
+          "token_count": 42,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 271,
+          "file": "bench/repos/puma/lib/puma/thread_pool.rb",
+          "start_line": 260
+        },
+        {
+          "end_line": 286,
+          "file": "bench/repos/puma/lib/puma/thread_pool.rb",
+          "start_line": 275
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "puma",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/puma/lib/puma/thread_pool.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "puma:4354e14716bd8dfb",
+      "candidate_sha256": "703fbf39c467bf80812bd60bd8683deacdbe5d71e02a971b3895df6a3bcd8360",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "4354e14716bd8dfb",
+      "feature_run": "cc0417d78e5e8ad603b6",
+      "inline_aug_mass": 7,
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 16,
+          "file": "bench/repos/puma/test/test_fiber_local_application.rb",
+          "kind": "Class",
+          "name": "FiberLocalApplication",
+          "pure_single_return": false,
+          "start_line": 11,
+          "token_count": 43,
+          "value_size": 20
+        },
+        {
+          "end_line": 15,
+          "file": "bench/repos/puma/test/test_fiber_storage_application.rb",
+          "kind": "Class",
+          "name": "FiberStorageApplication",
+          "pure_single_return": false,
+          "start_line": 11,
+          "token_count": 35,
+          "value_size": 18
+        }
+      ],
+      "members": [
+        {
+          "end_line": 16,
+          "file": "bench/repos/puma/test/test_fiber_local_application.rb",
+          "start_line": 11
+        },
+        {
+          "end_line": 15,
+          "file": "bench/repos/puma/test/test_fiber_storage_application.rb",
+          "start_line": 11
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "puma",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/puma/test/test_fiber_local_application.rb",
+        "bench/repos/puma/test/test_fiber_storage_application.rb"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        20,
+        18
+      ]
+    },
+    {
+      "candidate_key": "puma:93129e37c4504428",
+      "candidate_sha256": "d03f3f8cc86badfa3379af5fb5b351b5ea1f57438e2618058886387daa3d5b8d",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "93129e37c4504428",
+      "feature_run": "d3cf4f7527db4885cfa6",
+      "intersection_mass": 8,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 214,
+          "file": "bench/repos/puma/ext/puma_http11/puma_http11.c",
+          "kind": "Function",
+          "name": "request_uri",
+          "pure_single_return": false,
+          "start_line": 206,
+          "token_count": 29,
+          "value_size": 14
+        },
+        {
+          "end_line": 224,
+          "file": "bench/repos/puma/ext/puma_http11/puma_http11.c",
+          "kind": "Function",
+          "name": "fragment",
+          "pure_single_return": false,
+          "start_line": 216,
+          "token_count": 29,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 214,
+          "file": "bench/repos/puma/ext/puma_http11/puma_http11.c",
+          "start_line": 206
+        },
+        {
+          "end_line": 224,
+          "file": "bench/repos/puma/ext/puma_http11/puma_http11.c",
+          "start_line": 216
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "puma",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/puma/ext/puma_http11/puma_http11.c"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        14
+      ]
+    },
+    {
+      "candidate_key": "rack:b7b0b53fbcbab71c",
+      "candidate_sha256": "a28b9f78fb129b1e8c865743008ea1b9c245bb756a16eb93b5a7169e35284956",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "medium",
+      "family_id": "b7b0b53fbcbab71c",
+      "feature_run": "f4207b66d16d5a571e40",
+      "inline_aug_mass": 21,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 797,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 792,
+          "token_count": 22,
+          "value_size": 21
+        }
+      },
+      "intersection_mass": 5,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 797,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 792,
+          "token_count": 22,
+          "value_size": 21
+        },
+        {
+          "end_line": 812,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 806,
+          "token_count": 24,
+          "value_size": 15
+        }
+      ],
+      "members": [
+        {
+          "end_line": 799,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "start_line": 789
+        },
+        {
+          "end_line": 814,
+          "file": "bench/repos/rack/lib/rack/lint.rb",
+          "start_line": 804
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rack",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rack/lib/rack/lint.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        21,
+        15
+      ]
+    },
+    {
+      "candidate_key": "regex:1f02b28389d3dd36",
+      "candidate_sha256": "5237bb8689ae087b24116ad61ac1e7a5df6861f31ed02d9d4a2de1635e60ecfa",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "1f02b28389d3dd36",
+      "feature_run": "2221d8241f91b307e416",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 514,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 500
+        },
+        {
+          "end_line": 128,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 114
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "regex",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/regex/regex-capi/src/rure.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "regex:4de609e3891fcfc5",
+      "candidate_sha256": "77ce059d8bd1826eb6564d372b7708f06b0db35cf94c0c6092d049924dce9ed8",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "4de609e3891fcfc5",
+      "feature_run": "d181b3a8588ad9e17e85",
+      "intersection_mass": 62,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 1374,
+          "file": "bench/repos/regex/regex-lite/src/hir/parse.rs",
+          "kind": "Function",
+          "name": "posix_class",
+          "pure_single_return": true,
+          "start_line": 1343,
+          "token_count": 194,
+          "value_size": 117
+        },
+        {
+          "end_line": 1346,
+          "file": "bench/repos/regex/regex-syntax/src/hir/translate.rs",
+          "kind": "Function",
+          "name": "ascii_class",
+          "pure_single_return": false,
+          "start_line": 1319,
+          "token_count": 179,
+          "value_size": 115
+        }
+      ],
+      "members": [
+        {
+          "end_line": 1369,
+          "file": "bench/repos/regex/regex-lite/src/hir/parse.rs",
+          "start_line": 1346
+        },
+        {
+          "end_line": 1344,
+          "file": "bench/repos/regex/regex-syntax/src/hir/translate.rs",
+          "start_line": 1322
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "regex",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/regex/regex-lite/src/hir/parse.rs",
+        "bench/repos/regex/regex-syntax/src/hir/translate.rs"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        117,
+        115
+      ]
+    },
+    {
+      "candidate_key": "regex:817e81c856c71f82",
+      "candidate_sha256": "c88c830d30af95a5537546ad2efe7f125d9ec3938405078160985bd940e1dd07",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "817e81c856c71f82",
+      "feature_run": "336808270fa5b254e151",
+      "intersection_mass": 14,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 474,
+          "file": "bench/repos/regex/regex-automata/src/dfa/search.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 466,
+          "token_count": 46,
+          "value_size": 33
+        },
+        {
+          "end_line": 356,
+          "file": "bench/repos/regex/regex-automata/src/dfa/search.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 348,
+          "token_count": 46,
+          "value_size": 33
+        }
+      ],
+      "members": [
+        {
+          "end_line": 479,
+          "file": "bench/repos/regex/regex-automata/src/dfa/search.rs",
+          "start_line": 464
+        },
+        {
+          "end_line": 359,
+          "file": "bench/repos/regex/regex-automata/src/dfa/search.rs",
+          "start_line": 346
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "regex",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/regex/regex-automata/src/dfa/search.rs"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        33,
+        33
+      ]
+    },
+    {
+      "candidate_key": "regex:fc8646004b5ef173",
+      "candidate_sha256": "19941b1c55f3926f719ae238d31850c479f7ed61c6b731b16d93f06bddb778d8",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "fc8646004b5ef173",
+      "feature_run": "2221d8241f91b307e416",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 390,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 378
+        },
+        {
+          "end_line": 348,
+          "file": "bench/repos/regex/regex-capi/src/rure.rs",
+          "start_line": 336
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "regex",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/regex/regex-capi/src/rure.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "requests:8465ccbf517afa52",
+      "candidate_sha256": "214b609709c65f27e46ed4d9cfc080ae9a0686a1a7922de797bf0ab9c0cc537e",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "8465ccbf517afa52",
+      "feature_run": "b4482bff0c047212f57a",
+      "language": "Python",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2011,
+          "file": "bench/repos/requests/tests/test_requests.py",
+          "start_line": 1999
+        },
+        {
+          "end_line": 1997,
+          "file": "bench/repos/requests/tests/test_requests.py",
+          "start_line": 1986
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "requests",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/requests/tests/test_requests.py"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "retrofit:4ce2a10ac749debd",
+      "candidate_sha256": "55557d01053d5d25e0fd00a2e0bbd655832aa24e9ca92e0d5a7c19b73f9d4a5f",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "4ce2a10ac749debd",
+      "feature_run": "554244141348864a7683",
+      "intersection_mass": 8,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 320,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "deferredThrowEnqueue",
+          "pure_single_return": false,
+          "start_line": 298,
+          "token_count": 30,
+          "value_size": 15
+        },
+        {
+          "end_line": 216,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "failureEnqueue",
+          "pure_single_return": false,
+          "start_line": 195,
+          "token_count": 39,
+          "value_size": 22
+        }
+      ],
+      "members": [
+        {
+          "end_line": 320,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 307
+        },
+        {
+          "end_line": 215,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 202
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "retrofit",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        15,
+        22
+      ]
+    },
+    {
+      "candidate_key": "retrofit:68bb7155ddaec5fc",
+      "candidate_sha256": "a66771d93accae2804d9f39ed6313d5a1fbe133080929e22bab9698f0e47fb9e",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "68bb7155ddaec5fc",
+      "feature_run": "0445800b191e6bec7b37",
+      "inline_aug_mass": 2,
+      "intersection_mass": 2,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 37,
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java",
+          "kind": "Method",
+          "name": "apply",
+          "pure_single_return": true,
+          "start_line": 24,
+          "token_count": 6,
+          "value_size": 2
+        },
+        {
+          "end_line": 37,
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java",
+          "kind": "Method",
+          "name": "apply",
+          "pure_single_return": true,
+          "start_line": 24,
+          "token_count": 6,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 38,
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java",
+          "start_line": 18
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java",
+          "start_line": 18
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "retrofit",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java",
+        "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "retrofit:a4f7b2b24dac8ef2",
+      "candidate_sha256": "ca0985690204aa85cb055c214011d6e7a6f75a0c1e3ae4922d5cc6e66eb182aa",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "medium",
+      "family_id": "a4f7b2b24dac8ef2",
+      "feature_run": "554244141348864a7683",
+      "inline_aug_mass": 37,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 114,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "responseEnqueue",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 61,
+          "value_size": 37
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 114,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "responseEnqueue",
+          "pure_single_return": false,
+          "start_line": 75,
+          "token_count": 61,
+          "value_size": 37
+        },
+        {
+          "end_line": 58,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "bodyEnqueue",
+          "pure_single_return": false,
+          "start_line": 41,
+          "token_count": 27,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 94,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 79
+        },
+        {
+          "end_line": 57,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 43
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "retrofit",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        37,
+        17
+      ]
+    },
+    {
+      "candidate_key": "retrofit:ea9ce2ec096e44a2",
+      "candidate_sha256": "a6f45b7aa5f746ac164ffc9386d4d8625a434cfa63802c6e283816babd15f4e1",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "ea9ce2ec096e44a2",
+      "feature_run": "554244141348864a7683",
+      "intersection_mass": 9,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 280,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "deferredReturnEnqueue",
+          "pure_single_return": false,
+          "start_line": 247,
+          "token_count": 56,
+          "value_size": 23
+        },
+        {
+          "end_line": 245,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "deferredReturnExecute",
+          "pure_single_return": false,
+          "start_line": 228,
+          "token_count": 40,
+          "value_size": 19
+        }
+      ],
+      "members": [
+        {
+          "end_line": 262,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 248
+        },
+        {
+          "end_line": 243,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 229
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "retrofit",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        23,
+        19
+      ]
+    },
+    {
+      "candidate_key": "retrofit:fa87ceae24540615",
+      "candidate_sha256": "f01175d6244d23e7c62e30b66988cf4089072805ed5bda5189aefabeb39e5084",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "fa87ceae24540615",
+      "feature_run": "554244141348864a7683",
+      "intersection_mass": 12,
+      "language": "Java",
+      "matched_units": [
+        {
+          "end_line": 340,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Method",
+          "name": "deferredThrowUncheckedExceptionEnqueue",
+          "pure_single_return": false,
+          "start_line": 322,
+          "token_count": 24,
+          "value_size": 14
+        },
+        {
+          "end_line": 341,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "kind": "Class",
+          "name": "CallsTest",
+          "pure_single_return": false,
+          "start_line": 34,
+          "token_count": 629,
+          "value_size": 181
+        }
+      ],
+      "members": [
+        {
+          "end_line": 341,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 327
+        },
+        {
+          "end_line": 322,
+          "file": "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java",
+          "start_line": 202
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "retrofit",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        181
+      ]
+    },
+    {
+      "candidate_key": "rich:1cca23a830177a3b",
+      "candidate_sha256": "2904b1e9d0f510c2051857ad5353c131274ca453791565d5d296bcd9db6a2e08",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "1cca23a830177a3b",
+      "feature_run": "a41d7e018e9b831212a8",
+      "intersection_mass": 14,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 249,
+          "file": "bench/repos/rich/tests/test_win32_console.py",
+          "kind": "Function",
+          "name": "test_erase_start_of_line",
+          "pure_single_return": false,
+          "start_line": 233,
+          "token_count": 42,
+          "value_size": 25
+        },
+        {
+          "end_line": 208,
+          "file": "bench/repos/rich/tests/test_win32_console.py",
+          "kind": "Function",
+          "name": "test_erase_line",
+          "pure_single_return": false,
+          "start_line": 194,
+          "token_count": 44,
+          "value_size": 27
+        }
+      ],
+      "members": [
+        {
+          "end_line": 249,
+          "file": "bench/repos/rich/tests/test_win32_console.py",
+          "start_line": 233
+        },
+        {
+          "end_line": 208,
+          "file": "bench/repos/rich/tests/test_win32_console.py",
+          "start_line": 194
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rich",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rich/tests/test_win32_console.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        27
+      ]
+    },
+    {
+      "candidate_key": "rich:71efa9ae895b2852",
+      "candidate_sha256": "c0db31d870325d8a62aa85c6e485b768b26b18c883cbed60a25a31893ebb3975",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "71efa9ae895b2852",
+      "feature_run": "43bd3d6f421a288edd77",
+      "intersection_mass": 13,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 11,
+          "file": "bench/repos/rich/tests/test_tools.py",
+          "kind": "Function",
+          "name": "test_loop_first",
+          "pure_single_return": false,
+          "start_line": 5,
+          "token_count": 51,
+          "value_size": 31
+        },
+        {
+          "end_line": 20,
+          "file": "bench/repos/rich/tests/test_tools.py",
+          "kind": "Function",
+          "name": "test_loop_last",
+          "pure_single_return": false,
+          "start_line": 14,
+          "token_count": 51,
+          "value_size": 31
+        }
+      ],
+      "members": [
+        {
+          "end_line": 11,
+          "file": "bench/repos/rich/tests/test_tools.py",
+          "start_line": 5
+        },
+        {
+          "end_line": 20,
+          "file": "bench/repos/rich/tests/test_tools.py",
+          "start_line": 14
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rich",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rich/tests/test_tools.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        31,
+        31
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:17b81b759c25a493",
+      "candidate_sha256": "38f0a0ae7529caea8cf34131dcde1fbb7e0d6f72fab8558b7bd1cff149a94de0",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "17b81b759c25a493",
+      "feature_run": "13ead1049fac50b64d0a",
+      "inline_aug_mass": 2,
+      "intersection_mass": 2,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 37,
+          "file": "bench/repos/ripgrep/tests/macros.rs",
+          "kind": "Block",
+          "name": "eqnice:arm0",
+          "pure_single_return": false,
+          "start_line": 19,
+          "token_count": 10,
+          "value_size": 2
+        },
+        {
+          "end_line": 23,
+          "file": "bench/repos/ripgrep/crates/printer/src/macros.rs",
+          "kind": "Block",
+          "name": "assert_eq_printed:arm0",
+          "pure_single_return": false,
+          "start_line": 5,
+          "token_count": 10,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 38,
+          "file": "bench/repos/ripgrep/tests/macros.rs",
+          "start_line": 18
+        },
+        {
+          "end_line": 24,
+          "file": "bench/repos/ripgrep/crates/printer/src/macros.rs",
+          "start_line": 4
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "scope": "mixed",
+      "source_files": [
+        "bench/repos/ripgrep/crates/printer/src/macros.rs",
+        "bench/repos/ripgrep/tests/macros.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:1b6dd934f70b9533",
+      "candidate_sha256": "7dac6e253617bdfff6ea429db88f56fd1d3a1cfc2bc353a996b433be5843cf9b",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "1b6dd934f70b9533",
+      "feature_run": "e000f083c244b99a7346",
+      "inline_aug_mass": 15,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 432,
+          "file": "bench/repos/ripgrep/crates/ignore/src/walk.rs",
+          "kind": "Class",
+          "name": "DirEntryRaw",
+          "pure_single_return": false,
+          "start_line": 268,
+          "token_count": 330,
+          "value_size": 89
+        }
+      },
+      "intersection_mass": 6,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 293,
+          "file": "bench/repos/ripgrep/crates/ignore/src/walk.rs",
+          "kind": "Function",
+          "name": "metadata_internal",
+          "pure_single_return": true,
+          "start_line": 286,
+          "token_count": 32,
+          "value_size": 15
+        },
+        {
+          "end_line": 303,
+          "file": "bench/repos/ripgrep/crates/ignore/src/walk.rs",
+          "kind": "Function",
+          "name": "metadata_internal",
+          "pure_single_return": true,
+          "start_line": 296,
+          "token_count": 30,
+          "value_size": 12
+        }
+      ],
+      "members": [
+        {
+          "end_line": 293,
+          "file": "bench/repos/ripgrep/crates/ignore/src/walk.rs",
+          "start_line": 286
+        },
+        {
+          "end_line": 303,
+          "file": "bench/repos/ripgrep/crates/ignore/src/walk.rs",
+          "start_line": 296
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/ignore/src/walk.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        15,
+        12
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:395768df3c164d72",
+      "candidate_sha256": "07d4d56528873eefb58d59a4da4302fe1a96e0045844aafc5a54306c4f0edb6a",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "395768df3c164d72",
+      "feature_run": "2197d095059435b29de9",
+      "inline_aug_mass": 2,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 822,
+          "file": "bench/repos/ripgrep/crates/globset/src/lib.rs",
+          "kind": "Class",
+          "name": "PrefixStrategy",
+          "pure_single_return": false,
+          "start_line": 799,
+          "token_count": 68,
+          "value_size": 21
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 821,
+          "file": "bench/repos/ripgrep/crates/globset/src/lib.rs",
+          "kind": "Function",
+          "name": "matches_into",
+          "pure_single_return": true,
+          "start_line": 810,
+          "token_count": 37,
+          "value_size": 2
+        },
+        {
+          "end_line": 853,
+          "file": "bench/repos/ripgrep/crates/globset/src/lib.rs",
+          "kind": "Function",
+          "name": "matches_into",
+          "pure_single_return": true,
+          "start_line": 842,
+          "token_count": 39,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 822,
+          "file": "bench/repos/ripgrep/crates/globset/src/lib.rs",
+          "start_line": 799
+        },
+        {
+          "end_line": 854,
+          "file": "bench/repos/ripgrep/crates/globset/src/lib.rs",
+          "start_line": 831
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/globset/src/lib.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        2,
+        2
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:4b007c95b7bc5666",
+      "candidate_sha256": "866c09759a8efbe5bfac59be3567b2ca56a2fa41503809846695933c855fa433",
+      "channel": "structural",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "4b007c95b7bc5666",
+      "feature_run": "62d1a51df6902b825238",
+      "inline_aug_mass": 198,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 190,
+          "file": "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs",
+          "kind": "Function",
+          "name": "test_dirs_in_root",
+          "pure_single_return": false,
+          "start_line": 89,
+          "token_count": 467,
+          "value_size": 198
+        }
+      },
+      "intersection_mass": 6,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 318,
+          "file": "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs",
+          "kind": "Function",
+          "name": "test_dirs_in_deep",
+          "pure_single_return": false,
+          "start_line": 193,
+          "token_count": 467,
+          "value_size": 198
+        },
+        {
+          "end_line": 190,
+          "file": "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs",
+          "kind": "Function",
+          "name": "test_dirs_in_root",
+          "pure_single_return": false,
+          "start_line": 89,
+          "token_count": 467,
+          "value_size": 198
+        }
+      ],
+      "members": [
+        {
+          "end_line": 318,
+          "file": "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs",
+          "start_line": 193
+        },
+        {
+          "end_line": 190,
+          "file": "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs",
+          "start_line": 89
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        198,
+        198
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:519afdcaed73af0d",
+      "candidate_sha256": "8cc801b76980e41c492850a8eb29d633df91772439d70a1e8022ff40c3830d00",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "519afdcaed73af0d",
+      "feature_run": "aaac538fae31f459e184",
+      "intersection_mass": 26,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 614,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 577,
+          "token_count": 128,
+          "value_size": 76
+        },
+        {
+          "end_line": 576,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 529,
+          "token_count": 158,
+          "value_size": 90
+        }
+      ],
+      "members": [
+        {
+          "end_line": 608,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "start_line": 599
+        },
+        {
+          "end_line": 570,
+          "file": "bench/repos/ripgrep/crates/searcher/src/testutil.rs",
+          "start_line": 561
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/searcher/src/testutil.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        76,
+        90
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:645645048b72111d",
+      "candidate_sha256": "da91e4edb67b4c4940e50d96d3236b20bbe98159a9ca12b08a73a306bf4be2e0",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "645645048b72111d",
+      "feature_run": "fc942826add48d7f0682",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 116,
+          "file": "bench/repos/ripgrep/crates/core/flags/doc/version.rs",
+          "kind": "Function",
+          "name": "runtime_cpu_features",
+          "pure_single_return": false,
+          "start_line": 83,
+          "token_count": 78,
+          "value_size": 6
+        }
+      },
+      "intersection_mass": 4,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 116,
+          "file": "bench/repos/ripgrep/crates/core/flags/doc/version.rs",
+          "kind": "Function",
+          "name": "runtime_cpu_features",
+          "pure_single_return": false,
+          "start_line": 83,
+          "token_count": 78,
+          "value_size": 6
+        },
+        {
+          "end_line": 158,
+          "file": "bench/repos/ripgrep/crates/core/flags/doc/version.rs",
+          "kind": "Function",
+          "name": "compile_cpu_features",
+          "pure_single_return": false,
+          "start_line": 129,
+          "token_count": 81,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 116,
+          "file": "bench/repos/ripgrep/crates/core/flags/doc/version.rs",
+          "start_line": 83
+        },
+        {
+          "end_line": 158,
+          "file": "bench/repos/ripgrep/crates/core/flags/doc/version.rs",
+          "start_line": 129
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/core/flags/doc/version.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        6,
+        6
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:70daf912736d8c82",
+      "candidate_sha256": "6d5ab713c2f94e97cda415936a0babc0a1e519bcefedfd0b47e8c04b493f755b",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "70daf912736d8c82",
+      "feature_run": "69134373c04bbef74d48",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 8,
+          "file": "bench/repos/ripgrep/tests/hay.rs",
+          "start_line": 1
+        },
+        {
+          "end_line": 209,
+          "file": "bench/repos/ripgrep/crates/searcher/src/lines.rs",
+          "start_line": 203
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "ripgrep",
+      "scope": "mixed",
+      "source_files": [
+        "bench/repos/ripgrep/crates/searcher/src/lines.rs",
+        "bench/repos/ripgrep/tests/hay.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "ripgrep:8172f2a4057bdd27",
+      "candidate_sha256": "b1c227348e5cdcadb7898908d5c9a573578da32976077068ec057c08569da755",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "8172f2a4057bdd27",
+      "feature_run": "b1fbdb0743ade95185a5",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 241,
+          "file": "bench/repos/ripgrep/tests/json.rs",
+          "start_line": 207
+        },
+        {
+          "end_line": 190,
+          "file": "bench/repos/ripgrep/tests/json.rs",
+          "start_line": 157
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/ripgrep/tests/json.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "ripgrep:82baabefb13ac0e4",
+      "candidate_sha256": "6662affebb6d29b5e18fde36273be68a18502222638fee7b5308646defb731bd",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "medium",
+      "family_id": "82baabefb13ac0e4",
+      "feature_run": "6d84992a05bfa77e98ff",
+      "inline_aug_mass": 205,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 305,
+          "file": "bench/repos/ripgrep/crates/ignore/src/gitignore.rs",
+          "kind": "Class",
+          "name": "Gitignore",
+          "pure_single_return": false,
+          "start_line": 90,
+          "token_count": 400,
+          "value_size": 205
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 379,
+          "file": "bench/repos/ripgrep/crates/ignore/src/gitignore.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 373,
+          "token_count": 43,
+          "value_size": 26
+        },
+        {
+          "end_line": 305,
+          "file": "bench/repos/ripgrep/crates/ignore/src/gitignore.rs",
+          "kind": "Class",
+          "name": "Gitignore",
+          "pure_single_return": false,
+          "start_line": 90,
+          "token_count": 400,
+          "value_size": 205
+        }
+      ],
+      "members": [
+        {
+          "end_line": 381,
+          "file": "bench/repos/ripgrep/crates/ignore/src/gitignore.rs",
+          "start_line": 373
+        },
+        {
+          "end_line": 130,
+          "file": "bench/repos/ripgrep/crates/ignore/src/gitignore.rs",
+          "start_line": 111
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/ignore/src/gitignore.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        26,
+        205
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:9194611e3dd97015",
+      "candidate_sha256": "9fb26bdd7c7b711187dff2789f996db4d1735c74a0b28cfd4365f28ac81f5d71",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9194611e3dd97015",
+      "feature_run": "3111b3d0de34d67d5235",
+      "intersection_mass": 8,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 363,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "kind": "Function",
+          "name": "from_str",
+          "pure_single_return": false,
+          "start_line": 354,
+          "token_count": 56,
+          "value_size": 58
+        },
+        {
+          "end_line": 377,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "kind": "Function",
+          "name": "from_str",
+          "pure_single_return": false,
+          "start_line": 369,
+          "token_count": 47,
+          "value_size": 49
+        }
+      ],
+      "members": [
+        {
+          "end_line": 363,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "start_line": 354
+        },
+        {
+          "end_line": 377,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "start_line": 369
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/printer/src/color.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        58,
+        49
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:9b317c5d5b4ad4f5",
+      "candidate_sha256": "59d8278659467415a69792c275f845a03c5ef3e2016a6d854451ef01b80b03a6",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9b317c5d5b4ad4f5",
+      "feature_run": "20dfa695b6ff47bd4410",
+      "intersection_mass": 17,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 388,
+          "file": "bench/repos/ripgrep/crates/ignore/src/types.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 382,
+          "token_count": 35,
+          "value_size": 26
+        },
+        {
+          "end_line": 402,
+          "file": "bench/repos/ripgrep/crates/ignore/src/types.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 396,
+          "token_count": 35,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 390,
+          "file": "bench/repos/ripgrep/crates/ignore/src/types.rs",
+          "start_line": 381
+        },
+        {
+          "end_line": 404,
+          "file": "bench/repos/ripgrep/crates/ignore/src/types.rs",
+          "start_line": 395
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/ignore/src/types.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        26,
+        26
+      ]
+    },
+    {
+      "candidate_key": "ripgrep:9e4630087c22a3b0",
+      "candidate_sha256": "c5fbac4e0b11c206d847b0fa876d78077accb45db32ce6811f2d42ded69b6e92",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9e4630087c22a3b0",
+      "feature_run": "3111b3d0de34d67d5235",
+      "intersection_mass": 8,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 395,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "kind": "Function",
+          "name": "from_str",
+          "pure_single_return": false,
+          "start_line": 383,
+          "token_count": 83,
+          "value_size": 98
+        },
+        {
+          "end_line": 363,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "kind": "Function",
+          "name": "from_str",
+          "pure_single_return": false,
+          "start_line": 354,
+          "token_count": 56,
+          "value_size": 58
+        }
+      ],
+      "members": [
+        {
+          "end_line": 396,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "start_line": 380
+        },
+        {
+          "end_line": 364,
+          "file": "bench/repos/ripgrep/crates/printer/src/color.rs",
+          "start_line": 351
+        }
+      ],
+      "reason": "extract-base",
+      "repo": "ripgrep",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/ripgrep/crates/printer/src/color.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        98,
+        58
+      ]
+    },
+    {
+      "candidate_key": "rspec-core:32a7d7612a8cb12a",
+      "candidate_sha256": "f979c3bddb1644744d426d435bbea1766666bfa6327edfb673db43b9e2365fc8",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "32a7d7612a8cb12a",
+      "feature_run": "0110ad8cd10b3679a5ae",
+      "inline_aug_mass": 21,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 115,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb",
+          "kind": "Block",
+          "name": "it:aborts as soon as the last expected failure finishes, since we don't care about what happens after that",
+          "pure_single_return": false,
+          "start_line": 93,
+          "token_count": 27,
+          "value_size": 21
+        }
+      },
+      "intersection_mass": 5,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 115,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb",
+          "kind": "Block",
+          "name": "it:aborts as soon as the last expected failure finishes, since we don't care about what happens after that",
+          "pure_single_return": false,
+          "start_line": 93,
+          "token_count": 27,
+          "value_size": 21
+        },
+        {
+          "end_line": 88,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb",
+          "kind": "Block",
+          "name": "it:receives suite results",
+          "pure_single_return": false,
+          "start_line": 62,
+          "token_count": 40,
+          "value_size": 12
+        }
+      ],
+      "members": [
+        {
+          "end_line": 110,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb",
+          "start_line": 103
+        },
+        {
+          "end_line": 74,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb",
+          "start_line": 67
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "rspec-core",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        21,
+        12
+      ]
+    },
+    {
+      "candidate_key": "rspec-core:7b5147536093e82e",
+      "candidate_sha256": "a7328e0efd287e778d364d11b9733d6404de64c85bfdf7aa19bbd81e41efe968",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "7b5147536093e82e",
+      "feature_run": "f778ab3848f7cabe8b45",
+      "intersection_mass": 9,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 249,
+          "file": "bench/repos/rspec-core/spec/support/formatter_support.rb",
+          "kind": "Method",
+          "name": "expected_summary_output_for_example_specs",
+          "pure_single_return": false,
+          "start_line": 150,
+          "token_count": 110,
+          "value_size": 50
+        },
+        {
+          "end_line": 148,
+          "file": "bench/repos/rspec-core/spec/support/formatter_support.rb",
+          "kind": "Method",
+          "name": "expected_summary_output_for_example_specs",
+          "pure_single_return": false,
+          "start_line": 55,
+          "token_count": 14,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 242,
+          "file": "bench/repos/rspec-core/spec/support/formatter_support.rb",
+          "start_line": 230
+        },
+        {
+          "end_line": 142,
+          "file": "bench/repos/rspec-core/spec/support/formatter_support.rb",
+          "start_line": 129
+        }
+      ],
+      "reason": "extract-data-table",
+      "repo": "rspec-core",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rspec-core/spec/support/formatter_support.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        50,
+        11
+      ]
+    },
+    {
+      "candidate_key": "rspec-core:a1957f9937b645c3",
+      "candidate_sha256": "4b5c0e4ef02ef4adb85997167c46a25c3d219c181b06a45dc684b53d917153f8",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "a1957f9937b645c3",
+      "feature_run": "577a5f350ae9bcc92abe",
+      "inline_aug_mass": 37,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 220,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "kind": "Block",
+          "name": "it:prints the most minimal repro command it has found so far",
+          "pure_single_return": false,
+          "start_line": 197,
+          "token_count": 50,
+          "value_size": 37
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 220,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "kind": "Block",
+          "name": "it:prints the most minimal repro command it has found so far",
+          "pure_single_return": false,
+          "start_line": 197,
+          "token_count": 50,
+          "value_size": 37
+        },
+        {
+          "end_line": 43,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "kind": "Block",
+          "name": "it:notifies the bisect progress formatter of progress and closes the output",
+          "pure_single_return": false,
+          "start_line": 24,
+          "token_count": 49,
+          "value_size": 13
+        }
+      ],
+      "members": [
+        {
+          "end_line": 215,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "start_line": 207
+        },
+        {
+          "end_line": 36,
+          "file": "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb",
+          "start_line": 29
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rspec-core",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        37,
+        13
+      ]
+    },
+    {
+      "candidate_key": "rubocop:107837ec875c769b",
+      "candidate_sha256": "c02dede825b90cf058f597c61f30be5831d7a9b32d9f93368fe6cd524be2c6e6",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "107837ec875c769b",
+      "feature_run": "35e91f59f2e6b5c3b141",
+      "inline_aug_mass": 5,
+      "intersection_mass": 5,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 71,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb",
+          "kind": "Method",
+          "name": "on_send",
+          "pure_single_return": false,
+          "start_line": 54,
+          "token_count": 77,
+          "value_size": 16
+        },
+        {
+          "end_line": 59,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb",
+          "kind": "Method",
+          "name": "on_send",
+          "pure_single_return": false,
+          "start_line": 46,
+          "token_count": 66,
+          "value_size": 16
+        }
+      ],
+      "members": [
+        {
+          "end_line": 71,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb",
+          "start_line": 54
+        },
+        {
+          "end_line": 59,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb",
+          "start_line": 46
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        16,
+        16
+      ]
+    },
+    {
+      "candidate_key": "rubocop:1eead1acc41e3d0d",
+      "candidate_sha256": "b9fe0551e7f284c68a940eae1203bc687056637aa0ecfff6c80435de3ac434ae",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "1eead1acc41e3d0d",
+      "feature_run": "f6a72a06295fe4f90918",
+      "inline_aug_mass": 34,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 292,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "context:when `AllowMethodComparison: true`",
+          "pure_single_return": false,
+          "start_line": 201,
+          "token_count": 126,
+          "value_size": 34
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 261,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects when comparing with hash access on lhs",
+          "pure_single_return": false,
+          "start_line": 250,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 292,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "context:when `AllowMethodComparison: true`",
+          "pure_single_return": false,
+          "start_line": 201,
+          "token_count": 126,
+          "value_size": 34
+        }
+      ],
+      "members": [
+        {
+          "end_line": 264,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "start_line": 252
+        },
+        {
+          "end_line": 249,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "start_line": 34
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        34
+      ]
+    },
+    {
+      "candidate_key": "rubocop:267fc66c0a4ce915",
+      "candidate_sha256": "7eb4711593614592a7a2852ea9267ecaf23a966b9bfd6b1f590023ad26fc8287",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "267fc66c0a4ce915",
+      "feature_run": "ba47ff4dd05189d8f83f",
+      "inline_aug_mass": 38,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 152,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb",
+          "kind": "Block",
+          "name": "context:when EnforcedStyle is space",
+          "pure_single_return": false,
+          "start_line": 67,
+          "token_count": 130,
+          "value_size": 38
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 173,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense for no spaces inside parens",
+          "pure_single_return": false,
+          "start_line": 159,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 152,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb",
+          "kind": "Block",
+          "name": "context:when EnforcedStyle is space",
+          "pure_single_return": false,
+          "start_line": 67,
+          "token_count": 130,
+          "value_size": 38
+        }
+      ],
+      "members": [
+        {
+          "end_line": 243,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb",
+          "start_line": 156
+        },
+        {
+          "end_line": 153,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb",
+          "start_line": 67
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        38
+      ]
+    },
+    {
+      "candidate_key": "rubocop:40711dc868c3de45",
+      "candidate_sha256": "68a188129c17a6db22e7b11f3f74ecedda2f72b32a465383a39d420860e61ade",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "40711dc868c3de45",
+      "feature_run": "0e95f20223f201c709fd",
+      "intersection_mass": 11,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 19,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense for a while loop with #{lit} as condition",
+          "pure_single_return": false,
+          "start_line": 8,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 36,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense for a until loop with #{lit} as condition",
+          "pure_single_return": false,
+          "start_line": 25,
+          "token_count": 13,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 21,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb",
+          "start_line": 6
+        },
+        {
+          "end_line": 38,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb",
+          "start_line": 23
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "rubocop:40c914779a563002",
+      "candidate_sha256": "9b6bedfb8e05000737c1db547adaa54d41bb6bc6f14993be838cdbccd304e83d",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "40c914779a563002",
+      "feature_run": "522c598786f1b5a6b7ea",
+      "inline_aug_mass": 5,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 78,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb",
+          "kind": "Class",
+          "name": "RuboCop",
+          "pure_single_return": false,
+          "start_line": 4,
+          "token_count": 167,
+          "value_size": 62
+        }
+      },
+      "intersection_mass": 1,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb",
+          "kind": "Method",
+          "name": "on_numblock",
+          "pure_single_return": true,
+          "start_line": 36,
+          "token_count": 32,
+          "value_size": 5
+        },
+        {
+          "end_line": 54,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb",
+          "kind": "Method",
+          "name": "on_itblock",
+          "pure_single_return": true,
+          "start_line": 46,
+          "token_count": 32,
+          "value_size": 5
+        }
+      ],
+      "members": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb",
+          "start_line": 36
+        },
+        {
+          "end_line": 54,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb",
+          "start_line": 46
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        5,
+        5
+      ]
+    },
+    {
+      "candidate_key": "rubocop:42b457f15c15680c",
+      "candidate_sha256": "36f80cea602af56393213c46b24d85799bac0e2df5626b24077afe6c8fce09e9",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "42b457f15c15680c",
+      "feature_run": "88db6c2c479b254e5ad6",
+      "inline_aug_mass": 11,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 162,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb",
+          "kind": "Block",
+          "name": "it:preserves surrounding code when correcting",
+          "pure_single_return": false,
+          "start_line": 150,
+          "token_count": 13,
+          "value_size": 11
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 248,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects block_pass select with block reject",
+          "pure_single_return": false,
+          "start_line": 240,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 162,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb",
+          "kind": "Block",
+          "name": "it:preserves surrounding code when correcting",
+          "pure_single_return": false,
+          "start_line": 150,
+          "token_count": 13,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 251,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb",
+          "start_line": 243
+        },
+        {
+          "end_line": 179,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb",
+          "start_line": 99
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "rubocop:66ab28d58fc0aa09",
+      "candidate_sha256": "21ff00cad2a4953c2bc3db6e75e268b3d728396d9c03be9b9edd0bc2c4c3de15",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "66ab28d58fc0aa09",
+      "feature_run": "19cf6b752d6516d0d819",
+      "intersection_mass": 13,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 118,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects with `&:#{method}`",
+          "pure_single_return": false,
+          "start_line": 111,
+          "token_count": 16,
+          "value_size": 13
+        },
+        {
+          "end_line": 210,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects with `#{method}`",
+          "pure_single_return": false,
+          "start_line": 203,
+          "token_count": 16,
+          "value_size": 13
+        }
+      ],
+      "members": [
+        {
+          "end_line": 120,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb",
+          "start_line": 109
+        },
+        {
+          "end_line": 212,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb",
+          "start_line": 201
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        13,
+        13
+      ]
+    },
+    {
+      "candidate_key": "rubocop:6af0178a5e70efbc",
+      "candidate_sha256": "32d6c8935886fb369c7968803f357c88ddfd1abe447876682650f32a659ef9dc",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "6af0178a5e70efbc",
+      "feature_run": "00c0d5c2ebaca781dc99",
+      "inline_aug_mass": 14,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 168,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when without branch bodies",
+          "pure_single_return": false,
+          "start_line": 157,
+          "token_count": 19,
+          "value_size": 14
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 219,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when with `else` branch",
+          "pure_single_return": false,
+          "start_line": 206,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 168,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when without branch bodies",
+          "pure_single_return": false,
+          "start_line": 157,
+          "token_count": 19,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 216,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb",
+          "start_line": 208
+        },
+        {
+          "end_line": 182,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb",
+          "start_line": 95
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        14
+      ]
+    },
+    {
+      "candidate_key": "rubocop:7bd6307d63463a53",
+      "candidate_sha256": "80d160c299ec4cc83b0e67a20b3ca373e1fcfedf19af461aaaabf71cbafe2e9a",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "7bd6307d63463a53",
+      "feature_run": "f6a72a06295fe4f90918",
+      "inline_aug_mass": 34,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 292,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "context:when `AllowMethodComparison: true`",
+          "pure_single_return": false,
+          "start_line": 201,
+          "token_count": 126,
+          "value_size": 34
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 276,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects when comparing with safe navigation method call on rhs",
+          "pure_single_return": false,
+          "start_line": 265,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 292,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "kind": "Block",
+          "name": "context:when `AllowMethodComparison: true`",
+          "pure_single_return": false,
+          "start_line": 201,
+          "token_count": 126,
+          "value_size": 34
+        }
+      ],
+      "members": [
+        {
+          "end_line": 273,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "start_line": 267
+        },
+        {
+          "end_line": 243,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb",
+          "start_line": 34
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        34
+      ]
+    },
+    {
+      "candidate_key": "rubocop:8afc3058b26eb9b9",
+      "candidate_sha256": "0ac9cf5def628a085da23901ce057d57fb65267c023f1e462174ba6f211e895e",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "medium",
+      "family_id": "8afc3058b26eb9b9",
+      "feature_run": "8e381d0d42dbb88f347c",
+      "inline_aug_mass": 4,
+      "intersection_mass": 4,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 58,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb",
+          "kind": "Method",
+          "name": "on_new_investigation",
+          "pure_single_return": true,
+          "start_line": 43,
+          "token_count": 56,
+          "value_size": 7
+        },
+        {
+          "end_line": 43,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb",
+          "kind": "Method",
+          "name": "on_new_investigation",
+          "pure_single_return": true,
+          "start_line": 29,
+          "token_count": 57,
+          "value_size": 7
+        }
+      ],
+      "members": [
+        {
+          "end_line": 58,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb",
+          "start_line": 43
+        },
+        {
+          "end_line": 43,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb",
+          "start_line": 29
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        7,
+        7
+      ]
+    },
+    {
+      "candidate_key": "rubocop:8b9fd00e9f4e985b",
+      "candidate_sha256": "ab291e8517223219e63a5ead4bdd60065665cfc96540812cd38dbbaac4648180",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "8b9fd00e9f4e985b",
+      "feature_run": "382b25c322c0d82da5c0",
+      "intersection_mass": 10,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 270,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense",
+          "pure_single_return": false,
+          "start_line": 258,
+          "token_count": 13,
+          "value_size": 10
+        },
+        {
+          "end_line": 195,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense",
+          "pure_single_return": false,
+          "start_line": 183,
+          "token_count": 13,
+          "value_size": 10
+        }
+      ],
+      "members": [
+        {
+          "end_line": 274,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb",
+          "start_line": 256
+        },
+        {
+          "end_line": 199,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb",
+          "start_line": 181
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        10,
+        10
+      ]
+    },
+    {
+      "candidate_key": "rubocop:9ad4362831b976ff",
+      "candidate_sha256": "54afe9b0c2f1abfd8fa2659b7df0d6357dd66a6f2d94073a7c1123ce094069f6",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "9ad4362831b976ff",
+      "feature_run": "b363aeb29931fef86676",
+      "intersection_mass": 14,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 195,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense for !(foo #{method} bar)",
+          "pure_single_return": false,
+          "start_line": 188,
+          "token_count": 18,
+          "value_size": 14
+        },
+        {
+          "end_line": 177,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense for !foo.#{method}",
+          "pure_single_return": false,
+          "start_line": 170,
+          "token_count": 18,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 208,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb",
+          "start_line": 181
+        },
+        {
+          "end_line": 179,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb",
+          "start_line": 161
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        14
+      ]
+    },
+    {
+      "candidate_key": "rubocop:ace293d11479450b",
+      "candidate_sha256": "834c124160d6f8b5f545cf2290068387ffed7fc8b7545a21da575eed07626415",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "ace293d11479450b",
+      "feature_run": "06cab112eb61fe18b96b",
+      "inline_aug_mass": 11,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 243,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense but does not replace with `loc_is?`",
+          "pure_single_return": false,
+          "start_line": 236,
+          "token_count": 13,
+          "value_size": 11
+        }
+      },
+      "intersection_mass": 0,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 243,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense but does not replace with `loc_is?`",
+          "pure_single_return": false,
+          "start_line": 236,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 153,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb",
+          "kind": "Block",
+          "name": "context:when there is no receiver",
+          "pure_single_return": false,
+          "start_line": 144,
+          "token_count": 19,
+          "value_size": 5
+        }
+      ],
+      "members": [
+        {
+          "end_line": 242,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb",
+          "start_line": 237
+        },
+        {
+          "end_line": 229,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb",
+          "start_line": 123
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        5
+      ]
+    },
+    {
+      "candidate_key": "rubocop:b956b31a66387140",
+      "candidate_sha256": "f10fd6d5e5ce6567584176484eec4ccf35a55ec2981673dab9e91dd6c4f350d6",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "b956b31a66387140",
+      "feature_run": "3df9e62d112692390ac9",
+      "intersection_mass": 8,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 78,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb",
+          "kind": "Method",
+          "name": "on_new_investigation",
+          "pure_single_return": false,
+          "start_line": 68,
+          "token_count": 46,
+          "value_size": 14
+        },
+        {
+          "end_line": 53,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb",
+          "kind": "Method",
+          "name": "on_new_investigation",
+          "pure_single_return": false,
+          "start_line": 45,
+          "token_count": 41,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 78,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb",
+          "start_line": 68
+        },
+        {
+          "end_line": 53,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb",
+          "start_line": 45
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        14
+      ]
+    },
+    {
+      "candidate_key": "rubocop:c409de6f23092443",
+      "candidate_sha256": "152252ac9bb75ebc2c2a6eef6245a20ba6dd46c6f5df734e965628b1fd3f866f",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "c409de6f23092443",
+      "feature_run": "e8ad489feb4411ce1ae9",
+      "intersection_mass": 8,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 139,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb",
+          "kind": "Method",
+          "name": "move_pos_str",
+          "pure_single_return": false,
+          "start_line": 134,
+          "token_count": 48,
+          "value_size": 28
+        },
+        {
+          "end_line": 83,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb",
+          "kind": "Method",
+          "name": "reposition",
+          "pure_single_return": false,
+          "start_line": 78,
+          "token_count": 48,
+          "value_size": 28
+        }
+      ],
+      "members": [
+        {
+          "end_line": 139,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb",
+          "start_line": 134
+        },
+        {
+          "end_line": 83,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb",
+          "start_line": 78
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb",
+        "bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        28,
+        28
+      ]
+    },
+    {
+      "candidate_key": "rubocop:c6c89e4eb592a4cf",
+      "candidate_sha256": "15162dc483074dd4ccaad90bd9bfa705a212eb90fb2f1ee6834b04f51a065b69",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c6c89e4eb592a4cf",
+      "feature_run": "0a76b109597dca6038f5",
+      "inline_aug_mass": 11,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 32,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when given an improper description in `xit`",
+          "pure_single_return": false,
+          "start_line": 21,
+          "token_count": 13,
+          "value_size": 11
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 122,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when given an improper description with multiple options",
+          "pure_single_return": false,
+          "start_line": 111,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 32,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense when given an improper description in `xit`",
+          "pure_single_return": false,
+          "start_line": 21,
+          "token_count": 13,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 119,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb",
+          "start_line": 112
+        },
+        {
+          "end_line": 104,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb",
+          "start_line": 7
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "rubocop:c8a5713da90ca9c8",
+      "candidate_sha256": "d73ac56fead222d8ef8c248f14d30e576176f3104351cc782464a3497d3810b4",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c8a5713da90ca9c8",
+      "feature_run": "c5770322194a668734a7",
+      "inline_aug_mass": 16,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 63,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 58,
+          "token_count": 17,
+          "value_size": 16
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 63,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 58,
+          "token_count": 17,
+          "value_size": 16
+        },
+        {
+          "end_line": 74,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 69,
+          "token_count": 17,
+          "value_size": 16
+        }
+      ],
+      "members": [
+        {
+          "end_line": 66,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb",
+          "start_line": 57
+        },
+        {
+          "end_line": 77,
+          "file": "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb",
+          "start_line": 68
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "rubocop",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        16,
+        16
+      ]
+    },
+    {
+      "candidate_key": "rubocop:fc6e340b14f9df88",
+      "candidate_sha256": "c26c95ff9498a5354650e4158d230c631e2521b17dc6fca4042a9373dda5bd92",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "fc6e340b14f9df88",
+      "feature_run": "0c4393d57e1f7acba8c9",
+      "inline_aug_mass": 11,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 17,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects for code that immediately follows accessor",
+          "pure_single_return": false,
+          "start_line": 5,
+          "token_count": 13,
+          "value_size": 11
+        }
+      },
+      "intersection_mass": 7,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 33,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects for code that immediately follows accessor with comment",
+          "pure_single_return": false,
+          "start_line": 21,
+          "token_count": 13,
+          "value_size": 11
+        },
+        {
+          "end_line": 17,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb",
+          "kind": "Block",
+          "name": "it:registers an offense and corrects for code that immediately follows accessor",
+          "pure_single_return": false,
+          "start_line": 5,
+          "token_count": 13,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 36,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb",
+          "start_line": 20
+        },
+        {
+          "end_line": 20,
+          "file": "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb",
+          "start_line": 4
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rubocop",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "rustls:286cfa8283af3008",
+      "candidate_sha256": "aa890aa83a3968a1bccd909035107ae9a2a379e54f3850b82eea2776f44b0790",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "286cfa8283af3008",
+      "feature_run": "3e66f80b25d6bb4fe86d",
+      "intersection_mass": 31,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 134,
+          "file": "bench/repos/rustls/rustls-test/tests/api/crypto.rs",
+          "kind": "Function",
+          "name": "key_log_for_tls13",
+          "pure_single_return": false,
+          "start_line": 61,
+          "token_count": 298,
+          "value_size": 110
+        },
+        {
+          "end_line": 58,
+          "file": "bench/repos/rustls/rustls-test/tests/api/crypto.rs",
+          "kind": "Function",
+          "name": "key_log_for_tls12",
+          "pure_single_return": false,
+          "start_line": 24,
+          "token_count": 143,
+          "value_size": 60
+        }
+      ],
+      "members": [
+        {
+          "end_line": 102,
+          "file": "bench/repos/rustls/rustls-test/tests/api/crypto.rs",
+          "start_line": 93
+        },
+        {
+          "end_line": 54,
+          "file": "bench/repos/rustls/rustls-test/tests/api/crypto.rs",
+          "start_line": 46
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rustls",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/rustls/rustls-test/tests/api/crypto.rs"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        110,
+        60
+      ]
+    },
+    {
+      "candidate_key": "rustls:cb3ba04584140a2f",
+      "candidate_sha256": "8dc29069c2dd9172cf0778923a9b75a9a2f719b7dd9724b511b3648bad68f94c",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "cb3ba04584140a2f",
+      "feature_run": "1531784369f196976dd8",
+      "intersection_mass": 15,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 105,
+          "file": "bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 93,
+          "token_count": 33,
+          "value_size": 30
+        },
+        {
+          "end_line": 482,
+          "file": "bench/repos/rustls/examples/src/bin/tlsclient-mio.rs",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 470,
+          "token_count": 35,
+          "value_size": 31
+        }
+      ],
+      "members": [
+        {
+          "end_line": 105,
+          "file": "bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs",
+          "start_line": 93
+        },
+        {
+          "end_line": 481,
+          "file": "bench/repos/rustls/examples/src/bin/tlsclient-mio.rs",
+          "start_line": 470
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "rustls",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs",
+        "bench/repos/rustls/examples/src/bin/tlsclient-mio.rs"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        30,
+        31
+      ]
+    },
+    {
+      "candidate_key": "scrapy:533cc1e54f54c889",
+      "candidate_sha256": "ecbb3232eb5c714a8c6d2ffd28bf458ac128c5425416bbab358177b28e677eae",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "533cc1e54f54c889",
+      "feature_run": "9ed44ed16e8f42d9bea1",
+      "inline_aug_mass": 28,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 553,
+          "file": "bench/repos/scrapy/tests/test_pipelines.py",
+          "kind": "Class",
+          "name": "TestMiddlewareManagerSpider",
+          "pure_single_return": false,
+          "start_line": 414,
+          "token_count": 145,
+          "value_size": 58
+        }
+      },
+      "intersection_mass": 3,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 553,
+          "file": "bench/repos/scrapy/tests/test_pipelines.py",
+          "kind": "Method",
+          "name": "test_no_spider_arg_without_crawler",
+          "pure_single_return": false,
+          "start_line": 525,
+          "token_count": 19,
+          "value_size": 10
+        },
+        {
+          "end_line": 475,
+          "file": "bench/repos/scrapy/tests/test_pipelines.py",
+          "kind": "Method",
+          "name": "test_deprecated_spider_arg_no_crawler_spider",
+          "pure_single_return": false,
+          "start_line": 423,
+          "token_count": 45,
+          "value_size": 28
+        }
+      ],
+      "members": [
+        {
+          "end_line": 548,
+          "file": "bench/repos/scrapy/tests/test_pipelines.py",
+          "start_line": 531
+        },
+        {
+          "end_line": 445,
+          "file": "bench/repos/scrapy/tests/test_pipelines.py",
+          "start_line": 428
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "scrapy",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/scrapy/tests/test_pipelines.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        10,
+        28
+      ]
+    },
+    {
+      "candidate_key": "scrapy:be72d6b46ad8eaf1",
+      "candidate_sha256": "6963b79dc8e4de4ceecd58c6b4c029e31dfd9ff7de15f4a4d3dd6faa92274441",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "be72d6b46ad8eaf1",
+      "feature_run": "d9b45afa30ca9b61697d",
+      "intersection_mass": 33,
+      "language": "Python",
+      "matched_units": [
+        {
+          "end_line": 292,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "kind": "Method",
+          "name": "follow_all",
+          "pure_single_return": false,
+          "start_line": 221,
+          "token_count": 128,
+          "value_size": 75
+        },
+        {
+          "end_line": 219,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "kind": "Method",
+          "name": "follow",
+          "pure_single_return": false,
+          "start_line": 168,
+          "token_count": 79,
+          "value_size": 51
+        }
+      ],
+      "members": [
+        {
+          "end_line": 295,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "start_line": 279
+        },
+        {
+          "end_line": 221,
+          "file": "bench/repos/scrapy/scrapy/http/response/text.py",
+          "start_line": 206
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "scrapy",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/scrapy/scrapy/http/response/text.py"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        75,
+        51
+      ]
+    },
+    {
+      "candidate_key": "serde_json:2515a9bc2af59ece",
+      "candidate_sha256": "62c870bf522611ae0c96dac81e5c421eab766b1e7bd25c2f84319fe7b8d2e427",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "2515a9bc2af59ece",
+      "feature_run": "4c47c7871d3bee2af308",
+      "intersection_mass": 24,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 2018,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "kind": "Function",
+          "name": "has_next_key",
+          "pure_single_return": false,
+          "start_line": 1990,
+          "token_count": 150,
+          "value_size": 61
+        },
+        {
+          "end_line": 1962,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "kind": "Function",
+          "name": "has_next_element",
+          "pure_single_return": false,
+          "start_line": 1937,
+          "token_count": 122,
+          "value_size": 50
+        }
+      ],
+      "members": [
+        {
+          "end_line": 2017,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "start_line": 2000
+        },
+        {
+          "end_line": 1961,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "start_line": 1949
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "serde_json",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/serde_json/src/de.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        61,
+        50
+      ]
+    },
+    {
+      "candidate_key": "serde_json:2f42630683e613dd",
+      "candidate_sha256": "6594478fb9ba1f90c3d4b3b21e59cdd5e12a6927c1d5f98598ba96994f61f348",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "2f42630683e613dd",
+      "feature_run": "4ad65b30539580049df4",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2291,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 2287
+        },
+        {
+          "end_line": 2297,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 2293
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "serde_json",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/serde_json/tests/test.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "serde_json:3f1d50e522be29ae",
+      "candidate_sha256": "e9c065ca3ff8bf83c2678ffe174e2b3a4740238cd7be16d38ba3c39a5bee4464",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "3f1d50e522be29ae",
+      "feature_run": "4ad65b30539580049df4",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 2037,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 2011
+        },
+        {
+          "end_line": 2066,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 2040
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "serde_json",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/serde_json/tests/test.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "serde_json:8dc63e0bf59dff86",
+      "candidate_sha256": "403bd910e440a367948b99a06941c25603cb84bbdf0205b255c951760a1f360e",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "8dc63e0bf59dff86",
+      "feature_run": "4c47c7871d3bee2af308",
+      "intersection_mass": 24,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 1962,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "kind": "Function",
+          "name": "has_next_element",
+          "pure_single_return": false,
+          "start_line": 1937,
+          "token_count": 122,
+          "value_size": 50
+        },
+        {
+          "end_line": 2018,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "kind": "Function",
+          "name": "has_next_key",
+          "pure_single_return": false,
+          "start_line": 1990,
+          "token_count": 150,
+          "value_size": 61
+        }
+      ],
+      "members": [
+        {
+          "end_line": 1945,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "start_line": 1940
+        },
+        {
+          "end_line": 1996,
+          "file": "bench/repos/serde_json/src/de.rs",
+          "start_line": 1991
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "serde_json",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/serde_json/src/de.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        50,
+        61
+      ]
+    },
+    {
+      "candidate_key": "serde_json:946bfa61cb71d562",
+      "candidate_sha256": "d9014a0c4450f8a1a2798507d4ccce4c51d43e7720bf3cb98d64d39ffa5b5756",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "946bfa61cb71d562",
+      "feature_run": "f4600d9cc727f7cf5fad",
+      "intersection_mass": 29,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 581,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "kind": "Function",
+          "name": "imul_test",
+          "pure_single_return": false,
+          "start_line": 533,
+          "token_count": 106,
+          "value_size": 47
+        },
+        {
+          "end_line": 525,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "kind": "Function",
+          "name": "mul_test",
+          "pure_single_return": false,
+          "start_line": 480,
+          "token_count": 97,
+          "value_size": 39
+        }
+      ],
+      "members": [
+        {
+          "end_line": 547,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "start_line": 533
+        },
+        {
+          "end_line": 494,
+          "file": "bench/repos/serde_json/tests/lexical/float.rs",
+          "start_line": 480
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "serde_json",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/serde_json/tests/lexical/float.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        47,
+        39
+      ]
+    },
+    {
+      "candidate_key": "serde_json:c38a8703c271821c",
+      "candidate_sha256": "7f02544a571f3bd454d08d3f0d49f92b37a412698d0a0fbfb8d55833fc64b524",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "c38a8703c271821c",
+      "feature_run": "185b977cd442963d882f",
+      "intersection_mass": 11,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 395,
+          "file": "bench/repos/serde_json/src/number.rs",
+          "kind": "Function",
+          "name": "serialize",
+          "pure_single_return": false,
+          "start_line": 386,
+          "token_count": 29,
+          "value_size": 14
+        },
+        {
+          "end_line": 309,
+          "file": "bench/repos/serde_json/src/raw.rs",
+          "kind": "Function",
+          "name": "serialize",
+          "pure_single_return": false,
+          "start_line": 302,
+          "token_count": 24,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 395,
+          "file": "bench/repos/serde_json/src/number.rs",
+          "start_line": 386
+        },
+        {
+          "end_line": 309,
+          "file": "bench/repos/serde_json/src/raw.rs",
+          "start_line": 302
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "serde_json",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/serde_json/src/number.rs",
+        "bench/repos/serde_json/src/raw.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        14,
+        14
+      ]
+    },
+    {
+      "candidate_key": "serde_json:d4ed845b75ad1b1c",
+      "candidate_sha256": "442501fd63a58d848455acfd96ee7a9720f0dd05fbff4df8c0a868ee93393179",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "d4ed845b75ad1b1c",
+      "feature_run": "74d9481c3d71bdcdb216",
+      "intersection_mass": 10,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 848,
+          "file": "bench/repos/serde_json/src/read.rs",
+          "kind": "Function",
+          "name": "next_or_eof",
+          "pure_single_return": false,
+          "start_line": 840,
+          "token_count": 34,
+          "value_size": 26
+        },
+        {
+          "end_line": 858,
+          "file": "bench/repos/serde_json/src/read.rs",
+          "kind": "Function",
+          "name": "peek_or_eof",
+          "pure_single_return": false,
+          "start_line": 850,
+          "token_count": 34,
+          "value_size": 26
+        }
+      ],
+      "members": [
+        {
+          "end_line": 848,
+          "file": "bench/repos/serde_json/src/read.rs",
+          "start_line": 840
+        },
+        {
+          "end_line": 858,
+          "file": "bench/repos/serde_json/src/read.rs",
+          "start_line": 850
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "serde_json",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/serde_json/src/read.rs"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        26,
+        26
+      ]
+    },
+    {
+      "candidate_key": "serde_json:e05e8bc1734e5ef0",
+      "candidate_sha256": "649ecb6f45b3368bbade2f08632c04706de604561e63f28231b10f56242f1ce0",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "e05e8bc1734e5ef0",
+      "feature_run": "4ad65b30539580049df4",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 100,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 86
+        },
+        {
+          "end_line": 116,
+          "file": "bench/repos/serde_json/tests/test.rs",
+          "start_line": 102
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "serde_json",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/serde_json/tests/test.rs"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "sidekiq:fe3c6be4a61ad4de",
+      "candidate_sha256": "1747fbcc8a9093d1343439dac6a8dccc41121959e2979b0fcc89c0be710bf08f",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "fe3c6be4a61ad4de",
+      "feature_run": "fb03ea40370bc641770c",
+      "language": "Ruby",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 117,
+          "file": "bench/repos/sidekiq/bin/multi_queue_bench",
+          "start_line": 76
+        },
+        {
+          "end_line": 139,
+          "file": "bench/repos/sidekiq/bin/sidekiqload",
+          "start_line": 98
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "sidekiq",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/sidekiq/bin/multi_queue_bench",
+        "bench/repos/sidekiq/bin/sidekiqload"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "sinatra:c8eba586fdfacedc",
+      "candidate_sha256": "44a40ca5891725586c168b2595f8993665311fa7ee56bc7f8de50927b5a72ee0",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "c8eba586fdfacedc",
+      "feature_run": "50d0a104700c1d2927b1",
+      "intersection_mass": 8,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 255,
+          "file": "bench/repos/sinatra/test/indifferent_hash_test.rb",
+          "kind": "Method",
+          "name": "test_select",
+          "pure_single_return": false,
+          "start_line": 244,
+          "token_count": 60,
+          "value_size": 22
+        },
+        {
+          "end_line": 273,
+          "file": "bench/repos/sinatra/test/indifferent_hash_test.rb",
+          "kind": "Method",
+          "name": "test_reject",
+          "pure_single_return": false,
+          "start_line": 262,
+          "token_count": 60,
+          "value_size": 22
+        }
+      ],
+      "members": [
+        {
+          "end_line": 255,
+          "file": "bench/repos/sinatra/test/indifferent_hash_test.rb",
+          "start_line": 244
+        },
+        {
+          "end_line": 273,
+          "file": "bench/repos/sinatra/test/indifferent_hash_test.rb",
+          "start_line": 262
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "sinatra",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/sinatra/test/indifferent_hash_test.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        22,
+        22
+      ]
+    },
+    {
+      "candidate_key": "sinatra:e4ad961494fe684e",
+      "candidate_sha256": "33e03e00951de052ebf8c5199a22e79475c7d2d4d39bdff69ab278843a979058",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "e4ad961494fe684e",
+      "feature_run": "ce455b0bb06c773ab692",
+      "inline_aug_mass": 17,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 90,
+          "file": "bench/repos/sinatra/test/contest.rb",
+          "kind": "Class",
+          "name": "Minitest::Test",
+          "pure_single_return": false,
+          "start_line": 29,
+          "token_count": 237,
+          "value_size": 115
+        }
+      },
+      "intersection_mass": 6,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/sinatra/test/contest.rb",
+          "kind": "Method",
+          "name": "setup_blocks",
+          "pure_single_return": false,
+          "start_line": 34,
+          "token_count": 30,
+          "value_size": 17
+        },
+        {
+          "end_line": 46,
+          "file": "bench/repos/sinatra/test/contest.rb",
+          "kind": "Method",
+          "name": "teardown_blocks",
+          "pure_single_return": false,
+          "start_line": 41,
+          "token_count": 30,
+          "value_size": 17
+        }
+      ],
+      "members": [
+        {
+          "end_line": 39,
+          "file": "bench/repos/sinatra/test/contest.rb",
+          "start_line": 34
+        },
+        {
+          "end_line": 46,
+          "file": "bench/repos/sinatra/test/contest.rb",
+          "start_line": 41
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "sinatra",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/sinatra/test/contest.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        17,
+        17
+      ]
+    },
+    {
+      "candidate_key": "sled:a5e482f708ba7014",
+      "candidate_sha256": "499e4802a1ffc317554d445d024edb4e8e602dc113dfe5e669acaac278d7ff4a",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "medium",
+      "family_id": "a5e482f708ba7014",
+      "feature_run": "054806247a97103e9f3c",
+      "inline_aug_mass": 23,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 78,
+          "file": "bench/repos/sled/examples/bench_large.rs",
+          "kind": "Function",
+          "name": "git_hash",
+          "pure_single_return": true,
+          "start_line": 70,
+          "token_count": 41,
+          "value_size": 23
+        }
+      },
+      "intersection_mass": 4,
+      "language": "Rust",
+      "matched_units": [
+        {
+          "end_line": 88,
+          "file": "bench/repos/sled/examples/bench_large.rs",
+          "kind": "Function",
+          "name": "os_info",
+          "pure_single_return": true,
+          "start_line": 80,
+          "token_count": 38,
+          "value_size": 20
+        },
+        {
+          "end_line": 78,
+          "file": "bench/repos/sled/examples/bench_large.rs",
+          "kind": "Function",
+          "name": "git_hash",
+          "pure_single_return": true,
+          "start_line": 70,
+          "token_count": 41,
+          "value_size": 23
+        }
+      ],
+      "members": [
+        {
+          "end_line": 90,
+          "file": "bench/repos/sled/examples/bench_large.rs",
+          "start_line": 82
+        },
+        {
+          "end_line": 80,
+          "file": "bench/repos/sled/examples/bench_large.rs",
+          "start_line": 72
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "sled",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/sled/examples/bench_large.rs"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        20,
+        23
+      ]
+    },
+    {
+      "candidate_key": "swr:9b7a03feec3a4cce",
+      "candidate_sha256": "e2c696c8e4ae43729bbd7ed107be9b9fab9fa3238563adbba9db3581eba6e1a7",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "9b7a03feec3a4cce",
+      "feature_run": "aeb0fb56f2cb79b68dd0",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 1413,
+          "file": "bench/repos/swr/test/use-swr-local-mutation.test.tsx",
+          "start_line": 1403
+        },
+        {
+          "end_line": 1473,
+          "file": "bench/repos/swr/test/use-swr-local-mutation.test.tsx",
+          "start_line": 1463
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "swr",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/swr/test/use-swr-local-mutation.test.tsx"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "thor:07e233ddffad07f0",
+      "candidate_sha256": "c3607b8739203183114dff0787b5aa08759c4fb42acca06dbd7fb183d1e90149",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "medium",
+      "family_id": "07e233ddffad07f0",
+      "feature_run": "8158e58a07d52a483a07",
+      "intersection_mass": 27,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 41,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "kind": "Block",
+          "name": "it:uses the Basic line editor",
+          "pure_single_return": false,
+          "start_line": 38,
+          "token_count": 52,
+          "value_size": 40
+        },
+        {
+          "end_line": 21,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "kind": "Block",
+          "name": "it:uses the Readline line editor",
+          "pure_single_return": false,
+          "start_line": 18,
+          "token_count": 52,
+          "value_size": 40
+        }
+      ],
+      "members": [
+        {
+          "end_line": 44,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "start_line": 39
+        },
+        {
+          "end_line": 24,
+          "file": "bench/repos/thor/spec/line_editor_spec.rb",
+          "start_line": 19
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "thor",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/thor/spec/line_editor_spec.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        40,
+        40
+      ]
+    },
+    {
+      "candidate_key": "thor:c9e373f89995a6f6",
+      "candidate_sha256": "40bdfa3fc84c63f006826c975dbf01f4d5e7426ecc0fa4053ab37d9b0215df8c",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c9e373f89995a6f6",
+      "feature_run": "ab3ac7395feb766ff897",
+      "inline_aug_mass": 5,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 291,
+          "file": "bench/repos/thor/lib/thor/group.rb",
+          "kind": "Class",
+          "name": "Thor::Group",
+          "pure_single_return": false,
+          "start_line": 8,
+          "token_count": 716,
+          "value_size": 181
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Ruby",
+      "matched_units": [
+        {
+          "end_line": 141,
+          "file": "bench/repos/thor/lib/thor/group.rb",
+          "kind": "Method",
+          "name": "invoke_from_option",
+          "pure_single_return": true,
+          "start_line": 110,
+          "token_count": 95,
+          "value_size": 5
+        },
+        {
+          "end_line": 78,
+          "file": "bench/repos/thor/lib/thor/group.rb",
+          "kind": "Method",
+          "name": "invoke",
+          "pure_single_return": true,
+          "start_line": 56,
+          "token_count": 81,
+          "value_size": 5
+        }
+      ],
+      "members": [
+        {
+          "end_line": 141,
+          "file": "bench/repos/thor/lib/thor/group.rb",
+          "start_line": 110
+        },
+        {
+          "end_line": 78,
+          "file": "bench/repos/thor/lib/thor/group.rb",
+          "start_line": 56
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "thor",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/thor/lib/thor/group.rb"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        5,
+        5
+      ]
+    },
+    {
+      "candidate_key": "tmux:4d161d7f40bac6f1",
+      "candidate_sha256": "4f7c526daa79515217e08a28f45509a750a6a9374d57b58735554b3231e37f37",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "4d161d7f40bac6f1",
+      "feature_run": "bfb2e14ea116aa691167",
+      "inline_aug_mass": 10,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 264,
+          "file": "bench/repos/tmux/notify.c",
+          "kind": "Function",
+          "name": "notify_client",
+          "pure_single_return": false,
+          "start_line": 257,
+          "token_count": 26,
+          "value_size": 10
+        }
+      },
+      "intersection_mass": 5,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 264,
+          "file": "bench/repos/tmux/notify.c",
+          "kind": "Function",
+          "name": "notify_client",
+          "pure_single_return": false,
+          "start_line": 257,
+          "token_count": 26,
+          "value_size": 10
+        },
+        {
+          "end_line": 303,
+          "file": "bench/repos/tmux/notify.c",
+          "kind": "Function",
+          "name": "notify_window",
+          "pure_single_return": false,
+          "start_line": 296,
+          "token_count": 26,
+          "value_size": 10
+        }
+      ],
+      "members": [
+        {
+          "end_line": 264,
+          "file": "bench/repos/tmux/notify.c",
+          "start_line": 257
+        },
+        {
+          "end_line": 303,
+          "file": "bench/repos/tmux/notify.c",
+          "start_line": 296
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tmux",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/tmux/notify.c"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        10,
+        10
+      ]
+    },
+    {
+      "candidate_key": "tmux:6c7a09c2a9c5c2b2",
+      "candidate_sha256": "9b3c61ac9465a247ebfabfcf4a955aea2f93934b44a7d72bcef627ebe5964c06",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        321,
+        367
+      ],
+      "family_id": "6c7a09c2a9c5c2b2",
+      "feature_run": "4fe7afaae305adfa2784",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 367,
+          "file": "bench/repos/tmux/layout-custom.c",
+          "kind": "Function",
+          "name": "layout_construct_cell",
+          "pure_single_return": false,
+          "start_line": 321,
+          "token_count": 212,
+          "value_size": 109
+        },
+        {
+          "end_line": 367,
+          "file": "bench/repos/tmux/layout-custom.c",
+          "kind": "Function",
+          "name": "layout_construct_cell",
+          "pure_single_return": false,
+          "start_line": 321,
+          "token_count": 212,
+          "value_size": 109
+        }
+      ],
+      "members": [
+        {
+          "end_line": 351,
+          "file": "bench/repos/tmux/layout-custom.c",
+          "start_line": 341
+        },
+        {
+          "end_line": 346,
+          "file": "bench/repos/tmux/layout-custom.c",
+          "start_line": 336
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tmux",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/tmux/layout-custom.c"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "tmux:efdb8be4fa09f367",
+      "candidate_sha256": "d085f256956589d3913272f48bdf53d35a1a82556b92acae9b6720194f2dd9ca",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        765,
+        856
+      ],
+      "family_id": "efdb8be4fa09f367",
+      "feature_run": "f9b17c0c331639ad74d4",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 856,
+          "file": "bench/repos/tmux/tty.c",
+          "kind": "Function",
+          "name": "tty_update_cursor",
+          "pure_single_return": false,
+          "start_line": 765,
+          "token_count": 310,
+          "value_size": 243
+        },
+        {
+          "end_line": 856,
+          "file": "bench/repos/tmux/tty.c",
+          "kind": "Function",
+          "name": "tty_update_cursor",
+          "pure_single_return": false,
+          "start_line": 765,
+          "token_count": 310,
+          "value_size": 243
+        }
+      ],
+      "members": [
+        {
+          "end_line": 833,
+          "file": "bench/repos/tmux/tty.c",
+          "start_line": 827
+        },
+        {
+          "end_line": 842,
+          "file": "bench/repos/tmux/tty.c",
+          "start_line": 836
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "tmux",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/tmux/tty.c"
+      ],
+      "split": "dev"
+    },
+    {
+      "candidate_key": "tokio:1e05e06201182605",
+      "candidate_sha256": "a83eddb81211be8b44babb52167426536f601673e7b38dd358333b2366123993",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "1e05e06201182605",
+      "feature_run": "f4b48f81a5a7702fc399",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        {
+          "end_line": 43,
+          "file": "bench/repos/tokio/tokio-stream/tests/async_send_sync.rs",
+          "kind": "Block",
+          "name": "into_todo:arm0",
+          "pure_single_return": false,
+          "start_line": 40,
+          "token_count": 5,
+          "value_size": 2
+        }
+      ],
+      "members": [
+        {
+          "end_line": 86,
+          "file": "bench/repos/tokio/tokio/tests/async_send_sync.rs",
+          "start_line": 46
+        },
+        {
+          "end_line": 46,
+          "file": "bench/repos/tokio/tokio-stream/tests/async_send_sync.rs",
+          "start_line": 6
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tokio",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/tokio/tokio-stream/tests/async_send_sync.rs",
+        "bench/repos/tokio/tokio/tests/async_send_sync.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "tokio:6189ced49439fb29",
+      "candidate_sha256": "7a46302885bf56a6a15d5003901f23d9e4e70a5f6cc5bff1047237c5bfb1ba57",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "6189ced49439fb29",
+      "feature_run": "35faaa38d7b06eae733a",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 265,
+          "file": "bench/repos/tokio/tokio/src/io/poll_evented.rs",
+          "start_line": 238
+        },
+        {
+          "end_line": 211,
+          "file": "bench/repos/tokio/tokio/src/io/poll_evented.rs",
+          "start_line": 180
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tokio",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/tokio/tokio/src/io/poll_evented.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "tokio:af17a49f38c801e2",
+      "candidate_sha256": "8eb2847b49b14f54baaaf5186db1f9bb85dbda5629987bd0d30ae64aec373927",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "af17a49f38c801e2",
+      "feature_run": "983cda346a17a9e63253",
+      "language": "Rust",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 467,
+          "file": "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs",
+          "start_line": 457
+        },
+        {
+          "end_line": 401,
+          "file": "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs",
+          "start_line": 370
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "tokio",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "trpc:392570d60aac814e",
+      "candidate_sha256": "3f3d16cb29dd6a2807b28b31d25f4e8704e2751f99d9c39443b5c5521430d2ea",
+      "channel": "contiguous",
+      "class": "inline-ceiling",
+      "confidence": "high",
+      "family_id": "392570d60aac814e",
+      "feature_run": "0bd8daeffe09e90ba193",
+      "inline_aug_mass": 27,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 14,
+          "file": "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts",
+          "kind": "Function",
+          "name": "getBaseUrl",
+          "pure_single_return": false,
+          "start_line": 6,
+          "token_count": 35,
+          "value_size": 27
+        }
+      },
+      "intersection_mass": 0,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 21,
+          "file": "bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts",
+          "kind": "Function",
+          "name": "getBaseUrl",
+          "pure_single_return": false,
+          "start_line": 7,
+          "token_count": 35,
+          "value_size": 27
+        },
+        {
+          "end_line": 31,
+          "file": "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts",
+          "kind": "Method",
+          "name": "config",
+          "pure_single_return": true,
+          "start_line": 17,
+          "token_count": 16,
+          "value_size": 14
+        }
+      ],
+      "members": [
+        {
+          "end_line": 33,
+          "file": "bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts",
+          "start_line": 5
+        },
+        {
+          "end_line": 32,
+          "file": "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts",
+          "start_line": 4
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "trpc",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts",
+        "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        27,
+        14
+      ]
+    },
+    {
+      "candidate_key": "trpc:5c1809963c693d04",
+      "candidate_sha256": "f0e1b3d4784d26502e2b7b3da604be87f09036cdef0dfc61666a2e00e63efa9e",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "5c1809963c693d04",
+      "feature_run": "8ee52644558ec9288530",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 32,
+          "file": "bench/repos/trpc/packages/react-query/tsdown.config.ts",
+          "start_line": 7
+        },
+        {
+          "end_line": 27,
+          "file": "bench/repos/trpc/packages/server/tsdown.config.ts",
+          "start_line": 18
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "trpc",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/trpc/packages/react-query/tsdown.config.ts",
+        "bench/repos/trpc/packages/server/tsdown.config.ts"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "trpc:8624bd4a921aa255",
+      "candidate_sha256": "ab3d70520fee248eee19afed661943c0a8e9d50efd1474b465d96e34953a9fe5",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "8624bd4a921aa255",
+      "feature_run": "b1032b28fbdd7a7b9c49",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 99,
+          "file": "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 97,
+          "token_count": 9,
+          "value_size": 6
+        }
+      },
+      "intersection_mass": 3,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 303,
+          "file": "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 301,
+          "token_count": 8,
+          "value_size": 5
+        },
+        {
+          "end_line": 99,
+          "file": "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 97,
+          "token_count": 9,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 307,
+          "file": "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts",
+          "start_line": 280
+        },
+        {
+          "end_line": 103,
+          "file": "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts",
+          "start_line": 76
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "trpc",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        5,
+        6
+      ]
+    },
+    {
+      "candidate_key": "trpc:8eefa5a90b80ca48",
+      "candidate_sha256": "a2647e378ae750cbafcb8f5653a05aa7e19a41454fefe0e55d5ea2c4862b94b2",
+      "channel": "contiguous",
+      "class": "no-overlapping-unit",
+      "confidence": "medium",
+      "family_id": "8eefa5a90b80ca48",
+      "feature_run": "f49c73d3c95cc5054160",
+      "language": "TypeScript",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 40,
+          "file": "bench/repos/trpc/examples/next-big-router/scripts/codegen-base.ts",
+          "start_line": 4
+        },
+        {
+          "end_line": 41,
+          "file": "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen-base.ts",
+          "start_line": 5
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "trpc",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen-base.ts",
+        "bench/repos/trpc/examples/next-big-router/scripts/codegen-base.ts"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "trpc:b6d295fc4fe003ac",
+      "candidate_sha256": "c81da1a7edb7ed2f310f8cc25ca3bbfc31b72111fc3ef1b7bfdb410a7526a57e",
+      "channel": "contiguous",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "b6d295fc4fe003ac",
+      "feature_run": "395b5e92f6e14714a361",
+      "intersection_mass": 25,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 26,
+          "file": "bench/repos/trpc/examples/next-big-router/scripts/codegen.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 22,
+          "token_count": 36,
+          "value_size": 25
+        },
+        {
+          "end_line": 26,
+          "file": "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 22,
+          "token_count": 36,
+          "value_size": 25
+        }
+      ],
+      "members": [
+        {
+          "end_line": 42,
+          "file": "bench/repos/trpc/examples/next-big-router/scripts/codegen.ts",
+          "start_line": 1
+        },
+        {
+          "end_line": 42,
+          "file": "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts",
+          "start_line": 1
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "trpc",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts",
+        "bench/repos/trpc/examples/next-big-router/scripts/codegen.ts"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        25
+      ]
+    },
+    {
+      "candidate_key": "urfave-cli:8d16dc452f3936a2",
+      "candidate_sha256": "de5e7571b84a78c3f57aaabd4fde31f491602d8fdfcb6b857ecec36d8cd226e0",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "low",
+      "family_id": "8d16dc452f3936a2",
+      "feature_run": "9242ad049432e3ea9858",
+      "inline_aug_mass": 6,
+      "inline_helper": {
+        "side": "right",
+        "unit": {
+          "end_line": 191,
+          "file": "bench/repos/urfave-cli/flag_impl.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 189,
+          "token_count": 7,
+          "value_size": 6
+        }
+      },
+      "intersection_mass": 2,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 89,
+          "file": "bench/repos/urfave-cli/flag_bool_with_inverse.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 87,
+          "token_count": 7,
+          "value_size": 6
+        },
+        {
+          "end_line": 172,
+          "file": "bench/repos/urfave-cli/flag_impl.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": true,
+          "start_line": 170,
+          "token_count": 7,
+          "value_size": 6
+        }
+      ],
+      "members": [
+        {
+          "end_line": 90,
+          "file": "bench/repos/urfave-cli/flag_bool_with_inverse.go",
+          "start_line": 86
+        },
+        {
+          "end_line": 173,
+          "file": "bench/repos/urfave-cli/flag_impl.go",
+          "start_line": 169
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "urfave-cli",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/urfave-cli/flag_bool_with_inverse.go",
+        "bench/repos/urfave-cli/flag_impl.go"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        6,
+        6
+      ]
+    },
+    {
+      "candidate_key": "urfave-cli:ea93d66380eba837",
+      "candidate_sha256": "f2a8525acda8ea51727468df82fdc2421b99b106da9cbf04bf7b6d8f08d4edb2",
+      "channel": "structural",
+      "class": "no-overlapping-unit",
+      "confidence": "high",
+      "family_id": "ea93d66380eba837",
+      "feature_run": "450a75c020d154401c99",
+      "language": "Go",
+      "matched_units": [
+        null,
+        null
+      ],
+      "members": [
+        {
+          "end_line": 884,
+          "file": "bench/repos/urfave-cli/flag_test.go",
+          "start_line": 879
+        },
+        {
+          "end_line": 936,
+          "file": "bench/repos/urfave-cli/flag_test.go",
+          "start_line": 931
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "urfave-cli",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/urfave-cli/flag_test.go"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "vim:0d979b4ba53dad74",
+      "candidate_sha256": "f00825015c571fff7d05ae2804f991a3ebf797e6d98f5519ded47dd2652e67d2",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        3065,
+        3341
+      ],
+      "family_id": "0d979b4ba53dad74",
+      "feature_run": "8f83811708f0df3e82f2",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 3341,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "kind": "Function",
+          "name": "autocmd_add_or_delete",
+          "pure_single_return": false,
+          "start_line": 3065,
+          "token_count": 800,
+          "value_size": 441
+        },
+        {
+          "end_line": 3341,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "kind": "Function",
+          "name": "autocmd_add_or_delete",
+          "pure_single_return": false,
+          "start_line": 3065,
+          "token_count": 800,
+          "value_size": 441
+        }
+      ],
+      "members": [
+        {
+          "end_line": 3218,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "start_line": 3191
+        },
+        {
+          "end_line": 3144,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "start_line": 3119
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "vim",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/vim/src/autocmd.c"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "vim:a309eef0f8cb0f71",
+      "candidate_sha256": "657502d03bc7564c1dd83c108bdc4fe17b892d3bcfa6b1f0cb49c8cb6319e0a8",
+      "channel": "structural",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        3065,
+        3341
+      ],
+      "family_id": "a309eef0f8cb0f71",
+      "feature_run": "8f83811708f0df3e82f2",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 3341,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "kind": "Function",
+          "name": "autocmd_add_or_delete",
+          "pure_single_return": false,
+          "start_line": 3065,
+          "token_count": 800,
+          "value_size": 441
+        },
+        {
+          "end_line": 3341,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "kind": "Function",
+          "name": "autocmd_add_or_delete",
+          "pure_single_return": false,
+          "start_line": 3065,
+          "token_count": 800,
+          "value_size": 441
+        }
+      ],
+      "members": [
+        {
+          "end_line": 3143,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "start_line": 3121
+        },
+        {
+          "end_line": 3215,
+          "file": "bench/repos/vim/src/autocmd.c",
+          "start_line": 3193
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "vim",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/vim/src/autocmd.c"
+      ],
+      "split": "heldout"
+    },
+    {
+      "candidate_key": "vim:a3155684430a48be",
+      "candidate_sha256": "99961141559acfeafca2256eae4be93ee52e3bcad6b2dd67e45501be9a0e7e4a",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "a3155684430a48be",
+      "feature_run": "63b3f9a1191a6543ab6f",
+      "intersection_mass": 35,
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 2007,
+          "file": "bench/repos/vim/src/if_py_both.h",
+          "kind": "Function",
+          "name": "DictionarySetattr",
+          "pure_single_return": false,
+          "start_line": 1971,
+          "token_count": 87,
+          "value_size": 73
+        },
+        {
+          "end_line": 3580,
+          "file": "bench/repos/vim/src/if_py_both.h",
+          "kind": "Function",
+          "name": "TupleSetattr",
+          "pure_single_return": false,
+          "start_line": 3545,
+          "token_count": 87,
+          "value_size": 73
+        }
+      ],
+      "members": [
+        {
+          "end_line": 2007,
+          "file": "bench/repos/vim/src/if_py_both.h",
+          "start_line": 1971
+        },
+        {
+          "end_line": 3580,
+          "file": "bench/repos/vim/src/if_py_both.h",
+          "start_line": 3545
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "vim",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/vim/src/if_py_both.h"
+      ],
+      "split": "heldout",
+      "subdag_ge_12": true,
+      "subdag_ge_20": true,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        73,
+        73
+      ]
+    },
+    {
+      "candidate_key": "zap:23de1a83b5d5ff94",
+      "candidate_sha256": "5bc3f8cfe16e43bce128a9d5cff8cfa5b85e5930a321e16ac2e25e3da81771dd",
+      "channel": "structural",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "23de1a83b5d5ff94",
+      "feature_run": "4080f1abd3b2d288e465",
+      "inline_aug_mass": 5,
+      "intersection_mass": 5,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 91,
+          "file": "bench/repos/zap/benchmarks/zap_test.go",
+          "kind": "Method",
+          "name": "MarshalLogArray",
+          "pure_single_return": true,
+          "start_line": 85,
+          "token_count": 24,
+          "value_size": 11
+        },
+        {
+          "end_line": 476,
+          "file": "bench/repos/zap/sugar.go",
+          "kind": "Method",
+          "name": "MarshalLogArray",
+          "pure_single_return": true,
+          "start_line": 470,
+          "token_count": 24,
+          "value_size": 11
+        }
+      ],
+      "members": [
+        {
+          "end_line": 91,
+          "file": "bench/repos/zap/benchmarks/zap_test.go",
+          "start_line": 85
+        },
+        {
+          "end_line": 476,
+          "file": "bench/repos/zap/sugar.go",
+          "start_line": 470
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "zap",
+      "scope": "mixed",
+      "source_files": [
+        "bench/repos/zap/benchmarks/zap_test.go",
+        "bench/repos/zap/sugar.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        11,
+        11
+      ]
+    },
+    {
+      "candidate_key": "zap:c3ae8f9eecbafd9e",
+      "candidate_sha256": "28e6e7bc9e43e98ff6ff82aa2ec96bea150c305ffb57718a0dee635af908124a",
+      "channel": "contiguous",
+      "class": "unrecovered",
+      "confidence": "high",
+      "family_id": "c3ae8f9eecbafd9e",
+      "feature_run": "f43a5fddd36c19ca1fc8",
+      "inline_aug_mass": 8,
+      "inline_helper": {
+        "side": "left",
+        "unit": {
+          "end_line": 139,
+          "file": "bench/repos/zap/writer_test.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 124,
+          "token_count": 79,
+          "value_size": 8
+        }
+      },
+      "intersection_mass": 5,
+      "language": "Go",
+      "matched_units": [
+        {
+          "end_line": 224,
+          "file": "bench/repos/zap/writer_test.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 214,
+          "token_count": 49,
+          "value_size": 8
+        },
+        {
+          "end_line": 139,
+          "file": "bench/repos/zap/writer_test.go",
+          "kind": "Block",
+          "name": null,
+          "pure_single_return": false,
+          "start_line": 124,
+          "token_count": 79,
+          "value_size": 8
+        }
+      ],
+      "members": [
+        {
+          "end_line": 222,
+          "file": "bench/repos/zap/writer_test.go",
+          "start_line": 210
+        },
+        {
+          "end_line": 132,
+          "file": "bench/repos/zap/writer_test.go",
+          "start_line": 120
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "zap",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/zap/writer_test.go"
+      ],
+      "split": "dev",
+      "subdag_ge_12": false,
+      "subdag_ge_20": false,
+      "subdag_ge_8": false,
+      "unit_value_sizes": [
+        8,
+        8
+      ]
+    },
+    {
+      "candidate_key": "zod:1ad07dedfa877a0e",
+      "candidate_sha256": "11962c0913e6ba545a54e9f762bc65a9aac0a6225f1e88ccb4985185751344cb",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "1ad07dedfa877a0e",
+      "feature_run": "e0b0d0eaddb74ca5bb99",
+      "intersection_mass": 16,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 2787,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Method",
+          "name": "pick",
+          "pure_single_return": false,
+          "start_line": 2772,
+          "token_count": 44,
+          "value_size": 25
+        },
+        {
+          "end_line": 2804,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Method",
+          "name": "omit",
+          "pure_single_return": false,
+          "start_line": 2789,
+          "token_count": 41,
+          "value_size": 25
+        }
+      ],
+      "members": [
+        {
+          "end_line": 2787,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 2772
+        },
+        {
+          "end_line": 2804,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 2789
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "zod",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/zod/packages/zod/src/v3/types.ts"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        25,
+        25
+      ]
+    },
+    {
+      "candidate_key": "zod:aa98d1623d4fda52",
+      "candidate_sha256": "c9144a02941d22cb0907d7c83547d2b9105241ca7c33f8f2cae6f3628f2d351e",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "aa98d1623d4fda52",
+      "feature_run": "e0b0d0eaddb74ca5bb99",
+      "intersection_mass": 13,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 4496,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Method",
+          "name": "_parse",
+          "pure_single_return": false,
+          "start_line": 4490,
+          "token_count": 26,
+          "value_size": 21
+        },
+        {
+          "end_line": 4536,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Method",
+          "name": "_parse",
+          "pure_single_return": false,
+          "start_line": 4530,
+          "token_count": 26,
+          "value_size": 21
+        }
+      ],
+      "members": [
+        {
+          "end_line": 4496,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 4490
+        },
+        {
+          "end_line": 4536,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 4530
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "zod",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/zod/packages/zod/src/v3/types.ts"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        21,
+        21
+      ]
+    },
+    {
+      "candidate_key": "zod:e6c204c8d398e185",
+      "candidate_sha256": "82c6cd02f99bcee27a22f0ce51b8179097a191ccc81e7cc26fb29e62e74413e8",
+      "channel": "structural",
+      "class": "subdag-ceiling",
+      "confidence": "high",
+      "family_id": "e6c204c8d398e185",
+      "feature_run": "e0b0d0eaddb74ca5bb99",
+      "intersection_mass": 12,
+      "language": "TypeScript",
+      "matched_units": [
+        {
+          "end_line": 696,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Function",
+          "name": "isValidIP",
+          "pure_single_return": false,
+          "start_line": 687,
+          "token_count": 36,
+          "value_size": 30
+        },
+        {
+          "end_line": 729,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "kind": "Function",
+          "name": "isValidCidr",
+          "pure_single_return": false,
+          "start_line": 720,
+          "token_count": 36,
+          "value_size": 30
+        }
+      ],
+      "members": [
+        {
+          "end_line": 696,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 687
+        },
+        {
+          "end_line": 729,
+          "file": "bench/repos/zod/packages/zod/src/v3/types.ts",
+          "start_line": 720
+        }
+      ],
+      "reason": "parameterize",
+      "repo": "zod",
+      "scope": "prod",
+      "source_files": [
+        "bench/repos/zod/packages/zod/src/v3/types.ts"
+      ],
+      "split": "dev",
+      "subdag_ge_12": true,
+      "subdag_ge_20": false,
+      "subdag_ge_8": true,
+      "unit_value_sizes": [
+        30,
+        30
+      ]
+    },
+    {
+      "candidate_key": "zstd:3ad45bf126ac090a",
+      "candidate_sha256": "f50b8c40f8d1ef34ec96829299a2bf19ba10b89f8d50b267bc29ef68360ffb13",
+      "channel": "contiguous",
+      "class": "same-unit-window",
+      "confidence": "high",
+      "enclosing_unit_lines": [
+        15,
+        66
+      ],
+      "family_id": "3ad45bf126ac090a",
+      "feature_run": "214de89d475e776f44a3",
+      "language": "C",
+      "matched_units": [
+        {
+          "end_line": 66,
+          "file": "bench/repos/zstd/build/meson/tests/valgrindTest.py",
+          "kind": "Function",
+          "name": "valgrindTest",
+          "pure_single_return": false,
+          "start_line": 15,
+          "token_count": 159,
+          "value_size": 91
+        },
+        {
+          "end_line": 66,
+          "file": "bench/repos/zstd/build/meson/tests/valgrindTest.py",
+          "kind": "Function",
+          "name": "valgrindTest",
+          "pure_single_return": false,
+          "start_line": 15,
+          "token_count": 159,
+          "value_size": 91
+        }
+      ],
+      "members": [
+        {
+          "end_line": 65,
+          "file": "bench/repos/zstd/build/meson/tests/valgrindTest.py",
+          "start_line": 56
+        },
+        {
+          "end_line": 44,
+          "file": "bench/repos/zstd/build/meson/tests/valgrindTest.py",
+          "start_line": 35
+        }
+      ],
+      "reason": "extract-helper",
+      "repo": "zstd",
+      "scope": "test",
+      "source_files": [
+        "bench/repos/zstd/build/meson/tests/valgrindTest.py"
+      ],
+      "split": "heldout"
+    }
+  ],
+  "provenance": {
+    "command": "python3 bench/labels/recall_ceiling_probe.py --nose target/issue-820/release/nose --repos-root bench/repos --recall-labelset bench/labels/refactoring_families.v5.json --precision-labelset bench/labels/refactoring_families.v6.json --evaluation-report bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json --corpus-manifest bench/goldens/corpus.json --prune-manifest bench/labels/prune_manifest.json --json-out bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json",
+    "corpus_commit_digest": "366c977c096a91d50095253cce77a3ec8468d3147ecbd819353dc01196281083",
+    "git_sha": "60b8f943bbd629093444490bd3daa13c0ba61175",
+    "inputs": {
+      "corpus_manifest": {
+        "path": "bench/goldens/corpus.json",
+        "sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8"
+      },
+      "evaluation_report": {
+        "expected_worthy_recall": {
+          "dev": {
+            "hits": 2691,
+            "n": 2849
+          },
+          "heldout": {
+            "hits": 1996,
+            "n": 2091
+          }
+        },
+        "path": "bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json",
+        "sha256": "f7410ef73c1ab0ccd5ca23d938a032ee0a539ee57be662b4aa4d9045b93d6ce0"
+      },
+      "precision_labelset": {
+        "path": "bench/labels/refactoring_families.v6.json",
+        "role": "precision-only-current-output-overlay",
+        "sha256": "6b72927d0e68e05406540016d3fa136029c52a406af0938b5a805d3fa199ac23",
+        "version": "v6"
+      },
+      "prune_manifest": {
+        "path": "bench/labels/prune_manifest.json",
+        "sha256": "c22f34d3ab4da9b89b5938140bbfdf7664178b3b7b57e5ea3937ba0bb47c2980"
+      },
+      "query_schema": {
+        "path": "bench/labels/query_schema.py",
+        "sha256": "c7e7e94c74c09c33ee46fa2ab2092bb9b569dea915627f5bc4df39f2142d59e7"
+      },
+      "recall_labelset": {
+        "path": "bench/labels/refactoring_families.v5.json",
+        "role": "only-worthy-recall-pool",
+        "sha256": "e18b65543f4b6373d7eadbc93159adda69699eafe8f5f814d9ba53e245a6d9f9",
+        "version": "v5"
+      }
+    },
+    "nose": {
+      "path": "target/issue-820/release/nose",
+      "sha256": "5999e791c276a7d098099911b8252d35609d1ec7dbcf38888dad2815b126dd0a",
+      "version": "nose 0.18.0"
+    },
+    "post_prune_corpus_digest": {
+      "algorithm": "sha256(repo_path NUL kind NUL size NUL file_or_symlink_sha256 LF)",
+      "bytes": 1509667485,
+      "files": 119387,
+      "hex": "7247d64112bc20749de43d91fb86c6f288ae09271a08d67b68aa252d5abb5804"
+    },
+    "query_schema_version": 7,
+    "repository_commits": {
+      "alacritty": {
+        "expected": "aaf3bd744a4f7608fe7d7168fb12b62a2155d311",
+        "observed": "aaf3bd744a4f7608fe7d7168fb12b62a2155d311"
+      },
+      "alamofire": {
+        "expected": "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "observed": "7595cbcf59809f9977c5f6378500de2ad73b7ddb"
+      },
+      "antlr4": {
+        "expected": "7d5770395bb7b02eb56e7c62662cb1d7c08f42a3",
+        "observed": "7d5770395bb7b02eb56e7c62662cb1d7c08f42a3"
+      },
+      "arrow": {
+        "expected": "2224255c4acc594d734cef0bbc83360452a67983",
+        "observed": "2224255c4acc594d734cef0bbc83360452a67983"
+      },
+      "asciidoctor": {
+        "expected": "07fbd12b0cb51cef76a4cf624436b0a241aaa397",
+        "observed": "07fbd12b0cb51cef76a4cf624436b0a241aaa397"
+      },
+      "axios": {
+        "expected": "4306df21e84332fc576e98c2de549347c06bfb76",
+        "observed": "4306df21e84332fc576e98c2de549347c06bfb76"
+      },
+      "badger": {
+        "expected": "897f12fdb4631a9bf2aea347bde0a93d930d3001",
+        "observed": "897f12fdb4631a9bf2aea347bde0a93d930d3001"
+      },
+      "bat": {
+        "expected": "af1f53d9a977154216d01435991fe33631b74713",
+        "observed": "af1f53d9a977154216d01435991fe33631b74713"
+      },
+      "black": {
+        "expected": "d246367ab471cd56298407858661d475c33b3e36",
+        "observed": "d246367ab471cd56298407858661d475c33b3e36"
+      },
+      "boltons": {
+        "expected": "207651ee6055aabd0d9cdeac2e00140cdc208d44",
+        "observed": "207651ee6055aabd0d9cdeac2e00140cdc208d44"
+      },
+      "chi": {
+        "expected": "3b171578ca44dfd75ca3c5cbddc7b44c600a7b49",
+        "observed": "3b171578ca44dfd75ca3c5cbddc7b44c600a7b49"
+      },
+      "clap": {
+        "expected": "8387c812c4b9726474b8407f81ec97f0acf570ed",
+        "observed": "8387c812c4b9726474b8407f81ec97f0acf570ed"
+      },
+      "click": {
+        "expected": "c48021040a50c659b74e24ac2b11c9c9c6620a21",
+        "observed": "c48021040a50c659b74e24ac2b11c9c9c6620a21"
+      },
+      "cmark": {
+        "expected": "b6232e95c028eee78cdbc84a608815d6a945909c",
+        "observed": "b6232e95c028eee78cdbc84a608815d6a945909c"
+      },
+      "cobra": {
+        "expected": "ad460ea8f249db69c943a365fb84f3a59042d54e",
+        "observed": "ad460ea8f249db69c943a365fb84f3a59042d54e"
+      },
+      "commons-lang": {
+        "expected": "62ea4b620be45462ace4247df34ca938aa29a4da",
+        "observed": "62ea4b620be45462ace4247df34ca938aa29a4da"
+      },
+      "curl": {
+        "expected": "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc",
+        "observed": "ba600296d2a1d8a4e53a36eb4bd30c1f0d0152cc"
+      },
+      "date-fns": {
+        "expected": "cd53d2538cfa318404eff7ade6449b49bf34562e",
+        "observed": "cd53d2538cfa318404eff7ade6449b49bf34562e"
+      },
+      "delve": {
+        "expected": "b17af91dec79ddb2d1fcc08fa13c10d13de77b83",
+        "observed": "b17af91dec79ddb2d1fcc08fa13c10d13de77b83"
+      },
+      "devise": {
+        "expected": "9ea459de9aec5f1217ad738c58e0d23fb9f5beaa",
+        "observed": "9ea459de9aec5f1217ad738c58e0d23fb9f5beaa"
+      },
+      "drizzle-orm": {
+        "expected": "48e5406027103a9fca6eb66417187c4a8b5c6aa3",
+        "observed": "48e5406027103a9fca6eb66417187c4a8b5c6aa3"
+      },
+      "esbuild": {
+        "expected": "6a794dff68e6a43539f6da671e3080efdf11ca70",
+        "observed": "6a794dff68e6a43539f6da671e3080efdf11ca70"
+      },
+      "etcd": {
+        "expected": "9ed485d3e37bbdddff471f5c6d6d7f62048c07d1",
+        "observed": "9ed485d3e37bbdddff471f5c6d6d7f62048c07d1"
+      },
+      "execa": {
+        "expected": "f3a2e8481a1e9138de3895827895c834078b9456",
+        "observed": "f3a2e8481a1e9138de3895827895c834078b9456"
+      },
+      "faraday": {
+        "expected": "59334e0e9b1918bd26b143f4a7bbc8c765de3ac4",
+        "observed": "59334e0e9b1918bd26b143f4a7bbc8c765de3ac4"
+      },
+      "fastlane": {
+        "expected": "c30e449d26dc99fa3841f94f3a2a505a676aedbf",
+        "observed": "c30e449d26dc99fa3841f94f3a2a505a676aedbf"
+      },
+      "fd": {
+        "expected": "42b2ab8a84ddedf80eeed9079128c60161f64658",
+        "observed": "42b2ab8a84ddedf80eeed9079128c60161f64658"
+      },
+      "flask": {
+        "expected": "36e4a824f340fdee7ed50937ba8e7f6bc7d17f81",
+        "observed": "36e4a824f340fdee7ed50937ba8e7f6bc7d17f81"
+      },
+      "fzf": {
+        "expected": "7d647c70c286720c225ebb8ab75896e5dbee6af6",
+        "observed": "7d647c70c286720c225ebb8ab75896e5dbee6af6"
+      },
+      "gin": {
+        "expected": "5f4f9643258dc2a65e684b63f12c8d543c936c67",
+        "observed": "5f4f9643258dc2a65e684b63f12c8d543c936c67"
+      },
+      "git": {
+        "expected": "9ac3f193c05c2237e2b14ebaa1149e9fc8a1abe0",
+        "observed": "9ac3f193c05c2237e2b14ebaa1149e9fc8a1abe0"
+      },
+      "gorm": {
+        "expected": "d0ee5e2296150d691364c5f4f7f2b32abde04545",
+        "observed": "d0ee5e2296150d691364c5f4f7f2b32abde04545"
+      },
+      "graphhopper": {
+        "expected": "2d63716da2e1981fff64d52ee46a0a011202af02",
+        "observed": "2d63716da2e1981fff64d52ee46a0a011202af02"
+      },
+      "gson": {
+        "expected": "ed2397502708ebaba53643e5c3d60e0974d7045f",
+        "observed": "ed2397502708ebaba53643e5c3d60e0974d7045f"
+      },
+      "guava": {
+        "expected": "8ee72dc2b4f14a0d10ba434a2453262899a1ca0b",
+        "observed": "8ee72dc2b4f14a0d10ba434a2453262899a1ca0b"
+      },
+      "h2database": {
+        "expected": "c39970fff5fbda13cf3d16df88426c36d98e5c39",
+        "observed": "c39970fff5fbda13cf3d16df88426c36d98e5c39"
+      },
+      "httpie": {
+        "expected": "5b604c37c6c67e18e7c3e9aee6c88a8c22b98345",
+        "observed": "5b604c37c6c67e18e7c3e9aee6c88a8c22b98345"
+      },
+      "httpx": {
+        "expected": "b5addb64f0161ff6bfe94c124ef76f6a1fba5254",
+        "observed": "b5addb64f0161ff6bfe94c124ef76f6a1fba5254"
+      },
+      "hugo": {
+        "expected": "b01ecd4cd4377921efe427fed8a16326b85f2ace",
+        "observed": "b01ecd4cd4377921efe427fed8a16326b85f2ace"
+      },
+      "hyperfine": {
+        "expected": "f12f3d9f86f3643b3b7deace5e160b1f0f44d2b7",
+        "observed": "f12f3d9f86f3643b3b7deace5e160b1f0f44d2b7"
+      },
+      "image": {
+        "expected": "1063f55cef361fc55ab2e805030d07d11337dad3",
+        "observed": "1063f55cef361fc55ab2e805030d07d11337dad3"
+      },
+      "jackson-core": {
+        "expected": "7df7f1f24fdde585d6a35aa53f2b14d55cd8c734",
+        "observed": "7df7f1f24fdde585d6a35aa53f2b14d55cd8c734"
+      },
+      "jedis": {
+        "expected": "2ec0938d621aa324680490c7c20a09c27563d272",
+        "observed": "2ec0938d621aa324680490c7c20a09c27563d272"
+      },
+      "jekyll": {
+        "expected": "202df571314ba1d18e9fccd81d12aaad4a703c38",
+        "observed": "202df571314ba1d18e9fccd81d12aaad4a703c38"
+      },
+      "jest": {
+        "expected": "4c3091b4204d703f4ebe343b8ac9d8a28ac4388e",
+        "observed": "4c3091b4204d703f4ebe343b8ac9d8a28ac4388e"
+      },
+      "jq": {
+        "expected": "985abe534fdd48186015e169da7786c05fd7f868",
+        "observed": "985abe534fdd48186015e169da7786c05fd7f868"
+      },
+      "jsoup": {
+        "expected": "8fb8eb5633901f535b8867a1c5a6fcc07df266c3",
+        "observed": "8fb8eb5633901f535b8867a1c5a6fcc07df266c3"
+      },
+      "junit5": {
+        "expected": "9a7a266fdd22cbe62d0d06e69fe8aab0dd2649cd",
+        "observed": "9a7a266fdd22cbe62d0d06e69fe8aab0dd2649cd"
+      },
+      "kingfisher": {
+        "expected": "072c31174e9f481882e6c3ec8ddc74384d395789",
+        "observed": "072c31174e9f481882e6c3ec8ddc74384d395789"
+      },
+      "kramdown": {
+        "expected": "12b3d2e752793d4128b6355c338b23fefa674ee0",
+        "observed": "12b3d2e752793d4128b6355c338b23fefa674ee0"
+      },
+      "ky": {
+        "expected": "61d6d66d27911001b9b4d57ab93139f9ad61384b",
+        "observed": "61d6d66d27911001b9b4d57ab93139f9ad61384b"
+      },
+      "libgdx": {
+        "expected": "f9af1f6273e04da84eaffebbb782d083441634b0",
+        "observed": "f9af1f6273e04da84eaffebbb782d083441634b0"
+      },
+      "libsodium": {
+        "expected": "3591adef1c26061b3cce43366ec32e03f1df8a5e",
+        "observed": "3591adef1c26061b3cce43366ec32e03f1df8a5e"
+      },
+      "libuv": {
+        "expected": "ea493f19895bc0cc90b28b48a4e204bc139c48d3",
+        "observed": "ea493f19895bc0cc90b28b48a4e204bc139c48d3"
+      },
+      "liquid": {
+        "expected": "742ac3dbf5432c6c2689ea00da604d7379f73799",
+        "observed": "742ac3dbf5432c6c2689ea00da604d7379f73799"
+      },
+      "lua": {
+        "expected": "53b41d0cddd80bf33fdc631bdd32e3ba53842b89",
+        "observed": "53b41d0cddd80bf33fdc631bdd32e3ba53842b89"
+      },
+      "marked": {
+        "expected": "c1a86f00ccd81144422f1a4194756bd48111c531",
+        "observed": "c1a86f00ccd81144422f1a4194756bd48111c531"
+      },
+      "marshmallow": {
+        "expected": "db4aa4d00b0fa073e31c4d4ce2d05e4ea9e90d52",
+        "observed": "db4aa4d00b0fa073e31c4d4ce2d05e4ea9e90d52"
+      },
+      "meilisearch": {
+        "expected": "ded427cf58d75f5da740297a7eb8581444cb7b30",
+        "observed": "ded427cf58d75f5da740297a7eb8581444cb7b30"
+      },
+      "minio": {
+        "expected": "7aac2a2c5b7c882e68c1ce017d8256be2feea27f",
+        "observed": "7aac2a2c5b7c882e68c1ce017d8256be2feea27f"
+      },
+      "mockito": {
+        "expected": "70a97b057b36b4c0c165318826e3b12b49dbd970",
+        "observed": "70a97b057b36b4c0c165318826e3b12b49dbd970"
+      },
+      "nats-server": {
+        "expected": "050df88d3fb7e968ef8acf02b3ea092d439881c3",
+        "observed": "050df88d3fb7e968ef8acf02b3ea092d439881c3"
+      },
+      "netty": {
+        "expected": "e90eee9f556e3c770dda5ee171276e886266ae71",
+        "observed": "e90eee9f556e3c770dda5ee171276e886266ae71"
+      },
+      "nginx": {
+        "expected": "d44205284fa41662da803b796d6056fc1e59b1f3",
+        "observed": "d44205284fa41662da803b796d6056fc1e59b1f3"
+      },
+      "nimble": {
+        "expected": "727f75d91a0f7501d08d938966d17e6728b76a2a",
+        "observed": "727f75d91a0f7501d08d938966d17e6728b76a2a"
+      },
+      "nushell": {
+        "expected": "779e2473aa28092760fe91ceefb288f36f0670e7",
+        "observed": "779e2473aa28092760fe91ceefb288f36f0670e7"
+      },
+      "packaging": {
+        "expected": "cf5dc921b4e1e85b50e3146f94e69d0268d5543d",
+        "observed": "cf5dc921b4e1e85b50e3146f94e69d0268d5543d"
+      },
+      "pixijs": {
+        "expected": "b2f8668c2c3c3d8b4aa7dcd1906424a9bbf75241",
+        "observed": "b2f8668c2c3c3d8b4aa7dcd1906424a9bbf75241"
+      },
+      "poetry": {
+        "expected": "aab3194f200e52198101d0f303b0f6423897829c",
+        "observed": "aab3194f200e52198101d0f303b0f6423897829c"
+      },
+      "prettier": {
+        "expected": "a5e7b7c3bd1e783ce33d8b0e335530317fe85bab",
+        "observed": "a5e7b7c3bd1e783ce33d8b0e335530317fe85bab"
+      },
+      "prometheus": {
+        "expected": "f3d653fb5cee5e503356eef531b5da7e578cf22f",
+        "observed": "f3d653fb5cee5e503356eef531b5da7e578cf22f"
+      },
+      "pry": {
+        "expected": "135640262879544c6bfecbf3e78511289bfe956c",
+        "observed": "135640262879544c6bfecbf3e78511289bfe956c"
+      },
+      "puma": {
+        "expected": "c981c010f438596d958932c08d123d079033b7fa",
+        "observed": "c981c010f438596d958932c08d123d079033b7fa"
+      },
+      "quick": {
+        "expected": "2b4547b230e94d84320724fd6df65e418b058be2",
+        "observed": "2b4547b230e94d84320724fd6df65e418b058be2"
+      },
+      "rack": {
+        "expected": "1551230b9868c5981d8614e487646dd634a0eb41",
+        "observed": "1551230b9868c5981d8614e487646dd634a0eb41"
+      },
+      "radash": {
+        "expected": "4cab1900d08e0997abc4f17aec3cbfe18958d766",
+        "observed": "4cab1900d08e0997abc4f17aec3cbfe18958d766"
+      },
+      "raylib": {
+        "expected": "895154bcb2c55540cee9e2aa2de95c0e5ba9b729",
+        "observed": "895154bcb2c55540cee9e2aa2de95c0e5ba9b729"
+      },
+      "redis": {
+        "expected": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3",
+        "observed": "2df35f9fb0ac21fbc57e3b3d784c65d6928e6ef3"
+      },
+      "regex": {
+        "expected": "839d16bc65b60e2006d3599d20bfa6efc14049d8",
+        "observed": "839d16bc65b60e2006d3599d20bfa6efc14049d8"
+      },
+      "requests": {
+        "expected": "cd90742ed94d901759e26766197d0ce7c7bd9c8e",
+        "observed": "cd90742ed94d901759e26766197d0ce7c7bd9c8e"
+      },
+      "retrofit": {
+        "expected": "8e83a242eac1afc22a13c52098eddb27421353ff",
+        "observed": "8e83a242eac1afc22a13c52098eddb27421353ff"
+      },
+      "rich": {
+        "expected": "46cebbb032f920eb096efbaf23cdc6fe9dd541f7",
+        "observed": "46cebbb032f920eb096efbaf23cdc6fe9dd541f7"
+      },
+      "ripgrep": {
+        "expected": "4857d6fa67db69a95cd4b6f2adda5d807d4d0119",
+        "observed": "4857d6fa67db69a95cd4b6f2adda5d807d4d0119"
+      },
+      "rspec-core": {
+        "expected": "aec5f49485d97908183dbe790a7fefb8baaa8091",
+        "observed": "aec5f49485d97908183dbe790a7fefb8baaa8091"
+      },
+      "rubocop": {
+        "expected": "43942e260071e869bccc7497bbba82d5d458530e",
+        "observed": "43942e260071e869bccc7497bbba82d5d458530e"
+      },
+      "rustls": {
+        "expected": "22a546cfa1f24130514411be7c99295c093ec575",
+        "observed": "22a546cfa1f24130514411be7c99295c093ec575"
+      },
+      "rxjava": {
+        "expected": "17e6f21c87f5d75b832b6f6fc0448603ae959b58",
+        "observed": "17e6f21c87f5d75b832b6f6fc0448603ae959b58"
+      },
+      "rxjs": {
+        "expected": "c15b37f81ba5f5abea8c872b0189a70b150df4cb",
+        "observed": "c15b37f81ba5f5abea8c872b0189a70b150df4cb"
+      },
+      "rxswift": {
+        "expected": "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "observed": "132aea4f236ccadc51590b38af0357a331d51fa2"
+      },
+      "scrapy": {
+        "expected": "44406806f819b0e5230ed0dbe619a31defeb7afc",
+        "observed": "44406806f819b0e5230ed0dbe619a31defeb7afc"
+      },
+      "serde_json": {
+        "expected": "a1ae73ac6a6940a4a57c673aebaa13ed4dfe3e8c",
+        "observed": "a1ae73ac6a6940a4a57c673aebaa13ed4dfe3e8c"
+      },
+      "sidekiq": {
+        "expected": "ae2fcadb06147fc23e70ce8085443c845c737186",
+        "observed": "ae2fcadb06147fc23e70ce8085443c845c737186"
+      },
+      "sinatra": {
+        "expected": "5236d3459b8b9015e5ce21ddd0c6beb0db4081d4",
+        "observed": "5236d3459b8b9015e5ce21ddd0c6beb0db4081d4"
+      },
+      "sled": {
+        "expected": "e449d17111f4a097e1c66b6db241962ccb6a4136",
+        "observed": "e449d17111f4a097e1c66b6db241962ccb6a4136"
+      },
+      "sqlalchemy": {
+        "expected": "4fb459aaf05dd9c31ce3ece57c1bbf81ca9855de",
+        "observed": "4fb459aaf05dd9c31ce3ece57c1bbf81ca9855de"
+      },
+      "sqlite": {
+        "expected": "2acb57c1be48b34129b2d91b33d7b5fdbaac7d07",
+        "observed": "2acb57c1be48b34129b2d91b33d7b5fdbaac7d07"
+      },
+      "swift-algorithms": {
+        "expected": "0b4376902cfc3901c496a79f2cb70f1ffd583fff",
+        "observed": "0b4376902cfc3901c496a79f2cb70f1ffd583fff"
+      },
+      "swift-argument-parser": {
+        "expected": "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "observed": "6a52f3251125d74daf04fcbd5e6f08a75d074382"
+      },
+      "swift-collections": {
+        "expected": "f5b320c29f5af4087bc8f527ed52e0930f4f9fb4",
+        "observed": "f5b320c29f5af4087bc8f527ed52e0930f4f9fb4"
+      },
+      "swift-composable-architecture": {
+        "expected": "a28ddfada0ec31d726e5c8e525318c3745ad97d9",
+        "observed": "a28ddfada0ec31d726e5c8e525318c3745ad97d9"
+      },
+      "swift-log": {
+        "expected": "ca6118469893201380f29a4d67feb68bcb44fa25",
+        "observed": "ca6118469893201380f29a4d67feb68bcb44fa25"
+      },
+      "swift-metrics": {
+        "expected": "4d99a2ec9735d7738c642189a09a77ccbb117aeb",
+        "observed": "4d99a2ec9735d7738c642189a09a77ccbb117aeb"
+      },
+      "swift-nio": {
+        "expected": "eb8ac41afd91195d1095de61803402c27ecde293",
+        "observed": "eb8ac41afd91195d1095de61803402c27ecde293"
+      },
+      "swift-service-lifecycle": {
+        "expected": "2fd7a348e9d0333979108c2da83642a64df6cb2c",
+        "observed": "2fd7a348e9d0333979108c2da83642a64df6cb2c"
+      },
+      "swiftlint": {
+        "expected": "64b731e35cda419025868a9c5248a3bdf1b57631",
+        "observed": "64b731e35cda419025868a9c5248a3bdf1b57631"
+      },
+      "swr": {
+        "expected": "e384af7f0d3e8620e4ec10c5b7c2b0e9bb9466be",
+        "observed": "e384af7f0d3e8620e4ec10c5b7c2b0e9bb9466be"
+      },
+      "sympy": {
+        "expected": "da4a5fa52418ae593a941d4ba585cfef87a31870",
+        "observed": "da4a5fa52418ae593a941d4ba585cfef87a31870"
+      },
+      "thor": {
+        "expected": "036cb4ddd5ccecc3a61c16186d2810addb7d42f3",
+        "observed": "036cb4ddd5ccecc3a61c16186d2810addb7d42f3"
+      },
+      "tmux": {
+        "expected": "0759030ee8c44def03158bcbeac33338fd2b719e",
+        "observed": "0759030ee8c44def03158bcbeac33338fd2b719e"
+      },
+      "tokei": {
+        "expected": "fa44e5194060305576514d59b850353643afbfc8",
+        "observed": "fa44e5194060305576514d59b850353643afbfc8"
+      },
+      "tokio": {
+        "expected": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+        "observed": "2de86e557c576a74be7136e6fc2e21ccdf22da10"
+      },
+      "trpc": {
+        "expected": "c7360d4eb3c89c336468809a293e5cda4b302d4b",
+        "observed": "c7360d4eb3c89c336468809a293e5cda4b302d4b"
+      },
+      "urfave-cli": {
+        "expected": "be8b79d0c8de1a03812914c9c511c961e5ed6ecc",
+        "observed": "be8b79d0c8de1a03812914c9c511c961e5ed6ecc"
+      },
+      "vapor": {
+        "expected": "fff4892930e69b49ea2612699bed9583721723dc",
+        "observed": "fff4892930e69b49ea2612699bed9583721723dc"
+      },
+      "vim": {
+        "expected": "f1ed84158ab80240c42c9f2356767cad448ca151",
+        "observed": "f1ed84158ab80240c42c9f2356767cad448ca151"
+      },
+      "wrk": {
+        "expected": "a211dd5a7050b1f9e8a9870b95513060e72ac4a0",
+        "observed": "a211dd5a7050b1f9e8a9870b95513060e72ac4a0"
+      },
+      "zap": {
+        "expected": "5b81b37b81b8e2ed447a6f57991e372ee4fa5c8f",
+        "observed": "5b81b37b81b8e2ed447a6f57991e372ee4fa5c8f"
+      },
+      "zod": {
+        "expected": "bbc68f990c7e6a5e3f506c56fb04bd0279b9c9b5",
+        "observed": "bbc68f990c7e6a5e3f506c56fb04bd0279b9c9b5"
+      },
+      "zstd": {
+        "expected": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc",
+        "observed": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc"
+      },
+      "zustand": {
+        "expected": "04a8487aea075b13e71a327cc99b16fb68352c1a",
+        "observed": "04a8487aea075b13e71a327cc99b16fb68352c1a"
+      }
+    },
+    "working_tree_status_before_measurement": ""
+  },
+  "query_runs": {
+    "alacritty": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/alacritty all top=0 --format json --mode syntax,semantic",
+        "reported_families": 69,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "93b6452dc074ed32826f16b95bd776cc588aa3f6ccae4b31d1108a4d5e90a9b3"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/alacritty all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 113,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "aedeacddcc78df48cbf5f30cd1625f6aadf270f9892dfb188249920797f6bd31"
+      },
+      "hit_arm0": 23,
+      "hit_arm1": 35,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 37
+    },
+    "antlr4": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/antlr4 all top=0 --format json --mode syntax,semantic",
+        "reported_families": 594,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "429555f8c5bb5f321641d40ed0280d75b1d349226f64d584540c1ffb5a2614f3"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/antlr4 all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 909,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f55afb4d34931d030bfdd1d6cb688ea0d30c4a60daa047e924dbe625b1645e64"
+      },
+      "hit_arm0": 14,
+      "hit_arm1": 16,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 16
+    },
+    "arrow": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/arrow all top=0 --format json --mode syntax,semantic",
+        "reported_families": 69,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f0ec8544e7cbf182d2cb4db2e2c7962fbbd3ff52b0b4cfdc5dd69668cb9d911d"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/arrow all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 95,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4b33b0a06a2a9080a35662ae2dbbe879c4ba21a70e1e356cb9f9fa906398285e"
+      },
+      "hit_arm0": 7,
+      "hit_arm1": 7,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 7
+    },
+    "asciidoctor": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/asciidoctor all top=0 --format json --mode syntax,semantic",
+        "reported_families": 395,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a278dc896fdbfaa14e32556ddaff147ca2738dca6a85051ca6f886a5e5e211ac"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/asciidoctor all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 505,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "23144338475ddefd0882ac90a765badf32e28a7d7c8f2109938bdb0cb414e30e"
+      },
+      "hit_arm0": 40,
+      "hit_arm1": 50,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 58
+    },
+    "axios": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/axios all top=0 --format json --mode syntax,semantic",
+        "reported_families": 194,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e092524cea8c2121d1378a508001f627efaee7f924b24c186e04efa868d4db72"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/axios all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 211,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f88909ce63f94e9a0d0471b04e1534bba1881e2bc959b3d899c52ad32c276846"
+      },
+      "hit_arm0": 59,
+      "hit_arm1": 60,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 62
+    },
+    "badger": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/badger all top=0 --format json --mode syntax,semantic",
+        "reported_families": 267,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "68e0db354e160d25830c2c7d6a49b88cdcb796c2811f7fccfd4528f96d8a54c5"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/badger all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 279,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "17b715cc9fbf63f72848e23e50de55d6baa5fbc2e37c0c5478d8d123359ba316"
+      },
+      "hit_arm0": 62,
+      "hit_arm1": 71,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 71
+    },
+    "bat": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/bat all top=0 --format json --mode syntax,semantic",
+        "reported_families": 123,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1f2ff8afde8e70d4ea72fad88925ae41434b8196c592e49f751f4fb698c6c33e"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/bat all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 150,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9000aadaf28b2df33a42726fc4acf8720a08c1c02b84f4b459a28bc76f33a254"
+      },
+      "hit_arm0": 17,
+      "hit_arm1": 18,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 22
+    },
+    "black": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/black all top=0 --format json --mode syntax,semantic",
+        "reported_families": 187,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "894eb5cd1a16e9cd763f8b93fc801ba945a6303567b1ead35149dae6b3eb4026"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/black all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 248,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "81d926f9c989dcf95fa11a98ef903ea60856d5ff1b7220c4a7f676fa3822130b"
+      },
+      "hit_arm0": 7,
+      "hit_arm1": 12,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 12
+    },
+    "boltons": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/boltons all top=0 --format json --mode syntax,semantic",
+        "reported_families": 78,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ac976d4deac48ddeb7f5ba5cb5f133eca44f5af63fbdc83a7227953dc6f555c2"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/boltons all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 127,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "18323fe7d43d6c55e95422eea69b62140483a266b73c21b8ec5c9b0fb587b15f"
+      },
+      "hit_arm0": 21,
+      "hit_arm1": 22,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 23
+    },
+    "chi": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/chi all top=0 --format json --mode syntax,semantic",
+        "reported_families": 69,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "31e8b3bb835ae9020321de8f8c9c2ee877f510c2c4d1ca2826ea6175621415b5"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/chi all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 78,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "70040affc4c6e9443a20e36df444461898825379d85110e9864a7f4e6a5785a9"
+      },
+      "hit_arm0": 33,
+      "hit_arm1": 33,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 35
+    },
+    "clap": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/clap all top=0 --format json --mode syntax,semantic",
+        "reported_families": 500,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "7fe0553c70472a27505b969168a37759144c50746a4c4ad9bd011e47feff3bdf"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/clap all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 679,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3bbef776358b34eaaa02c2307c039dd31626e02a962995054e33cbc17c08c31c"
+      },
+      "hit_arm0": 93,
+      "hit_arm1": 105,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 109
+    },
+    "click": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/click all top=0 --format json --mode syntax,semantic",
+        "reported_families": 76,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "384bff978e78994e7dcfb988f551b3dad670d7757d6461355ee0165ffb423f2b"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/click all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 125,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3f419425390a0fe235fb20d566bddf6c0d57c844b6214c5ab1c42bc7103bca82"
+      },
+      "hit_arm0": 16,
+      "hit_arm1": 20,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 20
+    },
+    "cmark": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/cmark all top=0 --format json --mode syntax,semantic",
+        "reported_families": 111,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "39f0e68e39a5e782f6310c860df1f1d1ca3dac01a1c4a5f73403502aab91edb1"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/cmark all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 132,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "558108f8cc20875c2e917e87a9f2ce5ddc455fe657d646165cdfce6a20b9c622"
+      },
+      "hit_arm0": 1,
+      "hit_arm1": 1,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 1
+    },
+    "cobra": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/cobra all top=0 --format json --mode syntax,semantic",
+        "reported_families": 178,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ace0e727b2c7e8d8e2c0a77b3d89b5785060cfc5acda193e3cbc8b3aa6fbf8ae"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/cobra all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 197,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "bd7492f3ce78da51618ec5336f0d85d6c1696784218ab21489d67aff982717bf"
+      },
+      "hit_arm0": 40,
+      "hit_arm1": 42,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 43
+    },
+    "commons-lang": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/commons-lang all top=0 --format json --mode syntax,semantic",
+        "reported_families": 921,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b4fc7d27c82cde66d15b4abdc0948c1abef9340a70505bb491f722fdbfb2c86b"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/commons-lang all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1304,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "44a035b4c2778547153a0b372b41c755ea06110d2d54b7c9cedfcf64623d84c2"
+      },
+      "hit_arm0": 84,
+      "hit_arm1": 89,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 93
+    },
+    "curl": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/curl all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1116,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "825d1770bcf66a283d8168793ffe29fcc1ad8a959dbdf254e73b5b94d5dc9b84"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/curl all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1217,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d52b97f506f635fc94e73c314ac82efa365922a79c4d6c415bcabf543ee7dbd7"
+      },
+      "hit_arm0": 92,
+      "hit_arm1": 91,
+      "language": "C",
+      "split": "dev",
+      "worthy": 96
+    },
+    "date-fns": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/date-fns all top=0 --format json --mode syntax,semantic",
+        "reported_families": 413,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "824b80ceb1a43acbb0286204468abbe4a4c94f38ac74c022e6198dc01274c0b1"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/date-fns all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 451,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8d06de25e4b613d88acee1c88174ed03790ed7d2735918aa542bfa0b01ad4fa1"
+      },
+      "hit_arm0": 15,
+      "hit_arm1": 17,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 21
+    },
+    "delve": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/delve all top=0 --format json --mode syntax,semantic",
+        "reported_families": 571,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2d85f1d0f434d7ed66d2b11b4973d24c2ebb8bf240b7927e1c2cf4eeae84ae40"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/delve all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 697,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "07fe5ddbfadeb5ac204d6f049c31d32609e0c7d123849a3f1c9523bb175b24da"
+      },
+      "hit_arm0": 38,
+      "hit_arm1": 40,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 41
+    },
+    "devise": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/devise all top=0 --format json --mode syntax,semantic",
+        "reported_families": 67,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "adae697921b0bb9e70007e6c282008a1def73b9543bcb993a0fd7cad2e45678d"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/devise all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 105,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4815df8c3c82483921c323c4f6be06407a36cd36a05d4ccf5236b13233e1ff95"
+      },
+      "hit_arm0": 5,
+      "hit_arm1": 14,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 15
+    },
+    "drizzle-orm": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/drizzle-orm all top=0 --format json --mode syntax,semantic",
+        "reported_families": 3155,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "184a2e520629754a9ada9390f700b25a37ebc098e9e33332c101513f1eaf097e"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/drizzle-orm all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 3350,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b2d90d3dea3d1d2863940a067ef8b6d64956d6f879163048ea8569fa4148f63a"
+      },
+      "hit_arm0": 35,
+      "hit_arm1": 37,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 37
+    },
+    "esbuild": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/esbuild all top=0 --format json --mode syntax,semantic",
+        "reported_families": 997,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a8c244c6ff3681d0081f60af2811dd9a78d7f4db8cf96d6485b1777d50194836"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/esbuild all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1101,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ad728f8c6f939f7b2fc2ae9389af9ae0f0e93580424607ffebe145be2bd9e460"
+      },
+      "hit_arm0": 41,
+      "hit_arm1": 42,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 42
+    },
+    "etcd": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/etcd all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1126,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "22bf27a27f65fabca0dd5e83a5f209e91fd2ce469fc48ecb34034d1fdf55812d"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/etcd all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1418,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a4409bf884c6a7748225446665c5277d50786428063aa9eda27c34fe401b4b8c"
+      },
+      "hit_arm0": 46,
+      "hit_arm1": 51,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 51
+    },
+    "execa": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/execa all top=0 --format json --mode syntax,semantic",
+        "reported_families": 154,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9856a1d4847bc828da78a697448975ac22db5a7a21ddf2c126401795dfbf5679"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/execa all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 199,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "47124a6e3252de68403f8a7576b399d1ec284d49382bfcbc7e6cbc9a2c86f386"
+      },
+      "hit_arm0": 23,
+      "hit_arm1": 25,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 25
+    },
+    "faraday": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/faraday all top=0 --format json --mode syntax,semantic",
+        "reported_families": 47,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d61ef5e6ee89e520066ccd7b74d1f54619d544ad9750cc4afb47a5907f13db5a"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/faraday all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 74,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "419520f05678c6e3dd8a45f407c28580faacb7034be7c6ac6d4e7838f8b453b2"
+      },
+      "hit_arm0": 13,
+      "hit_arm1": 14,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 14
+    },
+    "fastlane": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/fastlane all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1009,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "487fdd69fd79ad29b548f019bc4776776026d04ec6e5dffde034ade77d58832a"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/fastlane all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1443,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b7915968a75beaae59a33a7841b8b203c3a1cb3788a07959b77f9e8e50fa2822"
+      },
+      "hit_arm0": 83,
+      "hit_arm1": 92,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 94
+    },
+    "fd": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/fd all top=0 --format json --mode syntax,semantic",
+        "reported_families": 5,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "782e8eff0afc3c9b70d175a1f866d7d8c5a73cec02b11fa5571bb35ac6c3102f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/fd all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 15,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "79710e8d4e72b00ed5e0ec518bbb33ec55cfc27fe02873a1b100998232af3dc4"
+      },
+      "hit_arm0": 2,
+      "hit_arm1": 3,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 5
+    },
+    "flask": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/flask all top=0 --format json --mode syntax,semantic",
+        "reported_families": 62,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ef64d1585f4d267fa3fddbd8420ab7137014d2b19ce4c2f9166bf1a986953b84"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/flask all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 136,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "5e1a6cde0dc1d8b827569271942a936312a7eddcdc73dc0342714bae396da97e"
+      },
+      "hit_arm0": 17,
+      "hit_arm1": 21,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 22
+    },
+    "fzf": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/fzf all top=0 --format json --mode syntax,semantic",
+        "reported_families": 114,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "64ec92a7de3280316c6febdecc9c06b2be581f98d5f42e35f1fb1510573d348c"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/fzf all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 158,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "73607d20fcb45737fa191a51f346aec9edf0b4e42f4f4d67420068d8b5f89f18"
+      },
+      "hit_arm0": 27,
+      "hit_arm1": 29,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 36
+    },
+    "gin": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/gin all top=0 --format json --mode syntax,semantic",
+        "reported_families": 199,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b896025406136f7ebdd3dd50f5682e3c4eb44614ccc214037fe589aa99d6cf88"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/gin all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 242,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1b3bafe3a7cd0e434a311952a632b614a5e07e784977431b7d042df7546a4c33"
+      },
+      "hit_arm0": 74,
+      "hit_arm1": 77,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 80
+    },
+    "git": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/git all top=0 --format json --mode syntax,semantic",
+        "reported_families": 838,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "158694c7431710af5035ef3d8b4887b0b0b92cef27f5b82ae93b8b71615662ce"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/git all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1189,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "bbea304b2939f1f68130d2e248645a0bc16cc2bc0ec5bc1901f10341b81adcf7"
+      },
+      "hit_arm0": 41,
+      "hit_arm1": 48,
+      "language": "C",
+      "split": "dev",
+      "worthy": 49
+    },
+    "gorm": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/gorm all top=0 --format json --mode syntax,semantic",
+        "reported_families": 325,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "0e048ad8a91986300b342fa37f6a87037eb1c6b31d5ac030c36b4755377ff61b"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/gorm all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 369,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d9c09dbb2930ed8ac745b0ef7624cde8d7eb0c422c50b6f8640663b820e417f0"
+      },
+      "hit_arm0": 90,
+      "hit_arm1": 100,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 112
+    },
+    "graphhopper": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/graphhopper all top=0 --format json --mode syntax,semantic",
+        "reported_families": 968,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2f5ec97a4fba1eaaf265079b9cfb0c8931b0a2064507ce96fc9b645ed15968e0"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/graphhopper all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1144,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4dcd025ca2071c1085605518ecae24ba04a97baf98df98d029bf2d93ba2de97e"
+      },
+      "hit_arm0": 40,
+      "hit_arm1": 44,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 45
+    },
+    "gson": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/gson all top=0 --format json --mode syntax,semantic",
+        "reported_families": 271,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d2bcda1f357e494b99ed55a19b4c4d5eb6089fb268e675b5b29a305d435b08fd"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/gson all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 328,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9d8f154912f8484ea721cff4b0e6cf0f8af4cb476b527f2cd376b4ca58861496"
+      },
+      "hit_arm0": 81,
+      "hit_arm1": 84,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 94
+    },
+    "h2database": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/h2database all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1517,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "5028c243e2f901e3a07c737b116c13a2f8c609280829ebe346175f0fbb55dda1"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/h2database all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1929,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8558b459b32273d5b5ffa71a97cd3571f722958309e4288b1190bb812cc4f71d"
+      },
+      "hit_arm0": 63,
+      "hit_arm1": 65,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 65
+    },
+    "httpie": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/httpie all top=0 --format json --mode syntax,semantic",
+        "reported_families": 44,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d0c56a835365c5814f66530e34acb342f03b57cc840d961c8e683d26a55d0027"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/httpie all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 106,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "71f3dd72447c1bc6bec4d8f677e36edcba25976857f2b56c2292011dd2d7319f"
+      },
+      "hit_arm0": 10,
+      "hit_arm1": 11,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 11
+    },
+    "httpx": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/httpx all top=0 --format json --mode syntax,semantic",
+        "reported_families": 128,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d40d407ed09a6a5b2f1c0c59062b3c7c6f33892524fc1a678336c8f2b9f0f6ff"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/httpx all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 186,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ff0ff907c7c16745197e3437e6c0277b769373863e81450cd4cd9f411de9ae4f"
+      },
+      "hit_arm0": 41,
+      "hit_arm1": 45,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 45
+    },
+    "hugo": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/hugo all top=0 --format json --mode syntax,semantic",
+        "reported_families": 580,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b02b44c43367ded2ff42de664fb6fc6587813084e4029692de7e9b126cc6b98f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/hugo all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 896,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a249f93058c61327e28a44108bc34dd94544c7038ec53903b29cf4f6d309498b"
+      },
+      "hit_arm0": 59,
+      "hit_arm1": 63,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 63
+    },
+    "hyperfine": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/hyperfine all top=0 --format json --mode syntax,semantic",
+        "reported_families": 15,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b1fbbba8fb3d584f8621abd4243b766e91b292040cd867c3efed69288eb82a68"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/hyperfine all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 30,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fca13b7ab15b1239e97c8522ddbe5d3c9620ab712dbb938520a265bb58fa0a02"
+      },
+      "hit_arm0": 7,
+      "hit_arm1": 9,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 10
+    },
+    "image": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/image all top=0 --format json --mode syntax,semantic",
+        "reported_families": 184,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1bf6889252a3ee2ce4a24f55ecb56a58074eaf9dad12ba2587ff2daa4572e5db"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/image all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 260,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b0cc32693893f13e5d45ece9d554866ff316d5ef8263f6bfe089d12f7e2f9574"
+      },
+      "hit_arm0": 41,
+      "hit_arm1": 51,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 56
+    },
+    "jackson-core": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jackson-core all top=0 --format json --mode syntax,semantic",
+        "reported_families": 703,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "39860475a63569be850183a5def7a783ee68d9bf1a79f66459ad6f4a67a1be3e"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jackson-core all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 855,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a0a3c81d4b2f5f5dca382e8e36360e311b279bd2f0908e1a3d496ec1d3a3510b"
+      },
+      "hit_arm0": 100,
+      "hit_arm1": 101,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 102
+    },
+    "jedis": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jedis all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1827,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "dc8121d0cc3918f30df2c4db709d68e9ea5f627f13dc479c9e7bd269a6e4eb0f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jedis all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 2649,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "67b68e9ad2f9987fdfa29cb3ef8f6836669db7784f306aaff6be0228fd1faba8"
+      },
+      "hit_arm0": 71,
+      "hit_arm1": 72,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 75
+    },
+    "jekyll": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jekyll all top=0 --format json --mode syntax,semantic",
+        "reported_families": 83,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b5eab224df89721326088051ef4b62d6255aa471255fcabe44b054d55c68bea7"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jekyll all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 129,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a6aae7e49720cb00ae26b12f6805cbc3af778421add7be84df4064b02a9d66a3"
+      },
+      "hit_arm0": 19,
+      "hit_arm1": 20,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 25
+    },
+    "jest": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jest all top=0 --format json --mode syntax,semantic",
+        "reported_families": 941,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "5bb1a95ef390078115e6c90572efe6c3f230e78c411142fd7b4052f4bfb764a3"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jest all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1049,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d008fa035c66bf785d6d28399ec118b5fcb0be674b995a45fd1eb8df393fd8cb"
+      },
+      "hit_arm0": 50,
+      "hit_arm1": 60,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 61
+    },
+    "jq": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jq all top=0 --format json --mode syntax,semantic",
+        "reported_families": 61,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fd17620f2f3485dbba19c67f4c71519ad97674f0ceb9d38d0b7939ac2622210f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jq all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 71,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fc3186c46dc44d58bfe84815373f68ccd4fedf6b668a529b4b6f5898ba42878a"
+      },
+      "hit_arm0": 15,
+      "hit_arm1": 18,
+      "language": "C",
+      "split": "dev",
+      "worthy": 19
+    },
+    "jsoup": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/jsoup all top=0 --format json --mode syntax,semantic",
+        "reported_families": 235,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d63e74e1a0aa82e6dcf91cba68f5c9c6b7cdac1e0f7042dd6e946b2e8b2e0cfa"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/jsoup all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 407,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "be1a8921814b2614e9cb34030f4dc5685f2c7cf5ab27e788218461969bf105cc"
+      },
+      "hit_arm0": 63,
+      "hit_arm1": 76,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 82
+    },
+    "junit5": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/junit5 all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1116,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2dc7440f2c2489945620a8b8ee09695857c91d7f9bbba53a1e592816d8f60a8c"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/junit5 all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1689,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1da7b2cbda25bd924d46a85e8ab2a2526629e39f4fbef37e65dd170f56c3a36b"
+      },
+      "hit_arm0": 32,
+      "hit_arm1": 35,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 35
+    },
+    "kramdown": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/kramdown all top=0 --format json --mode syntax,semantic",
+        "reported_families": 84,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "993f17b7e6bd71ca60ae8186656f9e7b98db4bbd51f5b31c6ec79653374ed701"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/kramdown all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 128,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d85f8201e9688e0762a9e359d9eef906f369a4cad262f792a10ba96c6921c98a"
+      },
+      "hit_arm0": 2,
+      "hit_arm1": 2,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 2
+    },
+    "ky": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/ky all top=0 --format json --mode syntax,semantic",
+        "reported_families": 146,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2bc410f6a7dc12952397563e67656f1e7795ff5603e0701fccd261173e2754f0"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/ky all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 150,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "55dfa8309dcafebd640fb540733a3fc778b81e490c10c2fc7371b633cc9423bb"
+      },
+      "hit_arm0": 19,
+      "hit_arm1": 18,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 20
+    },
+    "libgdx": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/libgdx all top=0 --format json --mode syntax,semantic",
+        "reported_families": 2363,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2e61a9551707171eaba959b115fe96ed86f5c0dc52a4ed63ba4ed06587df2357"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/libgdx all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 2712,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9c69eaf9137373d47f689ca19f3e6a8e330b6f5f59ea329f204e828f62dafd5c"
+      },
+      "hit_arm0": 92,
+      "hit_arm1": 92,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 94
+    },
+    "libsodium": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/libsodium all top=0 --format json --mode syntax,semantic",
+        "reported_families": 381,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a1cc1529cfb673ae0469f1381e526c4a99fba0d93b222324173d7b1944550dd8"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/libsodium all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 419,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "972d7313596918a2bae4dd317ad1757de0ff493e2d60c9e9f321ddffbd609ac8"
+      },
+      "hit_arm0": 55,
+      "hit_arm1": 63,
+      "language": "C",
+      "split": "dev",
+      "worthy": 63
+    },
+    "libuv": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/libuv all top=0 --format json --mode syntax,semantic",
+        "reported_families": 565,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f8f4edde8768cb2e93771e07e4e3ab686bf91e466a059274ea52caaf16881056"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/libuv all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 656,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a3d1cb0e4ccc5a8a1b76bf84e014d4db6ca777db1c998404846c28b6598c2289"
+      },
+      "hit_arm0": 99,
+      "hit_arm1": 106,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 113
+    },
+    "liquid": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/liquid all top=0 --format json --mode syntax,semantic",
+        "reported_families": 67,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "76416b35b3627c03e25cd6a98569df3ea17eaf8d815a13cc9e69585937651130"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/liquid all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 182,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e85fc8f3d865f6c0cf3d2036e1d13408dced2dfbce1be652167b341f090be167"
+      },
+      "hit_arm0": 31,
+      "hit_arm1": 52,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 60
+    },
+    "lua": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/lua all top=0 --format json --mode syntax,semantic",
+        "reported_families": 47,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f4cb12795e62bf90c8f47205477202839b2745da178cea518a7ef7df758864e4"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/lua all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 78,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "af33a922041274277f2af856b43e033205e5570ac6e058ffbc1d27e3e0160e4a"
+      },
+      "hit_arm0": 6,
+      "hit_arm1": 8,
+      "language": "C",
+      "split": "dev",
+      "worthy": 10
+    },
+    "marked": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/marked all top=0 --format json --mode syntax,semantic",
+        "reported_families": 163,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b5316879dfaf7fcfb51e2f469ec416ad97d3a05cb07cd48aa7bff7da799e1be8"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/marked all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 174,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8d5563881a58acaeed34e1d2d44371b47b143a1e1baf40cac5b2b49fa5c27ec3"
+      },
+      "hit_arm0": 17,
+      "hit_arm1": 19,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 19
+    },
+    "marshmallow": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/marshmallow all top=0 --format json --mode syntax,semantic",
+        "reported_families": 76,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4f72cffe3132da354af2a5de5cd412eadf9fd0ebb4d633b6dbd5390f617d6e64"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/marshmallow all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 101,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "54b2d639c11366288da5971bc2c5799f68772f2c9bfdb5cc80035d22020f51d1"
+      },
+      "hit_arm0": 22,
+      "hit_arm1": 24,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 29
+    },
+    "meilisearch": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/meilisearch all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1138,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "558377f03b628cebf0c732f734fa8546a4b8ba409f9e5984f0db4be60cc89d52"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/meilisearch all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1418,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e1559058fbf72c74c73a37d065b37097ce106edddf8becf09b969b03c2279cb5"
+      },
+      "hit_arm0": 17,
+      "hit_arm1": 19,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 19
+    },
+    "minio": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/minio all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1743,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ceb7c12ee61c751a655758cbda300d12ce79eef0c3c09cdff5261088cc6be247"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/minio all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 2001,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "892cebb6486d8f8a8fd4536ee28755c6e1db64ffff8dfcb6763af4ce2d1a9417"
+      },
+      "hit_arm0": 81,
+      "hit_arm1": 90,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 97
+    },
+    "mockito": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/mockito all top=0 --format json --mode syntax,semantic",
+        "reported_families": 376,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "cb55c4a737be544d8722e5a332a9c2bcd321b12fd8f330c48475e948973158f8"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/mockito all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 630,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "90491ef0be533c3b72e0ff7450c7efc723323d75fa1f1618cec153e331aa6f2a"
+      },
+      "hit_arm0": 88,
+      "hit_arm1": 96,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 106
+    },
+    "nats-server": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/nats-server all top=0 --format json --mode syntax,semantic",
+        "reported_families": 4281,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "7eed86e27a8ffade43645c168d636cc3986238bf137b3eb7eec58492cf47fdfc"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/nats-server all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 4462,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9acb3cf8c1a646ae6313ebd35c4c21c3329cb4d82e7a08dd68012d1a36bb966a"
+      },
+      "hit_arm0": 61,
+      "hit_arm1": 61,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 62
+    },
+    "netty": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/netty all top=0 --format json --mode syntax,semantic",
+        "reported_families": 3654,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ec3a0c0abf30c2c11792a22dcee3c5f8da8a5f58d7f93a4d281405a4790c6d60"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/netty all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 4873,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "652c5a52ed1f374b30db4d2423541dbd972e26d0601868b89f826112aff26974"
+      },
+      "hit_arm0": 99,
+      "hit_arm1": 99,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 100
+    },
+    "nginx": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/nginx all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1341,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "336e491c011138b685f8098c56cdb328a6139027f883be46d630d82dfd34a4be"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/nginx all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1289,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8c462cf5234387fe8aadc55ad7128cf9121e9ee83c1259ef6e608009d7173a91"
+      },
+      "hit_arm0": 46,
+      "hit_arm1": 46,
+      "language": "C",
+      "split": "dev",
+      "worthy": 46
+    },
+    "nushell": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/nushell all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1139,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "326dd5339f1830b62946d51cbe4a6d5fcc91e59aa2a0d668dd987c3a3d48469f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/nushell all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1940,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "92b8f3ba0bbd98cb49f45ee5d3b91b023d2b7b4389ce977f52ddf8eb3fe5eba3"
+      },
+      "hit_arm0": 52,
+      "hit_arm1": 57,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 63
+    },
+    "packaging": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/packaging all top=0 --format json --mode syntax,semantic",
+        "reported_families": 100,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4d6de7d03bdafb2974d6053bb93742d4c5af0e5b505c3fc44ca1d488a49aad27"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/packaging all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 161,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4b007f793cbc12940a4456c877df78bb45c02b54a0db8eb38cc1023619935a7a"
+      },
+      "hit_arm0": 45,
+      "hit_arm1": 47,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 51
+    },
+    "pixijs": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/pixijs all top=0 --format json --mode syntax,semantic",
+        "reported_families": 726,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "17dbce0ec68aba7fc45802cce1bd91bc2bab4a7c2e49301c809292c2c30bb4f9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/pixijs all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 829,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9cf1cb0c103009603d188547bf0a13a7d90d9f9e0e123fc8bf82492cc869d090"
+      },
+      "hit_arm0": 83,
+      "hit_arm1": 89,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 89
+    },
+    "poetry": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/poetry all top=0 --format json --mode syntax,semantic",
+        "reported_families": 528,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "95d77b824cb5752fd6d5156bed8a91d1f1ccb4d5df140ac9e42c48d4f7b01842"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/poetry all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 613,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "be76ae88d5a0e27a9171a374f33da591ee5fb51181efc1d0e0ce8d026dba7c9a"
+      },
+      "hit_arm0": 94,
+      "hit_arm1": 104,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 107
+    },
+    "prettier": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/prettier all top=0 --format json --mode syntax,semantic",
+        "reported_families": 463,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d0cda27f5d75003999f3709bdfe49b17707be8e4e667711c0337a716a67b520d"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/prettier all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 685,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "22e6312b5d217694f622c19f1794f83d926214e47e2d1b884f567aaebe6b66bb"
+      },
+      "hit_arm0": 15,
+      "hit_arm1": 15,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 15
+    },
+    "prometheus": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/prometheus all top=0 --format json --mode syntax,semantic",
+        "reported_families": 2272,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "5c34ba8f7c8f11e3e14da925ffd6735981c1c2888e5d363ff4366ea1de63c2c9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/prometheus all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 2623,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "cc047a68842fa6cdb292f937f8bc01dbfcb0de63a66084b453ab0c56d1cdeae7"
+      },
+      "hit_arm0": 81,
+      "hit_arm1": 83,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 83
+    },
+    "pry": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/pry all top=0 --format json --mode syntax,semantic",
+        "reported_families": 75,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "458e931e800c48c93e6ccdc52914a1d10a0de0d1adda5e70cc01b478443b8aef"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/pry all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 147,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "595b89e073398339d68756cc04effa07978d77d8f7f8156d7b8b76520118f956"
+      },
+      "hit_arm0": 15,
+      "hit_arm1": 18,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 20
+    },
+    "puma": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/puma all top=0 --format json --mode syntax,semantic",
+        "reported_families": 138,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "97ecc89c17027bca01e0e95d099157025d69f2d5df1fd33e107e6cfb4ba518b9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/puma all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 246,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2aa5886356361ec7834fe39dfba7886439ab5843c1caf8e06bfa28c87fa47b23"
+      },
+      "hit_arm0": 50,
+      "hit_arm1": 59,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 64
+    },
+    "rack": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rack all top=0 --format json --mode syntax,semantic",
+        "reported_families": 131,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "bb38e1f5ca34b0250e6d08ece4525d042603823e730b0a0e5cbe5c7e88093ac8"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rack all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 167,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "68187bb599e0cfa78ead33ef596b3cad0dc9a4630e49a6f610afc04d7fdf7d19"
+      },
+      "hit_arm0": 15,
+      "hit_arm1": 15,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 16
+    },
+    "radash": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/radash all top=0 --format json --mode syntax,semantic",
+        "reported_families": 43,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "87754ff31d22920b2717b90893557e70d30a7acedc75dd7fb1b2b1da4faf2f41"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/radash all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 99,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "595c0187bab81c947726693f9340f0d1a45823e948d61bd6818a23a2e0cd5912"
+      },
+      "hit_arm0": 7,
+      "hit_arm1": 9,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 9
+    },
+    "raylib": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/raylib all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1836,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "05104b4caa724c3b10d24821791bb718a65cca72ffd3f541f1d72a5f96394f83"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/raylib all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 2203,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "c74b5cb172523b504d48d9389eaa4d4c7197fdb832a23dcef26eb2557304c36f"
+      },
+      "hit_arm0": 14,
+      "hit_arm1": 14,
+      "language": "C",
+      "split": "dev",
+      "worthy": 14
+    },
+    "redis": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/redis all top=0 --format json --mode syntax,semantic",
+        "reported_families": 855,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "0aab8a661e61334e2b32a68ed7c4c72be72980b2d77275917079ed59e8001479"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/redis all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1123,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "c003e9567de6be153fa823cc728d46a5d6c5ae143da9a1406af21374d59e4053"
+      },
+      "hit_arm0": 41,
+      "hit_arm1": 41,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 41
+    },
+    "regex": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/regex all top=0 --format json --mode syntax,semantic",
+        "reported_families": 427,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e25a3738639a20568f78f4a452481baa04343f2abb06c97c0544c1e144596005"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/regex all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 631,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "04ea7cc3086f44a8867e1ae96597151cbe438553b11d2f71f1ab354955cf5f05"
+      },
+      "hit_arm0": 62,
+      "hit_arm1": 65,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 69
+    },
+    "requests": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/requests all top=0 --format json --mode syntax,semantic",
+        "reported_families": 34,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e37f4cc9b0ae8722bc4e7834888888cd9d469ba4b1ed9e42b2f9e861c832ecc2"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/requests all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 52,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "bcf0af6043666707ff6541bb361c14cb78edada33fcdcc37eb89c01d849f9c2d"
+      },
+      "hit_arm0": 7,
+      "hit_arm1": 8,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 9
+    },
+    "retrofit": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/retrofit all top=0 --format json --mode syntax,semantic",
+        "reported_families": 322,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f0fe7559bb16a29ea6ed40651c3d7702762f4b43207f7c7d6360bc505e958373"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/retrofit all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 348,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "6a456ca7455787691d54fe0074c3612a5b977f4e11e1f04dc0f43c79c43dbbf3"
+      },
+      "hit_arm0": 43,
+      "hit_arm1": 41,
+      "language": "Java",
+      "split": "dev",
+      "worthy": 46
+    },
+    "rich": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rich all top=0 --format json --mode syntax,semantic",
+        "reported_families": 118,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2c1f44b177fe162b98bda695ef02c4b8abd578775ace6e5e0580be0f442a08c8"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rich all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 217,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "47cf33c980589d9eaa34e1704d7233555d7498c030c25c8b80dce95a96f9fc85"
+      },
+      "hit_arm0": 21,
+      "hit_arm1": 27,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 29
+    },
+    "ripgrep": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/ripgrep all top=0 --format json --mode syntax,semantic",
+        "reported_families": 162,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2473baacbd8ba51452f09a5db7d0c5acd5c5936e6b960dd8dfb55ab1942d230f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/ripgrep all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 268,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3e63c8066de8ff1da878ee31019f6656cd1a578ad24e3c00a779e52b07e3ffb6"
+      },
+      "hit_arm0": 46,
+      "hit_arm1": 57,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 69
+    },
+    "rspec-core": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rspec-core all top=0 --format json --mode syntax,semantic",
+        "reported_families": 161,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1c34b42ecff0e0bf56366a9a937c5ff025f131eaee889a3c77bb45e81ed0f2b9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rspec-core all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 246,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "e373167c837b82f7093652aae5089e676af89a6a57e03e60f70fbd6fa76449ef"
+      },
+      "hit_arm0": 31,
+      "hit_arm1": 49,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 52
+    },
+    "rubocop": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rubocop all top=0 --format json --mode syntax,semantic",
+        "reported_families": 687,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "430b0ea4b793a3ea04f7a7107e4b1c85fa39cc3695a031a7ff2e256bdbb56df9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rubocop all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1231,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b7457d30bb30c347f9c99e945601e23184a2aa97216598a3744dcc92504209fd"
+      },
+      "hit_arm0": 72,
+      "hit_arm1": 88,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 106
+    },
+    "rustls": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rustls all top=0 --format json --mode syntax,semantic",
+        "reported_families": 224,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "dadab65c78217dc9474e195a8834474d7a5cc40c5531c72a70f473ebdd33cf95"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rustls all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 359,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ab687369e6f5bcb6525e0774c7e1aed9c14113576fe92274811d5e2b5ccef0e9"
+      },
+      "hit_arm0": 46,
+      "hit_arm1": 50,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 52
+    },
+    "rxjava": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rxjava all top=0 --format json --mode syntax,semantic",
+        "reported_families": 3957,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "89daf094c00fe3a421fc374944f0125a51797cc882e04c9b8b0440f2d3ef55d6"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rxjava all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 4083,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "292d4cfa34811e6b80931528d490b129ceee88c77c379236fd57694db917a35f"
+      },
+      "hit_arm0": 37,
+      "hit_arm1": 39,
+      "language": "Java",
+      "split": "heldout",
+      "worthy": 39
+    },
+    "rxjs": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/rxjs all top=0 --format json --mode syntax,semantic",
+        "reported_families": 939,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "000ded85cf0dc1e30b07507e7df51b1e9cd9c2bc9e48d9f2576736b0458d0d57"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/rxjs all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 998,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "85fe2305c984e7d7ef7ae7b9d89f369b9eae7f09c020da31ca8a3211bac49d6f"
+      },
+      "hit_arm0": 14,
+      "hit_arm1": 19,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 19
+    },
+    "scrapy": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/scrapy all top=0 --format json --mode syntax,semantic",
+        "reported_families": 517,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d95d7f9dd3879f27ec2b94f7ba9a323d7d52abb6eef3389aa5e3fde9589821a4"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/scrapy all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 756,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "1eecc305bad6bd9c65751ff7ffd957538bf31a4fbf009eb5d7681c1b7eda297e"
+      },
+      "hit_arm0": 62,
+      "hit_arm1": 69,
+      "language": "Python",
+      "split": "dev",
+      "worthy": 71
+    },
+    "serde_json": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/serde_json all top=0 --format json --mode syntax,semantic",
+        "reported_families": 99,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "743afdd295487f357bc9bc0e94c6f77aa3df6325f394a58c2757fcfd81f756c2"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/serde_json all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 148,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fdcbe5f6a44c13440bc09e2469c0bfabc909c396ab89dccd0bf774824f5d219e"
+      },
+      "hit_arm0": 40,
+      "hit_arm1": 42,
+      "language": "Rust",
+      "split": "dev",
+      "worthy": 50
+    },
+    "sidekiq": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sidekiq all top=0 --format json --mode syntax,semantic",
+        "reported_families": 101,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "29b2ab509a70638cc1b687cf22cc657850ea807a818203fde5f5d2338d7c6571"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sidekiq all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 164,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "ca58ed21415d91b4262d0a8df7aead3dbf948e67e2419adf6c3a21dc0b014df5"
+      },
+      "hit_arm0": 35,
+      "hit_arm1": 45,
+      "language": "Ruby",
+      "split": "heldout",
+      "worthy": 46
+    },
+    "sinatra": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sinatra all top=0 --format json --mode syntax,semantic",
+        "reported_families": 126,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "655d107c2c93900ba17cf97ff6c750f7dd130997fe4fff528b8b56ab6b3e5a2f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sinatra all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 186,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "76cfdc9f4f3fecc87e9536c181aa5fa2e30029671728fbecf4e08b8979459d53"
+      },
+      "hit_arm0": 33,
+      "hit_arm1": 37,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 39
+    },
+    "sled": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sled all top=0 --format json --mode syntax,semantic",
+        "reported_families": 44,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fef7c6b32469aff7c4cb92fad08d887ed5bb956223a637a7f0df7a1324a4ac5e"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sled all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 46,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3bdc7f15323a583b4eb3a4bd3b3184b6fae460974b866bd6598b7e04a5204354"
+      },
+      "hit_arm0": 19,
+      "hit_arm1": 23,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 24
+    },
+    "sqlalchemy": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sqlalchemy all top=0 --format json --mode syntax,semantic",
+        "reported_families": 3917,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fadb78d54627d63a651cd186361f3741ebefbe0f4519705b206c21d9134c1528"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sqlalchemy all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 4559,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9f26f44ac9d5b0099f605fe45b9ad71b74eb48399c903be791337489237bd2ca"
+      },
+      "hit_arm0": 55,
+      "hit_arm1": 57,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 57
+    },
+    "sqlite": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sqlite all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1158,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f2b89bdcd5cdd4c7d259bdd71729d5864081cd25d94efdd558858ce12d03cb1a"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sqlite all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1548,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3423551c566dfc62cfac5b7d81be66a6d51a2e90d1aad84ba1a35ee7005e3c84"
+      },
+      "hit_arm0": 48,
+      "hit_arm1": 50,
+      "language": "C",
+      "split": "dev",
+      "worthy": 50
+    },
+    "swr": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/swr all top=0 --format json --mode syntax,semantic",
+        "reported_families": 171,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "76a070073b98766ff269cc138988a34ea03ffdf88229ff50ebb965a7c080420e"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/swr all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 204,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "404bd471d8075e6786eab56f1494b805a50d2b73effd20476c125589d36ffc15"
+      },
+      "hit_arm0": 37,
+      "hit_arm1": 38,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 39
+    },
+    "sympy": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/sympy all top=0 --format json --mode syntax,semantic",
+        "reported_families": 3877,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d90d951f590687ef6d9928531b187485b86a8a7b9b96a87aa2e14c18bdd6bd7a"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/sympy all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 4975,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "365539d9bada9d8977344bfd9b5e50b0078a37802479170c62801b5c7eff8eb2"
+      },
+      "hit_arm0": 31,
+      "hit_arm1": 31,
+      "language": "Python",
+      "split": "heldout",
+      "worthy": 31
+    },
+    "thor": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/thor all top=0 --format json --mode syntax,semantic",
+        "reported_families": 58,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "41eecc43ddacc763fa6b1de701ad383608f1ad1c055cf577bba92be28f127675"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/thor all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 97,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "564d89303ef871cd4eb0ab85162cc2a9868cd36e088136206251fe5a3c3f2b69"
+      },
+      "hit_arm0": 17,
+      "hit_arm1": 17,
+      "language": "Ruby",
+      "split": "dev",
+      "worthy": 19
+    },
+    "tmux": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/tmux all top=0 --format json --mode syntax,semantic",
+        "reported_families": 446,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "9119bce986cdf53e365a68d0da1e984326dddb4687d6a14b0f46fcfc1e0e3050"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/tmux all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 519,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "adbb6879a4869d05d8f0005b1654706ad37c94d8f1913449b39198502142f73e"
+      },
+      "hit_arm0": 91,
+      "hit_arm1": 100,
+      "language": "C",
+      "split": "dev",
+      "worthy": 103
+    },
+    "tokei": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/tokei all top=0 --format json --mode syntax,semantic",
+        "reported_families": 10,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "fb2a66ea374fa2ee4e4dc6f451951d7cc47810183ff88ba1fdc50635c5176e39"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/tokei all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 10,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "3d90aa20b5b0152d0079ba380c80e3cfe4430df543332b20268afece0091ecc9"
+      },
+      "hit_arm0": 4,
+      "hit_arm1": 5,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 5
+    },
+    "tokio": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/tokio all top=0 --format json --mode syntax,semantic",
+        "reported_families": 755,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8d06c6d7a62b5b975a9a5be17ab6d3ff32cdc06ff0b1920a65a4170bbf2bc2e9"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/tokio all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1076,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "56e6ad4140497ab27ce67a8fdfaaec0393d8529e3928151634b858d27b3f0254"
+      },
+      "hit_arm0": 69,
+      "hit_arm1": 73,
+      "language": "Rust",
+      "split": "heldout",
+      "worthy": 76
+    },
+    "trpc": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/trpc all top=0 --format json --mode syntax,semantic",
+        "reported_families": 565,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "571a3fc247478f9e1a48e935ec766d754dcad1c67b78d095905f01d90fe724d4"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/trpc all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 691,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "7058dbc529a554f2cd8ec5ccd24e8b7ad2e4fe9063ac225fd66bca63e63b3e24"
+      },
+      "hit_arm0": 63,
+      "hit_arm1": 65,
+      "language": "TypeScript",
+      "split": "heldout",
+      "worthy": 70
+    },
+    "urfave-cli": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/urfave-cli all top=0 --format json --mode syntax,semantic",
+        "reported_families": 135,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "71cb1152039249e4b3e7989ac609509ee89c97b88b3c4318a71f6497520eea6d"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/urfave-cli all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 152,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "52667c0fa275c0ce48eb94d2994854fa2c481731f861112a6190f566220efc8c"
+      },
+      "hit_arm0": 42,
+      "hit_arm1": 47,
+      "language": "Go",
+      "split": "heldout",
+      "worthy": 49
+    },
+    "vim": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/vim all top=0 --format json --mode syntax,semantic",
+        "reported_families": 1090,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "a2ef7417816e6a84ca218fda8c02b3b60c58e5b0056730fcba97d3420f79be94"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/vim all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 1400,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "8d940c70a5460ef37c054811eabb356643e795fac278e0d847eac3e833ce32eb"
+      },
+      "hit_arm0": 43,
+      "hit_arm1": 44,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 47
+    },
+    "wrk": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/wrk all top=0 --format json --mode syntax,semantic",
+        "reported_families": 11,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "db89c19b99d8776a33f4591c8ba983c7d6719b71b3c7c9e9a8a7525a205e961f"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/wrk all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 19,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "4a2dc6b5d8284034f2ff25ca359a984ff8b3410818cc5f1fa7a3a74adad8d449"
+      },
+      "hit_arm0": 0,
+      "hit_arm1": 1,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 1
+    },
+    "zap": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/zap all top=0 --format json --mode syntax,semantic",
+        "reported_families": 110,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "2a9a49a146cd07e0a900240404faa309f871ff517c118bc1035c47ec50bd2469"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/zap all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 160,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d1b72b325c9459b67936d364ebe481c8b5395c158191080086b508f82f80ac43"
+      },
+      "hit_arm0": 29,
+      "hit_arm1": 34,
+      "language": "Go",
+      "split": "dev",
+      "worthy": 36
+    },
+    "zod": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/zod all top=0 --format json --mode syntax,semantic",
+        "reported_families": 505,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "631efd021562275d3b38abd1a86aba1d6498c062d162c8ddb381b94fb996b106"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/zod all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 628,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "115ddc5724057b7d368924e6adc80b6f855f4166440ac3f65fea9bc13b0583ea"
+      },
+      "hit_arm0": 44,
+      "hit_arm1": 52,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 55
+    },
+    "zstd": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/zstd all top=0 --format json --mode syntax,semantic",
+        "reported_families": 676,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "09feaddeaf44c93eef8dbd4444e9618618d4a29e82a7627c65d82f15e6e09aea"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/zstd all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 782,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "0cf38c81d02b43e74047ad44d41df0fe0fb39a2d108ac9959d3bd5170996ebfc"
+      },
+      "hit_arm0": 27,
+      "hit_arm1": 27,
+      "language": "C",
+      "split": "heldout",
+      "worthy": 28
+    },
+    "zustand": {
+      "arm0": {
+        "command": "target/issue-820/release/nose query bench/repos/zustand all top=0 --format json --mode syntax,semantic",
+        "reported_families": 125,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "f8a53f6934912fcecb168e9af4b8689af5fb0646da8b8ad4571b5773a18d6683"
+      },
+      "arm1": {
+        "command": "target/issue-820/release/nose query bench/repos/zustand all top=0 --format json --mode syntax,semantic,near --min-value 0 --min-members 2",
+        "reported_families": 116,
+        "returncode": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "58d3b401c7e30538341681407a49ac814131d90c30a48f15980e1c6d7124437e"
+      },
+      "hit_arm0": 5,
+      "hit_arm1": 5,
+      "language": "TypeScript",
+      "split": "dev",
+      "worthy": 5
+    }
+  },
+  "schema": "nose.missed_worthy_frontier.v2",
+  "source_files": {
+    "bench/repos/alacritty/alacritty/src/daemon.rs": {
+      "sha256": "4dd85ecab4dbc6f5a4d7e605109fea88128dcac654daac750e7d906f67357432",
+      "size_bytes": 5372
+    },
+    "bench/repos/alacritty/alacritty/src/display/window.rs": {
+      "sha256": "6c38067ee4b6a7ded8e6d6a9ec190dd67ba4ea07b9d4d6bddd9ddf274e61dda7",
+      "size_bytes": 17237
+    },
+    "bench/repos/asciidoctor/test/api_test.rb": {
+      "sha256": "f8c29d46d9cce7e6b2fc1e11edb655d1efb9cb55916d113001f5da3314c81a0a",
+      "size_bytes": 75099
+    },
+    "bench/repos/asciidoctor/test/links_test.rb": {
+      "sha256": "a84749c3477f6d6ac9413a4ab840e659ccbd5cd008027b6b8b890b0971b3cb8f",
+      "size_bytes": 55479
+    },
+    "bench/repos/asciidoctor/test/lists_test.rb": {
+      "sha256": "b628ef756961358c589805d8db34cec997f5981f6875ef37536c8e65ea8abfa3",
+      "size_bytes": 181469
+    },
+    "bench/repos/asciidoctor/test/reader_test.rb": {
+      "sha256": "659350352072763b0676ea4334422d28eb6c6261e992e629566010edfe0d7198",
+      "size_bytes": 108203
+    },
+    "bench/repos/asciidoctor/test/tables_test.rb": {
+      "sha256": "3471e0304cd3343adea1af21e377ab483362bdf43b23502d60b88f2b08fcf522",
+      "size_bytes": 79332
+    },
+    "bench/repos/axios/sandbox/client.html": {
+      "sha256": "1343bd4c22fb019c10a26cffa97d391c45dc21ed938cb68fc3f52cbb72e6b08b",
+      "size_bytes": 14126
+    },
+    "bench/repos/axios/tests/smoke/esm/tests/rateLimit.smoke.test.js": {
+      "sha256": "aa3b03684c0f25aff1d95531e7bd37c0fa18c9ce86d0a2218924ffa1266d1e7b",
+      "size_bytes": 2694
+    },
+    "bench/repos/bat/src/assets.rs": {
+      "sha256": "5d61a9e0f5e17cc29f068dbc01d4eaa7984ade9184633ad414b9a28ad56d1512",
+      "size_bytes": 29299
+    },
+    "bench/repos/bat/src/assets/lazy_theme_set.rs": {
+      "sha256": "9ba68c852629bec8af9110170c10c0090146ee066bd33d6766ac9eecebbb8ac3",
+      "size_bytes": 3171
+    },
+    "bench/repos/bat/tests/integration_tests.rs": {
+      "sha256": "8411f6e88e8792737e8176f927dbf59e447df6202f36672cbc35eb287ce9c465",
+      "size_bytes": 134822
+    },
+    "bench/repos/boltons/tests/test_strutils.py": {
+      "sha256": "a62d2bb411facdcb4d59c3faa3371fe49fab327365e1b4ced1d2afd5a5207b07",
+      "size_bytes": 10610
+    },
+    "bench/repos/chi/middleware/client_ip_test.go": {
+      "sha256": "7d646e5ce28db8a486a0fa5b050e5563a950d43e16ac889bca896a9c5a62d080",
+      "size_bytes": 26423
+    },
+    "bench/repos/chi/middleware/route_headers_test.go": {
+      "sha256": "dd48799f1da69155927452801354ef413a97b1a83109fc8ad5f0560ae1f66906",
+      "size_bytes": 5766
+    },
+    "bench/repos/clap/clap_builder/src/error/mod.rs": {
+      "sha256": "deb632e970f060d95ba944f0cb273434b3fc94e4a47e5c6bc08672dc47d8e749",
+      "size_bytes": 28799
+    },
+    "bench/repos/clap/tests/builder/help.rs": {
+      "sha256": "5bd509bf63e9beab5bf053a850244eb92af0e854f2821bb5e29514324d3e163a",
+      "size_bytes": 127801
+    },
+    "bench/repos/clap/tests/derive/non_literal_attributes.rs": {
+      "sha256": "50719ca7ea39b83b6c50f8194bc11107b0432b89e760880c6859045c7ad2de4a",
+      "size_bytes": 4578
+    },
+    "bench/repos/cobra/completions_test.go": {
+      "sha256": "3f8a8aabe2d279b84313fbfa08a08728008a8bc61744ab3522e7cee73b3faba9",
+      "size_bytes": 119057
+    },
+    "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/AnnotationUtilsTest.java": {
+      "sha256": "3df2459ebd2dcb2296fb03cc9eaeafa1e7e9a131c7d3d0f48f84c7d975a19a2f",
+      "size_bytes": 20096
+    },
+    "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java": {
+      "sha256": "8bfe242a2ddd2aa67bda86bd23503b2ddab5ca5ed5128e9ab3d301001ce4916d",
+      "size_bytes": 38367
+    },
+    "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java": {
+      "sha256": "e9e84bb52075b749cf19b82fca03ccbf4df0a2cd7132e03ee0774936f6a93ca2",
+      "size_bytes": 105510
+    },
+    "bench/repos/commons-lang/src/test/java/org/apache/commons/lang3/tuple/PairTest.java": {
+      "sha256": "88849a131e4b36aa7bc4f3755ac046528e704acd8714f8eb5d76bb921bcac5e5",
+      "size_bytes": 12104
+    },
+    "bench/repos/curl/lib/curl_share.c": {
+      "sha256": "054101ed4d30cc70d0826d9015ae63096aab04d6aeafca8bf308c8716f5a26e6",
+      "size_bytes": 11796
+    },
+    "bench/repos/curl/lib/curlx/warnless.c": {
+      "sha256": "073b1c2be4b34abb7e82dc63781d872ffaa1590f809b2f1b26bcd3dbe0636da0",
+      "size_bytes": 7456
+    },
+    "bench/repos/curl/tests/libtest/lib1525.c": {
+      "sha256": "955b02f05e754b7be308bbc75b6f976338e007ec4b364cda3555b572b45e3f1e",
+      "size_bytes": 3065
+    },
+    "bench/repos/curl/tests/libtest/lib1526.c": {
+      "sha256": "4e239b0e8b6366834ca277883fa08fd2778ad54ebad65fca63e40d291fa9b743",
+      "size_bytes": 3224
+    },
+    "bench/repos/curl/tests/unit/unit1607.c": {
+      "sha256": "ef2139fecc490cf2d1a2af04773cca19ead31a55a85546e727810a161252f911",
+      "size_bytes": 7026
+    },
+    "bench/repos/curl/tests/unit/unit1609.c": {
+      "sha256": "f6eb827476492d45e5dd3b29630e1395b8a9b072e45339614a795a85ec786fbd",
+      "size_bytes": 6656
+    },
+    "bench/repos/date-fns/pkgs/core/src/_lib/format/formatters/index.ts": {
+      "sha256": "e213ac323fcc9b7ef7d31e2e5c6ac522118bc7f2d288146917bb5de440c4f88d",
+      "size_bytes": 23820
+    },
+    "bench/repos/date-fns/pkgs/core/src/differenceInCalendarDays/index.ts": {
+      "sha256": "cd5bfee823f7645f680d176d4e2a490215bfe47cf434a97d5126e868a8ee9b5b",
+      "size_bytes": 2297
+    },
+    "bench/repos/date-fns/pkgs/core/src/differenceInCalendarISOWeeks/index.ts": {
+      "sha256": "0fa2ce3ea0c90633d1290939f0875fab95f8cf2fa4078c8cd4465c0353b18f5b",
+      "size_bytes": 2095
+    },
+    "bench/repos/date-fns/pkgs/core/src/isSameDay/index.ts": {
+      "sha256": "1bff5a39a623f22a771fc98f105f2c2ff4e93b7c7ddb3a09895cd4a77bf0400a",
+      "size_bytes": 1532
+    },
+    "bench/repos/date-fns/pkgs/core/src/isSameHour/index.ts": {
+      "sha256": "83cdda7d94ab34d96f63353586daf43dc0a393487e2f43d8a0ced54954fa72fa",
+      "size_bytes": 1396
+    },
+    "bench/repos/date-fns/pkgs/core/src/setISOWeek/index.ts": {
+      "sha256": "0d8a605c0fe73474efb6ff5e485a5fccbdcc78f27212ffb44a4e6c35c9d36868",
+      "size_bytes": 1518
+    },
+    "bench/repos/date-fns/pkgs/core/src/setWeek/index.ts": {
+      "sha256": "c86644664c8be152ac6a7aea2e11c74506f8f68183e6e40c62dc6a02787405df",
+      "size_bytes": 2343
+    },
+    "bench/repos/delve/pkg/dwarf/op/op.go": {
+      "sha256": "afab18becd06663e000067a9a961fabc3739fea7a07f6e6b24bcb129c454d124",
+      "size_bytes": 14176
+    },
+    "bench/repos/devise/lib/devise/orm.rb": {
+      "sha256": "f534b5bd86e906610d9328e0a1be4662bc866d00184644e1bd17e6d0af88707d",
+      "size_bytes": 2286
+    },
+    "bench/repos/fastlane/fastlane/lib/fastlane/actions/get_build_number_repository.rb": {
+      "sha256": "623908547071b03c0088ed3b7a165c5d6499014012ef878392d228e25a216e9f",
+      "size_bytes": 3418
+    },
+    "bench/repos/fastlane/spaceship/spec/client_spec.rb": {
+      "sha256": "8df4f0d655385fad823ef349b42e33d3f667a301aa378c0c3b3a78b271f4c476",
+      "size_bytes": 13174
+    },
+    "bench/repos/fd/src/exec/mod.rs": {
+      "sha256": "e6d9d1326e358da5c4879a7b2b921e24702791ca07f8e8677c6541b55a1c6a4c",
+      "size_bytes": 14232
+    },
+    "bench/repos/flask/tests/test_basic.py": {
+      "sha256": "02f801a3648fa63d8117111b1d8e3219aa946062f584fd9b252de5db6ac8ec17",
+      "size_bytes": 54121
+    },
+    "bench/repos/fzf/src/result.go": {
+      "sha256": "57a2ebd9d8fa7bba391b106c4b9fe69fe8e62d53a0891ed5c2b05224ce870893",
+      "size_bytes": 9905
+    },
+    "bench/repos/fzf/src/terminal.go": {
+      "sha256": "6ae3d0c9e02536a6b5688ae4b44d4520c9e041a543bbff0e24805ef016324442",
+      "size_bytes": 234861
+    },
+    "bench/repos/fzf/test/test_core.rb": {
+      "sha256": "7c10fc77b5e5f803a208884524d32d7401bd8d07dda655dba3dab6230a683860",
+      "size_bytes": 103067
+    },
+    "bench/repos/fzf/test/test_shell_integration.rb": {
+      "sha256": "13aef2123c3ee46dfe8274657c5db16dd6df7fd121a2d29e44f9d5fa0737295e",
+      "size_bytes": 38740
+    },
+    "bench/repos/gin/auth.go": {
+      "sha256": "be38ef38614d2b9488d0e73ff2f8b432fc61cc90f4b7e071d0bbf78d898464c1",
+      "size_bytes": 3838
+    },
+    "bench/repos/gin/binding/toml.go": {
+      "sha256": "ce9f395dd0c2d62da942cc9f9a8a576cb81b4cacc9934fa6f3d3f19881a82790",
+      "size_bytes": 698
+    },
+    "bench/repos/gin/binding/xml.go": {
+      "sha256": "02ada76ed4d142b4d3e1813c068c2c43e9e01c19276eda5c875039355947b18a",
+      "size_bytes": 677
+    },
+    "bench/repos/gin/routes_test.go": {
+      "sha256": "ceea3a87f178ef85fe342ef70dac93bb1fdd74f7de03d28425916df521fd3a9c",
+      "size_bytes": 24774
+    },
+    "bench/repos/git/remote-curl.c": {
+      "sha256": "9cc520ab00619ee8bc65409efc365d717674c47275d6eb777135983a6548b19b",
+      "size_bytes": 44923
+    },
+    "bench/repos/gorm/clause/from_test.go": {
+      "sha256": "497dae07461dbdb2315de3a099d7cb6f49aec56f7917002b5872523bda115fbf",
+      "size_bytes": 1956
+    },
+    "bench/repos/gorm/clause/insert.go": {
+      "sha256": "dacd693c92f077b8cbafa75f963b5737cd03376125be275b13cac5ca7af7a1f2",
+      "size_bytes": 767
+    },
+    "bench/repos/gorm/clause/joins_test.go": {
+      "sha256": "c761c41314fbfc10542f242fd24a97e00914c4ab4a9cdba0ee6b801da42ad24f",
+      "size_bytes": 2695
+    },
+    "bench/repos/gorm/clause/returning.go": {
+      "sha256": "7a12d99eeb271c220c3d14806faedca9b7129322994cb312ccbe1272f0c99bd5",
+      "size_bytes": 777
+    },
+    "bench/repos/gorm/clause/select.go": {
+      "sha256": "ff049a1375c8e17b92cb473c6734b97fce3204bb6e8672c331b3f1602fdaf40c",
+      "size_bytes": 1096
+    },
+    "bench/repos/gorm/clause/select_test.go": {
+      "sha256": "45ecb549cf30e33f9fc8d5c368daa09fec787e10857deceefe2cc01d46961b5c",
+      "size_bytes": 1721
+    },
+    "bench/repos/gorm/clause/update.go": {
+      "sha256": "8f9be811925014010a30cfd93fcfaf8b24e45b2423252b49536001a6fd5d621e",
+      "size_bytes": 737
+    },
+    "bench/repos/gorm/clause/where.go": {
+      "sha256": "c7bbb3255c2899dd1882dc3ecf37578e03fda0f193dc320df60586236082ebc4",
+      "size_bytes": 5236
+    },
+    "bench/repos/gorm/logger/logger.go": {
+      "sha256": "59fd7f0249178ab1abba2a8da15d6c01eeea65a21dc8b12479f936bd082ae932",
+      "size_bytes": 6486
+    },
+    "bench/repos/gorm/logger/slog.go": {
+      "sha256": "a6d3e993e0f86c43541a06815b022a682c3bbc413e8afb30dea613b42a7c5ac6",
+      "size_bytes": 2927
+    },
+    "bench/repos/gorm/migrator/migrator.go": {
+      "sha256": "62286d4ace7b00bda8ee635cff623f41108f6fe3861898d2b93c6e0ecffad49b",
+      "size_bytes": 30517
+    },
+    "bench/repos/gorm/tests/preload_test.go": {
+      "sha256": "e56af1b3266e37324c288951f1161da99ed4ab78df9edefa75498bace85a87f3",
+      "size_bytes": 16308
+    },
+    "bench/repos/graphhopper/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java": {
+      "sha256": "36a867368544e6d35ae7e8cda6ef4e755d870d4688bdb99c875f309e2db0b4cd",
+      "size_bytes": 3398
+    },
+    "bench/repos/gson/gson/src/main/java/com/google/gson/internal/Primitives.java": {
+      "sha256": "dbee9175d2fb298f3a13589584590e99c638379e8be6f26d2c893259ca9756d7",
+      "size_bytes": 3516
+    },
+    "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonReader.java": {
+      "sha256": "4fe70bd77c2e1a4d7b2ed898c1d01a9af6b8b12e54266084a404f14e5d3f8bff",
+      "size_bytes": 62390
+    },
+    "bench/repos/gson/gson/src/main/java/com/google/gson/stream/JsonWriter.java": {
+      "sha256": "6b739b0ba2cc5a8e6809f1bdd31244c12e4f9a7145f6e93cd8f39ea193bf0e5b",
+      "size_bytes": 27050
+    },
+    "bench/repos/gson/gson/src/test/java/com/google/gson/GsonTest.java": {
+      "sha256": "db3b31423b7d6c6c4528db29fb646ae0a7032bd0a2e9a9493ab10a26eb09e1a3",
+      "size_bytes": 23216
+    },
+    "bench/repos/gson/gson/src/test/java/com/google/gson/functional/FieldNamingTest.java": {
+      "sha256": "dd44c00a171b02bfc9775c28a2692d3c0aa94e1c29c6bcfcd26a65b1494c1931",
+      "size_bytes": 4646
+    },
+    "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnClassesTest.java": {
+      "sha256": "eac3031a9a31b7d18aa4a535dbe632cdc4aeb60a4f62e0058c5ae471d2c5b49e",
+      "size_bytes": 29056
+    },
+    "bench/repos/gson/gson/src/test/java/com/google/gson/functional/JsonAdapterAnnotationOnFieldsTest.java": {
+      "sha256": "c8aadf6260f46ac886a7956dd885826f1b8dcfb8e71e34dfeb664e924de98907",
+      "size_bytes": 25383
+    },
+    "bench/repos/gson/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java": {
+      "sha256": "9473bf3ae82e8dec2ddbe7be27f6c3690f0a9b2c8b287cc0281201b782d97663",
+      "size_bytes": 85647
+    },
+    "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/Java17RecordReflectionTest.java": {
+      "sha256": "0132afd1c9b427eab684ce44fca34d5604343264b25d4819e746d342855a17bf",
+      "size_bytes": 5663
+    },
+    "bench/repos/gson/test-graal-native-image/src/test/java/com/google/gson/native_test/ReflectionTest.java": {
+      "sha256": "f51030716b81c531d758aa16e9c6ad2bc11fddc196a2e6ff32906b2bbf85867d",
+      "size_bytes": 8373
+    },
+    "bench/repos/hyperfine/src/export/csv.rs": {
+      "sha256": "8242084adb6817454d47ea9cd7947c8125682c52a01a678d9b5f7578a4a4d8fe",
+      "size_bytes": 3723
+    },
+    "bench/repos/image/src/codecs/jpeg/encoder.rs": {
+      "sha256": "b6942de68429c44b28d34d3abe0227dfdc4c37b6311559309099ab690cd96580",
+      "size_bytes": 17155
+    },
+    "bench/repos/image/src/codecs/pnm/header.rs": {
+      "sha256": "7ef17159bc44a9c57cb3093bdbcf80d1919a4dff5354d914b8861a2a8cc986c1",
+      "size_bytes": 11200
+    },
+    "bench/repos/image/src/imageops/colorops.rs": {
+      "sha256": "a4157b7c3c203345725aacfecb0a50c4e87a0a7d396036de461b875f1229b11f",
+      "size_bytes": 22480
+    },
+    "bench/repos/image/src/math/utils.rs": {
+      "sha256": "a70c17e2d4276d90a1b76339e4d103bbc6f8b5a77222ef052e744f180e0f27ff",
+      "size_bytes": 5678
+    },
+    "bench/repos/image/src/traits.rs": {
+      "sha256": "d6b5250afbc9c69101629122fd9a96df0a3eb51d91f3e2b430af070a456d96d5",
+      "size_bytes": 19270
+    },
+    "bench/repos/jackson-core/src/test/java/tools/jackson/core/unittest/write/ArrayGenerationTest.java": {
+      "sha256": "075bc17d996d57c071d1fcf4014c45d39b913fbfeea3f0a3671e6ae50d25b68a",
+      "size_bytes": 10221
+    },
+    "bench/repos/jedis/src/main/java/redis/clients/jedis/resps/HotkeysInfo.java": {
+      "sha256": "59fd0e637a34366c7c3fb468eaa395b4d6c5f9753051ab4d89e84d8caf867a21",
+      "size_bytes": 13877
+    },
+    "bench/repos/jedis/src/main/java/redis/clients/jedis/search/hybrid/HybridResult.java": {
+      "sha256": "397cb48b37755cc7a97227154268a035633ba8b507d1b6d998dea503ba2c69dd",
+      "size_bytes": 6181
+    },
+    "bench/repos/jedis/src/test/java/redis/clients/jedis/util/CommandArgumentsMatchers.java": {
+      "sha256": "78c474c7694be544ccb1dccd50763be7f071f97d1c98323d0c843ca08cba3fa9",
+      "size_bytes": 10552
+    },
+    "bench/repos/jekyll/benchmark/file-dir-ensure-trailing-slash": {
+      "sha256": "22a2a3cbd87beaa5485525b380e92d105d6afde37e575b43c8f7e59e4eee86c2",
+      "size_bytes": 1282
+    },
+    "bench/repos/jekyll/lib/jekyll/commands/serve/livereload_assets/livereload.js": {
+      "sha256": "d2232b84449991363ede4068d402fe7f2139a29b08ad4507866bea2ddf7ef4ae",
+      "size_bytes": 38152
+    },
+    "bench/repos/jekyll/lib/jekyll/document.rb": {
+      "sha256": "f26fb22bdec25dcd97e05d5cab212b9ab3463d5e01b46052863a0e42a1c8fa4a",
+      "size_bytes": 16729
+    },
+    "bench/repos/jekyll/lib/jekyll/page.rb": {
+      "sha256": "ecf99e2b2599f6d23a450ab90f70421e201c036d896c55b0d52d32aefad6e919",
+      "size_bytes": 5518
+    },
+    "bench/repos/jekyll/rubocop/jekyll/assert_equal_literal_actual.rb": {
+      "sha256": "0bedbbdd222fd8f846f36c60c4f61f78199de1b3af1c95b90d84577d9d01bbfa",
+      "size_bytes": 4525
+    },
+    "bench/repos/jekyll/test/test_win_tz.rb": {
+      "sha256": "cd382c3a415f361b50cf8e71a97e3a8d98afdd4dc548a135b87c490153089b67",
+      "size_bytes": 1011
+    },
+    "bench/repos/jest/packages/jest-resolve/src/resolver.ts": {
+      "sha256": "c341e57e91b2f50dcab1a2c811dece57ac3356f34290395eb8cd08ebce9bb4c8",
+      "size_bytes": 29174
+    },
+    "bench/repos/jq/src/compile.c": {
+      "sha256": "4ac446f5e38ad723e83cf763a9b7841a38ffdbf995dcf176e69d31ea6eaaa8c8",
+      "size_bytes": 44648
+    },
+    "bench/repos/jsoup/src/main/java/org/jsoup/nodes/Attributes.java": {
+      "sha256": "28597f20e359d61ecf4e4afcd36cdb0b6d8867c6f45f3b3ee2ebf3c7e20c4e83",
+      "size_bytes": 25639
+    },
+    "bench/repos/jsoup/src/main/java/org/jsoup/parser/CharacterReader.java": {
+      "sha256": "35562e0f8bb18373bb812719e02c1ad4e61adb74551b1aa81d13c582b0afb786",
+      "size_bytes": 24503
+    },
+    "bench/repos/jsoup/src/test/java/org/jsoup/nodes/ElementTest.java": {
+      "sha256": "282328670f064a4ffb03b2eb979074fbcbf49496968326684b9373dd4745cb65",
+      "size_bytes": 140661
+    },
+    "bench/repos/jsoup/src/test/java/org/jsoup/parser/HtmlParserTest.java": {
+      "sha256": "5dc3a47c33588ed2b8fb579a7071b48c1cbbfd4f514d5d1b75e7686611acd395",
+      "size_bytes": 111875
+    },
+    "bench/repos/jsoup/src/test/java/org/jsoup/select/SelectorTest.java": {
+      "sha256": "56a9a69beba65360b1441269ebc276b11ec80c83a23d78276cba2657cd885113",
+      "size_bytes": 71170
+    },
+    "bench/repos/ky/test/retry.ts": {
+      "sha256": "73fd5188d5711891a632226d9d2da80737ec8882e8583f7f244c3f8291bab4a5",
+      "size_bytes": 49213
+    },
+    "bench/repos/ky/test/stream.ts": {
+      "sha256": "0064a3d2df36ae78afc52b62d4cfad5983f1f3fe1919504ae10577d059e93be3",
+      "size_bytes": 26562
+    },
+    "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java": {
+      "sha256": "58fdf473e1182c55d3fd76c6f4d2c4b3602dba64e208e4ae571b8b8897717197",
+      "size_bytes": 3665
+    },
+    "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java": {
+      "sha256": "7991a6f217326bb9c5066c935371153fa0cd82e65b13925c23d0b766c3e6e65c",
+      "size_bytes": 4513
+    },
+    "bench/repos/libgdx/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java": {
+      "sha256": "30f3195c607a9f571e0b7e646959deb7c97c3b5f268cf33b042eb7ad1235c820",
+      "size_bytes": 3715
+    },
+    "bench/repos/libuv/src/unix/fs.c": {
+      "sha256": "9b2ecc3b46af56b75b6bbb0609c9d726b172a3382ef704dd0765753a2530252e",
+      "size_bytes": 60407
+    },
+    "bench/repos/libuv/src/unix/udp.c": {
+      "sha256": "6b33e82b50b723064deea8807386b859f9b8d290f33c93f1c478878ae1a32998",
+      "size_bytes": 43663
+    },
+    "bench/repos/libuv/src/win/fs.c": {
+      "sha256": "5a9f4f7d0f46e0c82bdcfb7c1e88d44ee71bdb25aeccd94fa37ac00f565e132e",
+      "size_bytes": 107744
+    },
+    "bench/repos/libuv/test/runner.c": {
+      "sha256": "f4a729000e6f34ec8890254586b0481b46a3da4c36ec04ce770ef7e32c6d8945",
+      "size_bytes": 11032
+    },
+    "bench/repos/libuv/test/test-fs-readdir.c": {
+      "sha256": "91f250ae8775d59bf7923110740b954d175fffd9ad37cb4a378b7a7889124602",
+      "size_bytes": 16136
+    },
+    "bench/repos/libuv/test/test-fs.c": {
+      "sha256": "909e04e9c48a6d9e84c2107a28156fd446dabbada8d01d38dd3c1dbf458d956f",
+      "size_bytes": 131675
+    },
+    "bench/repos/liquid/lib/liquid/parser_switching.rb": {
+      "sha256": "faeb5fc671a1b16b60c9f87dbfa7cd44b503bfed413458fc42442e098f24a023",
+      "size_bytes": 2155
+    },
+    "bench/repos/liquid/lib/liquid/resource_limits.rb": {
+      "sha256": "ffcdc40e5e79b86643644f14c263e24ed1f25ae52e26c14be5e970d987079f20",
+      "size_bytes": 2709
+    },
+    "bench/repos/liquid/lib/liquid/standardfilters.rb": {
+      "sha256": "54033794d6975a9a60ab1a45a2e8b5c36ef35ee54c737543ddeae0d85b836dd9",
+      "size_bytes": 34875
+    },
+    "bench/repos/liquid/test/integration/context_test.rb": {
+      "sha256": "6881254717ec789d35f66e6ad333012aec8f137a329a493e21d5ad37a2795982",
+      "size_bytes": 20908
+    },
+    "bench/repos/liquid/test/integration/drop_test.rb": {
+      "sha256": "1206861937905539fd0223504beee758ec883748af299da0b140ad86c273bcf0",
+      "size_bytes": 10112
+    },
+    "bench/repos/liquid/test/integration/standard_filter_test.rb": {
+      "sha256": "e96a524a6818ec50c16a92e9dc7a3a40b8d546b327dc024e3dc27da307978a3b",
+      "size_bytes": 47235
+    },
+    "bench/repos/liquid/test/integration/tag/disableable_test.rb": {
+      "sha256": "3310d6a48feae781d5b311ec05019305241f0958c975b90b5dc3295d0ef7996c",
+      "size_bytes": 1422
+    },
+    "bench/repos/lua/lvm.c": {
+      "sha256": "a393e020444624867ea28e7f2e7e29090bfb370c08260290d91fa7c09c36cc0f",
+      "size_bytes": 61507
+    },
+    "bench/repos/marshmallow/tests/test_deserialization.py": {
+      "sha256": "939f16aec3c2a2fcb7086b6b7b20d3f34374a6b853e8b49d09d29c23220422e7",
+      "size_bytes": 91341
+    },
+    "bench/repos/marshmallow/tests/test_schema.py": {
+      "sha256": "26e19d494f0b662499aa2a558532234e7941ddb93f39c96e9fb1602047f569ab",
+      "size_bytes": 78701
+    },
+    "bench/repos/marshmallow/tests/test_validate.py": {
+      "sha256": "2d642083f53e2dece74e8d9c233001b74e0b49ffd6e245b2cc2db7786bda9098",
+      "size_bytes": 35894
+    },
+    "bench/repos/minio/cmd/erasure-metadata-utils.go": {
+      "sha256": "3b60e7f2daf787b066cfd1699a361e5eb8767c50af89d8e3f951422851e80fb6",
+      "size_bytes": 11932
+    },
+    "bench/repos/minio/docs/debugging/hash-set/main.go": {
+      "sha256": "266926b36b1bbca1121cd33b687d81e4bf8d294c1e330439a437f47c5b27a195",
+      "size_bytes": 3753
+    },
+    "bench/repos/minio/internal/config/lambda/help.go": {
+      "sha256": "c3b6572012c469748e419c1fadefbe1962ec5ce1aaafb856ac60c435e72b008e",
+      "size_bytes": 1895
+    },
+    "bench/repos/minio/internal/config/notify/help.go": {
+      "sha256": "28a3c03161fa549ae30a2a433904514dc0be0075f111d87775c56aff9376999e",
+      "size_bytes": 19675
+    },
+    "bench/repos/minio/internal/config/notify/parse.go": {
+      "sha256": "6230ca63ab5541673d77e1a7be39f6d2f0a2ffd306d4c210c8560d6c11159520",
+      "size_bytes": 48667
+    },
+    "bench/repos/minio/internal/logger/config.go": {
+      "sha256": "662369b6f5e0b5d9771d1b278c5340d89aaccdda88103728fa666b489244eeb8",
+      "size_bytes": 19166
+    },
+    "bench/repos/minio/internal/logger/help.go": {
+      "sha256": "76b25628520cc99215e3d1af7fcb31bef2be560c62b041bbb9926f3b1a35c571",
+      "size_bytes": 7609
+    },
+    "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/MockMethodAdvice.java": {
+      "sha256": "fb75137a3610aca0b57baac4acc68ee6623d6ca1b342bc93c7d6ff50c77a1f0f",
+      "size_bytes": 35950
+    },
+    "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/Contains.java": {
+      "sha256": "d206b2cc0ecc620a0a93856b6b12842755d70c3f40149cc1595181819331f668",
+      "size_bytes": 650
+    },
+    "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/matchers/EndsWith.java": {
+      "sha256": "7b2829fbb96deb457dca342d2e4c7e0f202acd128c479876d02e985bc65c7bb4",
+      "size_bytes": 632
+    },
+    "bench/repos/mockito/mockito-core/src/main/java/org/mockito/internal/stubbing/answers/AnswerFunctionalInterfaces.java": {
+      "sha256": "d9574c12db0e790b4f81bc416fa31a0d7fe84832e919d25cb2df40d148d10969",
+      "size_bytes": 13662
+    },
+    "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/creation/bytebuddy/ClinitSuppressionTransformerTest.java": {
+      "sha256": "3305dd2242768008bad3333a3a0557977d4148b12875ec0b3b93396577625a55",
+      "size_bytes": 11016
+    },
+    "bench/repos/mockito/mockito-core/src/test/java/org/mockito/internal/stubbing/InvocationContainerImplStubbingTest.java": {
+      "sha256": "b724ff7fe44299a9e0260ae423fba9ecacb41759bc3b355659634dfb72a010e8",
+      "size_bytes": 4370
+    },
+    "bench/repos/mockito/mockito-core/src/test/java/org/mockitousage/debugging/StubbingLookupListenerCallbackTest.java": {
+      "sha256": "f7f1355c63bf70c11bc342bbab2e81c34923cdc98bb47cbe5438c34ff17e3bd1",
+      "size_bytes": 7969
+    },
+    "bench/repos/nats-server/server/monitor_test.go": {
+      "sha256": "3f45a2e826892180e97372a9ac3aef447c146be0d024446b6f567dc7ae4d305e",
+      "size_bytes": 204497
+    },
+    "bench/repos/netty/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java": {
+      "sha256": "864b95c5013228d19c808b36ef105a9501faa481b01ef1361e32bf4b4045e1dc",
+      "size_bytes": 12837
+    },
+    "bench/repos/nushell/crates/nu-plugin-core/src/serializers/tests.rs": {
+      "sha256": "1dc8a9aaf69705ff9bb2d86df55cad2d50d991a69f1763950b26b2d5dc5845d7",
+      "size_bytes": 22180
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs": {
+      "sha256": "a72c202544b5e3e689cdfa73c16baa3d5cb991ca51d0445b2a8bbedd06644a8f",
+      "size_bytes": 5481
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs": {
+      "sha256": "fb3249c684dc13db7e06b5a1ac1fb62fbe8f5bf6d3251042aef591a2908670b0",
+      "size_bytes": 8169
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs": {
+      "sha256": "1d8f013381fd9f4955f61e92db39545ec37b3df03dff523b1a84f053edb247bd",
+      "size_bytes": 7884
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs": {
+      "sha256": "f3974149a34eceb5d285492d061697e4396eaca40736c661b3328d390f47fe5d",
+      "size_bytes": 9707
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs": {
+      "sha256": "73ce48bbf76511139bd5be4a5e3f8dc5db741d5995406a2dd17247117907f84b",
+      "size_bytes": 5220
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs": {
+      "sha256": "68e386fe07132526a4405c9c09ef120c973b787acdd6820af489e533d9c4c07e",
+      "size_bytes": 5215
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_signed_integer.rs": {
+      "sha256": "ad87675c681f8eac254e1c2f120106fce0e0961e8fbfbddc4bcf48e5cfa2d9ed",
+      "size_bytes": 2565
+    },
+    "bench/repos/nushell/crates/nu_plugin_polars/src/dataframe/command/selector/selector_unsigned_integer.rs": {
+      "sha256": "f03f3158f1f4ab8dbf53dbe43ea6a8ad144fa3a4e0f89b86f16dd06aca7ab058",
+      "size_bytes": 2523
+    },
+    "bench/repos/packaging/tests/test_markers.py": {
+      "sha256": "f1ce134168466c60e335db8179add471f1ff4445bcc38c1221ce0b9ffa268ee0",
+      "size_bytes": 27771
+    },
+    "bench/repos/packaging/tests/test_requirements.py": {
+      "sha256": "66f90668aa419f2b3b4cc3a7ca50a2598238febfba283b73d680beff3f004ea9",
+      "size_bytes": 27505
+    },
+    "bench/repos/packaging/tests/test_tags.py": {
+      "sha256": "5ce5ceb769222394c04456e33a887e1cd4123aa817a662e2fa965f7579b1034b",
+      "size_bytes": 80673
+    },
+    "bench/repos/packaging/tests/test_utils.py": {
+      "sha256": "566c84b0152388685eaf11abfbb9973039f301f42ffb05b1fa7ddb11c860c209",
+      "size_bytes": 6706
+    },
+    "bench/repos/poetry/tests/installation/test_chef.py": {
+      "sha256": "1769d4cfbbafc138067891d8b4a6b7cf3bc58fb5a817ab34828c945cd475b567",
+      "size_bytes": 4995
+    },
+    "bench/repos/poetry/tests/utils/test_cache.py": {
+      "sha256": "473038670ebde81601d49fba5213866bf9e1013194bad528174778e622dcc811",
+      "size_bytes": 11008
+    },
+    "bench/repos/poetry/tests/utils/test_password_manager.py": {
+      "sha256": "ae4c7b20e2352ff39994f0f1ae60d64104cf2ea77974b5a6d1530753c87bf4da",
+      "size_bytes": 12130
+    },
+    "bench/repos/pry/lib/pry/method.rb": {
+      "sha256": "7376257d356badd685af2396b6cbd5c87c596f4312b6e891843663ffdf0b28db",
+      "size_bytes": 19953
+    },
+    "bench/repos/pry/lib/pry/method/weird_method_locator.rb": {
+      "sha256": "d3eb2d20159321acab36d23bb5cedd0ab0c55b414f77169920eadd590b363987",
+      "size_bytes": 7416
+    },
+    "bench/repos/pry/lib/pry/wrapped_module.rb": {
+      "sha256": "a270d43729938c900255dea518aea9fccbfabd544f15731f8cde61598859fc59",
+      "size_bytes": 12439
+    },
+    "bench/repos/puma/ext/puma_http11/puma_http11.c": {
+      "sha256": "f670d0b996194439da8e2e0281b661833c14076a16cdc06cd4ccd9698b24cc6b",
+      "size_bytes": 13390
+    },
+    "bench/repos/puma/lib/puma/thread_pool.rb": {
+      "sha256": "4332be74d7046785d41a814fb568467160fe937d1590693051c3162e826b9c23",
+      "size_bytes": 14255
+    },
+    "bench/repos/puma/test/test_fiber_local_application.rb": {
+      "sha256": "f6e833b55fd23ab9bf38c1e615a2b8e0b19ef128c1e659b367c06bd90f896ec5",
+      "size_bytes": 952
+    },
+    "bench/repos/puma/test/test_fiber_storage_application.rb": {
+      "sha256": "1207a0efccfd2a8ef77ff961c705f7154ca2a64888a0c8766dd0205b523f2ba4",
+      "size_bytes": 968
+    },
+    "bench/repos/puma/test/test_puma_server.rb": {
+      "sha256": "1c5d88f1ab5ea6537921a6691a861f42e56e1c0ca0d1487a1c3e81ef5e922d7a",
+      "size_bytes": 67005
+    },
+    "bench/repos/puma/test/test_rack_handler.rb": {
+      "sha256": "96d982533dc77a86f12b07780478801577d907ac06e07102071f86768fdc2973",
+      "size_bytes": 10224
+    },
+    "bench/repos/rack/lib/rack/lint.rb": {
+      "sha256": "7ea50621021b3beeb10d5fef687c03727a02b5e8a6ada5247950798462ff85bb",
+      "size_bytes": 44976
+    },
+    "bench/repos/regex/regex-automata/src/dfa/search.rs": {
+      "sha256": "79b9ab2b0636177bc26d1ad6f0059ca033decf74824cb5a36f1ac19f020d2713",
+      "size_bytes": 24376
+    },
+    "bench/repos/regex/regex-capi/src/rure.rs": {
+      "sha256": "a62aa71cefb464ede98b142f83c244726487d0aecf06fd0a8e0419a9be606dee",
+      "size_bytes": 17466
+    },
+    "bench/repos/regex/regex-lite/src/hir/parse.rs": {
+      "sha256": "a53435d9f11672a7cc7507ac4d62d52816761afd9a5804d1996a450546c82c42",
+      "size_bytes": 82581
+    },
+    "bench/repos/regex/regex-syntax/src/hir/translate.rs": {
+      "sha256": "8c01783e74261a8562c2694394d94ccb8cb173274932731fa77118041fab4507",
+      "size_bytes": 128438
+    },
+    "bench/repos/requests/tests/test_requests.py": {
+      "sha256": "c97eaf5958378b2117fdb88b5df031002772a9f24ba5484b91fe983c5f51cc80",
+      "size_bytes": 107631
+    },
+    "bench/repos/retrofit/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RxJavaPluginsResetRule.java": {
+      "sha256": "5d7ce53692298200f801b75b9687c66730750aeb689840898e272fe7d46e1307",
+      "size_bytes": 1185
+    },
+    "bench/repos/retrofit/retrofit-adapters/rxjava3/src/test/java/retrofit2/adapter/rxjava3/RxJavaPluginsResetRule.java": {
+      "sha256": "6b0511e83390ab2a07855549270adb7174f9dbc46926e574e945529df2c0bbfb",
+      "size_bytes": 1193
+    },
+    "bench/repos/retrofit/retrofit-mock/src/test/java/retrofit2/mock/CallsTest.java": {
+      "sha256": "a3212bddd1444f55fd64e2fc7c4bc236ec7a6a044cd708276d21eee2830b6007",
+      "size_bytes": 9899
+    },
+    "bench/repos/rich/tests/test_tools.py": {
+      "sha256": "54ca44adcedc1e50d66d63ad6a8335a82192acd50ca09dde9d63851d72b4eba7",
+      "size_bytes": 1429
+    },
+    "bench/repos/rich/tests/test_win32_console.py": {
+      "sha256": "270c22e211126524ac3f3809e1a20205c252ed7923df9c04db91b8b18331a483",
+      "size_bytes": 15088
+    },
+    "bench/repos/ripgrep/crates/core/flags/doc/version.rs": {
+      "sha256": "190b63e9c03db51205ead9a80a61655b618961bea111366dbf4fc2adb38bd6ad",
+      "size_bytes": 5534
+    },
+    "bench/repos/ripgrep/crates/globset/src/lib.rs": {
+      "sha256": "7ffe5cab3b7f1320e264e3376f5fcb343f036995c504290fb047d83e0e3da743",
+      "size_bytes": 35759
+    },
+    "bench/repos/ripgrep/crates/ignore/src/gitignore.rs": {
+      "sha256": "f089d28ba4b07fd9fdb627d49f6d98084d5de55aefbdfdeda71a96468f485097",
+      "size_bytes": 30793
+    },
+    "bench/repos/ripgrep/crates/ignore/src/types.rs": {
+      "sha256": "a8d515917dbcf21f6d92f42d9dacb75013a71c91394dfd68677c5d1c15cda706",
+      "size_bytes": 19710
+    },
+    "bench/repos/ripgrep/crates/ignore/src/walk.rs": {
+      "sha256": "3173c55f99ac90119eb00b615fbd9f5532a27c7a969e7ba0a369aba7ba71f1f3",
+      "size_bytes": 85092
+    },
+    "bench/repos/ripgrep/crates/ignore/tests/gitignore_matched_path_or_any_parents_tests.rs": {
+      "sha256": "1a38fdb4ba4b555debca6587fd14f69468ef93c37d14992dd90374b2e160232c",
+      "size_bytes": 12496
+    },
+    "bench/repos/ripgrep/crates/printer/src/color.rs": {
+      "sha256": "f37f3a667459590e9defc0537246d34401521ec40757aaf787df88086dfa1097",
+      "size_bytes": 13158
+    },
+    "bench/repos/ripgrep/crates/printer/src/macros.rs": {
+      "sha256": "fba6a3f245286c63f6f031a3a3d1bee56bf1eab83bd81a258ad2ddd32aadbb67",
+      "size_bytes": 670
+    },
+    "bench/repos/ripgrep/crates/searcher/src/lines.rs": {
+      "sha256": "37ec6404ed642b0692a726e21313acadae8ca4202da859d6421d5dfd44594bc1",
+      "size_bytes": 16462
+    },
+    "bench/repos/ripgrep/crates/searcher/src/testutil.rs": {
+      "sha256": "34055e71ee830bdc897686554a3be65499150e1d67a7d4cde45d7bf9aa9e9e2b",
+      "size_bytes": 27568
+    },
+    "bench/repos/ripgrep/tests/hay.rs": {
+      "sha256": "ee8d21ddd6f053f2f5427847e2a7bdc80913570cc410ced9508465ff66549684",
+      "size_bytes": 834
+    },
+    "bench/repos/ripgrep/tests/json.rs": {
+      "sha256": "9dd91b0dadc9be38d4ac37551af4b7bca6f80da8fe9723009f87b11c750efaaa",
+      "size_bytes": 12554
+    },
+    "bench/repos/ripgrep/tests/macros.rs": {
+      "sha256": "27d0ee206b162f26f718e526a2f303ad587db76703648ba06c1ee3cb2877d3ee",
+      "size_bytes": 1583
+    },
+    "bench/repos/rspec-core/spec/rspec/core/bisect/coordinator_spec.rb": {
+      "sha256": "cd0a7bd8619060b4fe7fdb37492deabc58f8f3629dcea1d34c94e6f6c7faae1c",
+      "size_bytes": 9597
+    },
+    "bench/repos/rspec-core/spec/rspec/core/bisect/server_spec.rb": {
+      "sha256": "472a007694e0257ea4f989585b3f67863d81e7e6e02cad7153fcd1e9b7f6a559",
+      "size_bytes": 5965
+    },
+    "bench/repos/rspec-core/spec/support/formatter_support.rb": {
+      "sha256": "03dce842f2d1e4be0467cec5a196a5e8d840d4b62e0dcb84a798a378037d33c2",
+      "size_bytes": 15356
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_gem.rb": {
+      "sha256": "f1586a904317be0b0299874c2d5da063e5b2997d9dbbfaa241f7e46babb72b17",
+      "size_bytes": 2814
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/bundler/duplicated_group.rb": {
+      "sha256": "afcc26a3dca108d60683181d4ab60ae4abc00e588aca456446e9da68a413c61b",
+      "size_bytes": 3636
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/bundler/gem_filename.rb": {
+      "sha256": "04ef1ad5fe87fedf02c812de63b59d539254a038c9d6ff5f71b5629ab99f9d68",
+      "size_bytes": 3413
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_operator.rb": {
+      "sha256": "6788bae8625ca61f8b13d61215018118df7a1310e7bd0d81ec396be96b08c7a1",
+      "size_bytes": 3278
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb": {
+      "sha256": "3c998931ee243023ab7ca0aa5ee8101e0143b9a2fce43491afc0364aa9ea79c0",
+      "size_bytes": 2511
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/lint/data_define_override.rb": {
+      "sha256": "8d10c5de26ee04d7043f4eaadc52b7d48bd4a9f9da0b574d9a65fbab72e299f6",
+      "size_bytes": 2352
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/lint/struct_new_override.rb": {
+      "sha256": "33387053abfa2b0e8b1a5d05dd8f02b4c8a9a296bb9cab796f83a1abb8975b3a",
+      "size_bytes": 3144
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/mixin/range_help.rb": {
+      "sha256": "5662cc556c28cbf79b0613c9f1bb4764aa1b72b7d41b7bdd816b902021eb5660",
+      "size_bytes": 5624
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/mixin/surrounding_space.rb": {
+      "sha256": "54db61d6bedac50f539d13e8580ef8861079e3de52a122d4d08976e956385610",
+      "size_bytes": 4723
+    },
+    "bench/repos/rubocop/lib/rubocop/cop/style/redundant_sort_by.rb": {
+      "sha256": "7f86ae375c148432062dd12e3496822aeb63ba557af03444e81e0b5d6430fea4",
+      "size_bytes": 2264
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/example_description_spec.rb": {
+      "sha256": "93f40a9516bd8562e1ae1942fc8dae6af63fa5d7994f0e17db4d0cef112fc291",
+      "size_bytes": 12010
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/internal_affairs/location_exists_spec.rb": {
+      "sha256": "8b38f220e39cb00fc16191f092938ddb79dd52465aaff7bd00b4ef1f7d0ca2c5",
+      "size_bytes": 10164
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/layout/empty_lines_around_attribute_accessor_spec.rb": {
+      "sha256": "d517565df3ff396d185d9c85d3d5129b8ce1e0804cab8e0b46daf93678ec77bb",
+      "size_bytes": 7192
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/layout/heredoc_argument_closing_parenthesis_spec.rb": {
+      "sha256": "52bb76fb9793fe6ff9d5e9b0b87eb45cdc7c434dd208fa3674026979239a57f6",
+      "size_bytes": 18157
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/layout/space_inside_parens_spec.rb": {
+      "sha256": "a410ae14ddca73594c846ed199b73b6784c05103c24649f0663fd70936bde26e",
+      "size_bytes": 7922
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/if_with_semicolon_spec.rb": {
+      "sha256": "5560d059f4a52a8e490785c22d9ffcd09a34dd09b987d6da679a0e2f26955534",
+      "size_bytes": 13243
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/infinite_loop_spec.rb": {
+      "sha256": "b6053b02c52b2f23876249a57f42fd3aeaa40d85259f56a57529caee2243e007",
+      "size_bytes": 7408
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/inverse_methods_spec.rb": {
+      "sha256": "4d3cb10788f584cf39f14e9c43611272357baa6626d727eebd2facac15a0f781",
+      "size_bytes": 12745
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/multiple_comparison_spec.rb": {
+      "sha256": "d3d56de1d121a4ed33644e400da65ce9eef7e98a595b31c1b49c91e597885aac",
+      "size_bytes": 12365
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/partition_instead_of_double_select_spec.rb": {
+      "sha256": "e4ea6e8dfb328a017dfe1e9271afe242bb1a431213be3164f52640a285dc0f81",
+      "size_bytes": 13551
+    },
+    "bench/repos/rubocop/spec/rubocop/cop/style/tally_method_spec.rb": {
+      "sha256": "d4e5c77426fa2ea82328c451a689f87e56ef17cc8c7abcb8ecb89f56cac5eb5a",
+      "size_bytes": 9019
+    },
+    "bench/repos/rustls/examples/src/bin/simple_0rtt_client.rs": {
+      "sha256": "766b485b8c4bc5fd4e6c4ed27e3d411f3aaa54d54ff403010de12951b4c95788",
+      "size_bytes": 3945
+    },
+    "bench/repos/rustls/examples/src/bin/tlsclient-mio.rs": {
+      "sha256": "3fb4a0ef7208024c5b15d8cac200c40cfd5af938fd654197200fbe037447e87b",
+      "size_bytes": 17435
+    },
+    "bench/repos/rustls/rustls-test/tests/api/crypto.rs": {
+      "sha256": "9a02fd30356f371f05ff0148bdfea2bd7a214e391a02f550bb867f162aae356d",
+      "size_bytes": 19125
+    },
+    "bench/repos/scrapy/scrapy/http/response/text.py": {
+      "sha256": "643bd223b3a19260f2bb30beb589baeafbb7d6da222b13bca4060d55d79a11a9",
+      "size_bytes": 11334
+    },
+    "bench/repos/scrapy/tests/test_pipelines.py": {
+      "sha256": "5a46db11fa3ac13613aee339976fab801d4c6246cbcd2fc1eac0e292db6249c0",
+      "size_bytes": 19527
+    },
+    "bench/repos/serde_json/src/de.rs": {
+      "sha256": "4998d7e252eb513be85b298e287048b4fb283882e9ba7df905f572f07200f3f3",
+      "size_bytes": 86840
+    },
+    "bench/repos/serde_json/src/number.rs": {
+      "sha256": "70b83c36286f6c58123f544f27db2b54a1135f928fe33b08b521b2997773f862",
+      "size_bytes": 25285
+    },
+    "bench/repos/serde_json/src/raw.rs": {
+      "sha256": "bc15c4d82d07c2c8b5d3f598915e917f2177de6573f327717da33658d2528922",
+      "size_bytes": 21542
+    },
+    "bench/repos/serde_json/src/read.rs": {
+      "sha256": "17a2efe49e5a6937c8d7d4a5c0b9eac84453de0f86bf8e7ee421387e82341bb3",
+      "size_bytes": 33041
+    },
+    "bench/repos/serde_json/tests/lexical/float.rs": {
+      "sha256": "0440f2d85c993bcccd925096d7f4136bf624ffd66b3c7ee565d158390685eb11",
+      "size_bytes": 14186
+    },
+    "bench/repos/serde_json/tests/test.rs": {
+      "sha256": "5c6e629525978c8fd190bdbbe3d62ff391bc8c8e86c143a0087b34ae2e7923e9",
+      "size_bytes": 76680
+    },
+    "bench/repos/sidekiq/bin/multi_queue_bench": {
+      "sha256": "2a56351f80dd7e6313c16ea5c383d9ae7ef61a804d30da9480133f3b915cd858",
+      "size_bytes": 6752
+    },
+    "bench/repos/sidekiq/bin/sidekiqload": {
+      "sha256": "0e7e67c0f2b3def5f3171e267227865b9afb7f37cb34b2de0a4aea59fd39f7a8",
+      "size_bytes": 6872
+    },
+    "bench/repos/sinatra/test/contest.rb": {
+      "sha256": "748863034e8ccf8a95b699e488e657f7860cb52a4ab1cefc13b866ef3641a55c",
+      "size_bytes": 3237
+    },
+    "bench/repos/sinatra/test/indifferent_hash_test.rb": {
+      "sha256": "70744df3f972595a78c822a8499036c515480e901b127c76694afe14b03d045c",
+      "size_bytes": 8919
+    },
+    "bench/repos/sled/examples/bench_large.rs": {
+      "sha256": "7d583a685ac060a238710b00bd36dd006259ba82b088f0c342c7dbc3d040c34e",
+      "size_bytes": 9056
+    },
+    "bench/repos/swr/test/use-swr-local-mutation.test.tsx": {
+      "sha256": "165cbfe0ccd14cee6505c8a976dfd80ed978e287bca99d535203360aa939282f",
+      "size_bytes": 51494
+    },
+    "bench/repos/thor/lib/thor/group.rb": {
+      "sha256": "d7e6736656987d695611c759d8182ab122e32bfb8300cd29d92e2c1f60575ce6",
+      "size_bytes": 9237
+    },
+    "bench/repos/thor/spec/line_editor_spec.rb": {
+      "sha256": "5bc7535b9e84f20d9984ce86965cf3678da4bd36f4b69227b72421d39b5393a5",
+      "size_bytes": 1344
+    },
+    "bench/repos/tmux/layout-custom.c": {
+      "sha256": "e6d6efe80f16dcac9693c28cc48c98a3cd88da306e5e3223b5489abd701f2843",
+      "size_bytes": 9851
+    },
+    "bench/repos/tmux/notify.c": {
+      "sha256": "57b122e2af32414e69ed8855ebffdb57d3e816479e09116c4f7d03013dcd3db1",
+      "size_bytes": 8853
+    },
+    "bench/repos/tmux/tty.c": {
+      "sha256": "da3ce2cbea72fe4e871480b11cde74cf8405447c13f6132de06b31bd389650b6",
+      "size_bytes": 76983
+    },
+    "bench/repos/tokio/tokio-stream/tests/async_send_sync.rs": {
+      "sha256": "2fde5007212aba7efc1417fc8ea04e5be61545c2506983155fd3aa1cfb60c5fe",
+      "size_bytes": 3796
+    },
+    "bench/repos/tokio/tokio/src/io/poll_evented.rs": {
+      "sha256": "334619a06d840de8d5d7037bee6d6f48accf5e8e1252460841637a512fa233f8",
+      "size_bytes": 13237
+    },
+    "bench/repos/tokio/tokio/tests/async_send_sync.rs": {
+      "sha256": "b7ba1ef28da9363b3950cb45b539d15b70727e7a939d043cd00078359f4959bc",
+      "size_bytes": 44706
+    },
+    "bench/repos/tokio/tokio/tests/rt_handle_block_on.rs": {
+      "sha256": "39d2b9cfcbcdc4bf5c503632cf995e37485275c4a0c9a35281149dd5d7db4a63",
+      "size_bytes": 15339
+    },
+    "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen-base.ts": {
+      "sha256": "53318cee9bb584a18b83113f36ca1321f868d992cacf134ee48bf7e3e5bde326",
+      "size_bytes": 1059
+    },
+    "bench/repos/trpc/examples/.test/diagnostics-big-router/scripts/codegen.ts": {
+      "sha256": "ebcae2426083095d820ec97418ef46e080b2a12085890274d55f894bcf095f5a",
+      "size_bytes": 1257
+    },
+    "bench/repos/trpc/examples/.test/diagnostics-big-router/src/utils/trpc.ts": {
+      "sha256": "da6033e4bd2f6baf00dc54f44ed3d1258f8fbcf0573ddd56d783938b37154ae8",
+      "size_bytes": 814
+    },
+    "bench/repos/trpc/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts": {
+      "sha256": "5cff4fbd3bbce222ceb29f0edd09aaadb58735f73fe0dec963adb8ad3c2a7b1c",
+      "size_bytes": 765
+    },
+    "bench/repos/trpc/examples/next-big-router/scripts/codegen-base.ts": {
+      "sha256": "e5e34f8869cb33349d78e648541ed072de7a30630b630296db296bd592beb217",
+      "size_bytes": 1003
+    },
+    "bench/repos/trpc/examples/next-big-router/scripts/codegen.ts": {
+      "sha256": "ebcae2426083095d820ec97418ef46e080b2a12085890274d55f894bcf095f5a",
+      "size_bytes": 1257
+    },
+    "bench/repos/trpc/packages/react-query/tsdown.config.ts": {
+      "sha256": "e6a52f63781834c3974b7d0d9741cd2c289f322bc1c1316a0048bb0509922d7d",
+      "size_bytes": 797
+    },
+    "bench/repos/trpc/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts": {
+      "sha256": "9fec620a9ddcc17395f1978b4fb55bd0b04f0601e98414ba09f44bc5496ea7e3",
+      "size_bytes": 18293
+    },
+    "bench/repos/trpc/packages/server/tsdown.config.ts": {
+      "sha256": "ae51935ebdf8cadebfa49719cae711f8f00bfc9a3a4d6659a045dd0e1021ac08",
+      "size_bytes": 1139
+    },
+    "bench/repos/urfave-cli/flag_bool_with_inverse.go": {
+      "sha256": "e36e29e13f28c80f8162321fe463d766c31bdec0ea4fc3aca5aae3ea6fb484f6",
+      "size_bytes": 8391
+    },
+    "bench/repos/urfave-cli/flag_impl.go": {
+      "sha256": "10f22ad650637301f938c6f5eda9f2dbc0670f750fa8f1f56f5f36e8a68507c0",
+      "size_bytes": 10566
+    },
+    "bench/repos/urfave-cli/flag_test.go": {
+      "sha256": "d4973d66a771697e302e17268c7b2d2eefbb2810235de1b53c9c136c51badf85",
+      "size_bytes": 100063
+    },
+    "bench/repos/vim/src/autocmd.c": {
+      "sha256": "c94d0b08a337d23f5b2b1c3a2b492fb574fd6a84c7184709c90da85e7f823d70",
+      "size_bytes": 89938
+    },
+    "bench/repos/vim/src/if_py_both.h": {
+      "sha256": "8382d4cd2cfd0eb98762ea161c22a1e6077edbb5372e47e77a0c9664b82f0ea0",
+      "size_bytes": 174145
+    },
+    "bench/repos/zap/benchmarks/zap_test.go": {
+      "sha256": "b1322c63b7fde7950e1819b6b50cc652b933b8f05d1a16b8f9344b950a434113",
+      "size_bytes": 4348
+    },
+    "bench/repos/zap/sugar.go": {
+      "sha256": "de0dce48d7803a5438107a98dbeb692974f25ad0797f3d7b952b3a7f7eb5b447",
+      "size_bytes": 16003
+    },
+    "bench/repos/zap/writer_test.go": {
+      "sha256": "f490cdebef368505dcb2c4403d1245d6985f4fcf432cd6748e5f18318238e6ec",
+      "size_bytes": 7084
+    },
+    "bench/repos/zod/packages/zod/src/v3/types.ts": {
+      "sha256": "1cfe15702dbccfc592bb46679bb6979c6b1b44b9790114a01447436849f0900d",
+      "size_bytes": 160328
+    },
+    "bench/repos/zstd/build/meson/tests/valgrindTest.py": {
+      "sha256": "bde9b9457ac903b596ef81dbe438c31274f7eaf295e551c617f8c6333d9d4f1c",
+      "size_bytes": 3449
+    }
+  }
+}

--- a/docs/accepted-pair-coverage-817.md
+++ b/docs/accepted-pair-coverage-817.md
@@ -205,7 +205,9 @@ contains the exact recovered IDs, and the [confirmation record](../bench/labels/
 binds it to the pre-held-out dev gate.
 
 The selected next action is now the pass branch: merge this bounded fix, rerun the
-missed-worthy frontier, and choose the next tranche only from the remaining misses.
+missed-worthy frontier, and choose the next tranche only from the remaining misses. That
+rerun is the [#820 post-#817 frontier](missed-worthy-frontier-820.md), which selects the
+bounded connected-witness follow-up #821.
 
 ## Validation
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -84,15 +84,20 @@ The v2 report adds coverage/eligibility metadata only.
 
 ### Current missed-worthy frontier
 
-The [#816 dev-first frontier audit](missed-worthy-frontier-816.md) reruns the current
-nose 0.18.0 query against the unchanged v5 worthy-recall pool and exactly reproduces
-2,626/2,849 dev and 1,949/2,091 held-out hits. Its optimistic ceiling is not used as
-admission evidence: a frozen seven-language dev sample and a raw-stage census show that
-51/223 dev misses already have direct accepted structural pairs. After the then-labeled
-Route A dev proposal was committed, a one-time held-out stage check confirmed 42/142 across six
-languages. The next bounded issue is [#817](https://github.com/corca-ai/nose/issues/817),
-which preserves accepted-pair endpoint coverage through family folding; extraction,
-same-unit fragments, HOF work, ranking, and default policy remain separate.
+The [#816 dev-first frontier audit](missed-worthy-frontier-816.md) found that 51/223
+dev misses already had accepted raw pairs. [#817](accepted-pair-coverage-817.md)
+preserved those endpoints through family folding and recovered 65 dev plus 47 held-out
+worthy families with zero regressions.
+
+The current [post-#817 refresh](missed-worthy-frontier-820.md) exactly reproduces
+2,691/2,849 dev and 1,996/2,091 held-out recall, leaving 158 and 95 misses. Its regenerated
+raw-stage census confirms zero remaining direct accepted rows. A source-bound dev audit
+selects the complete candidate-only + sub-DAG>=20 cohort: six of nine rows have coherent
+connected witnesses and three are hard negatives. Same-unit windows are sampled at 3/4
+coherent but require bounded fragment output; six sampled extraction rows are real but
+span unrelated construct-specific laws. The bounded next issue is
+[#821](https://github.com/corca-ai/nose/issues/821), which must construct an actual connected
+witness without admitting optimistic intersection mass.
 
 No detector, ranking, or default-surface policy changed in this refresh. The historical
 anti-unification re-rank remains comparison-only and still supplies no generalizing reason

--- a/docs/design.md
+++ b/docs/design.md
@@ -190,9 +190,12 @@ its head is nose's one chance to demonstrate value. Two consequences:
   Type-4 below vj 0.8 — was measured 2026-06-11 ([experiments §BS](experiments.md)) via the
   behavior-keyed arm: one worthy pair in 105 repos. **Current planning is superseded by the
   2026-07-11 [missed-worthy frontier audit](missed-worthy-frontier-816.md): 51/223 dev and
-  42/142 held-out misses already have direct accepted raw pairs. That reopens no semantic
-  law; it routes the next bounded tranche to post-acceptance family coverage (#817), while
-  extraction, fragments, and unaccepted matcher residuals remain deferred.***
+  42/142 held-out misses already had direct accepted raw pairs, routing the next tranche to
+  post-acceptance family coverage (#817). After #817 shipped, the 2026-07-12
+  [post-#817 refresh](missed-worthy-frontier-820.md) confirms that accepted-pair loss is
+  zero and selects a smaller six-positive/three-negative connected-witness cohort for
+  #821. The optimistic multiset ceiling remains non-admission evidence; same-unit and
+  construct-specific extraction stay separate.***
 - **Extractability ranking** — a "good enough" deterministic triage signal; no need to chase
   more.
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -3536,6 +3536,32 @@ worthy recall, zero regressions, recovery across six languages, and P@10 **53.79
 55.73%**. Full methodology, exact recovered IDs, artifact links, and validation commands
 are in [the #817 closeout](accepted-pair-coverage-817.md).
 
+## DK. Post-#817 missed-worthy frontier — connected witness next (#820, 2026-07-12)
+
+The merged #817 result was rerun against the unchanged source-independent v5 worthy pool.
+The checked combined evaluation reproduces **2,691/2,849 dev** and **1,996/2,091
+held-out**, with 112 total recoveries and zero regressions versus pre-#817. The refreshed
+frontier leaves 158 dev and 95 held-out misses. A regenerated raw-stage census confirms
+that the former post-acceptance cohort is exhausted: direct accepted rows are zero; dev
+splits into 40 candidate-only, 85 extracted/no-candidate, and 33 missing-unit rows.
+
+The deterministic 35-row dev audit preserves sixteen exact #816 decisions, discloses three
+pre-freeze exploratory reads, and adds sixteen post-freeze decisions. The complete
+candidate-only + sub-DAG>=20 cohort is nine rows: six have coherent connected witnesses and
+three are source no-go controls. The same-unit ceiling is larger (16), but only four rows
+are sampled and output must be bounded fragments; the missing-unit ceiling is 33, but six
+reviewed positives span unrelated Go, Java, Python, Rust, and JavaScript extraction laws.
+
+**Decision:** open #821 for an actual connected mapped witness on both candidate endpoints.
+Do not admit multiset intersection mass, lower thresholds, infer A-C from A-B/B-C, or mix
+candidate generation, same-unit fragments, and extraction into the tranche. The dev gate
+requires all six positives, none of the three no-go IDs, zero regressions/false merges,
+zero unrelated output, at most 2% default growth on the #809 slice, and a 5% / 5 ms runtime
+budget. After the dev proposal was committed, one mechanical held-out check confirmed zero
+accepted rows and exactly two candidate-only + sub-DAG>=20 rows in C and Java; held-out
+source stayed closed. See [the #820 closeout](missed-worthy-frontier-820.md) for the full
+chronology, IDs, artifacts, and commands.
+
 ## DH. Parser-artifact hygiene and unsupported-header routing (2026-06-20)
 
 After §DG, the largest `gap-impact` rows were no longer ordinary lowering misses. They were parser

--- a/docs/home.md
+++ b/docs/home.md
@@ -137,6 +137,9 @@ fundamentals; the rest is grouped by area.
 - [accepted-pair endpoint coverage](accepted-pair-coverage-817.md) — the #817
   bounded grouping fix, full dev accepted-edge census, exact recovered worthy
   families, product/runtime price, hard negatives, and frozen held-out gate.
+- [post-#817 missed-worthy frontier](missed-worthy-frontier-820.md) — the #820
+  snapshot-aware refresh, source-bound dev comparison of connected witnesses,
+  same-unit fragments, and extraction, plus the bounded #821 decision.
 - [type4-benchmark](type4-benchmark.md) — the evidence-carrying synthetic Type-4 benchmark factory.
 - [type4-adversarial-coverage](type4-adversarial-coverage.md) — focused Type-4 cases, target-packet task cards, and verifier-lead draft workflow.
 - [frontier-platform](frontier-platform.md) — corpus-balanced evidence platform that ranks the next Type-4 axis by presence breadth (not raw count) and separates the queue signal from human-verified evidence.

--- a/docs/missed-worthy-frontier-820.md
+++ b/docs/missed-worthy-frontier-820.md
@@ -1,0 +1,201 @@
+# Post-#817 missed-worthy frontier (#820)
+
+Issue [#820](https://github.com/corca-ai/nose/issues/820) refreshes the
+source-independent worthy-recall frontier after accepted-pair endpoint coverage shipped in
+#817. The result is a bounded candidate-acceptance follow-up, not permission to lower a
+threshold or admit the optimistic multiset ceiling.
+
+## Protocol and chronology
+
+The audit kept the frozen v5 multi-source pool as the only worthy-recall denominator. The
+v6 overlay remained precision-only. Evidence was frozen in this order:
+
+1. Make frontier validation snapshot-aware, while retaining strong validation of the #816
+   artifact and rejecting unregistered evaluation/count substitutions.
+2. From a clean commit, freeze the combined post-#817 product evaluation and frontier.
+3. Commit the deterministic 35-row dev selection, then regenerate all 158 dev raw stages.
+4. Bind 35 dev source decisions to the selected candidate hashes and frozen source bytes.
+5. Commit the dev proposal before running one mechanical held-out stage confirmation.
+6. Open the result-dependent implementation issue only after those gates passed.
+
+Sixteen selected candidate hashes exactly overlap the frozen #816 audit and reuse those
+decisions byte-for-byte. Three sources — `curl:2a436119a08187ba`,
+`mockito:d82f6e75097748da`, and `ripgrep:519afdcaed73af0d` — had been read during #820
+planning before the new selection was committed. They are explicitly marked exploratory,
+not presented as freshly blinded judgments. The other sixteen new rows were reviewed only
+after the selection and stage artifacts were committed. No held-out source was rendered or
+judged.
+
+## Checked post-#817 product baseline
+
+The combined [product-quality report](../bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json)
+uses the post-#817 binary (`sha256 5999e791c276a7d098099911b8252d35609d1ec7dbcf38888dad2815b126dd0a`)
+and the pre-#817 binary as `--comparison-nose`. Its evaluation digest is registered with an
+exact recall and comparison contract; CI rejects a substituted digest, count, or regression
+summary.
+
+| split | worthy recall | remaining miss | labeled P@10 | delta from pre-#817 |
+| --- | ---: | ---: | ---: | ---: |
+| dev | 2,691 / 2,849 (94.45%) | 158 | 264 / 447 (59.06%) | +65 |
+| held-out | 1,996 / 2,091 (95.46%) | 95 | 214 / 384 (55.73%) | +47 |
+
+The exact comparison contains 112 recovered worthy families and zero regressions.
+
+## Refreshed frontier and raw stages
+
+The checked [frontier artifact](../bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json)
+binds the evaluation and binary hashes, all inputs, all 120 repository pins, the post-prune
+corpus digest, query/feature output hashes, and the deterministic dev selection.
+
+| split | miss | sub-DAG | sub-DAG >=20 | inline | same-unit | unrecovered | extraction/other |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| dev | 158 | 60 | 14 | 16 | 16 | 44 | 22 |
+| held-out | 95 | 29 | 8 | 5 | 10 | 10 | 41 |
+
+These are optimistic ceilings. In particular, `intersection_mass` is not a connected
+witness and never authorizes acceptance.
+
+The regenerated [dev stage artifact](../bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json)
+accounts for every remaining dev miss:
+
+| dev raw stage | families |
+| --- | ---: |
+| direct accepted pair | 0 |
+| candidate only | 40 |
+| extracted, no direct candidate | 85 |
+| missing unit | 33 |
+
+The accepted-pair grouping cohort fixed by #817 is therefore gone rather than counted a
+second time.
+
+## Frozen dev source audit
+
+The selection SHA-256 is
+`419ab53ca32c9d33443c64dca03687220d2d92940e47bb8dd2df4b61e40d3712`:
+five rows per language across C, Go, Java, Python, Ruby, Rust, and TypeScript. Every
+judgment is recorded in the [v2 decision artifact](../bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json),
+while adjacent [source bounds](../bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json)
+bind each evidence interval and cited file to the frozen candidate and source hashes.
+
+| judgment origin | rows |
+| --- | ---: |
+| unchanged frozen #816 decision | 16 |
+| exploratory read before #820 freeze | 3 |
+| reviewed after #820 selection freeze | 16 |
+
+| blocker classification | selected rows |
+| --- | ---: |
+| connected anchor / sub-DAG construction | 7 |
+| candidate generation | 6 |
+| unit extraction / missing unit kind | 10 |
+| same-unit actionable fragment | 3 |
+| no coherent general mechanism | 9 |
+
+## Cohort comparison and decision
+
+The three leading mechanisms do not have equal evidence:
+
+| cohort | exact dev ceiling | selected reviewed | source-coherent | no-go | coverage |
+| --- | ---: | ---: | ---: | ---: | --- |
+| candidate-only + sub-DAG >=20 | 9 | 9 | 6 | 3 | complete |
+| same-unit window | 16 | 4 | 3 | 1 | sampled |
+| missing-unit extraction | 33 | 6 | 6 | 0 | sampled, heterogeneous |
+
+Same-unit evidence is real, but it needs a new bounded-fragment output contract; reporting
+the enclosing function is forbidden. Missing-unit evidence is also real, but the reviewed
+rows cover unrelated Go helpers, Java/Python test methods, Rust local items, and JavaScript
+test callbacks. No one extraction invariant owns that mass.
+
+The selected tranche is therefore the complete nine-row candidate-only connected-witness
+cohort. Six rows are required recoveries:
+
+- `curl:2a436119a08187ba`
+- `delve:de84b1952aa09a8e`
+- `graphhopper:2acc71582f85cc79`
+- `mockito:d82f6e75097748da`
+- `ripgrep:519afdcaed73af0d`
+- `thor:07e233ddffad07f0`
+
+Three rows are mandatory hard negatives:
+
+- `gson:4014d594ab6a8e54`
+- `scrapy:be72d6b46ad8eaf1`
+- `serde_json:946bfa61cb71d562`
+
+The smallest sound invariant is:
+
+> Every newly accepted pair carries one connected mapped witness on both sides whose
+> entry, exit, ordering, and relevant effects are preserved. Multiset mass and transitive
+> A-B-C overlap never substitute for that witness.
+
+The implementation may not change candidate generation, thresholds, ranking,
+default-surface policy, or #817 grouping. Its dev gate requires all six positives, none of
+the three no-go rows, zero worthy regressions, and zero false merges. Every added output
+must be connected-witness-backed; unrelated added rows are zero. The checked #809 slice
+budgets at most 2% default-output growth and 5% / 5 ms control-adjusted runtime cost.
+
+The result-dependent follow-up is
+[#821](https://github.com/corca-ai/nose/issues/821). If a sound connected witness cannot
+meet those gates without admitting disconnected mass or lowering thresholds, the mechanism
+is a no-go and the next issue becomes a language-bounded same-unit fragment tranche. If a
+sound implementation exceeds product/runtime budget, bound or optimize it rather than
+relaxing precision. A surviving language-specific rule must be split into the narrowest
+language/construct issue.
+
+## Held-out mechanical confirmation
+
+Only after the dev proposal commit did the checked
+[v2 held-out stage artifact](../bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json) rerun
+the raw mechanical method once:
+
+| held-out raw stage | families |
+| --- | ---: |
+| direct accepted pair | 0 |
+| candidate only | 14 |
+| extracted, no direct candidate | 35 |
+| missing unit | 46 |
+
+The pre-registered gate expected exactly two candidate-only + sub-DAG>=20 rows in C and
+Java and observed `vim:a3155684430a48be` and `jsoup:9b909cd145cab0a1`. They are mechanical
+cross-split confirmation only. Their source was not read, they are not implementation
+fixtures, and no positive source claim is made for them.
+
+## Reproduction and validation
+
+```sh
+CARGO_TARGET_DIR=target/issue-820 cargo build --release -p nose-cli
+
+python3 bench/labels/eval_by_language.py \
+  --labelset bench/labels/refactoring_families.v6.json \
+  --nose target/issue-820/release/nose \
+  --comparison-nose target/release/nose \
+  --rank extractability --bootstrap 500 \
+  --cache-dir target/issue-820/eval-cache \
+  --json-out bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json
+
+python3 bench/labels/recall_ceiling_probe.py \
+  --nose target/issue-820/release/nose --repos-root bench/repos \
+  --recall-labelset bench/labels/refactoring_families.v5.json \
+  --precision-labelset bench/labels/refactoring_families.v6.json \
+  --evaluation-report bench/labels/product_quality_evaluation_post_817_2026_07_12.v1.json \
+  --corpus-manifest bench/goldens/corpus.json \
+  --prune-manifest bench/labels/prune_manifest.json \
+  --json-out bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+
+python3 bench/labels/recall_ceiling_probe.py \
+  --validate bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+python3 bench/labels/missed_worthy_stage_audit.py \
+  --validate bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json \
+  --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+python3 bench/labels/recall_ceiling_probe.py \
+  --validate-decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json \
+  --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+python3 bench/labels/missed_worthy_source_bounds.py \
+  --validate bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json \
+  --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+  --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
+python3 bench/labels/missed_worthy_heldout_confirmation.py \
+  --validate bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json \
+  --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+  --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
+```

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -181,6 +181,22 @@ run_missed_worthy_frontier_checks() {
         --check-markdown bench/labels/missed_worthy_grouping_pricing_2026_07_11.summary.md
     python3 bench/labels/recall_ceiling_probe.py \
         --validate-closeout bench/labels/missed_worthy_frontier_closeout_2026_07_11.v1.json
+    python3 bench/labels/recall_ceiling_probe.py \
+        --validate bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+    python3 bench/labels/missed_worthy_stage_audit.py \
+        --validate bench/labels/missed_worthy_stage_audit_post_817_2026_07_12.dev.v1.json \
+        --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+    python3 bench/labels/recall_ceiling_probe.py \
+        --validate-decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json \
+        --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json
+    python3 bench/labels/missed_worthy_source_bounds.py \
+        --validate bench/labels/missed_worthy_audit_source_bounds_post_817_2026_07_12.dev.v1.json \
+        --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+        --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
+    python3 bench/labels/missed_worthy_heldout_confirmation.py \
+        --validate bench/labels/missed_worthy_stage_confirmation_post_817_2026_07_12.heldout.v2.json \
+        --artifact bench/labels/recall_ceiling_probe_post_817_2026_07_12.v1.json \
+        --decisions bench/labels/missed_worthy_audit_decisions_post_817_2026_07_12.dev.v2.json
 }
 
 run_product_query_schema_live_check() {


### PR DESCRIPTION
## Summary

- make the frontier recall contract evaluation-digest-aware so both historical #816 and post-#817 snapshots validate strongly
- freeze the combined post-#817 product evaluation, full frontier, dev raw-stage audit, source-bound dev decisions, and one-time held-out mechanical confirmation
- select the complete candidate-only + sub-DAG>=20 dev cohort: 6 connected-witness positives and 3 source no-go controls
- document the result and open bounded implementation follow-up #821

## Checked result

| split | worthy recall | remaining miss | labeled P@10 |
| --- | ---: | ---: | ---: |
| dev | 2,691 / 2,849 | 158 | 264 / 447 = 59.0604% |
| held-out | 1,996 / 2,091 | 95 | 214 / 384 = 55.7292% |

The comparison to pre-#817 has 112 recovered worthy families and zero regressions.

The regenerated raw stages are:

- dev: accepted 0, candidate-only 40, extracted/no-candidate 85, missing-unit 33
- held-out mechanical confirmation: accepted 0, candidate-only 14, extracted/no-candidate 35, missing-unit 46

The deterministic 35-row dev audit distinguishes 16 unchanged #816 decisions, 3 disclosed exploratory pre-freeze reads, and 16 post-freeze reviews. Cohort comparison:

| cohort | ceiling | reviewed | coherent | no-go |
| --- | ---: | ---: | ---: | ---: |
| candidate-only + sub-DAG>=20 | 9 | 9 | 6 | 3 |
| same-unit | 16 | 4 | 3 | 1 |
| missing-unit extraction | 33 | 6 | 6 | 0 |

Connected witness wins because its exact mechanical cohort is completely reviewed and governed by one bounded invariant. Same-unit needs bounded fragment output; extraction positives span unrelated construct-specific laws.

## Sound boundary

Every newly accepted pair must carry one connected mapped witness on both source sides whose entry, exit, ordering, and relevant effects are preserved. Multiset mass and transitive A-B-C overlap never substitute for that witness.

This PR changes audit/validation code and checked evidence only. It does not change product detector behavior, thresholds, ranking, default-surface policy, or #817 grouping.

## Validation

- `./scripts/check-ci-local.sh --fast`
- historical #816 frontier/decisions/source bounds/held-out confirmation
- post-#817 frontier/stage/decisions/source bounds/held-out confirmation
- unregistered evaluation/count substitution and comparison-regression self-tests
- `scripts/check-docs.sh`

Closes #820.
Follow-up: #821.
