### PR TITLE
Release nose 0.19.0

### DIFF
--- a/.github/semantic-regression-expected-drift.json
+++ b/.github/semantic-regression-expected-drift.json
@@ -69,6 +69,118 @@
       "issue": "https://github.com/corca-ai/nose/issues/804",
       "reason": "Ruby core nil? proof metadata intentionally changed the serialized family witness",
       "repo": "sidekiq"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "0aa52023dca6602d810aad2329ba07c33562233e35624f21f71c51cd972698e7"
+          ],
+          "current": [
+            "60fa4483780df00b0edaccf4335833820dc43818fbc749dc8a64e56118851108"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "alacritty"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "53a97c9197ff8f93682db261d41c5cdf3dd6a3fec2281ab2759db94a24706a9f"
+          ],
+          "current": [
+            "7a598367716e80f9dfde8dec53d65d97a768e5628c1c28d91137bd1f37e8ab3a"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "asciidoctor"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "c15f32046cbd7a18f08da336f100ee256cb5d6cc788c9c3912611c3a431d310a"
+          ],
+          "current": [
+            "92778e916bfd64c0dbc0b0fb1da45a42d3fc6a234924b2157106c9ce0ed068c6"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "fastlane"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "0816231857d0a66549cfc1c15766ebc57b85311435ea6bd958c35d9cfdada060"
+          ],
+          "current": [
+            "14b3e4eb6d27e6c73963471e90a886d564e929e8fbedd331bf7e3f26cc679944"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "junit5"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "60d5fe8d153979e4c134c7db4ed320d00793cfb7cb75e32f2c57b148e902f0b5"
+          ],
+          "current": [
+            "519f2ff026ea1d7b51204891ab25d9034348c3d99ca8ea394c7b25058049be05"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "prettier"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "6d200e5a97600518316c8eac9b28bc39f2c053052737a83972247cb89b04f769"
+          ],
+          "current": [
+            "0aa530a54b23f06611fa854a1a072dc1c78340c82e68da61ecd679ea5c0932de"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "requests"
+    },
+    {
+      "baseline_source_sha": "2c30d1c9600cd97d9401344ee746b0e0a4c26370",
+      "changed": {
+        "hashes": {
+          "baseline": [
+            "5faace173bb7df105eb1b89339505b017431d5e6474658bc469b6b0d3efe0e4a"
+          ],
+          "current": [
+            "4979fbbb7c6a2d2009ec22cca5d3c987456faffa8b943ba9b1727bdc240591a8"
+          ]
+        }
+      },
+      "issue": "https://github.com/corca-ai/nose/issues/834",
+      "reason": "The 0.19.0 version metadata intentionally changes the serialized query header; family and byte counts are unchanged",
+      "repo": "sidekiq"
     }
   ],
   "schema": "nose.semantic_regression_expected_drift.v1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ break.
   output across the pinned 120-repository corpus.
 
 ### Performance
+- Stabilized the semantic runtime regression smoke by pairing base and head
+  measurements back-to-back within each repository, while still reversing pair
+  order between iterations and retaining the same-binary control. This prevents
+  runner load or temperature drift across the corpus from accumulating on only
+  one binary without relaxing the 5%/5ms thresholds.
 - Completed the 0.19.0 release pass against the published v0.18.0 Darwin arm64
   binary. The established semantic-only surface measured `24,822.49ms ->
   25,715.47ms` (`+3.60%`, approximately `+4.17%` after the same-binary control)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,9 +129,10 @@ break.
 ### Performance
 - Stabilized the semantic runtime regression smoke by pairing base and head
   measurements back-to-back within each repository, while still reversing pair
-  order between iterations and retaining the same-binary control. This prevents
-  runner load or temperature drift across the corpus from accumulating on only
-  one binary without relaxing the 5%/5ms thresholds.
+  order between iterations, using six focused samples for an exact 3:3 first-run
+  balance, and retaining the same-binary control. This prevents runner load or
+  temperature drift across the corpus from accumulating on only one binary
+  without relaxing the 5%/5ms thresholds.
 - Completed the 0.19.0 release pass against the published v0.18.0 Darwin arm64
   binary. The established semantic-only surface measured `24,822.49ms ->
   25,715.47ms` (`+3.60%`, approximately `+4.17%` after the same-binary control)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ break.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-13
+
 ### Added
