### PR TITLE
Finish 0.19.0 frontend runtime stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,11 +133,16 @@ break.
   balance, and retaining the same-binary control. This prevents runner load or
   temperature drift across the corpus from accumulating on only one binary
   without relaxing the 5%/5ms thresholds.
+- Replaced the front-end ANSI artifact detector's repeated 256 KiB adjacent-byte
+  scan with an escape-byte prefilter. Exact output is preserved; on the focused
+  control-paired Fastlane/Prettier slice, Prettier `lower` improved by about 8%
+  and `parse+lower` by about 13.5%, removing the Linux release-smoke outlier.
 - Completed the 0.19.0 release pass against the published v0.18.0 Darwin arm64
-  binary. The established semantic-only surface measured `24,822.49ms ->
-  25,715.47ms` (`+3.60%`, approximately `+4.17%` after the same-binary control)
-  across all 120 pinned repositories. The expanded default surface measured
-  `34,204.68ms -> 36,433.48ms` (`+6.52%`) while returning 9.47% more families.
+  binary using the final versioned candidate. The established semantic-only
+  surface measured `28,389.31ms -> 28,964.56ms` (`+2.03%`) across all 120 pinned
+  repositories. The expanded default surface measured `34,322.88ms ->
+  36,159.03ms` (`+5.35%`, approximately `+5.05%` after the same-binary control)
+  while returning 9.47% more families.
   Profiling also removed an accepted-coverage reporting hot path: the focused
   Alamofire/Raylib slice improved `6,787.93ms -> 3,591.61ms` (`-47.09%`) with
   identical output, and Alamofire `rank_map` fell from 3,203.7ms to 22.0ms.

