### PR TITLE
Close out blocked-surface audit and replay evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added the durable #791/#799 blocked-surface closeout. The checked snapshot
+  records all 7 frozen rows resolved, all 12 required neutral facts
+  `modeled-controlled`, 358/358 executable expectations, the unchanged 29/29
+  real-frontier replay, 7 unchanged target packets, and no exact-admission-ready
+  packet. No focused fixture or probe is promoted as new real-corpus evidence.
 - Added the controlled Swift `Dictionary` default-subscript slice for #798.
   Import-free plain parameters written as `[K: V]`, unshadowed
   `Dictionary<K, V>`, or `Swift.Dictionary<K, V>` now converge with existing

--- a/bench/type4/ITERATIONS.md
+++ b/bench/type4/ITERATIONS.md
@@ -517,6 +517,22 @@ Swift Dictionary default receiver/fallback facts, and final closeout. The audit 
 new unexpected blocked rows as drift while allowing frozen rows to become actionable or leave
 the open audit as their facts land.
 
+## Neutral-Fact Blocked Epic Closeout
+
+Completed #799's #791 closeout in `issue_791_closeout.v1.json` and
+`issue_791_closeout.md`. All seven frozen rows are now resolved through controlled focused
+admissions, all twelve facts across the six implementation groups are
+`modeled-controlled`, and the current open audit is empty. The audit's seventh group is the
+closeout itself and adds no fact.
+
+The final evidence state is 358/358 executable expectations, the unchanged 29/29
+real-frontier replay over 11 query runs, seven unchanged target packets, and zero
+exact-admission-ready packets. The 31-item real-frontier inventory contains no new
+source-backed pair for the #791 language surfaces, so focused fixtures and probes remain
+focused evidence instead of being relabeled as real-corpus replay. There is no residual
+row to reclassify and no evidence-backed packet to schedule; future work begins only from
+new source-backed evidence rather than an automatic follow-up issue.
+
 ## Option Absence-Channel Focused Admission
 
 Closed #793 by turning `option.absence-channel.identity` from specified-only into a

--- a/bench/type4/README.md
+++ b/bench/type4/README.md
@@ -276,7 +276,11 @@ current workflow.
 
 Epic closeouts that summarize an admission batch's final replay/blocker disposition live
 beside the frontier artifacts. The #778 audit-ready admission closeout is recorded in
-`issue_778_closeout.v1.json` and `issue_778_closeout.md`.
+`issue_778_closeout.v1.json` and `issue_778_closeout.md`. The #791 neutral-fact blocked
+slice closeout is recorded in `issue_791_closeout.v1.json` and
+`issue_791_closeout.md`; it distinguishes the 31-item real-frontier inventory from the
+unchanged 29-entry executable replay and does not promote focused fixtures as real-corpus
+evidence.
 
 ## Frontier evidence platform
 