+- Expanded proof-backed Type-4 equivalence coverage across common collection and
+  quantifier idioms: Python counterexample loops and `all`, JavaScript/TypeScript
+  `every`, Rust `Iterator::all`, Ruby `Enumerable#any?`/`all?`, and Swift
+  `allSatisfy`, membership, empty checks, and string prefix/suffix checks now
+  converge only when receiver identity, callback coordinates, effects, dispatch,
+  and language-specific safety obligations are proven.
+- Preserved every accepted pair endpoint through overlapping family-site folding
+  (#817), so a valid refactoring candidate is no longer lost merely because its
+  span collapses into a larger displayed site.
+- Added pair-local connected witnesses (#821) and bounded same-unit windows (#832)
+  as separate, budgeted near-match routes. They recover coherent refactoring
+  candidates that do not share one exact fragment while keeping ordinary accepted
+  pairs, work limits, deduplication, ranking, and output attribution explicit.
 - Added the durable #791/#799 blocked-surface closeout. The checked snapshot
   records all 7 frozen rows resolved, all 12 required neutral facts
   `modeled-controlled`, 358/358 executable expectations, the unchanged 29/29
@@ -110,6 +125,19 @@ break.
   indexing same-file method-redefinition facts, memoizing InstructionSequence
   resolution, and reusing first-party occurrence evidence without changing product
   output across the pinned 120-repository corpus.
+
+### Performance
+- Completed the 0.19.0 release pass against the published v0.18.0 Darwin arm64
+  binary. The established semantic-only surface measured `24,822.49ms ->
+  25,715.47ms` (`+3.60%`, approximately `+4.17%` after the same-binary control)
+  across all 120 pinned repositories. The expanded default surface measured
+  `34,204.68ms -> 36,433.48ms` (`+6.52%`) while returning 9.47% more families.
+  Profiling also removed an accepted-coverage reporting hot path: the focused
+  Alamofire/Raylib slice improved `6,787.93ms -> 3,591.61ms` (`-47.09%`) with
+  identical output, and Alamofire `rank_map` fell from 3,203.7ms to 22.0ms.
+  Product-quality metrics exactly reproduced the checked #832 result and the
+  recall-loss gate remained at 0 false merges and 0 canon-preservation violations.
+  See the [0.19.0 release evidence](docs/release-evidence-0.19.0.md).
 
 ## [0.18.0] - 2026-07-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nose-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "nose-detect"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "nose-frontend",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "nose-eval"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "nose-frontend"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "ignore",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "nose-il"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "lasso",
  "serde",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "nose-markdown"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "rayon",
  "regex",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "nose-normalize"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "nose-il",
  "nose-semantics",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "nose-semantics"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "nose-il",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/corca-ai/nose"
@@ -26,13 +26,13 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates carry an explicit `version` (not just `path`) so the tree has no
 # wildcard deps and the crates stay publishable; `path` wins for local builds.
-nose-il = { path = "crates/nose-il", version = "0.18.0" }
-nose-semantics = { path = "crates/nose-semantics", version = "0.18.0" }
-nose-frontend = { path = "crates/nose-frontend", version = "0.18.0" }
-nose-normalize = { path = "crates/nose-normalize", version = "0.18.0" }
-nose-detect = { path = "crates/nose-detect", version = "0.18.0" }
-nose-eval = { path = "crates/nose-eval", version = "0.18.0" }
-nose-markdown = { path = "crates/nose-markdown", version = "0.18.0" }
+nose-il = { path = "crates/nose-il", version = "0.19.0" }
+nose-semantics = { path = "crates/nose-semantics", version = "0.19.0" }
+nose-frontend = { path = "crates/nose-frontend", version = "0.19.0" }
+nose-normalize = { path = "crates/nose-normalize", version = "0.19.0" }
+nose-detect = { path = "crates/nose-detect", version = "0.19.0" }
+nose-eval = { path = "crates/nose-eval", version = "0.19.0" }
+nose-markdown = { path = "crates/nose-markdown", version = "0.19.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/bench/recall_loss/release-0.19.0-evidence-2026-07-13.v1.json
+++ b/bench/recall_loss/release-0.19.0-evidence-2026-07-13.v1.json
@@ -1,0 +1,183 @@
+{
+  "artifact_kind": "release-candidate-evidence",
+  "release_version": "0.19.0",
+  "generated_on": "2026-07-13",
+  "baseline": {
+    "version": "nose 0.18.0",
+    "git_ref": "v0.18.0",
+    "git_sha": "7cf9cd08c2a1c6f313f381c0bae31124ae152ef0",
+    "release_asset": "nose-cli-aarch64-apple-darwin.tar.xz",
+    "release_asset_sha256": "e4b1d073d83b87b645c2e2b616a0f70eff9ac2cbaefb7ea358b6cb8a79d01a46",
+    "binary": "target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose",
+    "binary_sha256": "aa22823c4c3e0ef71d4c43961e9326d8ee425c3d90368a0cbb1573d87103a040",
+    "binary_code_sha256": "e83f922a3600bfb71167fa977a067c0b5232d26a0ea5fbd046a78a0dbbb6246f",
+    "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1"
+  },
+  "release_candidate": {
+    "source_ref": "release-candidate-rank-index",
+    "git_sha": "9da281d6f257a585bda0639af8f4996c24632f2b",
+    "binary": "target/release-0.19.0/optimized-target/release/nose",
+    "binary_sha256": "d62417a363777c512fe6335caaaca64a033f4a7a1adfb9de67fc440955579573",
+    "binary_code_sha256": "1d7a5d2a2274fb755deda1f22826a645d330d0080cda893c24e62b6d81d6a63f",
+    "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+    "measured_version": "nose 0.18.0",
+    "working_tree_status_before_measurement": "",
+    "final_version_bump_binary": "target/release-0.19.0/final-target/release/nose",
+    "final_version_bump_binary_sha256": "96887e375a5d31738ef2e4877a9f8f6a41443d3b3a653be67974d5450d4aeb3c",
+    "final_version": "nose 0.19.0"
+  },
+  "performance": {
+    "initial_all_repo_regression": {
+      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-rc-default-allrepos-r3.json",
+      "artifact_sha256": "e618e11065d01d815e5fe857af36cee419d9c294c4b54a1eee3bc8a90b9c695f",
+      "aggregate_baseline_median_ms": 40160.33,
+      "aggregate_current_median_ms": 43404.30,
+      "aggregate_delta_pct": 8.08,
+      "diagnosis": "Alamofire exposed a real accepted-coverage ranking hot path: rank_map alone took about 3.2 seconds while an immediate same-binary control reproduced the cost."
+    },
+    "retained_patch": {
+      "git_sha": "9da281d6f257a585bda0639af8f4996c24632f2b",
+      "change": "Index collapsed accepted-coverage sites by file before mapping family members, instead of rescanning every collapsed site for every member.",
+      "focused_artifact": "target/release-0.19.0/query-regression-rank-index-focused-r5.json",
+      "focused_artifact_sha256": "4150728b58bb05a2c6aa5bc9893d5b55e53eb7e7401a0db1885414b79420cab2",
+      "repos": [
+        "alamofire",
+        "raylib"
+      ],
+      "iterations": 5,
+      "warmups": 1,
+      "aggregate_baseline_median_ms": 6787.92508400511,
+      "aggregate_current_median_ms": 3591.613457945641,
+      "aggregate_delta_pct": -47.08819833016682,
+      "alamofire_rank_map_median_ms": {
+        "baseline": 3203.7,
+        "current": 22.0
+      },
+      "hash_drift_repos": 0,
+      "family_drift_repos": 0,
+      "byte_drift_repos": 0
+    },
+    "same_binary_control": {
+      "artifact": "target/release-0.19.0/query-regression-optimized-rc-same-binary-control-default-allrepos-r3.json",
+      "artifact_sha256": "1fd7735034cbd1ee8df919a57658aca80e656db29e38225789e5ad0419dcc74b",
+      "repos": 120,
+      "iterations": 3,
+      "warmups": 1,
+      "aggregate_baseline_median_ms": 38954.3346609571,
+      "aggregate_current_median_ms": 38730.25733180111,
+      "aggregate_delta_pct": -0.5752307955103537,
+      "hash_drift_repos": 0,
+      "family_drift_repos": 0,
+      "byte_drift_repos": 0
+    },
+    "default_surface": {
+      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-default-allrepos-r3.json",
+      "artifact_sha256": "679389f19286b2f81105a8450ff8bff5182a897d28a54d4a7d8e762e713c95ff",
+      "repos": 120,
+      "iterations": 3,
+      "warmups": 1,
+      "aggregate_baseline_median_ms": 34204.67984012794,
+      "aggregate_current_median_ms": 36433.483380882535,
+      "aggregate_delta_pct": 6.516077774070641,
+      "approximate_control_adjusted_delta_pct": 7.091308569580995,
+      "baseline_families": 92229,
+      "current_families": 100966,
+      "family_delta": 8737,
+      "family_delta_pct": 9.473159201552656,
+      "family_increase_repos": 120,
+      "family_decrease_repos": 0,
+      "decision": "The default surface does more deliberate scoring and returns 9.47% more families. The measured runtime cost is retained as capability-growth price after removing the confirmed rank_map hot path."
+    },
+    "established_semantic_surface": {
+      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-semantic-allrepos-r3.json",
+      "artifact_sha256": "595db60f136e9e6d5a0abd1c5d2b1b05457fe19ccb8a6be2d03caa69e7789d82",
+      "query_args": "query {repo} all top=0 --mode semantic --format json",
+      "repos": 120,
+      "iterations": 3,
+      "warmups": 1,
+      "aggregate_baseline_median_ms": 24822.48829177115,
+      "aggregate_current_median_ms": 25715.468663838692,
+      "aggregate_delta_pct": 3.5974651758162812,
+      "approximate_control_adjusted_delta_pct": 4.172695971326635,
+      "baseline_families": 14884,
+      "current_families": 15815,
+      "family_drift_repos": 31,
+      "byte_drift_repos": 43,
+      "decision": "The established semantic-only release surface remains below the 5% regression threshold, including the directional same-binary adjustment."
+    }
+  },
+  "product_quality": {
+    "artifact": "target/release-0.19.0/product-quality-evaluation-0.19.0-rc.v1.json",
+    "artifact_sha256": "1aad008d4190123e0970cd7c398aff18318c63d05c7d582ebb92f250824d6210",
+    "labelset": "bench/labels/refactoring_families.v6.json",
+    "labelset_sha256": "6b72927d0e68e05406540016d3fa136029c52a406af0938b5a805d3fa199ac23",
+    "repositories": 120,
+    "dev": {
+      "worthy_recall": {
+        "hits": 2716,
+        "n": 2849,
+        "pct": 95.3317
+      },
+      "precision_at_10": {
+        "hits": 264,
+        "n": 444,
+        "pct": 59.4595
+      },
+      "label_match_coverage": {
+        "hits": 444,
+        "n": 660,
+        "pct": 67.2727
+      }
+    },
+    "heldout": {
+      "worthy_recall": {
+        "hits": 2005,
+        "n": 2091,
+        "pct": 95.8871
+      },
+      "precision_at_10": {
+        "hits": 213,
+        "n": 381,
+        "pct": 55.9055
+      },
+      "label_match_coverage": {
+        "hits": 381,
+        "n": 540,
+        "pct": 70.5556
+      }
+    },
+    "decision": "The clean release candidate exactly reproduces the checked #832 v6 product-quality result. Held-out source was not inspected during this release pass."
+  },
+  "recall_loss_gate": {
+    "artifact": "target/release-0.19.0/recall-loss.current.crates.json",
+    "artifact_sha256": "b3a3694ef7ca98295abb5b5e1397d9a485afff13f8c526c69670749eadd2f0b4",
+    "max_violations": 0,
+    "gate_passed": true,
+    "false_merges": 0,
+    "canon_preservation_violations": 0,
+    "advisory_disagreements": 6,
+    "summary": {
+      "total_units": 7835,
+      "interpretable_units": 1123,
+      "excluded_units": 6712,
+      "canon_checked": 117,
+      "admission_rejections": 930
+    },
+    "completeness": {
+      "behavior_groups": 5,
+      "behavior_equal_pairs": 180,
+      "fingerprint_equal_pairs": 63,
+      "completeness_percent": 35.0,
+      "under_merged_behavior_groups": 2,
+      "structurally_near_under_merged_groups": 0
+    }
+  },
+  "commands": [
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-default-allrepos-r3.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/optimized-target/release/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-optimized-rc-same-binary-control-default-allrepos-r3.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --mode semantic --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-semantic-allrepos-r3.json",
+    "python3 bench/labels/eval_by_language.py --labelset bench/labels/refactoring_families.v6.json --nose target/release-0.19.0/optimized-target/release/nose --rank extractability --bootstrap 500 --cache-dir target/release-0.19.0/eval-cache --json-out target/release-0.19.0/product-quality-evaluation-0.19.0-rc.v1.json",
+    "target/release-0.19.0/optimized-target/release/nose verify crates --max-violations 0 --recall-loss-report target/release-0.19.0/recall-loss.current.crates.json",
+    "./scripts/check-ci-local.sh --full"
+  ]
+}

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -47,7 +47,7 @@ fn semantic_pack_manifest(id: &str) -> String {
     "license": "MIT",
     "repository": "https://example.invalid/semantic-pack"
   }},
-  "compatibility": {{ "nose": ">=0.18.0 <0.19.0" }},
+  "compatibility": {{ "nose": ">=0.19.0 <0.20.0" }},
   "supported_languages": [{{ "id": "python" }}],
   "declares": {{
     "evidence_producers": [{{

--- a/crates/nose-detect/src/report/ranking.rs
+++ b/crates/nose-detect/src/report/ranking.rs
@@ -147,15 +147,23 @@ fn collapsed_accepted_edges(
     collapsed_sites: &[Loc],
     group_edges: &[(u32, u32)],
 ) -> Vec<(u32, u32)> {
+    let mut sites_by_file: rustc_hash::FxHashMap<&str, Vec<(u32, &Loc)>> =
+        rustc_hash::FxHashMap::default();
+    for (index, site) in collapsed_sites.iter().enumerate() {
+        sites_by_file
+            .entry(site.file.as_str())
+            .or_default()
+            .push((index as u32, site));
+    }
     let site_of: Vec<Option<u32>> = group
         .members
         .iter()
         .map(|member| {
-            collapsed_sites
-                .iter()
-                .enumerate()
-                .filter(|(_, site)| site.file == member.file)
-                .map(|(index, site)| (index as u32, overlap_frac(site, member)))
+            sites_by_file
+                .get(member.file.as_str())
+                .into_iter()
+                .flatten()
+                .map(|&(index, site)| (index, overlap_frac(site, member)))
                 .filter(|(_, overlap)| *overlap >= 0.5)
                 .max_by(|a, b| a.1.total_cmp(&b.1))
                 .map(|(index, _)| index)

--- a/crates/nose-detect/src/report/tests/grouping.rs
+++ b/crates/nose-detect/src/report/tests/grouping.rs
@@ -92,6 +92,35 @@ fn dedups_colocated_units() {
 }
 
 #[test]
+fn accepted_edges_follow_collapsed_sites_across_files() {
+    let g = Group {
+        score: 1.0,
+        members: vec![
+            loc("a.rs", 1, 20, "rust"),
+            loc("a.rs", 3, 18, "rust"),
+            loc("b.rs", 1, 20, "rust"),
+            loc("c.rs", 1, 20, "rust"),
+        ],
+        semantic_laws: Vec::new(),
+        abstraction_witness: None,
+        witness: None,
+    };
+    let mut report = report(vec![g]);
+    report.accepted_group_edges = vec![vec![(0, 2), (1, 2), (2, 3), (0, 1)]];
+
+    let families = rank_families(&report);
+    let [family] = families.as_slice() else {
+        panic!("the collapsed group must remain one family")
+    };
+    let [coverage] = family.accepted_coverage.as_slice() else {
+        panic!("the family must retain one accepted-edge obligation")
+    };
+
+    assert_eq!(coverage.sites.len(), 3);
+    assert_eq!(coverage.edges, vec![(0, 1), (1, 2)]);
+}
+
+#[test]
 fn subsumed_family_is_dropped() {
     // An outer family of two functions, and an inner family of blocks contained
     // within them (same regions, reported twice) — only the outer survives.

--- a/crates/nose-semantics/src/packs/tests.rs
+++ b/crates/nose-semantics/src/packs/tests.rs
@@ -69,7 +69,7 @@ fn manifest(id: &str) -> String {
     "license": "MIT",
     "repository": "https://example.invalid"
   }},
-  "compatibility": {{ "nose": ">=0.18.0 <0.19.0" }},
+  "compatibility": {{ "nose": ">=0.19.0 <0.20.0" }},
   "supported_languages": [{{ "id": "python" }}],
   "declares": {{
     "evidence_producers": [{{

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
@@ -89,7 +89,7 @@ fn compatibility_nose_must_be_version_requirement_like() {
     fs::write(
         &path,
         manifest("com.example.pack").replace(
-            r#""compatibility": { "nose": ">=0.18.0 <0.19.0" }"#,
+            r#""compatibility": { "nose": ">=0.19.0 <0.20.0" }"#,
             r#""compatibility": { "nose": "current stable" }"#,
         ),
     )
@@ -102,15 +102,15 @@ fn compatibility_nose_must_be_version_requirement_like() {
 #[test]
 fn compatibility_nose_accepts_semver_operator_spacing() {
     for (tag, supported_range) in [
-        ("operator_spacing", ">= 0.18.0, < 0.19.0"),
-        ("v_prefix", ">= v0.18.0 < v0.19.0"),
+        ("operator_spacing", ">= 0.19.0, < 0.20.0"),
+        ("v_prefix", ">= v0.19.0 < v0.20.0"),
     ] {
         let dir = unique_dir(&format!("compatibility_{tag}"));
         let path = dir.join("pack.json");
         fs::write(
             &path,
             manifest("com.example.pack").replace(
-                r#""compatibility": { "nose": ">=0.18.0 <0.19.0" }"#,
+                r#""compatibility": { "nose": ">=0.19.0 <0.20.0" }"#,
                 &format!(r#""compatibility": {{ "nose": "{supported_range}" }}"#),
             ),
         )
@@ -131,7 +131,7 @@ fn compatibility_nose_must_include_current_binary_version() {
         fs::write(
             &path,
             manifest("com.example.pack").replace(
-                r#""compatibility": { "nose": ">=0.18.0 <0.19.0" }"#,
+                r#""compatibility": { "nose": ">=0.19.0 <0.20.0" }"#,
                 &format!(r#""compatibility": {{ "nose": "{unsupported_range}" }}"#),
             ),
         )

--- a/docs/examples/ci/divergent-edit-enforcing.yml
+++ b/docs/examples/ci/divergent-edit-enforcing.yml
@@ -12,7 +12,7 @@ jobs:
   divergent-edit:
     runs-on: ubuntu-latest
     env:
-      NOSE_VERSION: v0.18.0
+      NOSE_VERSION: v0.19.0
       BASE_REF: origin/${{ github.base_ref }}
     steps:
       - name: Check out pull request

--- a/docs/examples/ci/divergent-edit-observe-only.yml
+++ b/docs/examples/ci/divergent-edit-observe-only.yml
@@ -12,7 +12,7 @@ jobs:
   divergent-edit:
     runs-on: ubuntu-latest
     env:
-      NOSE_VERSION: v0.18.0
+      NOSE_VERSION: v0.19.0
       BASE_REF: origin/${{ github.base_ref }}
     steps:
       - name: Check out pull request

--- a/docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json
+++ b/docs/examples/semantic-packs/v0/external-guava-immutable-collections-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.18.0 <0.19.0",
+    "nose": ">=0.19.0 <0.20.0",
     "schema": "v0",
     "notes": "Example only. v0 can validate the authoring shape but cannot execute external Guava evidence producers."
   },

--- a/docs/examples/semantic-packs/v0/language-pack.json
+++ b/docs/examples/semantic-packs/v0/language-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.18.0 <0.19.0",
+    "nose": ">=0.19.0 <0.20.0",
     "schema": "v0",
     "notes": "Example only. The loader compares this range before accepting the manifest."
   },

--- a/docs/examples/semantic-packs/v0/law-pack.json
+++ b/docs/examples/semantic-packs/v0/law-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.18.0 <0.19.0",
+    "nose": ">=0.19.0 <0.20.0",
     "schema": "v0",
     "notes": "Example only. nose's built-in value-graph law pack uses compiled builtin code and reports as nose.value_graph.laws."
   },

--- a/docs/examples/semantic-packs/v0/library-pack.json
+++ b/docs/examples/semantic-packs/v0/library-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.18.0 <0.19.0",
+    "nose": ">=0.19.0 <0.20.0",
     "schema": "v0",
     "notes": "Example only. The loader compares this range before accepting the manifest."
   },

--- a/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
+++ b/docs/examples/semantic-packs/v0/python-typing-domain-pack.json
@@ -21,7 +21,7 @@
     "source_revision": "0000000000000000000000000000000000000000"
   },
   "compatibility": {
-    "nose": ">=0.18.0 <0.19.0",
+    "nose": ">=0.19.0 <0.20.0",
     "schema": "v0",
     "notes": "Example only. nose's built-in pilot uses compiled builtin code and reports as nose.python.stdlib.type_domain."
   },

--- a/docs/home.md
+++ b/docs/home.md
@@ -157,6 +157,7 @@ fundamentals; the rest is grouped by area.
 - [hazard-release-checklist](hazard-release-checklist.md) — what to do for the hazard ranking on every new nose release (one-page runbook: refresh the dataset, re-tune, re-validate).
 - [runtime triage](runtime-triage.md) — reproducible query-runtime regression triage: harness, classification policy, timing knobs, and when not to optimize.
 - [Ruby redefinition runtime triage](runtime-triage-ruby-redefinitions-2026-07-10.md) — #807 diagnosis, indexed same-file facts, focused noise control, and all-corpus output evidence.
+- [0.19.0 release evidence](release-evidence-0.19.0.md) — the official v0.18.0 baseline comparison, accepted-coverage reporting hot-path fix, v6 product-quality reproduction, and recall-loss gate for the 0.19.0 release candidate.
 - [0.18.0 release evidence](release-evidence-0.18.0.md) — the pre-release performance pass, all-corpus query-regression, and recall-loss gate for the 0.18.0 release candidate.
 - [0.17.0 release evidence](release-evidence-0.17.0.md) — the hazard refresh, all-corpus query-regression, recall-loss gate, and profiling notes for the 0.17.0 release candidate.
 - [0.17.0 post-release runtime triage](runtime-triage-0.17.0.md) — focused follow-up on the largest release-candidate query-runtime regressions, including the `arrow` hot-path fix and remaining no-family-growth follow-ups.

--- a/docs/release-evidence-0.19.0.md
+++ b/docs/release-evidence-0.19.0.md
@@ -1,0 +1,97 @@
+# 0.19.0 release evidence
+
+Generated on 2026-07-13 for the `nose 0.19.0` release candidate.
+
+The machine-readable [release evidence artifact](../bench/recall_loss/release-0.19.0-evidence-2026-07-13.v1.json)
+records the exact commands, artifact hashes, and measurements.
+
+## Summary
+
+- The baseline is the published `v0.18.0` Darwin arm64 binary, verified against
+  its release checksum, rather than a local rebuild of the old source.
+- The established semantic-only query surface measured `24,822.49ms ->
+  25,715.47ms` (`+3.60%`) across all `120` pinned repositories. Applying the
+  directional `-0.58%` same-binary control gives approximately `+4.17%`, below
+  the `5%` release threshold.
+- The expanded default surface measured `34,204.68ms -> 36,433.48ms` (`+6.52%`)
+  while returning `92,229 -> 100,966` families (`+9.47%`). Every repository
+  gained families and none lost them, so this is retained as the measured price
+  of deliberate capability growth rather than a same-output regression.
+- Profiling found and removed a separate ranking defect introduced by accepted-pair
+  endpoint coverage. On the focused Alamofire/Raylib slice, indexing collapsed
+  sites by file reduced runtime `6,787.93ms -> 3,591.61ms` (`-47.09%`) with
+  identical output; Alamofire `rank_map` fell from `3,203.7ms` to `22.0ms`.
+- The clean candidate exactly reproduced the checked v6 product-quality result:
+  worthy recall is `95.33%` on dev and `95.89%` on held-out, with labeled P@10
+  of `59.46%` and `55.91%` respectively.
+- The `crates` recall-loss gate passed with `0` false merges and `0`
+  canon-preservation violations.
+
+## Performance diagnosis
+
+The first release-candidate run was `8.08%` slower than the official 0.18.0
+binary. Most of the apparent delta tracked the larger result surface, but
+Alamofire was a clear outlier: its `rank_map` stage alone took roughly `3.2`
+seconds in both the candidate run and an immediate same-binary control.
+
+The cause was an avoidable cross-file scan in accepted coverage reconstruction.
+For each family member, reporting scanned every collapsed accepted site and only
+then filtered by file. The retained patch builds a same-file index once and keeps
+the exact collapse, overlap, deduplication, and edge semantics. A behavior-level
+test covers overlapping sites in one file plus a linked site in another file.
+
+The optimized candidate's all-repository same-binary control measured
+`38,954.33ms -> 38,730.26ms` (`-0.58%`) with `120/120` identical hashes,
+family counts, and byte counts. The remaining default-surface time is concentrated
+in intended scoring and front-end work, while aggregate `rank_map` contributes
+only `23.5ms` more than 0.18.0 across the entire corpus.
+
+## Release comparison
+
+The official-release comparison was measured before the mechanical version bump:
+
+| Surface | Families | Runtime | Raw delta | Approx. control-adjusted |
+| --- | ---: | ---: | ---: | ---: |
+| established semantic | `14,884 -> 15,815` | `24,822.49ms -> 25,715.47ms` | `+3.60%` | `+4.17%` |
+| expanded default | `92,229 -> 100,966` | `34,204.68ms -> 36,433.48ms` | `+6.52%` | `+7.09%` |
+
+The control adjustment is directional subtraction of the same-binary default
+surface result, not a claim of deterministic timing. The semantic surface remains
+inside the release gate under either view. The default surface exceeds it, but
+also returns `8,737` additional families (`+9.47%`) across all `120` repos; this
+is explicitly accepted capability-growth cost. The confirmed superlinear
+reporting hot path was fixed before release.
+
+## Product quality
+
+The release pass reran the split-safe v6 label evaluation from a clean tree. It
+did not inspect held-out source.
+
+| Split | Worthy recall | Labeled P@10 | Top-10 label coverage |
+| --- | ---: | ---: | ---: |
+| dev | `2716/2849 = 95.33%` | `264/444 = 59.46%` | `444/660 = 67.27%` |
+| held-out | `2005/2091 = 95.89%` | `213/381 = 55.91%` | `381/540 = 70.56%` |
+
+These values exactly match the checked #832 closeout, so the performance patch
+did not change the evaluated product-quality result.
+
+## Recall-loss gate
+
+The release candidate passed:
+
+```sh
+target/release-0.19.0/optimized-target/release/nose verify crates \
+  --max-violations 0 \
+  --recall-loss-report target/release-0.19.0/recall-loss.current.crates.json
+```
+
+| Metric | Value |
+| --- | ---: |
+| total units | `7,835` |
+| interpretable units | `1,123` |
+| canon checked | `117` |
+| false merges | `0` |
+| canon-preservation violations | `0` |
+| completeness | `63/180 = 35.00%` |
+
+The six trace disagreements are advisory and do not enter the soundness gate.

--- a/docs/semantic-regression-smoke.md
+++ b/docs/semantic-regression-smoke.md
@@ -91,9 +91,10 @@ aggregate.
 
 A first-pass threshold crossing is not yet a hard regression failure. It exits
 with the dedicated focused-rerun status, selects the affected repositories (or the
-whole slice for an aggregate signal), and repeats five alternating measurements
-after one warmup with another same-binary control. Only a material signal confirmed
-by that focused run fails the runtime comparison.
+whole slice for an aggregate signal), and repeats six measurements after one warmup
+with another same-binary control. Six samples give base and head exactly three
+first-in-pair measurements each. Only a material signal confirmed by that balanced
+focused run fails the runtime comparison.
 
 ## Deterministic Ruby scaling tripwire
 

--- a/docs/semantic-regression-smoke.md
+++ b/docs/semantic-regression-smoke.md
@@ -74,10 +74,12 @@ declares its cost acceptable.
 
 ## Runtime policy
 
-The first pass takes two measurements with opposite base/head execution order and
-runs a base-vs-base same-binary control on the same corpus. It records wall time
-and every stage emitted by `NOSE_TIME=1`. A signal crosses the material threshold
-only when its
+The first pass takes two measurements, pairing base and head back-to-back within
+each repository and reversing that pair order on the next iteration. This prevents
+runner load or temperature changes across the corpus from accumulating on only one
+binary. It also runs a base-vs-base same-binary control with the same repo-local
+pairing. The harness records wall time and every stage emitted by `NOSE_TIME=1`.
+A signal crosses the material threshold only when its
 control-adjusted increase is both:
 
 - greater than 5%; and

--- a/scripts/query-regression-harness.py
+++ b/scripts/query-regression-harness.py
@@ -188,6 +188,11 @@ def run_once(
     }
 
 
+def measurement_order(repo_names: list[str], iteration: int) -> list[tuple[str, str]]:
+    labels = ("baseline", "current") if iteration % 2 else ("current", "baseline")
+    return [(label, repo_name) for repo_name in repo_names for label in labels]
+
+
 def warmup(
     *,
     binaries: dict[str, Path],
@@ -197,17 +202,15 @@ def warmup(
     query_args: tuple[str, ...],
 ) -> None:
     for iteration in range(1, warmups + 1):
-        order = ("baseline", "current") if iteration % 2 else ("current", "baseline")
-        for label in order:
-            for repo_name, _ in repos:
-                run_once(
-                    binary=binaries[label],
-                    label=label,
-                    repo_name=repo_name,
-                    repos_root=repos_root,
-                    iteration=-iteration,
-                    query_args=query_args,
-                )
+        for label, repo_name in measurement_order([name for name, _ in repos], iteration):
+            run_once(
+                binary=binaries[label],
+                label=label,
+                repo_name=repo_name,
+                repos_root=repos_root,
+                iteration=-iteration,
+                query_args=query_args,
+            )
 
 
 def repo_git_sha(repo_path: Path) -> str:
@@ -316,6 +319,10 @@ def corpus_provenance(
 
 def run_self_test() -> None:
     run_binary_identity_self_test()
+    assert measurement_order(["a", "b"], 1) == [
+        ("baseline", "a"), ("current", "a"), ("baseline", "b"), ("current", "b")
+    ]
+    assert measurement_order(["a"], 2) == [("current", "a"), ("baseline", "a")]
 
     def row(repo: str, label: str, elapsed_ms: float, size: int, stage_ms: float) -> dict[str, Any]:
         return {
@@ -425,6 +432,7 @@ def main() -> int:
     working_tree_status_before_measurement = git_output(["status", "--short"])
 
     binaries = {"baseline": baseline_binary, "current": current_binary}
+    repo_names = [repo for repo, _ in repos]
     warmup(
         binaries=binaries,
         repos=repos,
@@ -435,21 +443,17 @@ def main() -> int:
 
     runs: list[dict[str, Any]] = []
     for iteration in range(1, args.iterations + 1):
-        order = ("baseline", "current") if iteration % 2 else ("current", "baseline")
-        for label in order:
-            for repo_name, _ in repos:
-                runs.append(
-                    run_once(
-                        binary=binaries[label],
-                        label=label,
-                        repo_name=repo_name,
-                        repos_root=repos_root,
-                        iteration=iteration,
-                        query_args=query_args,
-                    )
+        for label, repo_name in measurement_order(repo_names, iteration):
+            runs.append(
+                run_once(
+                    binary=binaries[label],
+                    label=label,
+                    repo_name=repo_name,
+                    repos_root=repos_root,
+                    iteration=iteration,
+                    query_args=query_args,
                 )
-
-    repo_names = [repo for repo, _ in repos]
+            )
     baseline_identity = binary_identity(baseline_binary)
     current_identity = binary_identity(current_binary)
     output = {

--- a/scripts/semantic-regression-smoke.sh
+++ b/scripts/semantic-regression-smoke.sh
@@ -275,6 +275,7 @@ checker_args=(
   --require-corpus-provenance
   --max-runtime-delta-pct 5
   --min-runtime-delta-ms 5
+  --min-focused-iterations 6
   --status-output "$artifact_dir/check-status.json"
   --markdown-output "$artifact_dir/summary.md"
 )
@@ -301,11 +302,11 @@ PY
     focused_repo_args+=(--repo "$repo")
   done
   run_harness \
-    "$artifact_dir/focused.json" "$baseline_binary" "$current_binary" 5 1 \
+    "$artifact_dir/focused.json" "$baseline_binary" "$current_binary" 6 1 \
     "$base_ref" "$head_ref" "$base_sha" "$head_sha" \
     "${focused_repo_args[@]}"
   run_harness \
-    "$artifact_dir/focused-control.json" "$baseline_binary" "$baseline_binary" 5 1 \
+    "$artifact_dir/focused-control.json" "$baseline_binary" "$baseline_binary" 6 1 \
     "$base_ref" "$base_ref" "$base_sha" "$base_sha" \
     "${focused_repo_args[@]}"
   set +e


### PR DESCRIPTION
## Summary

- cut the 0.19.0 changelog and bump all workspace/internal compatibility versions
- record the official v0.18.0-binary performance comparison, v6 product-quality reproduction, and recall-loss evidence
- remove the accepted-coverage reporting hot path by indexing collapsed sites per file
- update semantic-pack and divergent-edit CI examples for 0.19.0

## Release evidence

- established semantic surface: 24,822.49ms -> 25,715.47ms (+3.60%; approximately +4.17% control-adjusted)
- expanded default surface: 34,204.68ms -> 36,433.48ms (+6.52%) while families increase 92,229 -> 100,966 (+9.47%)
- focused reporting optimization: 6,787.93ms -> 3,591.61ms (-47.09%) with identical output; Alamofire rank_map 3,203.7ms -> 22.0ms
- v6 worthy recall: dev 95.33%, held-out 95.89%
- recall-loss: 0 false merges, 0 canon-preservation violations
- full local CI, including MSRV and Lean proofs, passed

Refs #834