### PR TITLE
Document proof/actionability no-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             --pragmatic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.pragmatic.v1.json \
             --dedupe bench/labels/default_head_taxonomy_votes_2026_07_13.dev.dedupe.v1.json \
             --skeptic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.skeptic.v1.json
+          python3 bench/labels/proof_actionability_no_go.py --self-test
           python3 bench/labels/generated_provenance_behavior.py --self-test
           python3 bench/labels/generated_provenance_behavior.py validate
           python3 bench/labels/generated_provenance_closeout.py --self-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ break.
   agree that removing the proven-channel protection reaches only 60% non-action precision
   on its direct frozen boundary (0% for `trivial`, 75% for `shallow-extraction`), while
   the broader exact/subdag cohort reaches 42.19% and contains 37 worthy helper,
-  parameterization, data-table, and base-extraction hard negatives. The product behavior
-  remains byte-for-byte unchanged; CI reconstructs the result from the #841 taxonomy and
-  keeps witness, membership, fingerprint, fold, recall, and surface contracts fixed.
+  parameterization, data-table, and base-extraction hard negatives. Each reviewer's
+  five-judgment record is source-packet bound, and future admission requires a 90% point
+  precision and one-sided 95% Wilson lower-bound gate. CI reconstructs the no-go and zero
+  product drift from the #841 taxonomy, normalized executable-code identity, and the
+  checked #843 behavior, quality, and official-v0.19.0 performance evidence.
 - Classified strict declaration-only type contracts as reason-coded `declaration` output
   (#843). The all-member rule consumes existing language-neutral origin facets for Java,
   TypeScript, Rust, and Swift; incomplete, narrowed, runtime/data/implementation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ break.
 ## [Unreleased]
 
 ### Added
+- Recorded the checked #844 proof/actionability no-go. Three independent source reviews
+  agree that removing the proven-channel protection reaches only 60% non-action precision
+  on its direct frozen boundary (0% for `trivial`, 75% for `shallow-extraction`), while
+  the broader exact/subdag cohort reaches 42.19% and contains 37 worthy helper,
+  parameterization, data-table, and base-extraction hard negatives. The product behavior
+  remains byte-for-byte unchanged; CI reconstructs the result from the #841 taxonomy and
+  keeps witness, membership, fingerprint, fold, recall, and surface contracts fixed.
 - Classified strict declaration-only type contracts as reason-coded `declaration` output
   (#843). The all-member rule consumes existing language-neutral origin facets for Java,
   TypeScript, Rust, and Swift; incomplete, narrowed, runtime/data/implementation,

--- a/bench/labels/proof_actionability_no_go.py
+++ b/bench/labels/proof_actionability_no_go.py
@@ -16,9 +16,15 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT = ROOT / "bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json"
 CORE = ROOT / "bench/labels/default_head_taxonomy_2026_07_13.dev.core.v1.json"
 OVERLAY = ROOT / "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json"
-EXPECTED_ARTIFACT_SHA = "8645afd44f67bbcef19e295abec4b443e001deffaac7eaaa445e62c47560275e"
+PARENT_CLOSEOUT = (
+    ROOT / "bench/labels/declaration_type_contract_closeout_2026_07_14.dev.v1.json"
+)
+EXPECTED_ARTIFACT_SHA = "dc92cd6ca9741724c71ec69003eaaee737109ffe48845ad2866a6ae0baad4154"
 EXPECTED_CORE_BYTES = "98422f418b63745e51ee2dc0970b3d06ef308a0eb27e8829df9356aae5d2608e"
 EXPECTED_OVERLAY_BYTES = "68eff466212f0322a45a16648c1fcfd51a301bd5351c93f0795147f2baa33969"
+EXPECTED_PARENT_CLOSEOUT_BYTES = (
+    "1f393994f95e15a676f60eeee7f7594be65c31c646e573362aba0d3721ff3732"
+)
 EXPECTED_CORE_SEMANTIC = "e3e4d63aba1065bf37a2e5460decfd417c1f76d315405fce941801809d1fb0a2"
 EXPECTED_OVERLAY_SEMANTIC = "206f7e6c2eb9e5bb3750dd6e12f6f920228d719868b2e4922395433a2315c71a"
 
@@ -70,6 +76,32 @@ def boundary_row(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def review_packet(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            key: row[key]
+            for key in ("position_key", "predicate", "source_bounds_sha256", "witness")
+        }
+        for row in rows
+    ]
+
+
+def review_judgments(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: row[key] for key in ("position_key", "truth_reason", "worthy")} for row in rows
+    ]
+
+
+def wilson_lower(successes: int, reviewed: int, z: float = 1.6448536269514722) -> float:
+    if reviewed == 0:
+        return 0.0
+    proportion = successes / reviewed
+    denominator = 1 + z * z / reviewed
+    center = proportion + z * z / (2 * reviewed)
+    radius = z * ((proportion * (1 - proportion) / reviewed + z * z / (4 * reviewed**2)) ** 0.5)
+    return (center - radius) / denominator
+
+
 def derived(core: dict[str, Any]) -> dict[str, Any]:
     head = [row for row in core["head_rows"] if row["predicate_results"]["proof_backed"]]
     deep = [
@@ -109,6 +141,144 @@ def derived(core: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def validate_parent_evidence(
+    parent: dict[str, Any], artifact: dict[str, Any]
+) -> dict[str, Any]:
+    require(
+        parent["schema"] == "nose.declaration_type_contract_closeout.v1"
+        and parent["issue"] == 843
+        and parent["split"] == "dev"
+        and parent["result"] == "pass",
+        "wrong parent closeout",
+    )
+    require(
+        parent["heldout_policy"] == "closed; no held-out checkout or judgment was opened",
+        "parent held-out policy changed",
+    )
+    binary = artifact["binary_identity"]
+    require(
+        parent["implementation"]["binary_sha256"] == binary["parent"]["file_sha256"],
+        "parent binary is not bound to #843",
+    )
+    require(
+        parent["implementation"]["commit"]
+        == binary["parent"]["checked_evidence_commit"],
+        "parent implementation commit changed",
+    )
+    performance = parent["performance"]
+    require(
+        performance["current"]["binary_sha256"] == binary["parent"]["file_sha256"],
+        "parent performance current binary changed",
+    )
+    require(
+        performance["current"]["commit"] == binary["parent"]["checked_evidence_commit"],
+        "parent performance commit changed",
+    )
+    require(
+        performance["published_baseline"]["binary_sha256"]
+        == binary["published_v0_19_0"]["file_sha256"],
+        "published performance baseline changed",
+    )
+    require(len(performance["artifacts"]) == 8, "parent performance chain changed")
+    for reference in performance["artifacts"]:
+        evidence_path = ROOT / reference["path"]
+        require(sha256(evidence_path) == reference["sha256"], "raw performance evidence changed")
+
+    behavior = parent["behavior_evidence"]
+    behavior_path = ROOT / behavior["path"]
+    require(sha256(behavior_path) == behavior["sha256"], "parent behavior evidence changed")
+    require(
+        load(behavior_path)["evidence_digest"] == behavior["evidence_digest"],
+        "parent behavior digest changed",
+    )
+    quality = parent["product_quality"]
+    quality_path = ROOT / quality["path"]
+    require(sha256(quality_path) == quality["sha256"], "parent quality evidence changed")
+    require(
+        quality["worthy_recall"] == {"hits": 2716, "n": 2849, "pct": 95.3317}
+        and quality["comparison_worthy_recall_delta"] == 0,
+        "parent worthy recall changed",
+    )
+    return {
+        "basis": "normalized executable-code identity with the checked #843 parent",
+        "incremental": {
+            "accepted_pair_coverage_delta": 0,
+            "canon_preservation_violations": 0,
+            "family_membership_or_fingerprint_changes": 0,
+            "false_merges": 0,
+            "fold_forest_changes": 0,
+            "surface_or_reason_transitions": 0,
+            "witness_or_provenance_changes": 0,
+            "worthy_recall_delta": 0,
+        },
+        "parent_behavior": {
+            "evidence_digest": behavior["evidence_digest"],
+            "sha256": behavior["sha256"],
+        },
+        "parent_product_quality": {
+            "sha256": quality["sha256"],
+            "worthy_recall": {key: quality["worthy_recall"][key] for key in ("hits", "n")},
+        },
+    }
+
+
+def validate_independent_reviews(
+    independent: dict[str, Any], boundary_rows: list[dict[str, Any]]
+) -> None:
+    packet_sha = canonical_sha(review_packet(boundary_rows))
+    protocol = independent["protocol"]
+    minimum_reviewed = next(n for n in range(1, 1000) if wilson_lower(n, n) >= 0.9)
+    require(
+        protocol
+        == {
+            "confidence_method": "one-sided Wilson 95% lower bound",
+            "minimum_confirmatory_reviewed": minimum_reviewed,
+            "minimum_non_action_point_precision": 0.9,
+            "minimum_non_action_wilson_lower_bound": 0.9,
+            "source_packet_sha256": packet_sha,
+        },
+        "review protocol changed",
+    )
+    require(minimum_reviewed == 25, "confirmatory minimum changed")
+    expected_judgments = review_judgments(boundary_rows)
+    reviews = independent["reviews"]
+    require(len(reviews) == 3, "review count changed")
+    require(
+        {review["reviewer"] for review in reviews} == {"evidence", "product", "soundness"},
+        "reviewer roles changed",
+    )
+    for review in reviews:
+        require(
+            set(review)
+            == {
+                "decision",
+                "defensible_90_percent_subcohort",
+                "judgments",
+                "reviewer",
+                "source_packet_sha256",
+            },
+            "review schema changed",
+        )
+        require(review["source_packet_sha256"] == packet_sha, "review packet changed")
+        require(review["judgments"] == expected_judgments, "review judgments changed")
+        require(review["decision"] == "rejected-no-go", "review decision changed")
+        require(
+            review["defensible_90_percent_subcohort"] is False,
+            "review admitted an unqualified subcohort",
+        )
+    unanimous = all(review["judgments"] == reviews[0]["judgments"] for review in reviews)
+    no_subcohort = all(not review["defensible_90_percent_subcohort"] for review in reviews)
+    require(
+        independent["summary"]
+        == {
+            "all_five_source_labels_unanimous": unanimous,
+            "no_defensible_90_percent_subcohort": no_subcohort,
+            "reviewer_count": len(reviews),
+        },
+        "review summary is not derived",
+    )
+
+
 def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None:
     artifact = load(path)
     require(
@@ -133,24 +303,63 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
         require(sha256(path) == EXPECTED_ARTIFACT_SHA, "closeout artifact bytes changed")
     require(artifact["schema"] == "nose.proof_actionability_no_go.v1", "wrong schema")
     require(artifact["issue"] == 844 and artifact["split"] == "dev", "wrong scope")
-    require("closed" in artifact["heldout_policy"], "held-out was not kept closed")
+    require(
+        artifact["heldout_policy"]
+        == {
+            "opened": False,
+            "split": "dev",
+            "statement": "no held-out component, source path, or judgment was read",
+        },
+        "held-out policy changed",
+    )
     require(
         artifact["binary_identity"]
         == {
-            "closeout_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
-            "immediate_parent_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
-            "immediate_parent_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
-            "published_v0_19_0_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+            "algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+            "candidate": {
+                "build_command": (
+                    "CARGO_TARGET_DIR=/tmp/nose-844-review-target "
+                    "cargo build --release -p nose-cli"
+                ),
+                "code_sha256": "03cc5827cdadc225478a34266de78805c6e495810f90e8642f2ae2807b3a4f5a",
+                "file_sha256": "c0a70c0d31739da42260c94f910ddd89d46ae5e6979542f9d88d82a9808a42b3",
+                "source_commit": "0b57bd183317b35ea082b1629391ac59f748cab4",
+                "source_tree": "b81480bcf0d8b99137c9a4862ec3ea3b7a9d6e28",
+            },
+            "full_file_equal": False,
+            "normalized_code_equal": True,
+            "parent": {
+                "checked_evidence_commit": "182881a8097ff14ecf513a4fb32f1ad22cc31394",
+                "checked_evidence_tree": "7b4b4734571af8206311aa8862315b680619e6db",
+                "code_sha256": "03cc5827cdadc225478a34266de78805c6e495810f90e8642f2ae2807b3a4f5a",
+                "file_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+                "merge_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
+                "merge_tree": "6aae853031752a26ed2f80d40b0e548514723dff",
+            },
+            "published_v0_19_0": {
+                "code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+                "file_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+            },
         },
         "binary identity changed",
+    )
+    require(
+        artifact["binary_identity"]["candidate"]["code_sha256"]
+        == artifact["binary_identity"]["parent"]["code_sha256"],
+        "candidate executable code differs from the parent",
+    )
+    require(
+        artifact["binary_identity"]["candidate"]["file_sha256"]
+        != artifact["binary_identity"]["parent"]["file_sha256"],
+        "Mach-O full-file distinction was not recorded",
     )
 
     core = load(CORE)
     overlay = load(OVERLAY)
     inputs = artifact["inputs"]
     require(
-        set(inputs) == {"taxonomy_core", "taxonomy_overlay"},
-        "unexpected taxonomy inputs",
+        set(inputs) == {"parent_closeout", "taxonomy_core", "taxonomy_overlay"},
+        "unexpected closeout inputs",
     )
     require(
         inputs["taxonomy_core"]["path"]
@@ -162,8 +371,22 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
         == "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json",
         "overlay path changed",
     )
+    require(
+        inputs["parent_closeout"]
+        == {
+            "byte_sha256": EXPECTED_PARENT_CLOSEOUT_BYTES,
+            "path": "bench/labels/declaration_type_contract_closeout_2026_07_14.dev.v1.json",
+            "schema": "nose.declaration_type_contract_closeout.v1",
+            "split": "dev",
+        },
+        "parent closeout binding changed",
+    )
     require(sha256(CORE) == inputs["taxonomy_core"]["byte_sha256"], "core bytes changed")
     require(sha256(OVERLAY) == inputs["taxonomy_overlay"]["byte_sha256"], "overlay bytes changed")
+    require(
+        sha256(PARENT_CLOSEOUT) == inputs["parent_closeout"]["byte_sha256"],
+        "parent closeout bytes changed",
+    )
     require(inputs["taxonomy_core"]["byte_sha256"] == EXPECTED_CORE_BYTES, "unreviewed core")
     require(
         inputs["taxonomy_overlay"]["byte_sha256"] == EXPECTED_OVERLAY_BYTES,
@@ -182,6 +405,13 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
         inputs["taxonomy_overlay"]["semantic_sha256"] == overlay["artifact_sha256"],
         "overlay semantic binding changed",
     )
+    for value, label in ((core, "core"), (overlay, "overlay")):
+        require(value["split"] == "dev", f"{label} is not dev-only")
+        require(
+            value["heldout_policy"]
+            == "closed; no held-out component, source path, or judgment was read",
+            f"{label} held-out policy changed",
+        )
 
     expected = derived(core)
     for key, value in expected.items():
@@ -209,14 +439,8 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
             require(row["predicate_results"]["proof_backed"], "hard negative lost proof")
             require(row["truth"]["worthy"], "hard negative is no longer worthy")
             require(row["truth"]["reason"] == expected_reason, "hard-negative reason changed")
-    require(
-        artifact["independent_review"]
-        == {
-            "all_five_source_labels_unanimous": True,
-            "no_defensible_90_percent_subcohort": True,
-            "reviewers": ["evidence", "product", "soundness"],
-        },
-        "independent-review result changed",
+    validate_independent_reviews(
+        artifact["independent_review"], artifact["current_exemption_cohort"]["rows"]
     )
     require(
         artifact["decision"]
@@ -228,19 +452,11 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
         },
         "decision changed",
     )
+    parent = load(PARENT_CLOSEOUT)
+    expected_preservation = validate_parent_evidence(parent, artifact)
     require(
-        artifact["preservation"]
-        == {
-            "accepted_pair_coverage_unchanged": True,
-            "canon_preservation_violations_zero": True,
-            "family_membership_and_fingerprint_unchanged": True,
-            "family_universe_recall_unchanged": True,
-            "false_merges_zero": True,
-            "fold_forest_unchanged": True,
-            "surface_and_reason_transitions_zero": True,
-            "witness_and_provenance_unchanged": True,
-        },
-        "required semantic or output-preservation gates changed",
+        artifact["preservation"] == expected_preservation,
+        "preservation is not derived from parent evidence and code identity",
     )
     require(
         artifact["current_exemption_cohort"]["combined"]["non_action_precision"] < 0.9,
@@ -255,17 +471,33 @@ def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None
 
 def self_test() -> None:
     artifact = load(DEFAULT)
-    mutated = copy.deepcopy(artifact)
-    mutated["current_exemption_cohort"]["rows"][0]["worthy"] = False
     temporary = DEFAULT.with_suffix(".self-test.json")
-    temporary.write_text(json.dumps(mutated))
-    try:
+
+    def rejects(mutated: dict[str, Any], label: str) -> None:
+        temporary.write_text(json.dumps(mutated))
         try:
             validate(temporary, check_reviewed_bytes=False)
         except SystemExit:
-            pass
+            return
         else:
-            fail("truth mutation was accepted")
+            fail(f"{label} mutation was accepted")
+
+    try:
+        mutated = copy.deepcopy(artifact)
+        mutated["current_exemption_cohort"]["rows"][0]["worthy"] = False
+        rejects(mutated, "truth")
+
+        mutated = copy.deepcopy(artifact)
+        mutated["independent_review"]["reviews"][0]["judgments"][0]["worthy"] = False
+        rejects(mutated, "review")
+
+        mutated = copy.deepcopy(artifact)
+        mutated["heldout_policy"] = "not closed; held-out source was read"
+        rejects(mutated, "held-out policy")
+
+        mutated = copy.deepcopy(artifact)
+        mutated["preservation"]["incremental"]["surface_or_reason_transitions"] = 1
+        rejects(mutated, "preservation")
     finally:
         temporary.unlink(missing_ok=True)
     validate(DEFAULT)

--- a/bench/labels/proof_actionability_no_go.py
+++ b/bench/labels/proof_actionability_no_go.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Validate #844's checked proof/actionability no-go against the #841 dev taxonomy."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT = ROOT / "bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json"
+CORE = ROOT / "bench/labels/default_head_taxonomy_2026_07_13.dev.core.v1.json"
+OVERLAY = ROOT / "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json"
+EXPECTED_ARTIFACT_SHA = "8645afd44f67bbcef19e295abec4b443e001deffaac7eaaa445e62c47560275e"
+EXPECTED_CORE_BYTES = "98422f418b63745e51ee2dc0970b3d06ef308a0eb27e8829df9356aae5d2608e"
+EXPECTED_OVERLAY_BYTES = "68eff466212f0322a45a16648c1fcfd51a301bd5351c93f0795147f2baa33969"
+EXPECTED_CORE_SEMANTIC = "e3e4d63aba1065bf37a2e5460decfd417c1f76d315405fce941801809d1fb0a2"
+EXPECTED_OVERLAY_SEMANTIC = "206f7e6c2eb9e5bb3750dd6e12f6f920228d719868b2e4922395433a2315c71a"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"proof-actionability no-go validation failed: {message}")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def canonical_sha(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def summary(rows: list[dict[str, Any]]) -> dict[str, int | float]:
+    non_action = sum(not row["truth"]["worthy"] for row in rows)
+    worthy = len(rows) - non_action
+    return {
+        "non_action": non_action,
+        "non_action_precision": non_action / len(rows) if rows else 0.0,
+        "reviewed": len(rows),
+        "worthy": worthy,
+    }
+
+
+def boundary_row(row: dict[str, Any]) -> dict[str, Any]:
+    predicate = (
+        "trivial" if row["predicate_results"]["existing_trivial"] else "shallow-extraction"
+    )
+    return {
+        "position_key": row["position_key"],
+        "predicate": predicate,
+        "source_bounds_sha256": canonical_sha(row["source_bounds"]),
+        "truth_reason": row["truth"]["reason"],
+        "witness": row["facets"]["witness"],
+        "worthy": row["truth"]["worthy"],
+    }
+
+
+def derived(core: dict[str, Any]) -> dict[str, Any]:
+    head = [row for row in core["head_rows"] if row["predicate_results"]["proof_backed"]]
+    deep = [
+        row for row in core["deep_labeled_rows"] if row["predicate_results"]["proof_backed"]
+    ]
+    proof = head + deep
+    boundaries = [
+        row
+        for row in proof
+        if row["predicate_results"]["existing_trivial"]
+        or row["predicate_results"]["existing_shallow"]
+    ]
+    trivial = [row for row in boundaries if row["predicate_results"]["existing_trivial"]]
+    shallow = [row for row in boundaries if row["predicate_results"]["existing_shallow"]]
+    worthy = [row for row in proof if row["truth"]["worthy"]]
+    return {
+        "blanket_proof_cohort": {
+            "combined": summary(proof),
+            "deep": summary(deep),
+            "head": summary(head),
+            "position_key_set_sha256": canonical_sha([row["position_key"] for row in proof]),
+            "worthy_hard_negative_reasons": dict(
+                sorted(Counter(row["truth"]["reason"] for row in worthy).items())
+            ),
+            "worthy_position_key_set_sha256": canonical_sha(
+                [row["position_key"] for row in worthy]
+            ),
+        },
+        "current_exemption_cohort": {
+            "combined": summary(boundaries),
+            "predicate_summaries": {
+                "shallow-extraction": summary(shallow),
+                "trivial": summary(trivial),
+            },
+            "rows": [boundary_row(row) for row in boundaries],
+        },
+    }
+
+
+def validate(path: Path = DEFAULT, *, check_reviewed_bytes: bool = True) -> None:
+    artifact = load(path)
+    require(
+        set(artifact)
+        == {
+            "binary_identity",
+            "blanket_proof_cohort",
+            "current_exemption_cohort",
+            "decision",
+            "hard_negative_boundaries",
+            "heldout_policy",
+            "independent_review",
+            "inputs",
+            "issue",
+            "preservation",
+            "schema",
+            "split",
+        },
+        "unexpected top-level fields",
+    )
+    if path.resolve() == DEFAULT.resolve() and check_reviewed_bytes:
+        require(sha256(path) == EXPECTED_ARTIFACT_SHA, "closeout artifact bytes changed")
+    require(artifact["schema"] == "nose.proof_actionability_no_go.v1", "wrong schema")
+    require(artifact["issue"] == 844 and artifact["split"] == "dev", "wrong scope")
+    require("closed" in artifact["heldout_policy"], "held-out was not kept closed")
+    require(
+        artifact["binary_identity"]
+        == {
+            "closeout_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+            "immediate_parent_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
+            "immediate_parent_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+            "published_v0_19_0_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+        },
+        "binary identity changed",
+    )
+
+    core = load(CORE)
+    overlay = load(OVERLAY)
+    inputs = artifact["inputs"]
+    require(
+        set(inputs) == {"taxonomy_core", "taxonomy_overlay"},
+        "unexpected taxonomy inputs",
+    )
+    require(
+        inputs["taxonomy_core"]["path"]
+        == "bench/labels/default_head_taxonomy_2026_07_13.dev.core.v1.json",
+        "core path changed",
+    )
+    require(
+        inputs["taxonomy_overlay"]["path"]
+        == "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json",
+        "overlay path changed",
+    )
+    require(sha256(CORE) == inputs["taxonomy_core"]["byte_sha256"], "core bytes changed")
+    require(sha256(OVERLAY) == inputs["taxonomy_overlay"]["byte_sha256"], "overlay bytes changed")
+    require(inputs["taxonomy_core"]["byte_sha256"] == EXPECTED_CORE_BYTES, "unreviewed core")
+    require(
+        inputs["taxonomy_overlay"]["byte_sha256"] == EXPECTED_OVERLAY_BYTES,
+        "unreviewed overlay",
+    )
+    require(core["core_sha256"] == EXPECTED_CORE_SEMANTIC, "core semantic digest changed")
+    require(
+        overlay["artifact_sha256"] == EXPECTED_OVERLAY_SEMANTIC,
+        "overlay semantic digest changed",
+    )
+    require(
+        inputs["taxonomy_core"]["semantic_sha256"] == core["core_sha256"],
+        "core semantic binding changed",
+    )
+    require(
+        inputs["taxonomy_overlay"]["semantic_sha256"] == overlay["artifact_sha256"],
+        "overlay semantic binding changed",
+    )
+
+    expected = derived(core)
+    for key, value in expected.items():
+        require(artifact[key] == value, f"{key} is not derived from the taxonomy")
+    require(
+        artifact["hard_negative_boundaries"]
+        == {
+            "data_tables": [
+                "prometheus:524550adcecb8123:rank-2",
+                "prometheus:c1601349e39f9af1:rank-3",
+                "zap:b85ddcf733f2377d:rank-8",
+            ],
+            "small_helper": ["clap:b526f00d436e1689:rank-10"],
+        },
+        "hard-negative boundaries changed",
+    )
+    rows_by_key = {
+        row["position_key"]: row for row in core["head_rows"] + core["deep_labeled_rows"]
+    }
+    for kind, keys in artifact["hard_negative_boundaries"].items():
+        expected_reason = "extract-helper" if kind == "small_helper" else "extract-data-table"
+        for key in keys:
+            require(key in rows_by_key, "hard-negative key is outside the frozen rows")
+            row = rows_by_key[key]
+            require(row["predicate_results"]["proof_backed"], "hard negative lost proof")
+            require(row["truth"]["worthy"], "hard negative is no longer worthy")
+            require(row["truth"]["reason"] == expected_reason, "hard-negative reason changed")
+    require(
+        artifact["independent_review"]
+        == {
+            "all_five_source_labels_unanimous": True,
+            "no_defensible_90_percent_subcohort": True,
+            "reviewers": ["evidence", "product", "soundness"],
+        },
+        "independent-review result changed",
+    )
+    require(
+        artifact["decision"]
+        == {
+            "minimum_non_action_precision": 0.9,
+            "product_behavior_change": False,
+            "reason": "no audited proof/actionability predicate reaches the precision gate",
+            "result": "rejected-no-go",
+        },
+        "decision changed",
+    )
+    require(
+        artifact["preservation"]
+        == {
+            "accepted_pair_coverage_unchanged": True,
+            "canon_preservation_violations_zero": True,
+            "family_membership_and_fingerprint_unchanged": True,
+            "family_universe_recall_unchanged": True,
+            "false_merges_zero": True,
+            "fold_forest_unchanged": True,
+            "surface_and_reason_transitions_zero": True,
+            "witness_and_provenance_unchanged": True,
+        },
+        "required semantic or output-preservation gates changed",
+    )
+    require(
+        artifact["current_exemption_cohort"]["combined"]["non_action_precision"] < 0.9,
+        "current exemption removal unexpectedly clears the gate",
+    )
+    require(
+        artifact["blanket_proof_cohort"]["combined"]["non_action_precision"] < 0.9,
+        "blanket proof classifier unexpectedly clears the gate",
+    )
+    print(f"proof/actionability no-go OK: {path.relative_to(ROOT)}")
+
+
+def self_test() -> None:
+    artifact = load(DEFAULT)
+    mutated = copy.deepcopy(artifact)
+    mutated["current_exemption_cohort"]["rows"][0]["worthy"] = False
+    temporary = DEFAULT.with_suffix(".self-test.json")
+    temporary.write_text(json.dumps(mutated))
+    try:
+        try:
+            validate(temporary, check_reviewed_bytes=False)
+        except SystemExit:
+            pass
+        else:
+            fail("truth mutation was accepted")
+    finally:
+        temporary.unlink(missing_ok=True)
+    validate(DEFAULT)
+    print("proof/actionability no-go self-test passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact", nargs="?", type=Path, default=DEFAULT)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+    else:
+        validate(args.artifact.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json
+++ b/bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json
@@ -1,0 +1,151 @@
+{
+  "schema": "nose.proof_actionability_no_go.v1",
+  "issue": 844,
+  "split": "dev",
+  "heldout_policy": "closed; no held-out component, source path, or judgment was read",
+  "inputs": {
+    "taxonomy_core": {
+      "path": "bench/labels/default_head_taxonomy_2026_07_13.dev.core.v1.json",
+      "byte_sha256": "98422f418b63745e51ee2dc0970b3d06ef308a0eb27e8829df9356aae5d2608e",
+      "semantic_sha256": "e3e4d63aba1065bf37a2e5460decfd417c1f76d315405fce941801809d1fb0a2"
+    },
+    "taxonomy_overlay": {
+      "path": "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json",
+      "byte_sha256": "68eff466212f0322a45a16648c1fcfd51a301bd5351c93f0795147f2baa33969",
+      "semantic_sha256": "206f7e6c2eb9e5bb3750dd6e12f6f920228d719868b2e4922395433a2315c71a"
+    }
+  },
+  "binary_identity": {
+    "closeout_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+    "immediate_parent_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
+    "immediate_parent_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+    "published_v0_19_0_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+  },
+  "blanket_proof_cohort": {
+    "combined": {
+      "non_action": 27,
+      "non_action_precision": 0.421875,
+      "reviewed": 64,
+      "worthy": 37
+    },
+    "deep": {
+      "non_action": 5,
+      "non_action_precision": 0.7142857142857143,
+      "reviewed": 7,
+      "worthy": 2
+    },
+    "head": {
+      "non_action": 22,
+      "non_action_precision": 0.38596491228070173,
+      "reviewed": 57,
+      "worthy": 35
+    },
+    "position_key_set_sha256": "b713b19df827a838ab38b3faf29b7e9939610940cbf0c64443876a441875e593",
+    "worthy_hard_negative_reasons": {
+      "extract-base": 2,
+      "extract-data-table": 3,
+      "extract-helper": 23,
+      "parameterize": 9
+    },
+    "worthy_position_key_set_sha256": "0609a3cdcae1975577ad018c75da9c10c7948b03c0dfed4654e2f68238a26e1e"
+  },
+  "current_exemption_cohort": {
+    "combined": {
+      "non_action": 3,
+      "non_action_precision": 0.6,
+      "reviewed": 5,
+      "worthy": 2
+    },
+    "predicate_summaries": {
+      "shallow-extraction": {
+        "non_action": 3,
+        "non_action_precision": 0.75,
+        "reviewed": 4,
+        "worthy": 1
+      },
+      "trivial": {
+        "non_action": 0,
+        "non_action_precision": 0.0,
+        "reviewed": 1,
+        "worthy": 1
+      }
+    },
+    "rows": [
+      {
+        "position_key": "clap:b526f00d436e1689:rank-10",
+        "predicate": "trivial",
+        "source_bounds_sha256": "4a7a32e1feaa7420fec1fab3cd92380fa5d92a666ba29b7d2e6c5c80f512f900",
+        "truth_reason": "extract-helper",
+        "witness": "exact",
+        "worthy": true
+      },
+      {
+        "position_key": "delve:fdab89b0d9bf0735:rank-7",
+        "predicate": "shallow-extraction",
+        "source_bounds_sha256": "9308f333f22f504e91d1cbccaf2d2c87e8130520752e82ccf28fc3163313b5c0",
+        "truth_reason": "parallel-by-design",
+        "witness": "subdag",
+        "worthy": false
+      },
+      {
+        "position_key": "swiftlint:d28f52ac94be71f1:rank-6",
+        "predicate": "shallow-extraction",
+        "source_bounds_sha256": "a08280b9c27920ea9cee628aad16d39bc3744bf1882ecf2f9b4c2e708d4f9ebb",
+        "truth_reason": "parameterize",
+        "witness": "subdag",
+        "worthy": true
+      },
+      {
+        "position_key": "lua:b9746b4eeb10c562:rank-28",
+        "predicate": "shallow-extraction",
+        "source_bounds_sha256": "cda1205a6a1efeb0a7e108820d196420f12db72a66d9ff34b10fc77c8792f80d",
+        "truth_reason": "coincidental-shape",
+        "witness": "subdag",
+        "worthy": false
+      },
+      {
+        "position_key": "thor:3a25b222efed5f0b:rank-27",
+        "predicate": "shallow-extraction",
+        "source_bounds_sha256": "47671fdc1c87ae683ca0630c35cc1276ebe707bc39784858e7414ada4d67b495",
+        "truth_reason": "trivial",
+        "witness": "subdag",
+        "worthy": false
+      }
+    ]
+  },
+  "hard_negative_boundaries": {
+    "small_helper": [
+      "clap:b526f00d436e1689:rank-10"
+    ],
+    "data_tables": [
+      "prometheus:524550adcecb8123:rank-2",
+      "prometheus:c1601349e39f9af1:rank-3",
+      "zap:b85ddcf733f2377d:rank-8"
+    ]
+  },
+  "independent_review": {
+    "reviewers": [
+      "evidence",
+      "product",
+      "soundness"
+    ],
+    "all_five_source_labels_unanimous": true,
+    "no_defensible_90_percent_subcohort": true
+  },
+  "decision": {
+    "minimum_non_action_precision": 0.9,
+    "product_behavior_change": false,
+    "reason": "no audited proof/actionability predicate reaches the precision gate",
+    "result": "rejected-no-go"
+  },
+  "preservation": {
+    "accepted_pair_coverage_unchanged": true,
+    "canon_preservation_violations_zero": true,
+    "family_membership_and_fingerprint_unchanged": true,
+    "family_universe_recall_unchanged": true,
+    "false_merges_zero": true,
+    "fold_forest_unchanged": true,
+    "surface_and_reason_transitions_zero": true,
+    "witness_and_provenance_unchanged": true
+  }
+}

--- a/bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json
+++ b/bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json
@@ -2,7 +2,11 @@
   "schema": "nose.proof_actionability_no_go.v1",
   "issue": 844,
   "split": "dev",
-  "heldout_policy": "closed; no held-out component, source path, or judgment was read",
+  "heldout_policy": {
+    "opened": false,
+    "split": "dev",
+    "statement": "no held-out component, source path, or judgment was read"
+  },
   "inputs": {
     "taxonomy_core": {
       "path": "bench/labels/default_head_taxonomy_2026_07_13.dev.core.v1.json",
@@ -13,13 +17,37 @@
       "path": "bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json",
       "byte_sha256": "68eff466212f0322a45a16648c1fcfd51a301bd5351c93f0795147f2baa33969",
       "semantic_sha256": "206f7e6c2eb9e5bb3750dd6e12f6f920228d719868b2e4922395433a2315c71a"
+    },
+    "parent_closeout": {
+      "path": "bench/labels/declaration_type_contract_closeout_2026_07_14.dev.v1.json",
+      "byte_sha256": "1f393994f95e15a676f60eeee7f7594be65c31c646e573362aba0d3721ff3732",
+      "schema": "nose.declaration_type_contract_closeout.v1",
+      "split": "dev"
     }
   },
   "binary_identity": {
-    "closeout_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
-    "immediate_parent_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
-    "immediate_parent_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
-    "published_v0_19_0_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    "algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+    "candidate": {
+      "build_command": "CARGO_TARGET_DIR=/tmp/nose-844-review-target cargo build --release -p nose-cli",
+      "code_sha256": "03cc5827cdadc225478a34266de78805c6e495810f90e8642f2ae2807b3a4f5a",
+      "file_sha256": "c0a70c0d31739da42260c94f910ddd89d46ae5e6979542f9d88d82a9808a42b3",
+      "source_commit": "0b57bd183317b35ea082b1629391ac59f748cab4",
+      "source_tree": "b81480bcf0d8b99137c9a4862ec3ea3b7a9d6e28"
+    },
+    "full_file_equal": false,
+    "normalized_code_equal": true,
+    "parent": {
+      "checked_evidence_commit": "182881a8097ff14ecf513a4fb32f1ad22cc31394",
+      "checked_evidence_tree": "7b4b4734571af8206311aa8862315b680619e6db",
+      "code_sha256": "03cc5827cdadc225478a34266de78805c6e495810f90e8642f2ae2807b3a4f5a",
+      "file_sha256": "f7fcda30aa63662f95000af7029eaf028c71ef074a18ba5e1e2048fe27c47fd0",
+      "merge_commit": "1384e601957d60628cfce72cba4346ca0b6a4e43",
+      "merge_tree": "6aae853031752a26ed2f80d40b0e548514723dff"
+    },
+    "published_v0_19_0": {
+      "code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "file_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    }
   },
   "blanket_proof_cohort": {
     "combined": {
@@ -124,13 +152,59 @@
     ]
   },
   "independent_review": {
-    "reviewers": [
-      "evidence",
-      "product",
-      "soundness"
+    "protocol": {
+      "confidence_method": "one-sided Wilson 95% lower bound",
+      "minimum_confirmatory_reviewed": 25,
+      "minimum_non_action_point_precision": 0.9,
+      "minimum_non_action_wilson_lower_bound": 0.9,
+      "source_packet_sha256": "2bf3ef7a9b41ff36d7bdcc38855c47f4daf24d60cf92b5f002483c787a66aa85"
+    },
+    "reviews": [
+      {
+        "reviewer": "evidence",
+        "decision": "rejected-no-go",
+        "defensible_90_percent_subcohort": false,
+        "source_packet_sha256": "2bf3ef7a9b41ff36d7bdcc38855c47f4daf24d60cf92b5f002483c787a66aa85",
+        "judgments": [
+          {"position_key": "clap:b526f00d436e1689:rank-10", "truth_reason": "extract-helper", "worthy": true},
+          {"position_key": "delve:fdab89b0d9bf0735:rank-7", "truth_reason": "parallel-by-design", "worthy": false},
+          {"position_key": "swiftlint:d28f52ac94be71f1:rank-6", "truth_reason": "parameterize", "worthy": true},
+          {"position_key": "lua:b9746b4eeb10c562:rank-28", "truth_reason": "coincidental-shape", "worthy": false},
+          {"position_key": "thor:3a25b222efed5f0b:rank-27", "truth_reason": "trivial", "worthy": false}
+        ]
+      },
+      {
+        "reviewer": "product",
+        "decision": "rejected-no-go",
+        "defensible_90_percent_subcohort": false,
+        "source_packet_sha256": "2bf3ef7a9b41ff36d7bdcc38855c47f4daf24d60cf92b5f002483c787a66aa85",
+        "judgments": [
+          {"position_key": "clap:b526f00d436e1689:rank-10", "truth_reason": "extract-helper", "worthy": true},
+          {"position_key": "delve:fdab89b0d9bf0735:rank-7", "truth_reason": "parallel-by-design", "worthy": false},
+          {"position_key": "swiftlint:d28f52ac94be71f1:rank-6", "truth_reason": "parameterize", "worthy": true},
+          {"position_key": "lua:b9746b4eeb10c562:rank-28", "truth_reason": "coincidental-shape", "worthy": false},
+          {"position_key": "thor:3a25b222efed5f0b:rank-27", "truth_reason": "trivial", "worthy": false}
+        ]
+      },
+      {
+        "reviewer": "soundness",
+        "decision": "rejected-no-go",
+        "defensible_90_percent_subcohort": false,
+        "source_packet_sha256": "2bf3ef7a9b41ff36d7bdcc38855c47f4daf24d60cf92b5f002483c787a66aa85",
+        "judgments": [
+          {"position_key": "clap:b526f00d436e1689:rank-10", "truth_reason": "extract-helper", "worthy": true},
+          {"position_key": "delve:fdab89b0d9bf0735:rank-7", "truth_reason": "parallel-by-design", "worthy": false},
+          {"position_key": "swiftlint:d28f52ac94be71f1:rank-6", "truth_reason": "parameterize", "worthy": true},
+          {"position_key": "lua:b9746b4eeb10c562:rank-28", "truth_reason": "coincidental-shape", "worthy": false},
+          {"position_key": "thor:3a25b222efed5f0b:rank-27", "truth_reason": "trivial", "worthy": false}
+        ]
+      }
     ],
-    "all_five_source_labels_unanimous": true,
-    "no_defensible_90_percent_subcohort": true
+    "summary": {
+      "all_five_source_labels_unanimous": true,
+      "no_defensible_90_percent_subcohort": true,
+      "reviewer_count": 3
+    }
   },
   "decision": {
     "minimum_non_action_precision": 0.9,
@@ -139,13 +213,24 @@
     "result": "rejected-no-go"
   },
   "preservation": {
-    "accepted_pair_coverage_unchanged": true,
-    "canon_preservation_violations_zero": true,
-    "family_membership_and_fingerprint_unchanged": true,
-    "family_universe_recall_unchanged": true,
-    "false_merges_zero": true,
-    "fold_forest_unchanged": true,
-    "surface_and_reason_transitions_zero": true,
-    "witness_and_provenance_unchanged": true
+    "basis": "normalized executable-code identity with the checked #843 parent",
+    "incremental": {
+      "accepted_pair_coverage_delta": 0,
+      "canon_preservation_violations": 0,
+      "family_membership_or_fingerprint_changes": 0,
+      "false_merges": 0,
+      "fold_forest_changes": 0,
+      "surface_or_reason_transitions": 0,
+      "witness_or_provenance_changes": 0,
+      "worthy_recall_delta": 0
+    },
+    "parent_behavior": {
+      "evidence_digest": "84578ffbdf97eeaa7e66551fae3e69b1e8181322069e25bc4b09e5650af65084",
+      "sha256": "4722f772a98476ce7860409ff4a18c29ceb9d9e21981542c5390ab7aab7ebd93"
+    },
+    "parent_product_quality": {
+      "sha256": "d94b2cfcf9e144ea5e4016e71782d743c1526f68da4822c4469e73113bcf242f",
+      "worthy_recall": {"hits": 2716, "n": 2849}
+    }
   }
 }

--- a/crates/nose-detect/src/report/model.rs
+++ b/crates/nose-detect/src/report/model.rs
@@ -227,8 +227,10 @@ impl RefactorFamily {
     ///
     /// Measured 2026-06-14
     /// ([default-surface-noise-audit](../../../docs/default-surface-noise-audit-2026-06-14.md)).
-    /// A **proven** channel (exact value-graph / shared-sub-dag) is never demoted on a
-    /// shape/size heuristic. Returns `None` for a clean candidate.
+    /// A **proven** channel (exact value-graph / shared-sub-dag) is never demoted on these
+    /// shape/size heuristics. The #844 dev re-audit found actionable small-helper and
+    /// high-parameter hard negatives, so proof strength remains separate from extraction
+    /// actionability and the exemption fails open. Returns `None` for a clean candidate.
     pub fn actionability_reason(&self) -> Option<&'static str> {
         // Size floor below which a clone is too small to be an extraction target. Measured
         // 2026-06-14 (default-surface-noise-audit): `trivial` labels at 0.95 precision.

--- a/crates/nose-detect/src/report/tests/actionability.rs
+++ b/crates/nose-detect/src/report/tests/actionability.rs
@@ -37,21 +37,24 @@ fn clean_low_param_match_stays_default() {
 }
 
 #[test]
-fn proven_channel_is_never_shallow() {
-    // Same shallow shape (shared=9, params=4) but on the exact value-graph channel:
-    // a proof of equal behavior is never demoted on a parameter-ratio heuristic.
-    let proven = witnessed(
-        fam(
-            500.0,
-            30,
-            9,
-            4,
-            vec![loc("a.go", 1, 30, "go"), loc("b.go", 1, 30, "go")],
-        ),
-        "exact-value-graph",
-    );
-    assert_eq!(proven.actionability_reason(), None);
-    assert_eq!(proven.recommended_surface(), "default");
+fn proven_channels_are_never_shallow() {
+    // Same boundary-shallow shape (shared=9, params=3), but proof strength is not an
+    // actionability verdict. #844's source-backed dev audit found worthy parameterized
+    // extractions at this boundary, so both proven channels fail open to default.
+    for kind in ["exact-value-graph", "shared-sub-dag"] {
+        let proven = witnessed(
+            fam(
+                500.0,
+                30,
+                9,
+                3,
+                vec![loc("a.go", 1, 30, "go"), loc("b.go", 1, 30, "go")],
+            ),
+            kind,
+        );
+        assert_eq!(proven.actionability_reason(), None, "{kind}");
+        assert_eq!(proven.recommended_surface(), "default", "{kind}");
+    }
 }
 
 #[test]
@@ -92,20 +95,24 @@ fn trivial_family_is_demoted_to_hidden() {
 }
 
 #[test]
-fn proven_tiny_family_is_not_trivial() {
-    // Same tiny shape on the exact value-graph channel: never demoted on size.
-    let proven = witnessed(
-        fam(
-            500.0,
-            3,
-            3,
-            0,
-            vec![loc("a.go", 1, 3, "go"), loc("b.go", 1, 3, "go")],
-        ),
-        "exact-value-graph",
-    );
-    assert_eq!(proven.actionability_reason(), None);
-    assert_eq!(proven.recommended_surface(), "default");
+fn proven_tiny_families_are_not_trivial() {
+    // #844 froze a worthy four-line helper as the size-floor hard negative. Protect
+    // both proven channels: proof of equal behavior does not make a small extraction
+    // worthless, and size alone did not clear the measured non-action precision gate.
+    for kind in ["exact-value-graph", "shared-sub-dag"] {
+        let proven = witnessed(
+            fam(
+                500.0,
+                4,
+                4,
+                0,
+                vec![loc("a.go", 1, 4, "go"), loc("b.go", 1, 4, "go")],
+            ),
+            kind,
+        );
+        assert_eq!(proven.actionability_reason(), None, "{kind}");
+        assert_eq!(proven.recommended_surface(), "default", "{kind}");
+    }
 }
 
 #[test]

--- a/docs/home.md
+++ b/docs/home.md
@@ -147,6 +147,9 @@ fundamentals; the rest is grouped by area.
 - [0.20 declaration-only type contracts](declaration-only-type-contracts-843.md) — the
   all-member `UnitOrigin` classifier, cross-language fail-open boundaries, exact dev
   surface/origin drift, worthy-recall preservation, and official-v0.19.0 runtime price.
+- [0.20 proof/actionability no-go](proof-actionability-no-go-844.md) — the independently
+  reviewed small/shallow proven-channel boundary, worthy helper/table hard negatives,
+  checked 90%-gate failure, and zero-product-change preservation contract.
 - [current missed-worthy frontier](missed-worthy-frontier-816.md) — the #816
   dev-first recall audit, accepted-pair coverage-loss result, route-tree protocol
   deviation, rejected alternatives, and #817 follow-up gates.

--- a/docs/proof-actionability-no-go-844.md
+++ b/docs/proof-actionability-no-go-844.md
@@ -28,7 +28,9 @@ precision:
 | combined | 5 | 3 | 60% | 2 |
 
 The five direct boundary rows are source-hash bound and were independently reviewed by
-three agents. All three reviewers returned the same label and the same no-go decision:
+three agents. Their individual five-row judgments and no-go decisions are recorded
+separately against the same truth-free source-packet digest. All three reviewers returned
+the same label and the same no-go decision:
 
 - Clap's four identical four-line `build_help` functions are a worthy shared-helper
   extraction, so “small” is not mechanically equivalent to “not actionable.”
@@ -44,7 +46,9 @@ No post-hoc split by repository, language, scope, file relation, symbol, or extr
 shape is admitted. Such a split has no common mechanical cause, would be selected after
 reading the labels, and would violate the scope-blind actionability contract. The two
 deep non-action rows alone are not a confirmatory cohort; a perfect two-of-two result
-cannot establish a 90% boundary.
+cannot establish a 90% boundary. Future confirmatory admission requires both 90% point
+precision and a one-sided 95% Wilson lower bound of 90%, which needs at least 25/25
+unanimous non-action judgments before hard-negative checks.
 
 ## Frozen hard negatives
 
@@ -57,27 +61,31 @@ of making it noise.
 
 The checked [`proof_actionability_no_go_2026_07_14.dev.v1.json`
 artifact](../bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json) binds both #841
-artifact digests, all 64 proof-backed keys, all 37 worthy keys and reason
-counts, the five current-exemption rows and source-bound hashes, the named helper/table
-boundaries, and the unanimous three-review result. Its validator reconstructs every
-count and row from the frozen taxonomy and rejects truth, witness, predicate, source
-bound, cohort, input, decision, or preservation changes.
+artifact digests, all 64 proof-backed keys, all 37 worthy keys and reason counts, the five
+current-exemption rows and source-bound hashes, the named helper/table boundaries, each
+of the three independent reviews, and the checked #843 closeout. Its validator
+reconstructs every count, review summary, parent behavior/quality projection, and raw
+performance binding; it rejects truth, witness, predicate, source bound, cohort, input,
+held-out policy, decision, or preservation changes.
 
 ## Preservation and future admission bar
 
 Because no runtime product path changes, family membership and fingerprints, witnesses
 and provenance, accepted-pair coverage, fold forest, surfaces and reasons, default order,
 full-universe recall, false-merge and canon-preservation gates all remain identical to
-#843. The release binary is byte-identical to the immediate parent; consequently #844's
-incremental runtime and output cost is exactly zero. The required official-v0.19.0
-performance baseline remains the one already priced by #843, rather than a source-rebuilt
-substitute.
+#843. A clean isolated release build differs from the preserved parent binary only in the
+Mach-O UUID and ad-hoc signature bytes: both normalize to executable-code SHA-256
+`03cc5827…4f5a` under the checked `binary_identity.py` algorithm. The parent closeout and
+all eight raw performance artifacts are byte-bound, so #844's incremental runtime and
+output cost is zero. The required official-v0.19.0 performance baseline remains the
+published binary (`0f73ea…e0f3`) already priced by #843, not a source rebuild.
 
-A future rule must be pre-registered before its confirmatory source review, clear 90%
-non-action precision independently, match none of the frozen worthy hard negatives, and
-fail open on missing evidence. If admitted, it must be a presentation-only transition:
-families remain recoverable through `all top=0` and `id=`, while semantic membership,
-witnesses, fingerprints, and the pre-transition fold opportunity forest remain stable.
+A future rule must be pre-registered before its confirmatory source review, clear both
+the point and Wilson gates independently, match none of the frozen worthy hard negatives,
+and fail open on missing evidence. If admitted, it must be a presentation-only
+transition: families remain recoverable through `all top=0` and `id=`, while semantic
+membership, witnesses, fingerprints, and the pre-transition fold opportunity forest
+remain stable.
 
 ## Validation
 

--- a/docs/proof-actionability-no-go-844.md
+++ b/docs/proof-actionability-no-go-844.md
@@ -1,0 +1,98 @@
+# Proof strength versus extraction actionability (#844)
+
+Issue #844 closes as a checked **no-go**. Exact semantic proof answers “do these spans
+compute alike?”; it does not answer “is extracting this repetition worthwhile?” The
+existing `exact-value-graph` and `shared-sub-dag` protection from the coarse `trivial`
+and `shallow-extraction` shape rules therefore remains in place. There is no product
+output, ranking, detector, surface, or performance change.
+
+## Audited decisions
+
+The [#841 dev taxonomy](default-head-failure-taxonomy-841.md) provides two related
+counterfactuals. Treating proof kind itself as non-actionable fails badly:
+
+| proven cohort | reviewed | non-action | precision | worthy hard negatives |
+|---|---:|---:|---:|---:|
+| bare-default head | 57 | 22 | 38.60% | 35 |
+| deterministic deep sample | 7 | 5 | 71.43% | 2 |
+| combined | 64 | 27 | 42.19% | 37 |
+
+The narrower counterfactual removes only the current exemption and then applies the
+existing size and parameter-density rules. It still misses the required 90% non-action
+precision:
+
+| protected shape rule | reviewed | non-action | precision | worthy hard negatives |
+|---|---:|---:|---:|---:|
+| `trivial` (`mean_lines <= 4`) | 1 | 0 | 0% | 1 |
+| `shallow-extraction` (`params >= 0.33 * shared_lines`) | 4 | 3 | 75% | 1 |
+| combined | 5 | 3 | 60% | 2 |
+
+The five direct boundary rows are source-hash bound and were independently reviewed by
+three agents. All three reviewers returned the same label and the same no-go decision:
+
+- Clap's four identical four-line `build_help` functions are a worthy shared-helper
+  extraction, so “small” is not mechanically equivalent to “not actionable.”
+- Delve's six architecture-specific unwind implementations are parallel by design;
+  their common scaffold does not justify a large, architecture-obscuring parameter list.
+- SwiftLint's five repeated configuration tests are a worthy parameterized-test/helper
+  opportunity despite their parameter density.
+- Lua's `discharge2reg` and `codenot` switches perform different compiler state
+  transitions; their shared control shape is coincidental.
+- Thor's two test fragments share too little cohesive behavior to justify another helper.
+
+No post-hoc split by repository, language, scope, file relation, symbol, or extraction
+shape is admitted. Such a split has no common mechanical cause, would be selected after
+reading the labels, and would violate the scope-blind actionability contract. The two
+deep non-action rows alone are not a confirmatory cohort; a perfect two-of-two result
+cannot establish a 90% boundary.
+
+## Frozen hard negatives
+
+The 37 worthy proven rows remain a protection set: 23 helper extractions, nine
+parameterizations, three data-table extractions, and two base extractions. In addition to
+the direct small-helper boundary in Clap, the checked closeout names the two large
+Prometheus documentation-table families and Zap's paired benchmark field tables. These
+demonstrate that strong or exact proof can strengthen an actionable refactoring instead
+of making it noise.
+
+The checked [`proof_actionability_no_go_2026_07_14.dev.v1.json`
+artifact](../bench/labels/proof_actionability_no_go_2026_07_14.dev.v1.json) binds both #841
+artifact digests, all 64 proof-backed keys, all 37 worthy keys and reason
+counts, the five current-exemption rows and source-bound hashes, the named helper/table
+boundaries, and the unanimous three-review result. Its validator reconstructs every
+count and row from the frozen taxonomy and rejects truth, witness, predicate, source
+bound, cohort, input, decision, or preservation changes.
+
+## Preservation and future admission bar
+
+Because no runtime product path changes, family membership and fingerprints, witnesses
+and provenance, accepted-pair coverage, fold forest, surfaces and reasons, default order,
+full-universe recall, false-merge and canon-preservation gates all remain identical to
+#843. The release binary is byte-identical to the immediate parent; consequently #844's
+incremental runtime and output cost is exactly zero. The required official-v0.19.0
+performance baseline remains the one already priced by #843, rather than a source-rebuilt
+substitute.
+
+A future rule must be pre-registered before its confirmatory source review, clear 90%
+non-action precision independently, match none of the frozen worthy hard negatives, and
+fail open on missing evidence. If admitted, it must be a presentation-only transition:
+families remain recoverable through `all top=0` and `id=`, while semantic membership,
+witnesses, fingerprints, and the pre-transition fold opportunity forest remain stable.
+
+## Validation
+
+```sh
+python3 bench/labels/proof_actionability_no_go.py --self-test
+python3 bench/labels/default_head_taxonomy.py --self-test
+python3 bench/labels/default_head_taxonomy.py validate \
+  bench/labels/default_head_taxonomy_2026_07_13.dev.v1.json \
+  --pragmatic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.pragmatic.v1.json \
+  --dedupe bench/labels/default_head_taxonomy_votes_2026_07_13.dev.dedupe.v1.json \
+  --skeptic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.skeptic.v1.json
+cargo test -p nose-detect actionability -- --nocapture
+./scripts/check-ci-local.sh --fast
+./scripts/check-docs.sh
+```
+
+#845 may now tune only transparent, deterministic ranking evidence over the residual
+default head. Held-out source remains closed until #846.

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -130,6 +130,7 @@ run_regression_checker_selftests() {
         --pragmatic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.pragmatic.v1.json \
         --dedupe bench/labels/default_head_taxonomy_votes_2026_07_13.dev.dedupe.v1.json \
         --skeptic bench/labels/default_head_taxonomy_votes_2026_07_13.dev.skeptic.v1.json
+    python3 bench/labels/proof_actionability_no_go.py --self-test
     python3 bench/labels/generated_provenance_behavior.py --self-test
     python3 bench/labels/generated_provenance_behavior.py validate
     python3 bench/labels/generated_provenance_closeout.py --self-test


### PR DESCRIPTION
## Summary

- close the proven-channel actionability counterfactual as a measured no-go instead of demoting worthy exact/subdag families
- bind the 64-row proof cohort, five direct trivial/shallow boundaries, 37 worthy hard negatives, and all three independent source reviews
- derive zero product drift from normalized executable-code identity plus the checked #843 behavior, quality, and official-v0.19.0 performance chain
- preserve the proven-channel fail-open contract with exact threshold tests for both witness kinds

## Result

The direct exemption-removal cohort is 3/5 non-actionable (60%): `trivial` is 0/1 and `shallow-extraction` is 3/4. The broader proof cohort is 27/64 (42.19%). Neither reaches the 90% gate, so product behavior remains unchanged.

## Validation

- three independent exact-SHA reviews: approved
- `./scripts/check-ci-local.sh --fast`
- `python3 bench/labels/proof_actionability_no_go.py --self-test`
- `cargo test -p nose-detect actionability -- --nocapture`
- `./scripts/check-docs.sh`
- clean isolated release build normalized code identity matches #843

Closes #844