--- a/bench/type4/issue_791_closeout.md
+++ b/bench/type4/issue_791_closeout.md
@@ -1,0 +1,67 @@
+# Type-4 #791 Closeout
+
+Closeout issue: #799
+
+Status: complete with controlled admissions and explicit real-replay gaps.
+
+## Summary
+
+The #791 neutral-fact epic is closed at its proof perimeter. All seven rows frozen as
+`blocked-by-unmodeled-facts` have left the current open audit, and the twelve reusable
+facts they required are now `modeled-controlled`.
+
+- current open audit rows: 0
+- audit groups: 7, including the final closeout group
+- modeled neutral-fact groups: 6
+- frozen rows resolved or promoted: 7/7
+- frozen rows still blocked: 0
+- unexpected blocked rows or validation errors: 0
+- executable expectations: 358/358 across 41 query runs
+- real-frontier replay: 29/29 across 11 query runs
+- target packets: 7 unchanged
+- proof-carrying frontier: `no-exact-admission-ready-packets`
+
+## In-Scope Disposition
+
+| issue | surface | disposition | new real replay |
+|---|---|---|---|
+| #793 | Ruby nil/option presence | controlled focused admission | none available in the checked frontier |
+| #793 | Swift Optional presence/defaulting | controlled focused admission | none available in the checked frontier |
+| #795 | Swift `compactMap` option emission | controlled focused admission | none available in the checked frontier |
+| #796 | Swift one-level `flatMap` | controlled focused admission | none available in the checked frontier |
+| #797 | Java `Stream.flatMap` aggregate reduction | controlled focused admission | none available in the checked frontier |
+| #797 | Swift `flatMap` / `allSatisfy` aggregate reduction | controlled focused admission | none available in the checked frontier |
+| #798 | Swift `Dictionary` default subscript | controlled focused admission | none available in the checked frontier |
+
+The checked real-frontier inventory has 31 items and 29 executable replay entries, but
+none is a new source-backed pair for these seven language surfaces. The closeout therefore
+keeps replay at 29/29 instead of relabeling focused fixtures or probes as real-corpus
+evidence.
+
+## Proof-Fact Disposition
+
+Six implementation groups modeled twelve shared facts; the audit's seventh group is this
+closeout and does not introduce another fact:
+
+- option absence-channel identity;
+- HOF callback purity;
+- filter-map drop and emitted-value coordinates;
+- one-level flat-map depth, traversal order, and emitted-value coordinates;
+- flat-map aggregate guard coordinates;
+- map absence fallback, receiver identity, key/fallback coordinates, and mutation closure.
+
+The semantic cards and proof registry admit only the controlled slices backed by those
+facts. Unsupported callback effects, dispatch, receiver identity, mutation, channel
+coordinates, and deeper flattening remain explicit boundaries rather than residual open
+rows from this epic.
+
+## Frontier Decision
+
+The seven pre-existing target packets remain unchanged. Readiness reports no non-admitted
+packet to queue and the proof-carrying frontier has zero exact-admission-ready packets.
+That is a completed closeout state, not a reason to manufacture another follow-up issue:
+future work should begin only when new source-backed evidence identifies a concrete fact
+gap outside this frozen slice.
+
+The machine-readable snapshot and its cross-artifact validation command are recorded in
+`issue_791_closeout.v1.json`.