--- a/bench/recall_loss/release-0.19.0-evidence-2026-07-13.v1.json
+++ b/bench/recall_loss/release-0.19.0-evidence-2026-07-13.v1.json
@@ -14,17 +14,14 @@
     "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1"
   },
   "release_candidate": {
-    "source_ref": "release-candidate-rank-index",
-    "git_sha": "9da281d6f257a585bda0639af8f4996c24632f2b",
-    "binary": "target/release-0.19.0/optimized-target/release/nose",
-    "binary_sha256": "d62417a363777c512fe6335caaaca64a033f4a7a1adfb9de67fc440955579573",
-    "binary_code_sha256": "1d7a5d2a2274fb755deda1f22826a645d330d0080cda893c24e62b6d81d6a63f",
+    "source_ref": "v0.19.0-frontend-fastpath",
+    "git_sha": "bc4e9bc953ce3e2d11a13aebee33b5bced6258fe",
+    "binary": "target/release-0.19.0/frontend-perf-target/release/nose",
+    "binary_sha256": "559e1d565e231dda5ac7abacd749a5aac6337b63aef3bff008284e705096a25d",
+    "binary_code_sha256": "825a9c12c6ca260f500bb2dfa7a1d6ec9a9ed31160d8364e346b587c06500a8c",
     "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
-    "measured_version": "nose 0.18.0",
-    "working_tree_status_before_measurement": "",
-    "final_version_bump_binary": "target/release-0.19.0/final-target/release/nose",
-    "final_version_bump_binary_sha256": "96887e375a5d31738ef2e4877a9f8f6a41443d3b3a653be67974d5450d4aeb3c",
-    "final_version": "nose 0.19.0"
+    "measured_version": "nose 0.19.0",
+    "working_tree_status_before_measurement": ""
   },
   "performance": {
     "initial_all_repo_regression": {
@@ -57,48 +54,71 @@
       "family_drift_repos": 0,
       "byte_drift_repos": 0
     },
+    "frontend_ansi_fastpath": {
+      "git_sha": "bc4e9bc953ce3e2d11a13aebee33b5bced6258fe",
+      "change": "Prefilter ANSI-highlight artifact samples with memchr escape-byte offsets instead of scanning every adjacent byte in the 256 KiB sample.",
+      "focused_artifact": "target/release-0.19.0/query-regression-frontend-fastpath-r6.json",
+      "focused_artifact_sha256": "f82a971ad4040116be6f594549634a7067d25f078f9dcee6d4168d3c38d212aa",
+      "focused_control_artifact": "target/release-0.19.0/query-regression-frontend-fastpath-control-r6.json",
+      "focused_control_artifact_sha256": "be41fd85f8df5df4968a8e2878d41f133cc32ea67c966083a71c648bee5b8d7d",
+      "repos": [
+        "fastlane",
+        "prettier"
+      ],
+      "iterations": 6,
+      "warmups": 1,
+      "aggregate_baseline_median_ms": 944.9968130502384,
+      "aggregate_current_median_ms": 938.9689790259581,
+      "aggregate_delta_pct": -0.6378681854834842,
+      "control_adjusted_delta_ms": 2.2075429897118593,
+      "prettier_control_adjusted_lower_delta_ms": -26.6,
+      "prettier_control_adjusted_parse_lower_delta_ms": -24.55,
+      "hash_drift_repos": 0,
+      "family_drift_repos": 0,
+      "byte_drift_repos": 0
+    },
     "same_binary_control": {
-      "artifact": "target/release-0.19.0/query-regression-optimized-rc-same-binary-control-default-allrepos-r3.json",
-      "artifact_sha256": "1fd7735034cbd1ee8df919a57658aca80e656db29e38225789e5ad0419dcc74b",
+      "artifact": "target/release-0.19.0/query-regression-v0.19.0-final-rc-self-control-default-allrepos-r3.json",
+      "artifact_sha256": "a371497132fb4c593b12af79d23a4f111d9fe8acb5c68439ab104be49402e5e5",
       "repos": 120,
       "iterations": 3,
       "warmups": 1,
-      "aggregate_baseline_median_ms": 38954.3346609571,
-      "aggregate_current_median_ms": 38730.25733180111,
-      "aggregate_delta_pct": -0.5752307955103537,
+      "aggregate_baseline_median_ms": 37979.23579480266,
+      "aggregate_current_median_ms": 38092.00525016058,
+      "aggregate_delta_pct": 0.2969239717386639,
       "hash_drift_repos": 0,
       "family_drift_repos": 0,
       "byte_drift_repos": 0
     },
     "default_surface": {
-      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-default-allrepos-r3.json",
-      "artifact_sha256": "679389f19286b2f81105a8450ff8bff5182a897d28a54d4a7d8e762e713c95ff",
+      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-final-rc-default-allrepos-r3.json",
+      "artifact_sha256": "c338538253c77340eec0d873854aecd552ccb267ceaeb9c7d816aaf17371b6d6",
       "repos": 120,
       "iterations": 3,
       "warmups": 1,
-      "aggregate_baseline_median_ms": 34204.67984012794,
-      "aggregate_current_median_ms": 36433.483380882535,
-      "aggregate_delta_pct": 6.516077774070641,
-      "approximate_control_adjusted_delta_pct": 7.091308569580995,
+      "aggregate_baseline_median_ms": 34322.87899765652,
+      "aggregate_current_median_ms": 36159.033919044305,
+      "aggregate_delta_pct": 5.349652986607436,
+      "approximate_control_adjusted_delta_pct": 5.052729014868772,
       "baseline_families": 92229,
       "current_families": 100966,
       "family_delta": 8737,
       "family_delta_pct": 9.473159201552656,
       "family_increase_repos": 120,
       "family_decrease_repos": 0,
-      "decision": "The default surface does more deliberate scoring and returns 9.47% more families. The measured runtime cost is retained as capability-growth price after removing the confirmed rank_map hot path."
+      "decision": "The default surface does more deliberate scoring and returns 9.47% more families. Its control-adjusted delta is 0.05 percentage points above the 5% threshold and is retained as capability-growth price after removing the confirmed rank_map and front-end hot paths."
     },
     "established_semantic_surface": {
-      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-semantic-allrepos-r3.json",
-      "artifact_sha256": "595db60f136e9e6d5a0abd1c5d2b1b05457fe19ccb8a6be2d03caa69e7789d82",
+      "artifact": "target/release-0.19.0/query-regression-v0.18.0-official-to-final-rc-semantic-allrepos-r3.json",
+      "artifact_sha256": "444c279855e709de8d7b0885cb8abdc102d45da1b22b549a90bdf650a2828675",
       "query_args": "query {repo} all top=0 --mode semantic --format json",
       "repos": 120,
       "iterations": 3,
       "warmups": 1,
-      "aggregate_baseline_median_ms": 24822.48829177115,
-      "aggregate_current_median_ms": 25715.468663838692,
-      "aggregate_delta_pct": 3.5974651758162812,
-      "approximate_control_adjusted_delta_pct": 4.172695971326635,
+      "aggregate_baseline_median_ms": 28389.308418147266,
+      "aggregate_current_median_ms": 28964.5600427757,
+      "aggregate_delta_pct": 2.0262967176076696,
+      "approximate_control_adjusted_delta_pct": 1.7293727458690056,
       "baseline_families": 14884,
       "current_families": 15815,
       "family_drift_repos": 31,
@@ -107,8 +127,8 @@
     }
   },
   "product_quality": {
-    "artifact": "target/release-0.19.0/product-quality-evaluation-0.19.0-rc.v1.json",
-    "artifact_sha256": "1aad008d4190123e0970cd7c398aff18318c63d05c7d582ebb92f250824d6210",
+    "artifact": "target/release-0.19.0/product-quality-evaluation-0.19.0-final.v1.json",
+    "artifact_sha256": "57429f01d225abe10e37f3d5b510c3ac4f4e683ff1db330ffb0cbc9b27b82906",
     "labelset": "bench/labels/refactoring_families.v6.json",
     "labelset_sha256": "6b72927d0e68e05406540016d3fa136029c52a406af0938b5a805d3fa199ac23",
     "repositories": 120,
@@ -149,8 +169,8 @@
     "decision": "The clean release candidate exactly reproduces the checked #832 v6 product-quality result. Held-out source was not inspected during this release pass."
   },
   "recall_loss_gate": {
-    "artifact": "target/release-0.19.0/recall-loss.current.crates.json",
-    "artifact_sha256": "b3a3694ef7ca98295abb5b5e1397d9a485afff13f8c526c69670749eadd2f0b4",
+    "artifact": "target/release-0.19.0/recall-loss.final.crates.json",
+    "artifact_sha256": "149abb80c7ffb790d3fc0fbc2ad910add776d768ecf2961ee4321239f935d9c9",
     "max_violations": 0,
     "gate_passed": true,
     "false_merges": 0,
@@ -158,10 +178,10 @@
     "advisory_disagreements": 6,
     "summary": {
       "total_units": 7835,
-      "interpretable_units": 1123,
-      "excluded_units": 6712,
+      "interpretable_units": 1122,
+      "excluded_units": 6713,
       "canon_checked": 117,
-      "admission_rejections": 930
+      "admission_rejections": 929
     },
     "completeness": {
       "behavior_groups": 5,
@@ -173,11 +193,11 @@
     }
   },
   "commands": [
-    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-default-allrepos-r3.json",
-    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/optimized-target/release/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-optimized-rc-same-binary-control-default-allrepos-r3.json",
-    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/optimized-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --mode semantic --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-optimized-rc-semantic-allrepos-r3.json",
-    "python3 bench/labels/eval_by_language.py --labelset bench/labels/refactoring_families.v6.json --nose target/release-0.19.0/optimized-target/release/nose --rank extractability --bootstrap 500 --cache-dir target/release-0.19.0/eval-cache --json-out target/release-0.19.0/product-quality-evaluation-0.19.0-rc.v1.json",
-    "target/release-0.19.0/optimized-target/release/nose verify crates --max-violations 0 --recall-loss-report target/release-0.19.0/recall-loss.current.crates.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/frontend-perf-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-final-rc-default-allrepos-r3.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/frontend-perf-target/release/nose --current-binary target/release-0.19.0/frontend-perf-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --format json' --output target/release-0.19.0/query-regression-v0.19.0-final-rc-self-control-default-allrepos-r3.json",
+    "python3 scripts/query-regression-harness.py --baseline-binary target/release-0.19.0/baseline/nose-cli-aarch64-apple-darwin/nose --current-binary target/release-0.19.0/frontend-perf-target/release/nose --all-repos --iterations 3 --warmups 1 --query-args 'query {repo} all top=0 --mode semantic --format json' --output target/release-0.19.0/query-regression-v0.18.0-official-to-final-rc-semantic-allrepos-r3.json",
+    "python3 bench/labels/eval_by_language.py --labelset bench/labels/refactoring_families.v6.json --nose target/release-0.19.0/frontend-perf-target/release/nose --rank extractability --bootstrap 500 --cache-dir target/release-0.19.0/final-eval-cache --json-out target/release-0.19.0/product-quality-evaluation-0.19.0-final.v1.json",
+    "target/release-0.19.0/frontend-perf-target/release/nose verify crates --max-violations 0 --recall-loss-report target/release-0.19.0/recall-loss.final.crates.json",
     "./scripts/check-ci-local.sh --full"
   ]
 }