--- a/bench/type4/issue_791_closeout.v1.json
+++ b/bench/type4/issue_791_closeout.v1.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": 1,
+  "tool_version": "manual-closeout/1",
+  "closeout_date": "2026-07-12",
+  "epic_issue": 791,
+  "closeout_issue": 799,
+  "status": "complete-with-controlled-admissions-and-explicit-real-replay-gaps",
+  "source_artifacts": [
+    "bench/type4/proof_fact_registry.v1.json",
+    "bench/type4/semantic_pattern_cards.v1.json",
+    "bench/type4/open_surface_admission_audit.v1.json",
+    "bench/type4/frontier_target_packets.v1.json",
+    "bench/type4/proof_carrying_frontier.v1.json",
+    "bench/type4/frontier_readiness.v1.json",
+    "bench/type4/real_frontier.v1.json",
+    "bench/type4/real_frontier_replay.v1.json",
+    "bench/type4/real_frontier_replay_status.v1.json",
+    "bench/type4/executable_expectations.v1.json"
+  ],
+  "audit_summary": {
+    "open_surface_count": 0,
+    "fact_group_count_including_closeout": 7,
+    "frozen_blocked_count": 7,
+    "frozen_currently_blocked": 0,
+    "frozen_promoted_or_resolved": 7,
+    "current_actionable_open_count": 0,
+    "current_blocked_open_count": 0,
+    "unexpected_blocked_open_count": 0,
+    "validation_error_count": 0
+  },
+  "proof_fact_summary": {
+    "modeled_fact_group_count": 6,
+    "modeled_fact_count": 12,
+    "all_required_facts_modeled_controlled": true,
+    "facts": [
+      "option.absence-channel.identity",
+      "effect.pure-callback",
+      "hof.filter-map.drop-condition-coordinate",
+      "hof.filter-map.emitted-value-coordinate",
+      "collection.flatten-depth.one-level",
+      "hof.flat-map.nested-iteration-order",
+      "hof.flat-map.emitted-value-coordinate",
+      "hof.flat-map.aggregate-guard-coordinate",
+      "map.default.absence-fallback",
+      "map.receiver.source-identity",
+      "map.default.key-fallback-coordinate",
+      "map.receiver.no-intervening-mutation"
+    ]
+  },
+  "executable_expectation_summary": {
+    "expectation_count": 358,
+    "passed": 358,
+    "failed": 0,
+    "query_count": 41
+  },
+  "real_frontier_summary": {
+    "inventory_item_count": 31,
+    "replay_entry_count": 29,
+    "passed": 29,
+    "failed": 0,
+    "unavailable": 0,
+    "query_count": 11,
+    "new_epic_791_replay_entries": 0,
+    "promotion_decision": "No source-backed real-corpus pair for the newly admitted #791 language surfaces exists in the checked frontier; do not relabel focused fixtures as new real-corpus evidence."
+  },
+  "frontier_summary": {
+    "target_packet_count": 7,
+    "proof_carrying_frontier_verdict": "no-exact-admission-ready-packets",
+    "exact_admission_ready_packet_count": 0,
+    "next_work_group": "admitted/resolved",
+    "epic_791_packet_promotion_count": 0,
+    "promotion_decision": "No non-admitted frontier packet is queued, so the closeout does not manufacture a target packet from probe-only evidence."
+  },
+  "in_scope_dispositions": [
+    {
+      "issue": 793,
+      "surface": "Ruby nil?/nil comparison option presence",
+      "selector": "option.presence-default.proven-channel-coordinate:Ruby:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Ruby pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 793,
+      "surface": "Swift Optional presence and defaulting",
+      "selector": "option.presence-default.proven-channel-coordinate:Swift:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Swift Optional pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 795,
+      "surface": "Swift compactMap option emission",
+      "selector": "hof.filter-map.option-emission:Swift:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Swift compactMap pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 796,
+      "surface": "Swift one-level flatMap",
+      "selector": "hof.flat-map.one-level-flatten:Swift:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Swift one-level flatMap pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 797,
+      "surface": "Java Stream flatMap aggregate reduction",
+      "selector": "hof.flat-map.aggregate-reduction:Java:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Java flatMap aggregate pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 797,
+      "surface": "Swift flatMap/allSatisfy aggregate reduction",
+      "selector": "hof.flat-map.aggregate-reduction:Swift:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Swift flatMap aggregate pair for this admitted perimeter is present in the checked real frontier"
+    },
+    {
+      "issue": 798,
+      "surface": "Swift Dictionary default subscript",
+      "selector": "map.default.absence-lookup:Swift:blocked-by-unmodeled-facts",
+      "disposition": "controlled-admission-with-focused-executable-evidence",
+      "new_real_replay_ids": [],
+      "real_replay_gap": "no source-backed Swift Dictionary default-subscript pair for this admitted perimeter is present in the checked real frontier"
+    }
+  ],
+  "retained_boundaries": [
+    "unsupported callback effects, dispatch, receiver identity, mutation, channel coordinates, and nested flattening remain outside their controlled cards",
+    "focused or probe-only evidence is not promoted as a real-corpus replay",
+    "the seven existing target packets remain unchanged and none is exact-admission-ready",
+    "future expansions must start from new source-backed evidence and the named neutral fact gap instead of reopening this frozen slice"
+  ],
+  "done_criteria": [
+    "all seven frozen #791 rows are absent from the current open audit",
+    "all twelve required neutral facts are modeled-controlled",
+    "semantic cards, proof registry, audit, target packets, frontier, readiness, executable expectations, and replay artifacts agree",
+    "all 358 executable expectations and all 29 replay entries pass",
+    "no target packet or real replay is promoted from probe-only evidence"
+  ],
+  "validation_commands": [
+    "python3 -m json.tool bench/type4/issue_791_closeout.v1.json >/dev/null",
+    "jq -n -e --slurpfile closeout bench/type4/issue_791_closeout.v1.json --slurpfile audit bench/type4/open_surface_admission_audit.v1.json --slurpfile replay bench/type4/real_frontier_replay_status.v1.json --slurpfile exec bench/type4/executable_expectations.v1.json --slurpfile readiness bench/type4/frontier_readiness.v1.json --slurpfile proof_frontier bench/type4/proof_carrying_frontier.v1.json --slurpfile packets bench/type4/frontier_target_packets.v1.json --slurpfile real_frontier bench/type4/real_frontier.v1.json '($closeout[0].audit_summary.fact_group_count_including_closeout == $audit[0].epic_slices.epic_791.summary.fact_group_count) and ($closeout[0].audit_summary.frozen_blocked_count == $audit[0].epic_slices.epic_791.summary.frozen_blocked_count) and ($closeout[0].audit_summary.frozen_promoted_or_resolved == $audit[0].epic_slices.epic_791.summary.frozen_promoted_or_resolved) and ($closeout[0].audit_summary.frozen_currently_blocked == $audit[0].epic_slices.epic_791.summary.frozen_currently_blocked) and ($closeout[0].audit_summary.open_surface_count == $audit[0].summary.open_surface_count) and ($closeout[0].audit_summary.validation_error_count == $audit[0].epic_slices.epic_791.summary.validation_error_count) and ($closeout[0].real_frontier_summary.inventory_item_count == ($real_frontier[0].items | length)) and ($closeout[0].real_frontier_summary.replay_entry_count == $replay[0].entry_count) and ($closeout[0].real_frontier_summary.passed == $replay[0].passed) and ($closeout[0].real_frontier_summary.failed == $replay[0].failed) and ($closeout[0].real_frontier_summary.unavailable == $replay[0].unavailable) and ($closeout[0].real_frontier_summary.query_count == $replay[0].query_count) and ($closeout[0].executable_expectation_summary.expectation_count == $exec[0].expectation_count) and ($closeout[0].executable_expectation_summary.passed == $exec[0].passed) and ($closeout[0].executable_expectation_summary.failed == $exec[0].failed) and ($closeout[0].executable_expectation_summary.query_count == $exec[0].query_count) and ($closeout[0].frontier_summary.target_packet_count == ($packets[0].packets | length)) and ($closeout[0].frontier_summary.proof_carrying_frontier_verdict == $proof_frontier[0].verdict) and ($closeout[0].frontier_summary.proof_carrying_frontier_verdict == $readiness[0].source_report_verdict) and ($closeout[0].frontier_summary.exact_admission_ready_packet_count == $proof_frontier[0].target_packets.summary.ready_packet_count) and ($closeout[0].frontier_summary.next_work_group == $readiness[0].next_work.group)'",
+    "jq -n -e --slurpfile closeout bench/type4/issue_791_closeout.v1.json --slurpfile registry bench/type4/proof_fact_registry.v1.json '($closeout[0].proof_fact_summary.modeled_fact_count == ($closeout[0].proof_fact_summary.facts | length)) and (([$closeout[0].proof_fact_summary.facts[] as $fact_id | $registry[0].facts[] | select(.fact_id == $fact_id and .status == \"modeled-controlled\")] | length) == $closeout[0].proof_fact_summary.modeled_fact_count)'",
+    "python3 bench/type4/semantic_pattern_cards.py --check",
+    "python3 bench/type4/open_surface_admission_audit.py --selftest",
+    "python3 bench/type4/open_surface_admission_audit.py --check",
+    "python3 bench/type4/proof_carrying_frontier.py --selftest",
+    "python3 bench/type4/proof_carrying_frontier.py --check",
+    "python3 bench/type4/real_frontier_replay.py --selftest",
+    "python3 bench/type4/real_frontier_replay.py --stable-report --check",
+    "bench/type4/adversarial/scripts/type4-check",
+    "bench/type4/adversarial/scripts/type4-exec-check --stable-report --json-out bench/type4/executable_expectations.v1.json",
+    "./scripts/check-docs.sh",
+    "./scripts/check-ci-local.sh --fast"
+  ]
+}


### PR DESCRIPTION
Closes #799

## Summary
- record the durable #791 neutral-fact blocked-surface closeout
- prove all 7 frozen rows resolved and all 12 facts modeled-controlled
- preserve the distinction between 31 frontier inventory items and the unchanged 29/29 replay entries
- record 7 unchanged target packets and zero exact-admission-ready packets without creating another follow-up issue

## Validation
- all 14 commands recorded in `issue_791_closeout.v1.json`
- Type-4 executable expectations: 358/358 across 41 query runs
- real-frontier replay: 29/29 across 11 query runs
- `./scripts/check-docs.sh`
- `./scripts/check-ci-local.sh --fast`
- three independent reviews: soundness, maintainability, tests/artifacts