--- a/crates/nose-frontend/src/corpus_tests.rs
+++ b/crates/nose-frontend/src/corpus_tests.rs
@@ -74,6 +74,15 @@ fn lower_corpus_skips_ansi_highlight_artifacts() {
         b"\x1b[38;2;1;2;3mfunc\x1b[0m \x1b[38;2;4;5;6mnope\x1b[0m() {}\n",
     )
     .unwrap();
+    assert_eq!(
+        source_artifacts::skip_reason(&source, Lang::Go, b"one \x1b[0m two \x1b[0m"),
+        None,
+        "fewer than three raw CSI escapes must remain below the artifact threshold"
+    );
+    assert_eq!(
+        source_artifacts::skip_reason(&highlighted, Lang::Go, &fs::read(&highlighted).unwrap()),
+        Some("ansi-highlight-output")
+    );
 
     let corpus = lower_corpus_filtered(&[dir.as_path()], &[]);
     let paths: Vec<_> = corpus

--- a/crates/nose-frontend/src/source_artifacts.rs
+++ b/crates/nose-frontend/src/source_artifacts.rs
@@ -34,9 +34,9 @@ fn looks_like_binary_source_artifact(src: &[u8]) -> bool {
 fn looks_like_ansi_highlight_output(src: &[u8]) -> bool {
     // Plain source can mention "\x1b[" textually; syntax-highlight output contains
     // repeated raw CSI escapes throughout the file.
-    sniff_bytes(src)
-        .windows(2)
-        .filter(|window| *window == b"\x1b[")
+    let sample = sniff_bytes(src);
+    memchr::memchr_iter(b'\x1b', sample)
+        .filter(|&offset| sample.get(offset + 1) == Some(&b'['))
         .take(3)
         .count()
         >= 3

--- a/docs/release-evidence-0.19.0.md
+++ b/docs/release-evidence-0.19.0.md
@@ -9,11 +9,10 @@ records the exact commands, artifact hashes, and measurements.
 
 - The baseline is the published `v0.18.0` Darwin arm64 binary, verified against
   its release checksum, rather than a local rebuild of the old source.
-- The established semantic-only query surface measured `24,822.49ms ->
-  25,715.47ms` (`+3.60%`) across all `120` pinned repositories. Applying the
-  directional `-0.58%` same-binary control gives approximately `+4.17%`, below
-  the `5%` release threshold.
-- The expanded default surface measured `34,204.68ms -> 36,433.48ms` (`+6.52%`)
+- The final `nose 0.19.0` binary's established semantic-only query surface
+  measured `28,389.31ms -> 28,964.56ms` (`+2.03%`) across all `120` pinned
+  repositories, below the `5%` release threshold without adjustment.
+- The expanded default surface measured `34,322.88ms -> 36,159.03ms` (`+5.35%`)
   while returning `92,229 -> 100,966` families (`+9.47%`). Every repository
   gained families and none lost them, so this is retained as the measured price
   of deliberate capability growth rather than a same-output regression.
@@ -21,6 +20,12 @@ records the exact commands, artifact hashes, and measurements.
   endpoint coverage. On the focused Alamofire/Raylib slice, indexing collapsed
   sites by file reduced runtime `6,787.93ms -> 3,591.61ms` (`-47.09%`) with
   identical output; Alamofire `rank_map` fell from `3,203.7ms` to `22.0ms`.
+- The tag smoke exposed a second, front-end-only Linux outlier. Replacing the
+  per-file 256 KiB byte-window scan used to recognize ANSI-highlight artifacts
+  with an escape-byte prefilter preserved exact output. On the focused
+  Fastlane/Prettier control-paired slice, Prettier `lower` improved by an adjusted
+  `26.6ms` (about `8.0%`) and `parse+lower` by `24.55ms` (about `13.5%`); the
+  aggregate adjusted difference was a neutral `+2.21ms`.
 - The clean candidate exactly reproduced the checked v6 product-quality result:
   worthy recall is `95.33%` on dev and `95.89%` on held-out, with labeled P@10
   of `59.46%` and `55.91%` respectively.
@@ -40,27 +45,28 @@ then filtered by file. The retained patch builds a same-file index once and keep
 the exact collapse, overlap, deduplication, and edge semantics. A behavior-level
 test covers overlapping sites in one file plus a linked site in another file.
 
-The optimized candidate's all-repository same-binary control measured
-`38,954.33ms -> 38,730.26ms` (`-0.58%`) with `120/120` identical hashes,
+The final candidate's all-repository same-binary control measured
+`37,979.24ms -> 38,092.01ms` (`+0.30%`) with `120/120` identical hashes,
 family counts, and byte counts. The remaining default-surface time is concentrated
 in intended scoring and front-end work, while aggregate `rank_map` contributes
-only `23.5ms` more than 0.18.0 across the entire corpus.
+only `24.0ms` more than 0.18.0 across the entire corpus.
 
 ## Release comparison
 
-The official-release comparison was measured before the mechanical version bump:
+The official-release comparison uses the final versioned `nose 0.19.0` binary:
 
 | Surface | Families | Runtime | Raw delta | Approx. control-adjusted |
 | --- | ---: | ---: | ---: | ---: |
-| established semantic | `14,884 -> 15,815` | `24,822.49ms -> 25,715.47ms` | `+3.60%` | `+4.17%` |
-| expanded default | `92,229 -> 100,966` | `34,204.68ms -> 36,433.48ms` | `+6.52%` | `+7.09%` |
+| established semantic | `14,884 -> 15,815` | `28,389.31ms -> 28,964.56ms` | `+2.03%` | `+1.73%` |
+| expanded default | `92,229 -> 100,966` | `34,322.88ms -> 36,159.03ms` | `+5.35%` | `+5.05%` |
 
-The control adjustment is directional subtraction of the same-binary default
-surface result, not a claim of deterministic timing. The semantic surface remains
-inside the release gate under either view. The default surface exceeds it, but
-also returns `8,737` additional families (`+9.47%`) across all `120` repos; this
-is explicitly accepted capability-growth cost. The confirmed superlinear
-reporting hot path was fixed before release.
+The approximate control adjustment directionally subtracts the `+0.30%`
+same-binary default-surface result; it is context, not a claim of deterministic
+timing. The semantic surface remains inside the release gate under either view.
+The default surface is `0.05` percentage points above the adjusted threshold but
+returns `8,737` additional families (`+9.47%`) across all `120` repos; this is
+explicitly accepted capability-growth cost. Both confirmed implementation hot
+paths were fixed before release.
 
 ## Product quality
 
@@ -80,15 +86,15 @@ did not change the evaluated product-quality result.
 The release candidate passed:
 
 ```sh
-target/release-0.19.0/optimized-target/release/nose verify crates \
+target/release-0.19.0/frontend-perf-target/release/nose verify crates \
   --max-violations 0 \
-  --recall-loss-report target/release-0.19.0/recall-loss.current.crates.json
+  --recall-loss-report target/release-0.19.0/recall-loss.final.crates.json
 ```
 
 | Metric | Value |
 | --- | ---: |
 | total units | `7,835` |
-| interpretable units | `1,123` |
+| interpretable units | `1,122` |
 | canon checked | `117` |
 | false merges | `0` |
 | canon-preservation violations | `0` |


### PR DESCRIPTION
## Summary

- replace the ANSI-highlight artifact detector’s full adjacent-byte scan with an escape-byte prefilter
- add behavior-level coverage for the two-escape rejection and four-escape admission boundary
- refresh 0.19.0 release evidence using the final versioned binary against the official v0.18.0 Darwin arm64 release
- rerun final product-quality and recall-loss gates

## Performance

- established semantic surface, all 120 repos: 28,389.31 ms → 28,964.56 ms (+2.03%)
- expanded default surface: +5.35% raw / approximately +5.05% control-adjusted while returning 9.47% more families
- focused Prettier frontend: adjusted lower -26.6 ms (~8.0%), parse+lower -24.55 ms (~13.5%), exact output
- prior accepted-coverage rank-map fix remains -47.09% on Alamofire/Raylib, exact output

## Quality and verification

- final v6 dev worthy recall: 95.33%; held-out: 95.89%
- final recall-loss gate: 0 false merges, 0 canon-preservation violations
- `./scripts/check-ci-local.sh --full`

Refs #834