### PR TITLE
Add fail-closed Soundness Lab release gates

### DIFF
--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -1,60 +1,392 @@
-name: corpus verify
+name: Soundness Lab
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/corpus-verify.yml"
+      - "bench/soundness/**"
+      - "bench/type4/**"
+      - "crates/nose-cli/**"
+      - "crates/nose-detect/**"
+      - "crates/nose-eval/**"
+      - "crates/nose-frontend/**"
+      - "crates/nose-il/**"
+      - "crates/nose-normalize/**"
+      - "crates/nose-semantics/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "formal/**"
+      - "scripts/check-domain-calibration.py"
+      - "scripts/check-formal-obligations.py"
+      - "scripts/check-lean-proofs.sh"
+      - "scripts/check-soundness-scorecard.py"
+      - "scripts/corpus-verify-nightly.sh"
+      - "scripts/formal_claim_schema.py"
+      - "scripts/soundness-lab-gate.py"
+      - "scripts/soundness_exclusions.py"
   schedule:
-    # Nightly tripwire for the pinned corpus soundness invariant.
+    # Full pinned corpus every night; deeper independent campaigns every Sunday.
     - cron: "17 18 * * *"
+    - cron: "43 17 * * 0"
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Campaign to run; release composes nightly and deep evidence.
+        type: choice
+        options: [nightly, deep, release]
+        default: nightly
 
 permissions:
   contents: read
 
 concurrency:
-  group: corpus-verify-${{ github.ref }}
+  group: soundness-lab-${{ github.event_name }}-${{ github.ref }}-${{ inputs.mode || github.event.schedule || 'pr' }}
   cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  verify:
-    name: nightly pinned-corpus verify
+  pr-claims:
+    name: touched claims · batteries · proofs · scorecard
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: cache pinned benchmark corpus
-        uses: actions/cache@v6
         with:
-          path: bench/repos
-          key: bench-corpus-${{ hashFiles('bench/goldens/corpus.json', 'bench/setup_repos.sh', 'bench/prune_corpus.py', 'bench/labels/prune_manifest.json') }}
-
-      - name: build nose
-        run: cargo build --release -p nose-cli
-
-      - name: reconstruct pinned corpus
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: install Lean
+        id: lean
+        continue-on-error: true
         run: |
-          bench/setup_repos.sh
-          python3 bench/prune_corpus.py --check-manifest
-
-      - name: verify corpus soundness
-        env:
-          NOSE_CORPUS_VERIFY_JOBS: "6"
+          toolchain="$(cat lean-toolchain)"
+          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain "$toolchain"
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: index touched claims
+        id: plan
+        if: ${{ failure() || success() }}
+        continue-on-error: true
         run: |
-          ./scripts/corpus-verify-nightly.sh \
-            --nose target/release/nose \
-            --repos-root bench/repos \
-            --logs-dir target/corpus-verify-logs
-
-      - name: upload per-repo verify logs on failure
-        if: ${{ failure() || cancelled() }}
+          mkdir -p target/soundness-pr
+          python3 scripts/soundness-lab-gate.py pr-plan \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --output target/soundness-pr/plan.json \
+            --markdown target/soundness-pr/plan.md
+          cat target/soundness-pr/plan.md >> "$GITHUB_STEP_SUMMARY"
+      - name: build focused battery binary
+        id: build
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: cargo build --release -p nose-cli 2>&1 | tee target/soundness-pr/build.log
+      - name: workflow and producer mutation self-tests
+        id: selftest
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          {
+            ./scripts/corpus-verify-nightly.sh --self-test
+            python3 scripts/check-soundness-scorecard.py --self-test
+            python3 scripts/check-formal-obligations.py --self-test
+            python3 bench/type4/check_axis_language_claims.py --self-test
+            python3 scripts/soundness_exclusions.py --self-test
+            python3 scripts/soundness-lab-gate.py self-test
+          } 2>&1 | tee target/soundness-pr/self-tests.log
+      - name: touched-claim executable batteries and scorecard
+        id: batteries
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          {
+            python3 scripts/check-domain-calibration.py
+            python3 scripts/check-soundness-scorecard.py
+            cargo test --release -p nose-cli --test equivalence
+            python3 bench/type4/check_axis_language_claims.py \
+              --nose target/release/nose \
+              --ratchet-base "${{ github.event.pull_request.base.sha }}"
+          } 2>&1 | tee target/soundness-pr/batteries.log
+      - name: touched-claim registry and proofs
+        id: proofs
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          {
+            python3 scripts/check-formal-obligations.py
+            ./scripts/check-lean-proofs.sh
+          } 2>&1 | tee target/soundness-pr/proofs.log
+      - name: upload PR evidence
+        id: upload
+        if: ${{ failure() || cancelled() || success() }}
         uses: actions/upload-artifact@v7
         with:
-          name: corpus-verify-logs
-          path: target/corpus-verify-logs
-          if-no-files-found: warn
+          name: soundness-pr-${{ github.event.pull_request.head.sha }}
+          path: target/soundness-pr
+          if-no-files-found: error
+      - name: enforce PR gate
+        if: ${{ failure() || success() }}
+        run: |
+          test "${{ steps.lean.outcome }}" = success
+          test "${{ steps.plan.outcome }}" = success
+          test "${{ steps.build.outcome }}" = success
+          test "${{ steps.selftest.outcome }}" = success
+          test "${{ steps.batteries.outcome }}" = success
+          test "${{ steps.proofs.outcome }}" = success
+          test "${{ steps.upload.outcome }}" = success
+
+  plan-nightly:
+    name: plan all pinned repositories
+    if: >-
+      ${{
+        (github.event_name == 'schedule' && github.event.schedule == '17 18 * * *') ||
+        (github.event_name == 'workflow_dispatch' && (inputs.mode == 'nightly' || inputs.mode == 'release'))
+      }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: validate workflow and make deterministic shard plan
+        id: plan
+        run: |
+          python3 scripts/soundness-lab-gate.py check
+          matrix="$(python3 scripts/soundness-lab-gate.py plan-shards --count 4)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  nightly-shard:
+    name: pinned corpus shard ${{ matrix.shard.id }}
+    needs: plan-nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan-nightly.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: prepare shard evidence
+        id: prepare
+        run: mkdir -p target/soundness-nightly-shard
+      - name: build nose
+        id: build
+        continue-on-error: true
+        run: cargo build --release -p nose-cli 2>&1 | tee target/soundness-nightly-shard/build.log
+      - name: reconstruct this pinned shard
+        id: setup
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        env:
+          SHARD_REPOS: ${{ toJSON(matrix.shard.repos) }}
+        run: |
+          mapfile -t repos < <(python3 -c 'import json,os; print("\n".join(json.loads(os.environ["SHARD_REPOS"])))')
+          args=()
+          for repo in "${repos[@]}"; do args+=(--repo "$repo"); done
+          bench/setup_repos.sh "${args[@]}" 2>&1 | tee target/soundness-nightly-shard/setup.log
+      - name: verify this pinned shard
+        id: verify
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        env:
+          SHARD_REPOS: ${{ toJSON(matrix.shard.repos) }}
+        run: |
+          mapfile -t repos < <(python3 -c 'import json,os; print("\n".join(json.loads(os.environ["SHARD_REPOS"])))')
+          args=()
+          for repo in "${repos[@]}"; do args+=(--repo "$repo"); done
+          ./scripts/corpus-verify-nightly.sh \
+            --nose target/release/nose \
+            --source-commit "${{ github.sha }}" \
+            --repos-root bench/repos \
+            --logs-dir target/soundness-nightly-shard \
+            --jobs 6 \
+            --timeout-seconds 900 \
+            "${args[@]}"
+      - name: upload shard evidence on every outcome
+        id: upload
+        if: ${{ failure() || cancelled() || success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: soundness-nightly-shard-${{ matrix.shard.id }}
+          path: target/soundness-nightly-shard
+          if-no-files-found: error
+      - name: enforce shard gate
+        if: ${{ failure() || success() }}
+        run: |
+          test "${{ steps.prepare.outcome }}" = success
+          test "${{ steps.build.outcome }}" = success
+          test "${{ steps.setup.outcome }}" = success
+          test "${{ steps.verify.outcome }}" = success
+          test "${{ steps.upload.outcome }}" = success
+
+  merge-nightly:
+    name: merge complete nightly evidence
+    if: >-
+      ${{
+        always() && (
+          (github.event_name == 'schedule' && github.event.schedule == '17 18 * * *') ||
+          (github.event_name == 'workflow_dispatch' && (inputs.mode == 'nightly' || inputs.mode == 'release'))
+        )
+      }}
+    needs: [plan-nightly, nightly-shard]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: prepare merged evidence
+        id: prepare
+        run: mkdir -p target/soundness-nightly
+      - name: download every shard
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: soundness-nightly-shard-*
+          path: target/soundness-nightly-inputs
+      - name: reject missing, overlapping, timed-out, or unsound shards
+        id: merge
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          python3 scripts/soundness-lab-gate.py merge-nightly \
+            --inputs target/soundness-nightly-inputs \
+            --output target/soundness-nightly/corpus-evidence.json \
+            --markdown target/soundness-nightly/summary.md \
+            2>&1 | tee target/soundness-nightly/merge.log
+          cat target/soundness-nightly/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: upload complete nightly evidence on every outcome
+        id: upload
+        if: ${{ failure() || cancelled() || success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: soundness-nightly-${{ github.sha }}
+          path: target/soundness-nightly
+          if-no-files-found: error
+      - name: enforce complete nightly gate
+        if: ${{ failure() || success() }}
+        run: |
+          test "${{ needs.nightly-shard.result }}" = success
+          test "${{ steps.prepare.outcome }}" = success
+          test "${{ steps.download.outcome }}" = success
+          test "${{ steps.merge.outcome }}" = success
+          test "${{ steps.upload.outcome }}" = success
+
+  deep-campaign:
+    name: deep source-runtime · metamorphic · falsification
+    if: >-
+      ${{
+        (github.event_name == 'schedule' && github.event.schedule == '43 17 * * 0') ||
+        (github.event_name == 'workflow_dispatch' && (inputs.mode == 'deep' || inputs.mode == 'release'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: build deep-campaign binary
+        id: build
+        continue-on-error: true
+        run: |
+          mkdir -p target/soundness-deep
+          cargo build --release -p nose-cli 2>&1 | tee target/soundness-deep/build.log
+      - name: independent source-runtime campaign
+        id: domain
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: python3 scripts/check-domain-calibration.py 2>&1 | tee target/soundness-deep/domain.log
+      - name: metamorphic equivalence campaign
+        id: equivalence
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: cargo test --release -p nose-cli --test equivalence 2>&1 | tee target/soundness-deep/equivalence.log
+      - name: multi-seed distinguishing-input campaign
+        id: falsification
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          for seed in 1 11400714819323198485 13787848793156543929; do
+            RAYON_NUM_THREADS=1 target/release/nose verify crates \
+              --max-violations 0 --falsify --falsify-seed "$seed" \
+              > "target/soundness-deep/falsify-$seed.log" 2>&1
+          done
+      - name: record deep evidence even after failure
+        id: evidence
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          python3 scripts/soundness-lab-gate.py deep-evidence \
+            --commit "${{ github.sha }}" \
+            --domain "${{ steps.domain.outcome }}" \
+            --equivalence "${{ steps.equivalence.outcome }}" \
+            --falsification "${{ steps.falsification.outcome }}" \
+            --output target/soundness-deep/evidence.json
+      - name: upload deep evidence on every outcome
+        id: upload
+        if: ${{ failure() || cancelled() || success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: soundness-deep-${{ github.sha }}
+          path: target/soundness-deep
+          if-no-files-found: error
+      - name: enforce deep campaign
+        if: ${{ failure() || success() }}
+        run: |
+          test "${{ steps.build.outcome }}" = success
+          test "${{ steps.domain.outcome }}" = success
+          test "${{ steps.equivalence.outcome }}" = success
+          test "${{ steps.falsification.outcome }}" = success
+          test "${{ steps.evidence.outcome }}" = success
+          test "${{ steps.upload.outcome }}" = success
+
+  release-gate:
+    name: compose 0.20 release evidence against official v0.19.0
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.mode == 'release' }}
+    needs: [merge-nightly, deep-campaign]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: download nightly evidence
+        id: nightly
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: soundness-nightly-${{ github.sha }}
+          path: target/release-input/nightly
+      - name: download deep evidence
+        id: deep
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: soundness-deep-${{ github.sha }}
+          path: target/release-input/deep
+      - name: compose fail-closed release report
+        id: release
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: |
+          python3 scripts/soundness-lab-gate.py release \
+            --corpus target/release-input/nightly/corpus-evidence.json \
+            --deep target/release-input/deep/evidence.json \
+            --commit "${{ github.sha }}" \
+            --output target/soundness-release/evidence.json \
+            --markdown target/soundness-release/summary.md
+          cat target/soundness-release/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: upload release evidence on every outcome
+        id: upload
+        if: ${{ failure() || cancelled() || success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: soundness-release-${{ github.sha }}
+          path: target/soundness-release
+          if-no-files-found: error
+      - name: enforce release gate
+        if: ${{ failure() || success() }}
+        run: |
+          test "${{ needs.merge-nightly.result }}" = success
+          test "${{ needs.deep-campaign.result }}" = success
+          test "${{ steps.nightly.outcome }}" = success
+          test "${{ steps.deep.outcome }}" = success
+          test "${{ steps.release.outcome }}" = success
+          test "${{ steps.upload.outcome }}" = success

--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -6,6 +6,11 @@ on:
       - ".github/workflows/corpus-verify.yml"
       - "bench/soundness/**"
       - "bench/type4/**"
+      - "bench/recall_loss/**"
+      - "bench/goldens/corpus.json"
+      - "bench/setup_repos.sh"
+      - "bench/prune_corpus.py"
+      - "bench/labels/prune_manifest.json"
       - "crates/nose-cli/**"
       - "crates/nose-detect/**"
       - "crates/nose-eval/**"
@@ -168,13 +173,15 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: prepare shard evidence
+      - name: prepare shard outputs
         id: prepare
-        run: mkdir -p target/soundness-nightly-shard
+        run: |
+          mkdir -p target/soundness-nightly-shard-evidence
+          mkdir -p target/soundness-nightly-diagnostics/run
       - name: build nose
         id: build
         continue-on-error: true
-        run: cargo build --release -p nose-cli 2>&1 | tee target/soundness-nightly-shard/build.log
+        run: cargo build --release -p nose-cli 2>&1 | tee target/soundness-nightly-diagnostics/build.log
       - name: reconstruct this pinned shard
         id: setup
         if: ${{ failure() || success() }}
@@ -185,7 +192,7 @@ jobs:
           mapfile -t repos < <(python3 -c 'import json,os; print("\n".join(json.loads(os.environ["SHARD_REPOS"])))')
           args=()
           for repo in "${repos[@]}"; do args+=(--repo "$repo"); done
-          bench/setup_repos.sh "${args[@]}" 2>&1 | tee target/soundness-nightly-shard/setup.log
+          bench/setup_repos.sh "${args[@]}" 2>&1 | tee target/soundness-nightly-diagnostics/setup.log
       - name: verify this pinned shard
         id: verify
         if: ${{ failure() || success() }}
@@ -200,17 +207,39 @@ jobs:
             --nose target/release/nose \
             --source-commit "${{ github.sha }}" \
             --repos-root bench/repos \
-            --logs-dir target/soundness-nightly-shard \
+            --logs-dir target/soundness-nightly-diagnostics/run \
             --jobs 6 \
             --timeout-seconds 900 \
             "${args[@]}"
+      - name: collect byte-deterministic shard evidence
+        id: collect
+        if: ${{ failure() || success() }}
+        run: |
+          for file in evidence.json repos.txt summary.md summary.tsv; do
+            if test -f "target/soundness-nightly-diagnostics/run/$file"; then
+              cp "target/soundness-nightly-diagnostics/run/$file" \
+                "target/soundness-nightly-shard-evidence/$file"
+            fi
+          done
+          if ! test -f target/soundness-nightly-shard-evidence/evidence.json; then
+            echo "deterministic shard evidence unavailable; inspect the diagnostics artifact" \
+              > target/soundness-nightly-shard-evidence/unavailable.txt
+          fi
       - name: upload shard evidence on every outcome
         id: upload
         if: ${{ failure() || cancelled() || success() }}
         uses: actions/upload-artifact@v7
         with:
           name: soundness-nightly-shard-${{ matrix.shard.id }}
-          path: target/soundness-nightly-shard
+          path: target/soundness-nightly-shard-evidence
+          if-no-files-found: error
+      - name: upload shard diagnostics on every outcome
+        id: diagnostics
+        if: ${{ failure() || cancelled() || success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: soundness-nightly-diagnostics-${{ matrix.shard.id }}
+          path: target/soundness-nightly-diagnostics
           if-no-files-found: error
       - name: enforce shard gate
         if: ${{ failure() || success() }}
@@ -219,7 +248,9 @@ jobs:
           test "${{ steps.build.outcome }}" = success
           test "${{ steps.setup.outcome }}" = success
           test "${{ steps.verify.outcome }}" = success
+          test "${{ steps.collect.outcome }}" = success
           test "${{ steps.upload.outcome }}" = success
+          test "${{ steps.diagnostics.outcome }}" = success
 
   merge-nightly:
     name: merge complete nightly evidence
@@ -347,6 +378,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: prepare release evidence
+        id: prepare
+        run: mkdir -p target/soundness-release
       - name: download nightly evidence
         id: nightly
         continue-on-error: true
@@ -366,13 +400,27 @@ jobs:
         if: ${{ failure() || success() }}
         continue-on-error: true
         run: |
+          set +e
           python3 scripts/soundness-lab-gate.py release \
             --corpus target/release-input/nightly/corpus-evidence.json \
             --deep target/release-input/deep/evidence.json \
             --commit "${{ github.sha }}" \
             --output target/soundness-release/evidence.json \
-            --markdown target/soundness-release/summary.md
+            --markdown target/soundness-release/summary.md \
+            2>&1 | tee target/soundness-release/compose.log
+          code="${PIPESTATUS[0]}"
+          set -e
+          if ! test -f target/soundness-release/summary.md; then
+            {
+              echo "## Soundness Lab 0.20 release gate"
+              echo
+              echo "- result: failed closed"
+              echo "- composer exit code: $code"
+              echo "- diagnostics: compose.log"
+            } > target/soundness-release/summary.md
+          fi
           cat target/soundness-release/summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$code"
       - name: upload release evidence on every outcome
         id: upload
         if: ${{ failure() || cancelled() || success() }}
@@ -386,6 +434,7 @@ jobs:
         run: |
           test "${{ needs.merge-nightly.result }}" = success
           test "${{ needs.deep-campaign.result }}" = success
+          test "${{ steps.prepare.outcome }}" = success
           test "${{ steps.nightly.outcome }}" = success
           test "${{ steps.deep.outcome }}" = success
           test "${{ steps.release.outcome }}" = success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ break.
   failure, binds shards to one source commit and binary, fully diffs non-blocking advisory
   disagreements against the published v0.19.0 binary, and rejects missing artifacts, changed
   pins, timeouts, false merges, canon violations, coverage regressions, unregistered claims,
-  unguarded Tier-A cells, and unattributed exclusions.
+  unguarded Tier-A cells, and unattributed exclusions. Deterministic shard evidence is separated
+  from diagnostic logs, release failures retain a summary, and the release commit's product tree
+  must match the checked binding.
 - Kept mixed-exit fragments distinct from whole functions in exact fingerprints. A conditional
   fragment that may return or throw but can also fall through no longer collides with a whole
   function whose completion has different enclosing-control behavior; the Soundness Lab found
-  and reproduced this boundary across five pinned repositories.
+  and reproduced this boundary across pinned repositories. The audit oracle now distinguishes
+  explicit throw from ordinary evaluation errors independently of the product classifier, and
+  cache schema v12 prevents pre-fix feature entries from being reused.
 - Committed the #846 held-out review inputs without publishing their source. The
   official v0.19.0 replay reproduces 54 queries, 1,564 candidate commitments, and the
   exact 214-family sealed selection, then creates three persona-specific packets outside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ break.
 ## [Unreleased]
 
 ### Added
+- Added fail-closed Soundness Lab PR, nightly, deep-campaign, and 0.20 release
+  gates. Nightly evidence covers every pinned repository exactly once, retains artifacts on
+  failure, binds shards to one source commit and binary, fully diffs non-blocking advisory
+  disagreements against the published v0.19.0 binary, and rejects missing artifacts, changed
+  pins, timeouts, false merges, canon violations, coverage regressions, unregistered claims,
+  unguarded Tier-A cells, and unattributed exclusions.
+- Kept mixed-exit fragments distinct from whole functions in exact fingerprints. A conditional
+  fragment that may return or throw but can also fall through no longer collides with a whole
+  function whose completion has different enclosing-control behavior; the Soundness Lab found
+  and reproduced this boundary across five pinned repositories.
 - Committed the #846 held-out review inputs without publishing their source. The
   official v0.19.0 replay reproduces 54 queries, 1,564 candidate commitments, and the
   exact 214-family sealed selection, then creates three persona-specific packets outside

--- a/bench/recall_loss/issue-859-official-v0.19.0-performance-2026-07-17.v1.json
+++ b/bench/recall_loss/issue-859-official-v0.19.0-performance-2026-07-17.v1.json
@@ -9,7 +9,7 @@
     "binary_code_sha256": "e438b594aa95f0a6169c69b00b659f6f67df70d90fbf0a01d198078d7edb5931",
     "binary_sha256": "7af52f4bb094a37cf539c7dd343dc63d0dab344fabca38a3c291c3f566a9209d",
     "crates_tree": "9695959bd28e9b126674996c8fb47f39e7ae059c",
-    "source_sha": "acb87669c54dc941d94d72cdd81e4a71a0fcd591"
+    "source_sha": "478b21e8599a2230bc8143f92dce87b2383fe06b"
   },
   "continuity": {
     "falsification_sha256": "4b8c2682cf01881cbd545f60e816e92f096ebace9bb5014cc07f6fa48dd2fe5f",
@@ -71,7 +71,7 @@
     "pre_issue_output_parity": {
       "baseline_source_sha": "7db472bae53867a0e2c2b5f7108c469bbe28819a",
       "byte_identical_repositories": 7,
-      "candidate_source_sha": "acb87669c54dc941d94d72cdd81e4a71a0fcd591",
+      "candidate_source_sha": "478b21e8599a2230bc8143f92dce87b2383fe06b",
       "raw_artifact_sha256": "0524b65e1f2d77efa50ea6eff9b51c86b6a2711fb708bb3635f833834fff3fa3",
       "repository_count": 7,
       "transfer_raw_artifact_sha256": "0298d5dcd36034ed1eb70e65e3bd4596bf33a8c29cd7e5af566becd68e4b501f",

--- a/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
@@ -8,8 +8,8 @@
   "candidate": {
     "binary_code_sha256": "9b8760574a86cefd36a670d70f46f4ac2a80ba18f5b0a09b5a9dee9d74b8690d",
     "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
-    "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
-    "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e"
+    "crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
+    "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b"
   },
   "corpus": {
     "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",

--- a/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
@@ -6,10 +6,10 @@
     "version": "v0.19.0"
   },
   "candidate": {
-    "binary_code_sha256": "d924a693deae8af3c2659154ef51faba76aab77e3d33b0246b20b5a938fa1ef2",
-    "binary_sha256": "8a81f6f416904915a67b8a82eac3c154d4d9296f03a4e7de55a96ca7579f429d",
-    "crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
-    "source_sha": "c3f3caccfb86b6c3b40cc1cbd0714e40baf02471"
+    "binary_code_sha256": "9b8760574a86cefd36a670d70f46f4ac2a80ba18f5b0a09b5a9dee9d74b8690d",
+    "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
+    "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+    "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e"
   },
   "corpus": {
     "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",
@@ -34,19 +34,19 @@
   },
   "issue": 862,
   "measurement": {
-    "adjusted_delta_ms": 110.37266731727868,
-    "adjusted_delta_pct": 1.3425801925177503,
-    "aggregate_baseline_median_ms": 8220.936666009948,
-    "aggregate_current_median_ms": 8325.394790037535,
-    "aggregate_raw_delta_ms": 104.45812402758747,
-    "aggregate_raw_delta_pct": 1.2706353092279263,
+    "adjusted_delta_ms": 133.06908158119768,
+    "adjusted_delta_pct": 1.6324586958299498,
+    "aggregate_baseline_median_ms": 8151.451667421497,
+    "aggregate_current_median_ms": 8303.407373838127,
+    "aggregate_raw_delta_ms": 151.95570641662925,
+    "aggregate_raw_delta_pct": 1.8641551543995911,
     "command": "nose query <repo> all top=0 --format json",
-    "control_baseline_median_ms": 8688.472333946265,
-    "control_current_median_ms": 8682.557790656574,
-    "control_delta_ms": -5.91454328969121,
-    "control_raw_sha256": "25ae8265b95a8d2a0d347d04219f69c4dc8b567ae0973d38fa91b6143b0830f1",
+    "control_baseline_median_ms": 8907.669874257408,
+    "control_current_median_ms": 8926.55649909284,
+    "control_delta_ms": 18.886624835431576,
+    "control_raw_sha256": "ce3837af9858b5cafb9afc7120d60441a121fec06a0ddda90d0fef26941d9a27",
     "iterations": 9,
-    "primary_raw_sha256": "d50e38e4c6884b6b0fb710a307e2a79c2a6203aaa31f6a569f5d303a8cf19609",
+    "primary_raw_sha256": "9a3f0c529216644817f6bc5a896e6e7b859dc75998c2f862d7c736d372b2c323",
     "warmups": 2
   },
   "parent_issue": 855,

--- a/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
@@ -1,0 +1,54 @@
+{
+  "baseline": {
+    "binary_code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+    "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+    "source_sha": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+    "version": "v0.19.0"
+  },
+  "candidate": {
+    "binary_code_sha256": "d924a693deae8af3c2659154ef51faba76aab77e3d33b0246b20b5a938fa1ef2",
+    "binary_sha256": "8a81f6f416904915a67b8a82eac3c154d4d9296f03a4e7de55a96ca7579f429d",
+    "crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
+    "source_sha": "c3f3caccfb86b6c3b40cc1cbd0714e40baf02471"
+  },
+  "corpus": {
+    "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",
+    "corpus_state_sha256": "781b5c5082c5ddf03cf5a3b3622eb4944bd2389b233e8a593b08f54e96ef6eda",
+    "expected_corpus_state_sha256": "b28d7245aa34d7e0320d0c80ef988803ba6acb65b63eaf1bae6d7ac840b168e0",
+    "prune_manifest_sha256": "c22f34d3ab4da9b89b5938140bbfdf7664178b3b7b57e5ea3937ba0bb47c2980",
+    "repositories": [
+      "alamofire",
+      "guava",
+      "hugo",
+      "netty",
+      "rxjava",
+      "sqlalchemy",
+      "sympy"
+    ],
+    "selection_sha256": "71f212ab2cddd5d59494b244f8a6b2be20cbf021d6a20c9ac33ffe6adc5a22f6",
+    "subset_sha256": "7247d64112bc20749de43d91fb86c6f288ae09271a08d67b68aa252d5abb5804"
+  },
+  "gate": {
+    "adjusted_delta_pct_limit": 5.0,
+    "passed": true
+  },
+  "issue": 862,
+  "measurement": {
+    "adjusted_delta_ms": 110.37266731727868,
+    "adjusted_delta_pct": 1.3425801925177503,
+    "aggregate_baseline_median_ms": 8220.936666009948,
+    "aggregate_current_median_ms": 8325.394790037535,
+    "aggregate_raw_delta_ms": 104.45812402758747,
+    "aggregate_raw_delta_pct": 1.2706353092279263,
+    "command": "nose query <repo> all top=0 --format json",
+    "control_baseline_median_ms": 8688.472333946265,
+    "control_current_median_ms": 8682.557790656574,
+    "control_delta_ms": -5.91454328969121,
+    "control_raw_sha256": "25ae8265b95a8d2a0d347d04219f69c4dc8b567ae0973d38fa91b6143b0830f1",
+    "iterations": 9,
+    "primary_raw_sha256": "d50e38e4c6884b6b0fb710a307e2a79c2a6203aaa31f6a569f5d303a8cf19609",
+    "warmups": 2
+  },
+  "parent_issue": 855,
+  "schema": "nose.issue-862.performance/v1"
+}

--- a/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
+++ b/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
@@ -1,0 +1,44 @@
+{
+  "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
+  "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+  "issue": 862,
+  "parent_issue": 855,
+  "raw_census": {
+    "schema": "nose-oracle-exclusion-census/v2",
+    "sha256": "c3afa0b0c8807fe9dd4e5783135788b335004b112b06a2c6c8a833f7e4deae7d"
+  },
+  "schema": "nose-soundness-current-exclusion-attribution/v1",
+  "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e",
+  "summary": {
+    "by_capability": {
+      "budget.oracle-cost": 1,
+      "budget.symbolic-branch-sites": 6,
+      "il.conditional-shape": 62,
+      "il.expression-node-unsupported": 2304,
+      "il.fragment-core-span": 1,
+      "il.literal-payload-missing": 100,
+      "il.statement-node-unsupported": 74,
+      "il.variable-identity-missing": 7969,
+      "protocol.assignment-target": 61,
+      "protocol.field-write-proof": 17,
+      "value.binding-missing": 56,
+      "value.condition-truthiness": 492,
+      "value.empty-fingerprint": 1,
+      "value.hof-predicate-truthiness": 3,
+      "value.literal-not-retained": 28,
+      "value.loop-condition-truthiness": 3
+    },
+    "by_classification": {
+      "core-span-missing": 1,
+      "empty-value-fingerprint": 1,
+      "missing-oracle-support": 10507,
+      "oracle-cost-budget": 1,
+      "path-exploration-budget": 6,
+      "semantic-boundary-attributed": 662
+    },
+    "excluded_units": 11178,
+    "generic_unattributed_exclusions": 0,
+    "interpretable_units": 2612,
+    "total_units": 13790
+  }
+}

--- a/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
+++ b/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
@@ -1,27 +1,27 @@
 {
   "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
-  "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+  "crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
   "issue": 862,
   "parent_issue": 855,
   "raw_census": {
     "schema": "nose-oracle-exclusion-census/v2",
-    "sha256": "c3afa0b0c8807fe9dd4e5783135788b335004b112b06a2c6c8a833f7e4deae7d"
+    "sha256": "6d6137b6fe831b5657500c0f4fec77b77c0a6a26d20d6ae76defbcae765f1a1f"
   },
   "schema": "nose-soundness-current-exclusion-attribution/v1",
-  "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e",
+  "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b",
   "summary": {
     "by_capability": {
       "budget.oracle-cost": 1,
       "budget.symbolic-branch-sites": 6,
-      "il.conditional-shape": 62,
-      "il.expression-node-unsupported": 2304,
+      "il.conditional-shape": 64,
+      "il.expression-node-unsupported": 2302,
       "il.fragment-core-span": 1,
       "il.literal-payload-missing": 100,
       "il.statement-node-unsupported": 74,
-      "il.variable-identity-missing": 7969,
+      "il.variable-identity-missing": 7972,
       "protocol.assignment-target": 61,
       "protocol.field-write-proof": 17,
-      "value.binding-missing": 56,
+      "value.binding-missing": 57,
       "value.condition-truthiness": 492,
       "value.empty-fingerprint": 1,
       "value.hof-predicate-truthiness": 3,
@@ -31,14 +31,14 @@
     "by_classification": {
       "core-span-missing": 1,
       "empty-value-fingerprint": 1,
-      "missing-oracle-support": 10507,
+      "missing-oracle-support": 10511,
       "oracle-cost-budget": 1,
       "path-exploration-budget": 6,
       "semantic-boundary-attributed": 662
     },
-    "excluded_units": 11178,
+    "excluded_units": 11182,
     "generic_unattributed_exclusions": 0,
     "interpretable_units": 2612,
-    "total_units": 13790
+    "total_units": 13794
   }
 }

--- a/bench/soundness/0.20.0/nightly-advisory-baseline.v1.json
+++ b/bench/soundness/0.20.0/nightly-advisory-baseline.v1.json
@@ -1,0 +1,491 @@
+{
+  "repositories": [
+    {
+      "advisory": 11,
+      "id": "alacritty"
+    },
+    {
+      "advisory": 30,
+      "id": "alamofire"
+    },
+    {
+      "advisory": 119,
+      "id": "antlr4"
+    },
+    {
+      "advisory": 0,
+      "id": "arrow"
+    },
+    {
+      "advisory": 0,
+      "id": "asciidoctor"
+    },
+    {
+      "advisory": 0,
+      "id": "axios"
+    },
+    {
+      "advisory": 0,
+      "id": "badger"
+    },
+    {
+      "advisory": 0,
+      "id": "bat"
+    },
+    {
+      "advisory": 66,
+      "id": "black"
+    },
+    {
+      "advisory": 3,
+      "id": "boltons"
+    },
+    {
+      "advisory": 0,
+      "id": "chi"
+    },
+    {
+      "advisory": 8,
+      "id": "clap"
+    },
+    {
+      "advisory": 0,
+      "id": "click"
+    },
+    {
+      "advisory": 0,
+      "id": "cmark"
+    },
+    {
+      "advisory": 0,
+      "id": "cobra"
+    },
+    {
+      "advisory": 142,
+      "id": "commons-lang"
+    },
+    {
+      "advisory": 1,
+      "id": "curl"
+    },
+    {
+      "advisory": 0,
+      "id": "date-fns"
+    },
+    {
+      "advisory": 19,
+      "id": "delve"
+    },
+    {
+      "advisory": 0,
+      "id": "devise"
+    },
+    {
+      "advisory": 4,
+      "id": "drizzle-orm"
+    },
+    {
+      "advisory": 3,
+      "id": "esbuild"
+    },
+    {
+      "advisory": 32,
+      "id": "etcd"
+    },
+    {
+      "advisory": 0,
+      "id": "execa"
+    },
+    {
+      "advisory": 0,
+      "id": "faraday"
+    },
+    {
+      "advisory": 0,
+      "id": "fastlane"
+    },
+    {
+      "advisory": 0,
+      "id": "fd"
+    },
+    {
+      "advisory": 0,
+      "id": "flask"
+    },
+    {
+      "advisory": 0,
+      "id": "fzf"
+    },
+    {
+      "advisory": 2,
+      "id": "gin"
+    },
+    {
+      "advisory": 15,
+      "id": "git"
+    },
+    {
+      "advisory": 11,
+      "id": "gorm"
+    },
+    {
+      "advisory": 45,
+      "id": "graphhopper"
+    },
+    {
+      "advisory": 17,
+      "id": "gson"
+    },
+    {
+      "advisory": 775,
+      "id": "guava"
+    },
+    {
+      "advisory": 154,
+      "id": "h2database"
+    },
+    {
+      "advisory": 0,
+      "id": "httpie"
+    },
+    {
+      "advisory": 0,
+      "id": "httpx"
+    },
+    {
+      "advisory": 18,
+      "id": "hugo"
+    },
+    {
+      "advisory": 0,
+      "id": "hyperfine"
+    },
+    {
+      "advisory": 6,
+      "id": "image"
+    },
+    {
+      "advisory": 45,
+      "id": "jackson-core"
+    },
+    {
+      "advisory": 999,
+      "id": "jedis"
+    },
+    {
+      "advisory": 0,
+      "id": "jekyll"
+    },
+    {
+      "advisory": 3,
+      "id": "jest"
+    },
+    {
+      "advisory": 0,
+      "id": "jq"
+    },
+    {
+      "advisory": 8,
+      "id": "jsoup"
+    },
+    {
+      "advisory": 137,
+      "id": "junit5"
+    },
+    {
+      "advisory": 5,
+      "id": "kingfisher"
+    },
+    {
+      "advisory": 0,
+      "id": "kramdown"
+    },
+    {
+      "advisory": 0,
+      "id": "ky"
+    },
+    {
+      "advisory": 703,
+      "id": "libgdx"
+    },
+    {
+      "advisory": 0,
+      "id": "libsodium"
+    },
+    {
+      "advisory": 6,
+      "id": "libuv"
+    },
+    {
+      "advisory": 1,
+      "id": "liquid"
+    },
+    {
+      "advisory": 2,
+      "id": "lua"
+    },
+    {
+      "advisory": 0,
+      "id": "marked"
+    },
+    {
+      "advisory": 3,
+      "id": "marshmallow"
+    },
+    {
+      "advisory": 10,
+      "id": "meilisearch"
+    },
+    {
+      "advisory": 6,
+      "id": "minio"
+    },
+    {
+      "advisory": 19,
+      "id": "mockito"
+    },
+    {
+      "advisory": 2,
+      "id": "nats-server"
+    },
+    {
+      "advisory": 611,
+      "id": "netty"
+    },
+    {
+      "advisory": 0,
+      "id": "nginx"
+    },
+    {
+      "advisory": 2,
+      "id": "nimble"
+    },
+    {
+      "advisory": 44,
+      "id": "nushell"
+    },
+    {
+      "advisory": 0,
+      "id": "packaging"
+    },
+    {
+      "advisory": 0,
+      "id": "pixijs"
+    },
+    {
+      "advisory": 3,
+      "id": "poetry"
+    },
+    {
+      "advisory": 0,
+      "id": "prettier"
+    },
+    {
+      "advisory": 29,
+      "id": "prometheus"
+    },
+    {
+      "advisory": 1,
+      "id": "pry"
+    },
+    {
+      "advisory": 0,
+      "id": "puma"
+    },
+    {
+      "advisory": 0,
+      "id": "quick"
+    },
+    {
+      "advisory": 1,
+      "id": "rack"
+    },
+    {
+      "advisory": 0,
+      "id": "radash"
+    },
+    {
+      "advisory": 16,
+      "id": "raylib"
+    },
+    {
+      "advisory": 9,
+      "id": "redis"
+    },
+    {
+      "advisory": 42,
+      "id": "regex"
+    },
+    {
+      "advisory": 2,
+      "id": "requests"
+    },
+    {
+      "advisory": 0,
+      "id": "retrofit"
+    },
+    {
+      "advisory": 0,
+      "id": "rich"
+    },
+    {
+      "advisory": 0,
+      "id": "ripgrep"
+    },
+    {
+      "advisory": 0,
+      "id": "rspec-core"
+    },
+    {
+      "advisory": 2,
+      "id": "rubocop"
+    },
+    {
+      "advisory": 8,
+      "id": "rustls"
+    },
+    {
+      "advisory": 129,
+      "id": "rxjava"
+    },
+    {
+      "advisory": 1,
+      "id": "rxjs"
+    },
+    {
+      "advisory": 192,
+      "id": "rxswift"
+    },
+    {
+      "advisory": 5,
+      "id": "scrapy"
+    },
+    {
+      "advisory": 1,
+      "id": "serde_json"
+    },
+    {
+      "advisory": 1,
+      "id": "sidekiq"
+    },
+    {
+      "advisory": 0,
+      "id": "sinatra"
+    },
+    {
+      "advisory": 1,
+      "id": "sled"
+    },
+    {
+      "advisory": 16,
+      "id": "sqlalchemy"
+    },
+    {
+      "advisory": 32,
+      "id": "sqlite"
+    },
+    {
+      "advisory": 1,
+      "id": "swift-algorithms"
+    },
+    {
+      "advisory": 4,
+      "id": "swift-argument-parser"
+    },
+    {
+      "advisory": 26,
+      "id": "swift-collections"
+    },
+    {
+      "advisory": 5,
+      "id": "swift-composable-architecture"
+    },
+    {
+      "advisory": 0,
+      "id": "swift-log"
+    },
+    {
+      "advisory": 2,
+      "id": "swift-metrics"
+    },
+    {
+      "advisory": 6,
+      "id": "swift-nio"
+    },
+    {
+      "advisory": 0,
+      "id": "swift-service-lifecycle"
+    },
+    {
+      "advisory": 1,
+      "id": "swiftlint"
+    },
+    {
+      "advisory": 2,
+      "id": "swr"
+    },
+    {
+      "advisory": 67,
+      "id": "sympy"
+    },
+    {
+      "advisory": 0,
+      "id": "thor"
+    },
+    {
+      "advisory": 0,
+      "id": "tmux"
+    },
+    {
+      "advisory": 0,
+      "id": "tokei"
+    },
+    {
+      "advisory": 13,
+      "id": "tokio"
+    },
+    {
+      "advisory": 7,
+      "id": "trpc"
+    },
+    {
+      "advisory": 15,
+      "id": "urfave-cli"
+    },
+    {
+      "advisory": 0,
+      "id": "vapor"
+    },
+    {
+      "advisory": 18,
+      "id": "vim"
+    },
+    {
+      "advisory": 0,
+      "id": "wrk"
+    },
+    {
+      "advisory": 1,
+      "id": "zap"
+    },
+    {
+      "advisory": 5,
+      "id": "zod"
+    },
+    {
+      "advisory": 5,
+      "id": "zstd"
+    },
+    {
+      "advisory": 0,
+      "id": "zustand"
+    }
+  ],
+  "schema": "nose-corpus-advisory-baseline/v1",
+  "source": {
+    "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+    "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",
+    "version": "0.19.0"
+  },
+  "total": 4756
+}

--- a/bench/soundness/0.20.0/oracle-expansion-859.v1.json
+++ b/bench/soundness/0.20.0/oracle-expansion-859.v1.json
@@ -14,7 +14,7 @@
     },
     "performance": {
       "path": "../../recall_loss/issue-859-official-v0.19.0-performance-2026-07-17.v1.json",
-      "sha256": "d0407b56f4ab829ec10a1c94189566d5bdb52934c4c8a889106f0270d3ae5eee"
+      "sha256": "d6ee837cf8ffce97b185bf428db82b0029d999a12d0fc6451864c57b56d69c9a"
     }
   },
   "branch_base": "7db472bae53867a0e2c2b5f7108c469bbe28819a",
@@ -55,7 +55,7 @@
     "release_target_ppm": 424999,
     "scorecard_sha256": "b5edb7340a7a9c7b45bb6ba8c561c77315955059016f971cf25332cf8e2f60f2"
   },
-  "implementation_source_sha": "acb87669c54dc941d94d72cdd81e4a71a0fcd591",
+  "implementation_source_sha": "478b21e8599a2230bc8143f92dce87b2383fe06b",
   "implementation_crates_tree": "9695959bd28e9b126674996c8fb47f39e7ae059c",
   "issue": 859,
   "parent_issue": 855,

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -2,7 +2,11 @@
   "artifacts": {
     "blind_attack": {
       "path": "../../type4/blind_attack.v1.json",
-      "sha256": "67d1eedc77c9c6fed7daefe7770966b069a2f618f4178bcb0ce1c3768eacb788"
+      "sha256": "688d4f46c689cfe7473f999f2800c0d39d99be499c5e81069a79e1f3e8ada7b5"
+    },
+    "current_exclusion_attribution": {
+      "path": "current-exclusion-attribution-862.v1.json",
+      "sha256": "741a2d25907332ddaa8ffa03eabfc5109eab1778eb984fa80535a27db3b01583"
     },
     "expansion_receipt": {
       "path": "oracle-expansion-859.v1.json",
@@ -10,7 +14,7 @@
     },
     "falsification": {
       "path": "release-falsification-862.v1.txt",
-      "sha256": "8475256e910856862e97e171b32eb01ac785100e5d8cdc233a1be0ddcc4b76b9"
+      "sha256": "733d3a9022ecec5aee68e6b974c736a9806d3d17f0eff0eec288bf72af41ba1d"
     },
     "historical_overlay": {
       "path": "oracle-expansion-overlay.v2.json",
@@ -18,16 +22,16 @@
     },
     "overlay": {
       "path": "release-overlay-862.v1.json",
-      "sha256": "8a6c8b43fe33657e459d1efa1e5577d70e23350b787807364946ed1ded40a419"
+      "sha256": "802ecee41defb6cef5f7970d1fc3e2c8f8d63dbf9318ae94b75397fcb6e9de08"
     },
     "performance": {
       "path": "../../recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json",
-      "sha256": "4ebb58e8375b4932a260dcdfa6968384d45a3d5449d8e71b8a4a7844c282ca8b"
+      "sha256": "8f157d4b28a2f96bce444704757cdb0063e7d5305d5a373b0afead722de33357"
     }
   },
   "completeness": {
-    "behavior_equal_pairs": 222,
-    "fingerprint_equal_pairs": 108,
+    "behavior_equal_pairs": 221,
+    "fingerprint_equal_pairs": 107,
     "structurally_near_under_merged_groups": 0,
     "under_merged_behavior_groups": 8
   },
@@ -36,23 +40,23 @@
     "score_and_pair_status_unchanged": true
   },
   "falsification": {
-    "advisory_disagreements": 59,
+    "advisory_disagreements": 64,
     "canon_checked": 304,
     "canon_preservation_violations": 0,
     "eligible_pairs": 63,
     "executed_cases": 25766,
     "false_merges": 0,
-    "interpretable_units": 2520,
+    "interpretable_units": 2612,
     "new_distinguishers": 0,
     "searched_pairs": 63,
     "skipped_pairs": 0,
-    "total_units": 13283
+    "total_units": 13790
   },
   "implementation": {
-    "binary_sha256": "8a81f6f416904915a67b8a82eac3c154d4d9296f03a4e7de55a96ca7579f429d",
-    "crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
-    "raw_units_sha256": "35e8ecd90f839bcc1c7cd55c8437049c528979145c667c18e83b608bf09fd1d4",
-    "source_sha": "c3f3caccfb86b6c3b40cc1cbd0714e40baf02471"
+    "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
+    "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+    "raw_units_sha256": "ddbf5e83f194a28f5607a1eb4c15523c0d448d877fc834968d39f8c9ecc41341",
+    "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e"
   },
   "issue": 862,
   "parent_issue": 855,
@@ -78,7 +82,7 @@
   },
   "result": {
     "baseline_verified_pair_regressions": [],
-    "candidate_cohort_sha256": "aba9aff33baef8682addebcbfa8b684cb0401fac501d158f8bb17085f11ee574",
+    "candidate_cohort_sha256": "218f1aa3b3c58fe9f832eddf3c05b423f97f5a0ed31ed26bcfe8a0159e7ecb79",
     "denominator_unchanged": true,
     "exact_unsafe_pair_mass": 62,
     "gate_passed": true,

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -2,11 +2,11 @@
   "artifacts": {
     "blind_attack": {
       "path": "../../type4/blind_attack.v1.json",
-      "sha256": "688d4f46c689cfe7473f999f2800c0d39d99be499c5e81069a79e1f3e8ada7b5"
+      "sha256": "622601e62ed10b5b822ca606397dd7ab1ef97f47b31f2ce88dbae22a8cdb4c4c"
     },
     "current_exclusion_attribution": {
       "path": "current-exclusion-attribution-862.v1.json",
-      "sha256": "741a2d25907332ddaa8ffa03eabfc5109eab1778eb984fa80535a27db3b01583"
+      "sha256": "57774fad7159f6038624e5ec4f2683e7107a863de6eca0bb70259ec400d6045a"
     },
     "expansion_receipt": {
       "path": "oracle-expansion-859.v1.json",
@@ -14,7 +14,7 @@
     },
     "falsification": {
       "path": "release-falsification-862.v1.txt",
-      "sha256": "733d3a9022ecec5aee68e6b974c736a9806d3d17f0eff0eec288bf72af41ba1d"
+      "sha256": "62812503900c9e32481ced7493a603a615529faff5be35e9153e8ee5fc1b7046"
     },
     "historical_overlay": {
       "path": "oracle-expansion-overlay.v2.json",
@@ -26,7 +26,7 @@
     },
     "performance": {
       "path": "../../recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json",
-      "sha256": "8f157d4b28a2f96bce444704757cdb0063e7d5305d5a373b0afead722de33357"
+      "sha256": "b5cc9acbd0657cf1c215c4a2367477e1e12e02b41e0d16925c51c0fbea8f5386"
     }
   },
   "completeness": {
@@ -50,13 +50,13 @@
     "new_distinguishers": 0,
     "searched_pairs": 63,
     "skipped_pairs": 0,
-    "total_units": 13790
+    "total_units": 13794
   },
   "implementation": {
     "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
-    "crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+    "crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
     "raw_units_sha256": "ddbf5e83f194a28f5607a1eb4c15523c0d448d877fc834968d39f8c9ecc41341",
-    "source_sha": "a75c3d8c924513d59e6ae4a97941e6241f4ca01e"
+    "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b"
   },
   "issue": 862,
   "parent_issue": 855,

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -1,0 +1,92 @@
+{
+  "artifacts": {
+    "blind_attack": {
+      "path": "../../type4/blind_attack.v1.json",
+      "sha256": "67d1eedc77c9c6fed7daefe7770966b069a2f618f4178bcb0ce1c3768eacb788"
+    },
+    "expansion_receipt": {
+      "path": "oracle-expansion-859.v1.json",
+      "sha256": "fea5783c139b9bf5bbd385cd30a9cddc3604ea7b80ae903eb195c575c7186fbf"
+    },
+    "falsification": {
+      "path": "release-falsification-862.v1.txt",
+      "sha256": "8475256e910856862e97e171b32eb01ac785100e5d8cdc233a1be0ddcc4b76b9"
+    },
+    "historical_overlay": {
+      "path": "oracle-expansion-overlay.v2.json",
+      "sha256": "7f29837556de24e3abd0628a6def5ae1e3b882c5954a2ae4d7c1a3158933309c"
+    },
+    "overlay": {
+      "path": "release-overlay-862.v1.json",
+      "sha256": "8a6c8b43fe33657e459d1efa1e5577d70e23350b787807364946ed1ded40a419"
+    },
+    "performance": {
+      "path": "../../recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json",
+      "sha256": "4ebb58e8375b4932a260dcdfa6968384d45a3d5449d8e71b8a4a7844c282ca8b"
+    }
+  },
+  "completeness": {
+    "behavior_equal_pairs": 222,
+    "fingerprint_equal_pairs": 108,
+    "structurally_near_under_merged_groups": 0,
+    "under_merged_behavior_groups": 8
+  },
+  "continuity": {
+    "reason": "The mixed-exit control coordinate changes fragment fingerprint identities but preserves every frozen pair decision, coverage aggregate, and language floor from the completed issue-859 expansion.",
+    "score_and_pair_status_unchanged": true
+  },
+  "falsification": {
+    "advisory_disagreements": 59,
+    "canon_checked": 304,
+    "canon_preservation_violations": 0,
+    "eligible_pairs": 63,
+    "executed_cases": 25766,
+    "false_merges": 0,
+    "interpretable_units": 2520,
+    "new_distinguishers": 0,
+    "searched_pairs": 63,
+    "skipped_pairs": 0,
+    "total_units": 13283
+  },
+  "implementation": {
+    "binary_sha256": "8a81f6f416904915a67b8a82eac3c154d4d9296f03a4e7de55a96ca7579f429d",
+    "crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
+    "raw_units_sha256": "35e8ecd90f839bcc1c7cd55c8437049c528979145c667c18e83b608bf09fd1d4",
+    "source_sha": "c3f3caccfb86b6c3b40cc1cbd0714e40baf02471"
+  },
+  "issue": 862,
+  "parent_issue": 855,
+  "release_tree": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+  "reproduction": {
+    "falsification_argv": [
+      "verify",
+      "crates",
+      "--max-violations",
+      "0",
+      "--falsify"
+    ],
+    "rayon_num_threads": 1,
+    "units_argv": [
+      "verify",
+      "crates",
+      "--json",
+      "--max-violations",
+      "0",
+      "--soundness-tranche",
+      "unused-trailing-parameters"
+    ]
+  },
+  "result": {
+    "baseline_verified_pair_regressions": [],
+    "candidate_cohort_sha256": "aba9aff33baef8682addebcbfa8b684cb0401fac501d158f8bb17085f11ee574",
+    "denominator_unchanged": true,
+    "exact_unsafe_pair_mass": 62,
+    "gate_passed": true,
+    "language_regressions": [],
+    "macro_ppm": 457620,
+    "pair_micro_ppm": 360824,
+    "release_target_met": true,
+    "verified_pair_mass": 35
+  },
+  "schema": "nose-soundness-release-binding/v1"
+}

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -10,7 +10,7 @@
     },
     "expansion_receipt": {
       "path": "oracle-expansion-859.v1.json",
-      "sha256": "fea5783c139b9bf5bbd385cd30a9cddc3604ea7b80ae903eb195c575c7186fbf"
+      "sha256": "92d991811e8c93948ca0276e661a407b8b6c0fbf20f27c2fd71ffea5103aded0"
     },
     "falsification": {
       "path": "release-falsification-862.v1.txt",

--- a/bench/soundness/0.20.0/release-falsification-862.v1.txt
+++ b/bench/soundness/0.20.0/release-falsification-862.v1.txt
@@ -1,11 +1,11 @@
 === value-graph oracle (soundness + completeness) ===
-units: 13283 total, 2520 interpretable (10763 excluded)
+units: 13790 total, 2612 interpretable (11178 excluded)
 
 EXCLUSIONS — fail-closed units by reason:
   core-missing: 1
   battery-bail: 1 (>384000 node-rows)
   empty-fingerprint: 1
-  uninterpretable: 10754
+  uninterpretable: 11169
   path-bail: 6 (> 3 symbolic branch sites)
 
 CANON PRESERVATION — normalization preserves behavior:
@@ -13,11 +13,11 @@ CANON PRESERVATION — normalization preserves behavior:
   PRESERVED: every canon-changed unit computes the same thing ✓
 
 SOUNDNESS — fingerprint-equal ⟹ behavior-equal (exact claim surface):
-  fingerprint groups (≥2): 713
+  fingerprint groups (≥2): 746
   SOUND: no false merges ✓
-  advisory (symbolic or non-hard-domain disagreements — divergence, not gated): 59
+  advisory (symbolic or non-hard-domain disagreements — divergence, not gated): 64
     crates/nose-cli/src/divergence/detect.rs:422  ≢?  crates/nose-cli/src/divergence/detect.rs:423-426@15776-15835   (129 differing inputs)
-    crates/nose-cli/src/ignores.rs:473  ≢?  crates/nose-cli/src/ignores.rs:474-480@14920-15084   (64 differing inputs)
+    crates/nose-cli/src/ignores.rs:473  ≢?  crates/nose-cli/src/ignores.rs:474-480@14920-15084   (63 differing inputs)
     crates/nose-cli/src/path_utils.rs:59  ≢?  crates/nose-cli/src/path_utils.rs:65-68@2394-2624   (201 differing inputs)
     crates/nose-cli/src/recall_loss_report/location.rs:5  ≢?  crates/nose-cli/src/recall_loss_report/location.rs:6-12@179-362   (201 differing inputs)
     crates/nose-cli/src/semantic_pack/inventory.rs:185  ≢?  crates/nose-cli/src/semantic_pack/inventory.rs:189-210@6191-7160   (201 differing inputs)
@@ -28,11 +28,11 @@ SOUNDNESS — fingerprint-equal ⟹ behavior-equal (exact claim surface):
     crates/nose-cli/tests/cli/exact_fragments/support.rs:121  ≢?  crates/nose-il/src/span.rs:32-38@957-1083   (198 differing inputs)
 
 COMPLETENESS — behavior-equal ⟹ fingerprint-equal (non-trivial only):
-  behavior groups (≥2): 35
-  completeness: 108/222 = 49% of behavior-equal pairs also converge
+  behavior groups (≥2): 34
+  completeness: 107/221 = 48% of behavior-equal pairs also converge
   under-merged behavior groups (missed clones): 8
   of which structurally-near (max cross-fp vj ≥ 0.7 → behavior-gated near-match would recover): 0
-    vj=0.33  crates/nose-cli/tests/fixtures/string_affix_552/param_suffix_python.py:1  ↮  crates/nose-normalize/src/interp/value.rs:134-134@6206-6212
+    vj=0.33  crates/nose-cli/tests/fixtures/string_affix_552/param_suffix_python.py:1  ↮  crates/nose-normalize/src/interp/value.rs:155-155@6858-6864
     vj=0.33  crates/nose-frontend/src/lower/library_api_evidence.rs:152-154@5279-5333  ↮  crates/nose-semantics/src/method_families.rs:140-142@5123-5169
     vj=0.33  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/instruction_sequence.rs:115-117@2991-3034  ↮  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/instruction_sequence.rs:187-189@5153-5196
     vj=0.33  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/method_objects.rs:331-333@9818-9860  ↮  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/method_objects.rs:436-438@12690-12732
@@ -43,10 +43,10 @@ COMPLETENESS — behavior-equal ⟹ fingerprint-equal (non-trivial only):
 
 CALIBRATION — P(behavior-equal | value-Jaccard) [windowed sample]:
   (the detector accepts an exact match [1.0]; this is how safe near-match is)
-  vj [1.0]  :  2577/2671  =  96% behavior-equal
-  vj [.8,.9) :     0/1     =   0% behavior-equal
-  vj [.7,.8) :     1/10    =  10% behavior-equal
-  vj [.5,.7) :     1/134   =   1% behavior-equal
+  vj [1.0]  :  2605/2704  =  96% behavior-equal
+  vj [.8,.9) :     1/1     = 100% behavior-equal
+  vj [.7,.8) :     1/15    =   7% behavior-equal
+  vj [.5,.7) :     2/135   =   1% behavior-equal
 
 FALSIFICATION SEARCH (#317) — distinguishing inputs beyond the fixed battery:
   eligible pairs: 63; searched: 63; skipped: 0; executed cases: 25766

--- a/bench/soundness/0.20.0/release-falsification-862.v1.txt
+++ b/bench/soundness/0.20.0/release-falsification-862.v1.txt
@@ -1,11 +1,11 @@
 === value-graph oracle (soundness + completeness) ===
-units: 13790 total, 2612 interpretable (11178 excluded)
+units: 13794 total, 2612 interpretable (11182 excluded)
 
 EXCLUSIONS — fail-closed units by reason:
   core-missing: 1
   battery-bail: 1 (>384000 node-rows)
   empty-fingerprint: 1
-  uninterpretable: 11169
+  uninterpretable: 11173
   path-bail: 6 (> 3 symbolic branch sites)
 
 CANON PRESERVATION — normalization preserves behavior:

--- a/bench/soundness/0.20.0/release-falsification-862.v1.txt
+++ b/bench/soundness/0.20.0/release-falsification-862.v1.txt
@@ -1,0 +1,55 @@
+=== value-graph oracle (soundness + completeness) ===
+units: 13283 total, 2520 interpretable (10763 excluded)
+
+EXCLUSIONS — fail-closed units by reason:
+  core-missing: 1
+  battery-bail: 1 (>384000 node-rows)
+  empty-fingerprint: 1
+  uninterpretable: 10754
+  path-bail: 6 (> 3 symbolic branch sites)
+
+CANON PRESERVATION — normalization preserves behavior:
+  units checked (interpretable both ways): 304
+  PRESERVED: every canon-changed unit computes the same thing ✓
+
+SOUNDNESS — fingerprint-equal ⟹ behavior-equal (exact claim surface):
+  fingerprint groups (≥2): 713
+  SOUND: no false merges ✓
+  advisory (symbolic or non-hard-domain disagreements — divergence, not gated): 59
+    crates/nose-cli/src/divergence/detect.rs:422  ≢?  crates/nose-cli/src/divergence/detect.rs:423-426@15776-15835   (129 differing inputs)
+    crates/nose-cli/src/ignores.rs:473  ≢?  crates/nose-cli/src/ignores.rs:474-480@14920-15084   (64 differing inputs)
+    crates/nose-cli/src/path_utils.rs:59  ≢?  crates/nose-cli/src/path_utils.rs:65-68@2394-2624   (201 differing inputs)
+    crates/nose-cli/src/recall_loss_report/location.rs:5  ≢?  crates/nose-cli/src/recall_loss_report/location.rs:6-12@179-362   (201 differing inputs)
+    crates/nose-cli/src/semantic_pack/inventory.rs:185  ≢?  crates/nose-cli/src/semantic_pack/inventory.rs:189-210@6191-7160   (201 differing inputs)
+    crates/nose-cli/src/verify_admission.rs:116  ≢?  crates/nose-cli/src/verify_admission.rs:117-118@4037-4117   (201 differing inputs)
+    crates/nose-cli/tests/cli/exact_fragments/support.rs:121  ≢?  crates/nose-detect/src/fragment/contract.rs:124   (201 differing inputs)
+    crates/nose-cli/tests/cli/exact_fragments/support.rs:121  ≢?  crates/nose-detect/src/fragment/contract.rs:131-137@5477-5600   (201 differing inputs)
+    crates/nose-cli/tests/cli/exact_fragments/support.rs:121  ≢?  crates/nose-il/src/span.rs:25   (198 differing inputs)
+    crates/nose-cli/tests/cli/exact_fragments/support.rs:121  ≢?  crates/nose-il/src/span.rs:32-38@957-1083   (198 differing inputs)
+
+COMPLETENESS — behavior-equal ⟹ fingerprint-equal (non-trivial only):
+  behavior groups (≥2): 35
+  completeness: 108/222 = 49% of behavior-equal pairs also converge
+  under-merged behavior groups (missed clones): 8
+  of which structurally-near (max cross-fp vj ≥ 0.7 → behavior-gated near-match would recover): 0
+    vj=0.33  crates/nose-cli/tests/fixtures/string_affix_552/param_suffix_python.py:1  ↮  crates/nose-normalize/src/interp/value.rs:134-134@6206-6212
+    vj=0.33  crates/nose-frontend/src/lower/library_api_evidence.rs:152-154@5279-5333  ↮  crates/nose-semantics/src/method_families.rs:140-142@5123-5169
+    vj=0.33  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/instruction_sequence.rs:115-117@2991-3034  ↮  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/instruction_sequence.rs:187-189@5153-5196
+    vj=0.33  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/method_objects.rs:331-333@9818-9860  ↮  crates/nose-semantics/src/ruby_redefinitions/dynamic_method_changes/method_objects.rs:436-438@12690-12732
+    vj=0.29  crates/nose-normalize/src/value_graph/collections/cardinality.rs:142-144@4789-4844  ↮  crates/nose-normalize/src/value_graph/collections/reductions.rs:234-236@10365-10420
+    vj=0.27  crates/nose-semantics/src/library_api/callee_dependencies/span.rs:207-209@6922-6963  ↮  crates/nose-semantics/src/library_api/callee_dependencies/span.rs:232-234@7487-7528
+    vj=0.27  crates/nose-detect/src/abstraction.rs:120-122@2954-3001  ↮  crates/nose-detect/src/connected.rs:455-457@16789-16838
+    vj=0.00  crates/nose-cli/src/divergence/detect.rs:423-426@15776-15835  ↮  crates/nose-il/src/node/evidence.rs:30
+
+CALIBRATION — P(behavior-equal | value-Jaccard) [windowed sample]:
+  (the detector accepts an exact match [1.0]; this is how safe near-match is)
+  vj [1.0]  :  2577/2671  =  96% behavior-equal
+  vj [.8,.9) :     0/1     =   0% behavior-equal
+  vj [.7,.8) :     1/10    =  10% behavior-equal
+  vj [.5,.7) :     1/134   =   1% behavior-equal
+
+FALSIFICATION SEARCH (#317) — distinguishing inputs beyond the fixed battery:
+  eligible pairs: 63; searched: 63; skipped: 0; executed cases: 25766
+  no new distinguishers — the fixed battery already separates every checked group ✓
+
+GATE: 0 ≤ 0 false merges — OK ✓

--- a/bench/soundness/0.20.0/release-overlay-862.v1.json
+++ b/bench/soundness/0.20.0/release-overlay-862.v1.json
@@ -1,5 +1,5 @@
 {
-  "candidate_cohort_sha256": "aba9aff33baef8682addebcbfa8b684cb0401fac501d158f8bb17085f11ee574",
+  "candidate_cohort_sha256": "218f1aa3b3c58fe9f832eddf3c05b423f97f5a0ed31ed26bcfe8a0159e7ecb79",
   "cells": [
     {
       "baseline_pair_mass": 1,
@@ -171,7 +171,7 @@
       "baseline_status": "exact-unsafe-uninterpretable",
       "candidate_members": [
         {
-          "behavior_hash": "1e8075c8331eed2b",
+          "behavior_hash": "6d9554b263f46217",
           "claimable": true,
           "core_il_sha256": "5f152a6f5935ec602b925ea8e6467fd5c63ba259652d686121c6393abe82c295",
           "domain_hosted": true,
@@ -183,7 +183,7 @@
           "unit_id": "b5dea943b5b97e1c0c8ca1595ef16d38bc14ecd97a2c16652e25dedd481518fd"
         },
         {
-          "behavior_hash": "1e8075c8331eed2b",
+          "behavior_hash": "6d9554b263f46217",
           "claimable": true,
           "core_il_sha256": "5f152a6f5935ec602b925ea8e6467fd5c63ba259652d686121c6393abe82c295",
           "domain_hosted": true,

--- a/bench/soundness/0.20.0/release-overlay-862.v1.json
+++ b/bench/soundness/0.20.0/release-overlay-862.v1.json
@@ -1,0 +1,3747 @@
+{
+  "candidate_cohort_sha256": "aba9aff33baef8682addebcbfa8b684cb0401fac501d158f8bb17085f11ee574",
+  "cells": [
+    {
+      "baseline_pair_mass": 1,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "oracle-gap",
+      "coverage_ppm": 1000000,
+      "exact_unsafe_pair_mass": 0,
+      "language": "cross-language",
+      "obligation_id": "exact-soundness.oracle-gap",
+      "prevalence_weight": 2,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 1,
+      "weight_units": 10
+    },
+    {
+      "baseline_pair_mass": 34,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "oracle-gap",
+      "coverage_ppm": 382352,
+      "exact_unsafe_pair_mass": 21,
+      "language": "rust",
+      "obligation_id": "exact-soundness.oracle-gap",
+      "prevalence_weight": 7,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 13,
+      "weight_units": 35
+    },
+    {
+      "baseline_pair_mass": 20,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "runtime-protocol",
+      "coverage_ppm": 800000,
+      "exact_unsafe_pair_mass": 4,
+      "language": "cross-language",
+      "obligation_id": "exact-soundness.runtime-protocol",
+      "prevalence_weight": 6,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 16,
+      "weight_units": 30
+    },
+    {
+      "baseline_pair_mass": 2,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "runtime-protocol",
+      "coverage_ppm": 1000000,
+      "exact_unsafe_pair_mass": 0,
+      "language": "python",
+      "obligation_id": "exact-soundness.runtime-protocol",
+      "prevalence_weight": 3,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 2,
+      "weight_units": 15
+    },
+    {
+      "baseline_pair_mass": 3,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "runtime-protocol",
+      "coverage_ppm": 666666,
+      "exact_unsafe_pair_mass": 1,
+      "language": "ruby",
+      "obligation_id": "exact-soundness.runtime-protocol",
+      "prevalence_weight": 3,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 2,
+      "weight_units": 15
+    },
+    {
+      "baseline_pair_mass": 20,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "runtime-protocol",
+      "coverage_ppm": 0,
+      "exact_unsafe_pair_mass": 20,
+      "language": "rust",
+      "obligation_id": "exact-soundness.runtime-protocol",
+      "prevalence_weight": 6,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 0,
+      "weight_units": 30
+    },
+    {
+      "baseline_pair_mass": 8,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "runtime-protocol",
+      "coverage_ppm": 125000,
+      "exact_unsafe_pair_mass": 7,
+      "language": "typescript",
+      "obligation_id": "exact-soundness.runtime-protocol",
+      "prevalence_weight": 5,
+      "risk_tier": "tier-a",
+      "risk_weight": 5,
+      "verified_pair_mass": 1,
+      "weight_units": 25
+    },
+    {
+      "baseline_pair_mass": 9,
+      "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+      "construct": "scalar-value",
+      "coverage_ppm": 0,
+      "exact_unsafe_pair_mass": 9,
+      "language": "rust",
+      "obligation_id": "exact-soundness.scalar-value",
+      "prevalence_weight": 5,
+      "risk_tier": "tier-c",
+      "risk_weight": 1,
+      "verified_pair_mass": 0,
+      "weight_units": 5
+    }
+  ],
+  "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+  "frozen_contract": {
+    "baseline_pair_ids_sha256": "612597cd4e9cd61ca684767c22f0fe348b024573f5b810c2f67e1b0d37e22be2",
+    "cell_contract_sha256": "3b58dba70ff657bd3bd996ec4ad0f66be63e3e97c1a4d6f68af9e4ef4fa5c677",
+    "release_target_ppm": 424999,
+    "scorecard_sha256": "b5edb7340a7a9c7b45bb6ba8c561c77315955059016f971cf25332cf8e2f60f2"
+  },
+  "gates": {
+    "baseline_verified_pair_regressions": [],
+    "denominator_unchanged": true,
+    "language_regressions": [],
+    "passed": true,
+    "release_target_met": true
+  },
+  "pair_ledger": [
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "63fc3397b3d9e6d921676a4571cbdb96eb95e4a64a7baa02e9b8fb755379e150"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7658be69bebe0435a892c6906ebc89ee402ee678668beaa22da80058392ef41e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0041f7eb24094544ed17b247ed2ba81ebac62955817debabc81a0a5127b636ff"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "1e8075c8331eed2b",
+          "claimable": true,
+          "core_il_sha256": "5f152a6f5935ec602b925ea8e6467fd5c63ba259652d686121c6393abe82c295",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b5dea943b5b97e1c0c8ca1595ef16d38bc14ecd97a2c16652e25dedd481518fd"
+        },
+        {
+          "behavior_hash": "1e8075c8331eed2b",
+          "claimable": true,
+          "core_il_sha256": "5f152a6f5935ec602b925ea8e6467fd5c63ba259652d686121c6393abe82c295",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "408c60e4fe6e10c23cb61927d564546433ff56800ba63f0f564957ec46e02635"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "02ff7265d564f6c6b31d72e2f6615c05cc56cd459c0fa0321ce5315620c194b4"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "cf0c6ab73bdeca25",
+          "claimable": true,
+          "core_il_sha256": "a84605ddff4b1547e884d4f943c0fe7067e98dd9f2b8f96bbd4cc75dcb0f97ad",
+          "domain_hosted": true,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "c8dc23f0484516fcf983d2548453bc9c2992821786b10aab50735548c43eadd8"
+        },
+        {
+          "behavior_hash": "cf0c6ab73bdeca25",
+          "claimable": true,
+          "core_il_sha256": "a84605ddff4b1547e884d4f943c0fe7067e98dd9f2b8f96bbd4cc75dcb0f97ad",
+          "domain_hosted": true,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "9d3debdde0f09348c7f9bfc6ad0682d619ed68487f8c61ca8739d64cd18a8830"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "python",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0321bd4069cce787caabd00100646f90cb764de5a1a6bf5e30f1c4374974c7c8"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "90ef17e5fb90bbfe417affc95ccb75d689953c88b7b8cd267a979e33df8adb1b"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "efc38b8a200f474531583ef52b260f5ed7cbb00f7fd27773aabdbdeafb590445"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0420f02e54978c88488668759e738b24b68ffbcc41801ca9aebd4859d93b2a29"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "9bdbfde1c7e53d418fbe927ea97982eb31cc546b393d7432188d988aad2cbd54"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0751e98659e639e05da75da04aa500b2588790828b010cf1d7e74dbaee1d1352"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "09ed91230ab266d4e29017a1e792be4b6c9afaa1943bb01f6e1fc0214a5d822c"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7fee9acb3dffaa46cb61613c603b048f19c285b87d54129b615f75c061e66c4d"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "a79bbbdf4cab3f8d615b77345d07460fb6d35bd7e1c0373ab525f7152257c962"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0a0d593970bb74cb289b1e6137731f9b7a8fb3f6518b4f9d385b07b5619832dd"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "908f6834112833b41b77c66cac64551dca32c976e66889f60257ba85448d7bd0"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "154046f9a8535297812db8017c9d71607064aae9d1af9e72545f5d24d781a4d8"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0a4cc4edbf7247f0acc7a2fca7bf95d083675e70008b246a5a1a0f06bad89260"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "48472097bf74745e05aed1200963ba3d335e4fd697251b3f86e37732b0696ac4"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "472cbecf3f89a2ce185766411f5fb7e7160fc8a3cdbe319de6eaa1f329d20cce"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0d10d3bce48edfe9ed40675ac73ac13b884d08f71545ae83524d05212ee7bc0c"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "e686cde9cdda4493d94c4f735aebababb3a34757d9adab7a202e031b333a5451"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "60346d167e6e935306cf09ae456a03fa966092b4f5007ea67695cabe27ba59e6"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0dc51515f9dde1f679be6f1e0fa5b319b0b74daebf0b687aa48bb637f44a1c0f"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "9ae51aa942312f75",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "6b493bf2e674c52a",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7c99bcb1a48e556e4bbd6cee19d99a8b51e5827da472d78b3c4576ae4f4ce0ab"
+        },
+        {
+          "behavior_hash": "1df0fbc82b9f337d",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "76e9ad45af3595fe0370ca34d1e8657ad8f359b904c74b816f8ca78a45181ce8"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "0decc25270d3dcedbd2c034525ebdb1415b60f1e330b9d70ea25b9d6628a7207"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0f02a2f6bc3ee917fbf2e44ae60cbebfad131e184036903e3a29440677b4feef"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "4a88f625f8767769",
+          "claimable": true,
+          "core_il_sha256": "a46db326d5242ecd0133a01a07bb5021db236df5231ab21aa13eea74227be338",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": true,
+          "unit_id": "f521fc76c8e8204375d9fe0f88ccc83f70512c348e4444bd6285f6ee15dc7af6"
+        },
+        {
+          "behavior_hash": "4a88f625f8767769",
+          "claimable": true,
+          "core_il_sha256": "a46db326d5242ecd0133a01a07bb5021db236df5231ab21aa13eea74227be338",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": true,
+          "unit_id": "8292f93edabcdb28ca46c89efe5b8a6cb7819deba45f7ac6fa8fdfd97b411726"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0fbd198546516c438caf12f3847c9674e23c2e5a5d8d0682cfbe9d508bf93fe4"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7fee9acb3dffaa46cb61613c603b048f19c285b87d54129b615f75c061e66c4d"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b2beecd92111f0956378daa3718c179474114ab8bea2c43fa3b9b7b8a6d077c4"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "0ff03a0ecab38bad46ea73cd4ecf6bcc778aba188092842ac78a2dffe265433a"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "e686cde9cdda4493d94c4f735aebababb3a34757d9adab7a202e031b333a5451"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "d377b26358c61bd5c0dcfff9093dae22451b5956b4a63b6cd835760a608ca355"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1010987f330603eb813dea6a319b978ccaa7c5bdef60272473e31b5ad234982d"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "73c401bec8608e3cd4306a719f24b202625e6139f5d88d6f932ce0148a78fe41"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "2a56450284232e2fc08b4789a65c4e6f42805534cae2dc388bf6302b1c4a890e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1257501697ea0b3ef177b33220aa43170aae5cd4acb2a7b44231d222fa05514e"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b381ad622b00afe32ab33ea72c3e896bb9126700f6fe0393536af04310940800"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "f74b510ba0e39572d5bbeca8bf5852d8b963f3c2b2370bffbb1af87634dccfcf"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "12adb16a57efe125af356476ea98c0468c9e1704d1de3f7ede650e6d8d0756af"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0e309268793df933dbdf151b46d23410fe543407b767aed57e8726702f1f59a5"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "d82f6211eda4c31ff80a0de4287b5f3701c945df66a182511bf18adf12e44e88"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1323e59286d8113364e767c55e32d4906c80e5942785a24356cb2db309000cdd"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "48472097bf74745e05aed1200963ba3d335e4fd697251b3f86e37732b0696ac4"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "b2c3cb647983c4a7020f01573ce884e196b9ab847afd9f2ff17dcffeee09ec78"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1789b1c7986568a613b75baa148272d374ca7aa422936688638e9530b02acfd6"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7fdb60be1d4f928912df128f05e4b23f07c02f3377d5c0efd30d1275ed6c493b"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b2beecd92111f0956378daa3718c179474114ab8bea2c43fa3b9b7b8a6d077c4"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "18ba86852da56671d36ea3fe0566950e960331474b1f7b610c6ecb84575986a7"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "e5f504458f9abd9f",
+          "claimable": true,
+          "core_il_sha256": "0d75e483263a8346f1e114f31585ebc063df4a88573245d1927dea50c91248ac",
+          "domain_hosted": false,
+          "domain_signature": "347873722cd99e04",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "c3645dc5b5ee16d586a5bb9317aeb6e010f4ad18280d1e6d886ca63398dbc53e"
+        },
+        {
+          "behavior_hash": "e5f504458f9abd9f",
+          "claimable": true,
+          "core_il_sha256": "0d75e483263a8346f1e114f31585ebc063df4a88573245d1927dea50c91248ac",
+          "domain_hosted": false,
+          "domain_signature": "347873722cd99e04",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "6dad225d4d690fd4f3100b8c98720e6d7f9122038589a367016105a64cbdea0a"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1a4f326bea8b1ffb93bb38fe963087f3f0dbe19aa3e4b1e12e5aa2de100f7408"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "38dcf942c6cac59059c151a41ffeed4dbf69c8581ee7f0144808219a445328a2"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "3762205d4d36efab549f3ea8773ea82e8faba57a79defc7f08b6d06c21ffdff8"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1c692ef4c9b9b322bdbf1a55011e9d109e74fa9a9f49bedd1b46e51af5d111c1"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "90ef17e5fb90bbfe417affc95ccb75d689953c88b7b8cd267a979e33df8adb1b"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "908f6834112833b41b77c66cac64551dca32c976e66889f60257ba85448d7bd0"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1d5ceb3b903063a6bc76b43c6d405975cbeea34b04bc562483a949135131d354"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "e686cde9cdda4493d94c4f735aebababb3a34757d9adab7a202e031b333a5451"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "efc38b8a200f474531583ef52b260f5ed7cbb00f7fd27773aabdbdeafb590445"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "1d894b8c6ac8ce8dfad602bee1804c208504b93afbee2fa47d15b28628f64561"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "d2878c27511f1e63deb4a108c45a46d109a69d8b06bc90badc8dfd6669da12c2",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "f2366eeb598ffb6a1378449b3f0ddd778fe39889b1534a9e898acf4e66f55669"
+        },
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "d2878c27511f1e63deb4a108c45a46d109a69d8b06bc90badc8dfd6669da12c2",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "e118297abe0408de7feba7f3aa03f65086470388c7b722d701eea6b017da3175"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "211e235263c3236e40d2dcaabeb3af8d85596857c43d2a804cec2e33567fd0fe"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "a79bbbdf4cab3f8d615b77345d07460fb6d35bd7e1c0373ab525f7152257c962"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "663cc976e219feb90a75cc5844deb1af4dc0d725232548eadb5f8feafb34fabc"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "21609956de724dd47acbc9a6e7a4fdecffb17a5910a5cae039dd63cf57601268"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "0882d1b930966f811872c6f60646edeb4347a8f371692f1638c6be742ac64c4e"
+        },
+        {
+          "behavior_hash": "94a57ea83a55cbed",
+          "claimable": true,
+          "core_il_sha256": "8f735a417041f450431fb8e2e99322d7a61791cb387eea8c590bed1a9cb8c689",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "d377b26358c61bd5c0dcfff9093dae22451b5956b4a63b6cd835760a608ca355"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "2268bfcff1df1e9301e6642037080fb43d3d3afddc3ac0326fb318af6013b7ca"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "5b6cdb32a256a48e",
+          "claimable": true,
+          "core_il_sha256": "d9c58c53a14e4001746f5b36296442f13edf5839e480b063445121ff77ad5d13",
+          "domain_hosted": false,
+          "domain_signature": "78239c4afb29808a",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "13fc6a85b8fe21fc2b3ea849038d4e0ec3148351637f589da6e6f10d90d627bc"
+        },
+        {
+          "behavior_hash": "5b6cdb32a256a48e",
+          "claimable": true,
+          "core_il_sha256": "d9c58c53a14e4001746f5b36296442f13edf5839e480b063445121ff77ad5d13",
+          "domain_hosted": false,
+          "domain_signature": "78239c4afb29808a",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "d3f48bc5a47542ee5383095e861546c8240d6ef028a886bcf5e4bd0b797ee2df"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "2273b0425472703589671d0b0890834eac1016baee5247d7e1d660c61cea7e6c"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "230783542dee3159a169a27129ebab7de8292e436b16c6d9a07b73a9b69afe92"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "3234cde04b86b18155f3629d5b28b3fcbab8fd5efbd670631f0fbf71e5f84aed"
+        },
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "732041f32bb8daf3e8910015ff88545c06b4a03ca8273e09c4336b8b8b85aca0"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "23fdef75609e3b6ae8eda6fbc442cc27df53179e6612b046a7104710cf189504"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "08f03e84ac5c1791",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "826b456a34125e97",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "e6961c3a6e05025a62ae1e63fa9c4c2f68cb54f70e9fc22259f6b77972e0c122"
+        },
+        {
+          "behavior_hash": "1df0fbc82b9f337d",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "76e9ad45af3595fe0370ca34d1e8657ad8f359b904c74b816f8ca78a45181ce8"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "25ebebcd5a4d681f62c7dc06021c73792524f81bc0cf50b9bfff7d40ded2a95e"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "472cbecf3f89a2ce185766411f5fb7e7160fc8a3cdbe319de6eaa1f329d20cce"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "b2c3cb647983c4a7020f01573ce884e196b9ab847afd9f2ff17dcffeee09ec78"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "29bd1970ce959036861d2076b95d04cfa3d2ff9d7f4c0e0afb7e8c225ef6ba10"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "4bcdf15bd88d858cd442d281299a7e03cfa4b030619794e30c2f564807cc95cb"
+        },
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "fb607f92d5839398f3b413a86a5c42995dd1d25e2816216a4258383722d0ac54"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "2a2642976ac2aa4c9322e54233a6395ffdb08068a9dda82985b9f73d182ae67e"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "12358c6bd864e06966196795b439f6e61fdd9eb729f990ffd3ced7d6e3728841"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0e1c7876344df4a93fe486267f639821921b14ab6aff67d9dd2417f0e9fb223d"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "typescript",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "2bbeb3edd75f1226fcfa81d8f61e28703255cd918a3ee55ae3039fccca912444"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "615e0c9a7ce5c5b3a7e5fdb25956966dfb9abc3328c1c7dcbb0ab41e04226a12"
+        },
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "8786db28f6122f0aabe327973a4298d8d7f95fa441c33f18308636f352120331"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "2c2372765cf98ea511b82b3fa48357efd092bb58689489a183e6711afe3be2f6"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "4bdd630901e9e06914ec6d835a3750405412ac453794f149a107e334cd99d3f8"
+        },
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "476559c8f0c486fc07dc5520d05e584774471feb1f33a6a227342f495c5aaf4c"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "33011c8dec2b18b25dcf14615c57b04f20e233c5a3bb296cb80898882b754f6a"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0e1c7876344df4a93fe486267f639821921b14ab6aff67d9dd2417f0e9fb223d"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7fee9acb3dffaa46cb61613c603b048f19c285b87d54129b615f75c061e66c4d"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "35fc0cabf4ea2da97d3c549e381c3fd7445e16a9554b865b7269ecdb4b2a6c3a"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0e1c7876344df4a93fe486267f639821921b14ab6aff67d9dd2417f0e9fb223d"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "90f78473e2e0aea8d0ece0aaea500619a85cc23859e80cf89c7b9359d9c5acf8"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "3ae4a5556d7843c599936be8f700e128ebaaff3b661357ed4cb2e6964d29c640"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "f2c5f4740b7450153736669d9d156e3146ca2d538c20aa7646831f059cc88ee1"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "e12bf8911a3f11a564d19b4f166d1717459dee32fc17f0ae047aef23942b849a",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "a79bbbdf4cab3f8d615b77345d07460fb6d35bd7e1c0373ab525f7152257c962"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "python",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "3c3729f12513222bf6fc73a1466e8ddd2254cd585e3e36323393612e0162260c"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "60854b60cd85f69a",
+          "claimable": true,
+          "core_il_sha256": "4075088ce7437406a409c66f140f0bc937bbfe1b4b32bf34a74f3d34f8af9285",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "b5732ba2c21f62a29bf31e66fd8add3618a5cb3ea8f513236f86ffb474e3a721"
+        },
+        {
+          "behavior_hash": "60854b60cd85f69a",
+          "claimable": true,
+          "core_il_sha256": "4075088ce7437406a409c66f140f0bc937bbfe1b4b32bf34a74f3d34f8af9285",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "505b9ad4ec9db1ddb5838d5255c6a6a9c63f80d691c46e6d0b123705c4579018"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "3d630f0a728b5f94aa2607771b9e2a4faf91dfd5207537d5c43eb2ddaf2b7e37"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "47e5c24715df0e65fda31dab47660142eadff33c06f6cb42c98a89d492ef3979"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "d50bd6747406d572",
+          "claimable": true,
+          "core_il_sha256": "f1b50631f0fc40484e407ba9cd9157dc656e86ea9d6eb57fd7975639ef10f462",
+          "domain_hosted": true,
+          "domain_signature": "cf0af296efbb5700",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "3596befb3dbe9beae2ac932d7f64c593f201591aa46000e9ad417549ff97ebb8"
+        },
+        {
+          "behavior_hash": "d50bd6747406d572",
+          "claimable": true,
+          "core_il_sha256": "f1b50631f0fc40484e407ba9cd9157dc656e86ea9d6eb57fd7975639ef10f462",
+          "domain_hosted": true,
+          "domain_signature": "cf0af296efbb5700",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "3aeecb1d4595cc967166d11e1a59ce933f4ea5b8d0e9248eb7915d8fa94eebe1"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "52bf305cf2a68a30a094ffda60a8a1c1a814c603eeeec2d959b656a1d55473e2"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "eebc3af552e07b1a",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "9c0d025fd395f65b",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "d3d38cbc6ad67c0dfb7c33bc5cc72bc2b19c52205235c69dcb75318184320352"
+        },
+        {
+          "behavior_hash": "7021bc0329eda925",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "5a70451a066bcb7c",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "66ba03b3007f3299dc2e6a88a46ee3372300c23c2d31b38a3a9001d03edba2c7"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "561342e766aebe59e04cc3674a82217b3a2e8b1d199a5bb0a70e5e4405432926"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "169fb16745da2e0c",
+          "claimable": true,
+          "core_il_sha256": "7387fb7e7184c6348a673d425a28d3a0b4c8f0e4d25f88f742a38575ca2a78f5",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "f272c5a3062a66c828aec66c5ba621d4e3db47a2e0c5a7346fa0db27f8510327"
+        },
+        {
+          "behavior_hash": "169fb16745da2e0c",
+          "claimable": true,
+          "core_il_sha256": "7387fb7e7184c6348a673d425a28d3a0b4c8f0e4d25f88f742a38575ca2a78f5",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "3070ab6875a253b89db7a2178563e8efbc5b00b07e416762386965cac4f6c374"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "58c58aeef8354a224ced18a3da0d7e73f3672cf0d04d43b67bbbbbee2e89f94b"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "8aa1d53eaf40f6462c98cebc75dee4ffdece3bf8c4c5f5bab7e47b006d33f67c"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b6c5b2938dfefe02bc27475339185b7fa962acead7464a1617c473a5275b6b44"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "58d4ebed796003831e3312a771e63588fc1883523e1381e3e95bea44e0663fb6"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "cdef42a8b97eaa5f",
+          "claimable": true,
+          "core_il_sha256": "633bcd101ff1a316f9c12e4e84c2a56e95f5090d813b40f10b23b1453713346c",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6923e6ce012de95922507bdc45a53d45f58b0d1a9e81b66364ce77d1af65230c"
+        },
+        {
+          "behavior_hash": "cdef42a8b97eaa5f",
+          "claimable": true,
+          "core_il_sha256": "633bcd101ff1a316f9c12e4e84c2a56e95f5090d813b40f10b23b1453713346c",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "d243c4ca23a8768b4bba8bcc9ecf2c613fa3440369bce93d079a771cb904b2d0"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "ruby",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "5b571b6b57bdf5ec73a73743818e489b9354ecdb6e232abab6de2012abdf4bab"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "0569429bbdbe1739",
+          "claimable": true,
+          "core_il_sha256": "c3087980d4f37609c7beb2d4686e35f678bc6ae71c15b2ba76183d587e844f82",
+          "domain_hosted": false,
+          "domain_signature": "13425e959c79a19e",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "98e50e3d28536a1d10740486a9d9b88d52b7c429f61e0930e857148b10520f40"
+        },
+        {
+          "behavior_hash": "a8aefcaf6e93f20e",
+          "claimable": true,
+          "core_il_sha256": "c3087980d4f37609c7beb2d4686e35f678bc6ae71c15b2ba76183d587e844f82",
+          "domain_hosted": false,
+          "domain_signature": "8350208d25b2d913",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "7e58bd5e90c78cbd03815acef9c2e47988ac0ee4b47a7f951118bac5260f366f"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "5c4aba145200611c79f17443d59e9fc7eeb074a2024292ab1ac83c78f1f7b75d"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "73c401bec8608e3cd4306a719f24b202625e6139f5d88d6f932ce0148a78fe41"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0a706501c22a96ef83367b3a3fd8fedd260efed6436a1b0e4153ffad3f8a83d9"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "600371198868892a10a00264379521ade7879df55aa673529a07e62ed19c415d"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "7613b2e2d903cd15",
+          "claimable": true,
+          "core_il_sha256": "446c2086dae9eb9f61613f398f4cae01d4a876659579e297e2b6461d6a425b30",
+          "domain_hosted": false,
+          "domain_signature": "14552732a8900803",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6f7252ef03240470a07f29c472e5bf8af67bbd35ffe33bfd91174f84c0f2647a"
+        },
+        {
+          "behavior_hash": "7613b2e2d903cd15",
+          "claimable": true,
+          "core_il_sha256": "446c2086dae9eb9f61613f398f4cae01d4a876659579e297e2b6461d6a425b30",
+          "domain_hosted": false,
+          "domain_signature": "14552732a8900803",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "68bc4054bb5aab3957a87f26f462da683a55ce8e4fbf6ff5222f2c836a4aa5b3"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "60fe20c4d3b8a320e3b1e047ca9c9f225ac5e14e3b07e13c23abac7aa17df858"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "739f2bfe28edcfb98ec6bb42cf850edaadd0e815f3d56714c5d7e44e0187d942"
+        },
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "732041f32bb8daf3e8910015ff88545c06b4a03ca8273e09c4336b8b8b85aca0"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "6292e1b30187cca937aba76293b198201543173b17b86277e154e1cd96720b86"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "02fa0afa09529000c53617d4a7fc5ee062bd01b9e6b936b7d49da3a3bc241640"
+        },
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "615e0c9a7ce5c5b3a7e5fdb25956966dfb9abc3328c1c7dcbb0ab41e04226a12"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "6ad4137333a45877bb301b2f202a6fc54b61efa9e3a199d0266feb82a7650bf9"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6da07059027e006a0dea4d4eacc9c0924b0597415e76ea3919021481295b2481"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "bf5fd4c4753842161912e9c7bd667fd7778af38a7f4dd1e61d29583eac74c965"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "6fff41a162d9f824796902050b80aa49e8861fda1fda7be4ea9cf0a639757a01"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "710b65c9c2880c1652a044a7e7c46b3d375ca5aa6955fc8f419533c35ea68563"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "80d2dd174beef836",
+          "claimable": true,
+          "core_il_sha256": "de20f7245cf0d515366ff950ea3e20edc216e1f559932f132937dfa6a56304b5",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7657eab545035e5aff6ed0c0442db544fd56bb420a8238502db262309eec0f6b"
+        },
+        {
+          "behavior_hash": "80d2dd174beef836",
+          "claimable": true,
+          "core_il_sha256": "de20f7245cf0d515366ff950ea3e20edc216e1f559932f132937dfa6a56304b5",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "c39f881d30b14bb4233a0a004315a84875ee6363eec6b747e1697ca3772cdf02"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "733f22604d4bbcb1a9772d49e54ba9ab4772ffc5f997db8c30fa7ed5f05589ce"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "24a632168e3dabbcdfa55b66ad32ed38f9f89f46012b9f38a1837e638f02ee2f"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0a706501c22a96ef83367b3a3fd8fedd260efed6436a1b0e4153ffad3f8a83d9"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "7366ce99de4960da1cc1f764194677e401a8cbb145da3baac5c98d3d4998110d"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "741be248e7332fbf70919baa73813d90d8b4f2a3e40ba3ca556847343e218aaf"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "476559c8f0c486fc07dc5520d05e584774471feb1f33a6a227342f495c5aaf4c"
+        },
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "a35f99816f54ca6b2e3babdf2b900d54a3bc4ca61d5c41c0be8946b0cfaa8291"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "751aca8d84fd78be6cbefee4ccedc58cd67caf8d5230f22622337d83f3f87099"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "472cbecf3f89a2ce185766411f5fb7e7160fc8a3cdbe319de6eaa1f329d20cce"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "bf5fd4c4753842161912e9c7bd667fd7778af38a7f4dd1e61d29583eac74c965"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "81636ba5b278b96a90cef62c9ba69f7ffa0afa4f435ab29b9a1215bfaf227d1f"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "472cbecf3f89a2ce185766411f5fb7e7160fc8a3cdbe319de6eaa1f329d20cce"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6da07059027e006a0dea4d4eacc9c0924b0597415e76ea3919021481295b2481"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "839981c55b22308f1db74dcb1d7ef704641736617748eaa0830c051631a965c3"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0751e98659e639e05da75da04aa500b2588790828b010cf1d7e74dbaee1d1352"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7658be69bebe0435a892c6906ebc89ee402ee678668beaa22da80058392ef41e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "87b67c0880ff8fc22e2e65b23e01ebed992ee761594f21c1a516de6d38c5e6c7"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "f74b510ba0e39572d5bbeca8bf5852d8b963f3c2b2370bffbb1af87634dccfcf"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "41adc82835d34aab045c77353c57070261be84e41eff906f177efdac35357bbb"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "8f543d56c30ab21c3b55dcd47527572c03bfb06d42e41b07ed1ab879528e5115"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "42c9a152283287b4",
+          "claimable": true,
+          "core_il_sha256": "7c0d6c8a9038d4b29d729134923c9a40ddc0b7ac361fce261fcb830324219870",
+          "domain_hosted": false,
+          "domain_signature": "1e9644249664077c",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "b8d192ee21dbee0fb59a878772ec90019baf47a9829eb6c010c86f8e44ee2891"
+        },
+        {
+          "behavior_hash": "42c9a152283287b4",
+          "claimable": true,
+          "core_il_sha256": "7c0d6c8a9038d4b29d729134923c9a40ddc0b7ac361fce261fcb830324219870",
+          "domain_hosted": false,
+          "domain_signature": "1e9644249664077c",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "5a535f2b73d07e9b6b951056d547291654eeb8b553fb0e9a82c203d2446392a2"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "936da3744c1dc4d0d8063deffdff27b10f91f16b88186c70eeae1f92bcddbbd1"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "6022c7d8673a7af2",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "347873722cd99e04",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "993937cd013e03e456b9280ed07816fbe1d4d0ad326149590eebbe16c26a87d4"
+        },
+        {
+          "behavior_hash": "1df0fbc82b9f337d",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "76e9ad45af3595fe0370ca34d1e8657ad8f359b904c74b816f8ca78a45181ce8"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "95764ebb07e2a1bb1a9e128564b348f216deab6bf640d52c9e656013a57dda77"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a24eed69c9096bc98aee20e864cdc994a2601e37bac0ec8c58ffc114457df7e6"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "96b3a9e2d542dbd44d5c329de7dbb629ccb1a6e7afa069a933e13e270cf90500",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "ddb96dbb90c3c6029359d9efab0968c0e5418665302e0240d8fd499d52ff2073"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "96b3a9e2d542dbd44d5c329de7dbb629ccb1a6e7afa069a933e13e270cf90500",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "369ebd9810daa12526460c9395fffe639c40b4e9e1b1a6a0e088068089772239"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a3286682597783fdf513d77c82d3701b256fccbbfd6397a593d25842a2aa37a4"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "7021bc0329eda925",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "5a70451a066bcb7c",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "66ba03b3007f3299dc2e6a88a46ee3372300c23c2d31b38a3a9001d03edba2c7"
+        },
+        {
+          "behavior_hash": "327a0a9375374001",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "fe8af148e38314eb",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7a11a213e5643c6d35d01fb00b00bd853695185e0278c5c029e1e68d5c994cd6"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "a3414ec15d880e8d2f13278339cbc5657687b0c44f546c4afdb8bce7f79d58d4"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "c480acfbc2ac68897b18eede30272bf5255ee04198ce5a5c01edb135bfb26c27",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": false,
+          "unit_id": "0c52a0f027e07b29551cdac5bfd293f121478fc26f246cc80d6623b7c70f2111"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "c480acfbc2ac68897b18eede30272bf5255ee04198ce5a5c01edb135bfb26c27",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": false,
+          "unit_id": "092a4354d069019ae3b5770cc7a94e9e993acd26964d44e8273ecd8f3d6ce295"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "ruby",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a43344facff23fe3830437d2f65751c582f679c0a61de2e2908097dff6c36c2c"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6da07059027e006a0dea4d4eacc9c0924b0597415e76ea3919021481295b2481"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "b2c3cb647983c4a7020f01573ce884e196b9ab847afd9f2ff17dcffeee09ec78"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a4f41dc155855433e1c2c81fac3f2dc2d00fa75d9a47563488aec44cbe8eeac2"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0a706501c22a96ef83367b3a3fd8fedd260efed6436a1b0e4153ffad3f8a83d9"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "2a56450284232e2fc08b4789a65c4e6f42805534cae2dc388bf6302b1c4a890e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a58209ed77e6f5ad02a6ab0113e23034cfb4ac09c0975f82544f3ce6793ae22e"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "5ed7f368ad82fa8b",
+          "claimable": true,
+          "core_il_sha256": "c0d0ebc406693bd5a6871ac3f611a3e68a2fea752624f0990f23416ec1f038c8",
+          "domain_hosted": false,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "5aa120b621c456303c8de14315fff403856e468d858805ec2e933e6adb703e65"
+        },
+        {
+          "behavior_hash": "5ed7f368ad82fa8b",
+          "claimable": true,
+          "core_il_sha256": "c0d0ebc406693bd5a6871ac3f611a3e68a2fea752624f0990f23416ec1f038c8",
+          "domain_hosted": false,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "34a182aacaab0deacc4dc4ce32b7f3edb3cd50e82d0c931d17403d2eb0555eb9"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a64c35354b0c4b604ec7800bdb67275d1b07699b24eaad51d581f892e7efe3f5"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "48472097bf74745e05aed1200963ba3d335e4fd697251b3f86e37732b0696ac4"
+        },
+        {
+          "behavior_hash": "fb1d0ab9bea60764",
+          "claimable": true,
+          "core_il_sha256": "0e5ad45791d9b93cf6d4d7c1b222687f8f45e47830d1b83dc631ffa9ce12041b",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "6da07059027e006a0dea4d4eacc9c0924b0597415e76ea3919021481295b2481"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "a921c7b92ecd4c9efb14a8667c84044d750639b106a8fec4bccc1f5dd6424e8e"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "ac1ff01ae8be7b0bd3ea9bc859085546729905dd92adda0581af84a79b5b43a5"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "73d1898e0fa48143ca267c581a108ad8765cb648fbde8d58e68b62ae094825aa"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "d82f6211eda4c31ff80a0de4287b5f3701c945df66a182511bf18adf12e44e88"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "b11a5ba014d798e3bd34d1163fb983b0364d9b7c687b9de453c00061774fb9b9"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "08f03e84ac5c1791",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "826b456a34125e97",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "e6961c3a6e05025a62ae1e63fa9c4c2f68cb54f70e9fc22259f6b77972e0c122"
+        },
+        {
+          "behavior_hash": "6022c7d8673a7af2",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "347873722cd99e04",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "993937cd013e03e456b9280ed07816fbe1d4d0ad326149590eebbe16c26a87d4"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "b1aea946b8d73df37bd23b2d249886b361c18f2271b4f286b230d7a068658782"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "b9a5ca2423ce76d0fa4efa25ec8330696e1197a91c50e1cbea16224c97338cc2"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "2f67098536da321c827dd79b6bca1580872a7833e38a4516a80900a12749efcc",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": false,
+          "unit_id": "71a40c1175542a281fb1804471d4b69b225ea7df600a6b6bceef0aacbc4d9eb2"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "2f67098536da321c827dd79b6bca1580872a7833e38a4516a80900a12749efcc",
+          "domain_hosted": true,
+          "domain_signature": "d1fba762150c532c",
+          "input_projections": [],
+          "symbolic_behavior": false,
+          "unit_id": "57dd6d2fbccd4539be0aa446cda2ecf2e62b6e05ce6932c2551ae45668dd4ecd"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "ruby",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "be9bac8020f6112e786c8b88edbef68bbd476e79967429c9f48c18a64abef1ac"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "63fc3397b3d9e6d921676a4571cbdb96eb95e4a64a7baa02e9b8fb755379e150"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "9bdbfde1c7e53d418fbe927ea97982eb31cc546b393d7432188d988aad2cbd54"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "bf10043302150fd236042e72eeb87f0ddf823f5f71379a0cdd513bc21d4fd327"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "bfd782fa921bf607690ebd8d53306237427f24c6fea611a95d3a5094d88e539d"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        null,
+        null
+      ],
+      "candidate_status": "exact-unsafe-uninterpretable",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "c23025853a8c49a997c8c716cd24871e084f54ecc475e735dc7e242903d7736a"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "0993ccb467d65075",
+          "claimable": true,
+          "core_il_sha256": "feeafb36f6dbbac5ffb81c684076807574d0fe4bfc82a4138964aa2cefff18d1",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "1df02d6e2631d5a3e1b4f8b8f9debead19222e26c972b0f360d956187b1f0874"
+        },
+        {
+          "behavior_hash": "0993ccb467d65075",
+          "claimable": true,
+          "core_il_sha256": "feeafb36f6dbbac5ffb81c684076807574d0fe4bfc82a4138964aa2cefff18d1",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "90a3f960fdb4a91fda8aa97fcf2cfc59faacf5fd644bee685583f1099373925e"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "c2a8322ab77f00ce3e52de43e041e0a98d3bc9f08d4a0568696c80d5117366a5"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "9ae51aa942312f75",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "6b493bf2e674c52a",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7c99bcb1a48e556e4bbd6cee19d99a8b51e5827da472d78b3c4576ae4f4ce0ab"
+        },
+        {
+          "behavior_hash": "6022c7d8673a7af2",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "347873722cd99e04",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "993937cd013e03e456b9280ed07816fbe1d4d0ad326149590eebbe16c26a87d4"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "c59d476ac9996fe3d22ee4dbffc483d66bf56cd170768ec7577b00c27a7692ea"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "8549b234d62505db",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "02fa0afa09529000c53617d4a7fc5ee062bd01b9e6b936b7d49da3a3bc241640"
+        },
+        {
+          "behavior_hash": "7d6ae29c0c52c0ee",
+          "claimable": true,
+          "core_il_sha256": "e75c12f338f9fc0c911ca8c3a389e7fb5ee68287caaf58a48f03b7ab53663904",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "8786db28f6122f0aabe327973a4298d8d7f95fa441c33f18308636f352120331"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "c6525fc0bafd919ccc5c24f6d672c106f03159c4bb1d15f1a50474670cd988cc"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "eebc3af552e07b1a",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "9c0d025fd395f65b",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "d3d38cbc6ad67c0dfb7c33bc5cc72bc2b19c52205235c69dcb75318184320352"
+        },
+        {
+          "behavior_hash": "327a0a9375374001",
+          "claimable": true,
+          "core_il_sha256": "556cec4a8100e7b4b9bdf8f396a834eed6f3238ef74d770b8793ab53e9e7043b",
+          "domain_hosted": false,
+          "domain_signature": "fe8af148e38314eb",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7a11a213e5643c6d35d01fb00b00bd853695185e0278c5c029e1e68d5c994cd6"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "c86758f5ed14b6dcdd025b4c396675efa2ce459d81409a6f28f20c8e2fcbcabe"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "24a632168e3dabbcdfa55b66ad32ed38f9f89f46012b9f38a1837e638f02ee2f"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "2a56450284232e2fc08b4789a65c4e6f42805534cae2dc388bf6302b1c4a890e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "d2140aded87131ec1b6f1ab658538699114788cab6bb242bc08704ee59d1f3d9"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "5b55349fbccdc87df6cdde9daec6e5d2326bb87e6c5da58201e1b53d352b861d"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "8aa1d53eaf40f6462c98cebc75dee4ffdece3bf8c4c5f5bab7e47b006d33f67c"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "d2c3e691c4a9d7fc395e88842469520b2c5c5f6c12a3006e051dc51c669a5d0a"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "63fc3397b3d9e6d921676a4571cbdb96eb95e4a64a7baa02e9b8fb755379e150"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0751e98659e639e05da75da04aa500b2588790828b010cf1d7e74dbaee1d1352"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "d34a6071b88d8ce70f86da9cb2c4f73682adcda9da13b9218ccd3b2e1d479a70"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "5b55349fbccdc87df6cdde9daec6e5d2326bb87e6c5da58201e1b53d352b861d"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "70035f06e7d0f69791c624e129617ba634585e2295dddc8c49f328dfe00bbfec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b6c5b2938dfefe02bc27475339185b7fa962acead7464a1617c473a5275b6b44"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "d7152883aeb411ffc51cecf3ef61ac54037cbfb0e643f3cc08c103f168f4fa9a"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "ff7f550af24b399fede90705473d60f479cd70cb2bdeea3bdaee9b8b4950f732"
+        },
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "fb607f92d5839398f3b413a86a5c42995dd1d25e2816216a4258383722d0ac54"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "d99f14832277ce5075d5de5cca2dec85eed9f8dc290a5cd641383c32e5861621"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "4bcdf15bd88d858cd442d281299a7e03cfa4b030619794e30c2f564807cc95cb"
+        },
+        {
+          "behavior_hash": "581b3121ce724cca",
+          "claimable": true,
+          "core_il_sha256": "a7ea05d714e1566faf15d909731c9da53b8355d651cca1327266f78719bb091e",
+          "domain_hosted": false,
+          "domain_signature": "74ccec96dbe776b7",
+          "input_projections": [
+            "declared",
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "ff7f550af24b399fede90705473d60f479cd70cb2bdeea3bdaee9b8b4950f732"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "dead4c96ad6689267b2c7782814730f8d1f3ece39561aac747392cb4904edad8"
+    },
+    {
+      "baseline_status": "exact-unsafe-domain",
+      "candidate_members": [
+        {
+          "behavior_hash": "9ae51aa942312f75",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "6b493bf2e674c52a",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7c99bcb1a48e556e4bbd6cee19d99a8b51e5827da472d78b3c4576ae4f4ce0ab"
+        },
+        {
+          "behavior_hash": "08f03e84ac5c1791",
+          "claimable": true,
+          "core_il_sha256": "1953b6bfeee1e200966980debbee271130ceef06d71ea52a26f83e5e9de7f5f6",
+          "domain_hosted": false,
+          "domain_signature": "826b456a34125e97",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "e6961c3a6e05025a62ae1e63fa9c4c2f68cb54f70e9fc22259f6b77972e0c122"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "scalar-value",
+        "language": "rust",
+        "obligation_id": "exact-soundness.scalar-value",
+        "risk_tier": "tier-c"
+      },
+      "pair_id": "e4a5172397d86036cccaab701dc6aff866cc0a04b4868c12e593a11c2a508477"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "9bdbfde1c7e53d418fbe927ea97982eb31cc546b393d7432188d988aad2cbd54"
+        },
+        {
+          "behavior_hash": "975f3a9947dd744a",
+          "claimable": true,
+          "core_il_sha256": "04699900945a199f378a149bc32c14da507009999e8ef3adcbd65ad304a8243e",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "7658be69bebe0435a892c6906ebc89ee402ee678668beaa22da80058392ef41e"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "ec4e7b6e24a937586b7b9b8abac1a0f5919b376941fa2061e9b209cb872b1095"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "4bdd630901e9e06914ec6d835a3750405412ac453794f149a107e334cd99d3f8"
+        },
+        {
+          "behavior_hash": "63dd7dd9ab1a68c0",
+          "claimable": true,
+          "core_il_sha256": "7ec6ef8493afe0fdd07d53ddf9486c3ac0176864abd4623f5901832a5574470a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "a35f99816f54ca6b2e3babdf2b900d54a3bc4ca61d5c41c0be8946b0cfaa8291"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "ed3ba527ae0b7e343c3080501376b41790c4f58bee37b98b45c7fb308fa71e00"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0e309268793df933dbdf151b46d23410fe543407b767aed57e8726702f1f59a5"
+        },
+        {
+          "behavior_hash": "0ff6aa10c98c38b4",
+          "claimable": true,
+          "core_il_sha256": "eb3e000b542c1dd097a660954208a16f6fe8acffe558f92c291899dbd9dd8c0e",
+          "domain_hosted": true,
+          "domain_signature": "7548c4fcbe6ef526",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "73d1898e0fa48143ca267c581a108ad8765cb648fbde8d58e68b62ae094825aa"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "f0289ab5e36bec4f7ea57ec513c334cf9873a50aaafd7ecce70758ed061e7948"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "24a632168e3dabbcdfa55b66ad32ed38f9f89f46012b9f38a1837e638f02ee2f"
+        },
+        {
+          "behavior_hash": "04883ac320842b46",
+          "claimable": true,
+          "core_il_sha256": "c33b4b50de66850fcfb8ce015d7f480d78aa9428d9205a31fc93446aad1edcd7",
+          "domain_hosted": true,
+          "domain_signature": "b95740cc6e7e4a23",
+          "input_projections": [
+            "cardinality"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "73c401bec8608e3cd4306a719f24b202625e6139f5d88d6f932ce0148a78fe41"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "f435bbf86963a2b7db85753d40c73be7b08b64a3fa16ea5a73c178e594050c76"
+    },
+    {
+      "baseline_status": "exact-unsafe-symbolic",
+      "candidate_members": [
+        {
+          "behavior_hash": "8bdde575918a8c00",
+          "claimable": true,
+          "core_il_sha256": "efb794f9cd4eb66d2a2fe5498d378bc5367177064d43d1565199685e0e7c8abb",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "afc651b041753aed837d76cf6ec3bf0fea2987fb4d19b87ad48b87b095708e74"
+        },
+        {
+          "behavior_hash": "8bdde575918a8c00",
+          "claimable": true,
+          "core_il_sha256": "efb794f9cd4eb66d2a2fe5498d378bc5367177064d43d1565199685e0e7c8abb",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": true,
+          "unit_id": "2192e08ed22344a5276e5214373d90aabd431ab2d8c022488827c486ae698a2d"
+        }
+      ],
+      "candidate_status": "exact-unsafe-symbolic",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "rust",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "f4a3a2b5751d9ec212ce3f662d4cc101b37eb1beeeb221447037a008ea69136a"
+    },
+    {
+      "baseline_status": "exact-safe-verified",
+      "candidate_members": [
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "b381ad622b00afe32ab33ea72c3e896bb9126700f6fe0393536af04310940800"
+        },
+        {
+          "behavior_hash": "0beb0ce840113548",
+          "claimable": true,
+          "core_il_sha256": "e5ff0639191ab720b94d3a3ca76982ecdb070ae946d880e9c3af82aa8d704eec",
+          "domain_hosted": true,
+          "domain_signature": "5412234deae82590",
+          "input_projections": [
+            "declared",
+            "declared",
+            "unused-trailing"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "41adc82835d34aab045c77353c57070261be84e41eff906f177efdac35357bbb"
+        }
+      ],
+      "candidate_status": "exact-safe-verified",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "runtime-protocol",
+        "language": "cross-language",
+        "obligation_id": "exact-soundness.runtime-protocol",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "f9cc088f20fa7b3a6eab4485e2e01d70fa6929a9993765c93286ca010665ee9e"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "7d18d6185b7c7087",
+          "claimable": true,
+          "core_il_sha256": "36955c534799636b2ec079df8a78bc172f301d2daab828c0ffda7861e672388f",
+          "domain_hosted": false,
+          "domain_signature": "da158ccd7c438827",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "0eae0ea54c326a3f12218e5cedb46dbaeb3cd6af9c925dedfc363b8ff063ae00"
+        },
+        {
+          "behavior_hash": "f0edf1f21cb422cd",
+          "claimable": true,
+          "core_il_sha256": "36955c534799636b2ec079df8a78bc172f301d2daab828c0ffda7861e672388f",
+          "domain_hosted": false,
+          "domain_signature": "826b456a34125e97",
+          "input_projections": [
+            "declared",
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "e54cf22728af606d2ef52692ee5fa946bd99ea3bcce0ae030da170b1af855308"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "fa4ce47b81b8bb5be9758dbf64486c2835bee46685d1777051a55143413258b3"
+    },
+    {
+      "baseline_status": "exact-unsafe-uninterpretable",
+      "candidate_members": [
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "739f2bfe28edcfb98ec6bb42cf850edaadd0e815f3d56714c5d7e44e0187d942"
+        },
+        {
+          "behavior_hash": "6982736bf4ba7452",
+          "claimable": true,
+          "core_il_sha256": "66689e72e712e22d82b4f32e802d64ed4147192127c55daa22122c5592e5ce2a",
+          "domain_hosted": false,
+          "domain_signature": "fbd8f25ee5d0c5a8",
+          "input_projections": [
+            "declared"
+          ],
+          "symbolic_behavior": false,
+          "unit_id": "3234cde04b86b18155f3629d5b28b3fcbab8fd5efbd670631f0fbf71e5f84aed"
+        }
+      ],
+      "candidate_status": "exact-unsafe-unhosted-domain",
+      "frozen_cell": {
+        "claim_id": "nose.strict-exact.value-fingerprint/v0.19.0",
+        "construct": "oracle-gap",
+        "language": "rust",
+        "obligation_id": "exact-soundness.oracle-gap",
+        "risk_tier": "tier-a"
+      },
+      "pair_id": "feb1fb212d8bf8efb77caaaf84bf92f313ab5861640bbb00b5d7d2a5be7488f1"
+    }
+  ],
+  "repo_pin": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+  "schema": "nose-soundness-scorecard-overlay/v2",
+  "summary": {
+    "baseline_pair_mass": 97,
+    "by_language": {
+      "cross-language": {
+        "macro_ppm": 850000,
+        "pair_micro_ppm": 809523
+      },
+      "python": {
+        "macro_ppm": 1000000,
+        "pair_micro_ppm": 1000000
+      },
+      "ruby": {
+        "macro_ppm": 666666,
+        "pair_micro_ppm": 666666
+      },
+      "rust": {
+        "macro_ppm": 191176,
+        "pair_micro_ppm": 206349
+      },
+      "typescript": {
+        "macro_ppm": 125000,
+        "pair_micro_ppm": 125000
+      }
+    },
+    "cell_count": 8,
+    "exact_unsafe_pair_mass": 62,
+    "macro_ppm": 457620,
+    "pair_micro_ppm": 360824,
+    "release_target_ppm": 424999,
+    "verified_pair_mass": 35
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "9695959bd28e9b126674996c8fb47f39e7ae059c",
+  "product_crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
+  "product_crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "f32119d1c8d0d7f6ec9af7ba250417315d2de96c",
+  "product_crates_tree": "0feac652bb481a2a68042ef68574f8530cd982bb",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -21,9 +21,9 @@ use rayon::prelude::*;
 use std::path::Path;
 
 /// Bump when the cached payload's layout, extraction, or feature hashing changes — old
-/// cache entries then live under a different directory and are ignored. (v11: compact
-/// connected-witness tokens were added to near-channel unit features.)
-const SCHEMA: u32 = 11;
+/// cache entries then live under a different directory and are ignored. (v12: exact fragment
+/// fingerprints gained the mixed-terminal-control coordinate.)
+const SCHEMA: u32 = 12;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,
@@ -164,5 +164,40 @@ mod tests {
             return;
         }
         assert_eq!(out.files, 1, "only the readable file should be counted");
+    }
+
+    #[test]
+    fn schema_12_ignores_pre_mixed_exit_cache_entries() {
+        let root = std::env::temp_dir().join(format!("nose_cache_schema_{}", std::process::id()));
+        let source = root.join("source");
+        let cache = root.join("cache");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::write(
+            source.join("mixed.ts"),
+            "function f(x: boolean) { if (x) { return 1; } }\n",
+        )
+        .unwrap();
+
+        let corpus = nose_frontend::lower_corpus_filtered(&[source.as_path()], &[]);
+        let options = DetectOptions::default();
+        let signature = options_signature(&options);
+        let current = cache.join(format!("v12-{signature:016x}"));
+        let stale = cache.join(format!("v11-{signature:016x}"));
+        let first = build_units_cached(&corpus, &options, &cache);
+        assert!(!first.units.is_empty());
+        std::fs::rename(&current, &stale).unwrap();
+        assert!(!current.exists());
+
+        let second = build_units_cached(&corpus, &options, &cache);
+        assert_eq!(second.units.len(), first.units.len());
+        assert!(
+            current.is_dir(),
+            "v11 entries must be ignored and a fresh v12 bucket written"
+        );
+        assert!(stale.is_dir(), "the stale bucket should remain untouched");
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/nose-cli/src/verify_collect/fragments.rs
+++ b/crates/nose-cli/src/verify_collect/fragments.rs
@@ -1,25 +1,5 @@
 use super::*;
 
-fn fragment_observes_mixed_exit(
-    il: &nose_il::Il,
-    contract: &nose_detect::FragmentContract,
-) -> bool {
-    if contract.exit != nose_detect::Exit::Normal {
-        return false;
-    }
-    let mut stack = vec![contract.root];
-    while let Some(node) = stack.pop() {
-        if matches!(
-            il.kind(node),
-            nose_il::NodeKind::Return | nose_il::NodeKind::Throw
-        ) {
-            return true;
-        }
-        stack.extend(il.children(node));
-    }
-    false
-}
-
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
 pub(super) fn collect_product_fragment_verify_rec(
@@ -248,8 +228,14 @@ pub(super) fn collect_product_fragment_verify_rec(
         );
         return;
     }
-    let observe_mixed_exit = fragment_observes_mixed_exit(n, &fragment.contract);
-    if observe_mixed_exit != fragment_observes_mixed_exit(core, core_contract) {
+    let observe_mixed_exit = nose_detect::fragment_observes_mixed_exit(
+        n,
+        fragment.contract.root,
+        fragment.contract.kind,
+    );
+    if observe_mixed_exit
+        != nose_detect::fragment_observes_mixed_exit(core, core_contract.root, core_contract.kind)
+    {
         record_fragment_oracle_exclusion(
             oracle,
             &location,

--- a/crates/nose-cli/src/verify_collect/fragments.rs
+++ b/crates/nose-cli/src/verify_collect/fragments.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+fn independently_observes_mixed_exit(exits: &[nose_normalize::UnitExit]) -> bool {
+    exits
+        .iter()
+        .any(|exit| *exit == nose_normalize::UnitExit::Fallthrough)
+        && exits.iter().any(|exit| {
+            matches!(
+                exit,
+                nose_normalize::UnitExit::Return | nose_normalize::UnitExit::Throw
+            )
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
 pub(super) fn collect_product_fragment_verify_rec(
@@ -228,12 +240,12 @@ pub(super) fn collect_product_fragment_verify_rec(
         );
         return;
     }
-    let observe_mixed_exit = nose_detect::fragment_observes_mixed_exit(
+    let product_observes_mixed_exit = nose_detect::fragment_observes_mixed_exit(
         n,
         fragment.contract.root,
         fragment.contract.kind,
     );
-    if observe_mixed_exit
+    if product_observes_mixed_exit
         != nose_detect::fragment_observes_mixed_exit(core, core_contract.root, core_contract.kind)
     {
         record_fragment_oracle_exclusion(
@@ -293,6 +305,11 @@ pub(super) fn collect_product_fragment_verify_rec(
     );
     push_verify_census(oracle, &location, core, core_contract.root, &fp, outcome);
 
+    // Keep the audit oracle independent from the product's structural mixed-exit classifier.
+    // If a fingerprint-tag regression makes a mixed fragment collide with a whole function,
+    // the executed battery must still retain the terminal-control distinction and report it.
+    let oracle_observes_mixed_exit = independently_observes_mixed_exit(&fragment_exits);
+
     let mut canon_exposed = false;
     if let Ok((full_beh, full_exits)) = run_fragment_battery_diagnostic_with_oracle_proofs(
         &full_wrapper,
@@ -308,7 +325,7 @@ pub(super) fn collect_product_fragment_verify_rec(
             canon_exposed = true;
             oracle.canon_checked += 1;
             if (canon_changed_behavior(&beh, &full_beh)
-                || (observe_mixed_exit && fragment_exits != full_exits))
+                || (oracle_observes_mixed_exit && fragment_exits != full_exits))
                 && oracle.canon_violations.len() < 20
             {
                 oracle.canon_violations.push(format!(
@@ -341,8 +358,34 @@ pub(super) fn collect_product_fragment_verify_rec(
         file_idx,
         core_root: core_contract.root,
         core_fragment: Some(core_contract.clone()),
-        fragment_exits: observe_mixed_exit.then_some(fragment_exits),
+        fragment_exits: oracle_observes_mixed_exit.then_some(fragment_exits),
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::independently_observes_mixed_exit;
+    use nose_normalize::UnitExit;
+
+    #[test]
+    fn oracle_mixed_exit_requires_fallthrough_and_terminal_control() {
+        assert!(independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Return,
+        ]));
+        assert!(!independently_observes_mixed_exit(&[
+            UnitExit::Return,
+            UnitExit::Error,
+        ]));
+        assert!(independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Throw,
+        ]));
+        assert!(!independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Fallthrough,
+        ]));
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/nose-cli/src/verify_collect/fragments.rs
+++ b/crates/nose-cli/src/verify_collect/fragments.rs
@@ -1,9 +1,7 @@
 use super::*;
 
 fn independently_observes_mixed_exit(exits: &[nose_normalize::UnitExit]) -> bool {
-    exits
-        .iter()
-        .any(|exit| *exit == nose_normalize::UnitExit::Fallthrough)
+    exits.contains(&nose_normalize::UnitExit::Fallthrough)
         && exits.iter().any(|exit| {
             matches!(
                 exit,
@@ -362,32 +360,6 @@ pub(super) fn collect_product_fragment_verify_rec(
     });
 }
 
-#[cfg(test)]
-mod tests {
-    use super::independently_observes_mixed_exit;
-    use nose_normalize::UnitExit;
-
-    #[test]
-    fn oracle_mixed_exit_requires_fallthrough_and_terminal_control() {
-        assert!(independently_observes_mixed_exit(&[
-            UnitExit::Fallthrough,
-            UnitExit::Return,
-        ]));
-        assert!(!independently_observes_mixed_exit(&[
-            UnitExit::Return,
-            UnitExit::Error,
-        ]));
-        assert!(independently_observes_mixed_exit(&[
-            UnitExit::Fallthrough,
-            UnitExit::Throw,
-        ]));
-        assert!(!independently_observes_mixed_exit(&[
-            UnitExit::Fallthrough,
-            UnitExit::Fallthrough,
-        ]));
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn record_fragment_oracle_exclusion(
     oracle: &mut VerifyOracle,
@@ -421,4 +393,30 @@ fn record_fragment_oracle_exclusion(
     oracle
         .exclusions
         .record(exclusion, file_path, span, tokens, None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::independently_observes_mixed_exit;
+    use nose_normalize::UnitExit;
+
+    #[test]
+    fn oracle_mixed_exit_requires_fallthrough_and_terminal_control() {
+        assert!(independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Return,
+        ]));
+        assert!(!independently_observes_mixed_exit(&[
+            UnitExit::Return,
+            UnitExit::Error,
+        ]));
+        assert!(independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Throw,
+        ]));
+        assert!(!independently_observes_mixed_exit(&[
+            UnitExit::Fallthrough,
+            UnitExit::Fallthrough,
+        ]));
+    }
 }

--- a/crates/nose-cli/src/verify_soundness.rs
+++ b/crates/nose-cli/src/verify_soundness.rs
@@ -258,7 +258,7 @@ mod tests {
     use super::*;
     use crate::verify_collect::VerifyRec;
     use nose_il::{DomainEvidence, Lang, NodeId};
-    use nose_normalize::{Behavior, Value};
+    use nose_normalize::{Behavior, UnitExit, Value};
 
     fn behavior(value: Value) -> Vec<Behavior> {
         vec![Behavior {
@@ -350,6 +350,18 @@ mod tests {
             counts.advisory_disagreements,
             summary.advisory_disagreements.len()
         );
+    }
+
+    #[test]
+    fn mixed_exit_oracle_catches_a_missing_product_fingerprint_tag() {
+        let whole = rec("whole", &[1], behavior(Value::Int(1)), true, 7, &[]);
+        let mut fragment = rec("fragment", &[1], behavior(Value::Int(1)), true, 7, &[]);
+        fragment.fragment_exits = Some(vec![UnitExit::Fallthrough, UnitExit::Return]);
+
+        let summary = classify_verify_soundness(&[whole, fragment]);
+
+        assert_eq!(summary.false_merges.len(), 1);
+        assert_eq!(summary.false_merges[0].differing_inputs, 1);
     }
 
     #[test]

--- a/crates/nose-detect/src/fragment.rs
+++ b/crates/nose-detect/src/fragment.rs
@@ -33,6 +33,49 @@ pub use oracle::{
 };
 pub use recognize::recognized_contracts as recognized_fragment_contracts;
 
+const MIXED_EXIT_FINGERPRINT_TAG: u64 =
+    nose_il::stable_symbol_hash("nose.fragment.control.mixed-exit/v1");
+
+/// Whether an otherwise fallthrough fragment can also return or throw from its enclosing unit.
+///
+/// Whole functions intentionally erase fallthrough-vs-explicit-return when their returned value
+/// agrees. A sub-function fragment cannot: falling through continues the enclosing function.
+/// This control coordinate therefore belongs to the exact product identity, not only the
+/// offline oracle. `proof-claim: nose.claim.detect.fragment.wrapper_synthesis`
+pub fn fragment_observes_mixed_exit(
+    il: &nose_il::Il,
+    root: nose_il::NodeId,
+    kind: FragmentKind,
+) -> bool {
+    if kind.primary_exit() != Exit::Normal {
+        return false;
+    }
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if matches!(
+            il.kind(node),
+            nose_il::NodeKind::Return | nose_il::NodeKind::Throw
+        ) {
+            return true;
+        }
+        stack.extend(il.children(node));
+    }
+    false
+}
+
+/// Add the fragment-only terminal-control coordinate to an already sorted exact fingerprint.
+pub(crate) fn bind_fragment_control_identity(
+    il: &nose_il::Il,
+    root: nose_il::NodeId,
+    kind: FragmentKind,
+    value: &mut Vec<u64>,
+) {
+    if fragment_observes_mixed_exit(il, root, kind) {
+        value.push(MIXED_EXIT_FINGERPRINT_TAG);
+        value.sort_unstable();
+    }
+}
+
 /// The shape of an accepted exact sub-function fragment.
 ///
 /// Each variant is the classification of one recognizer branch in

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -38,9 +38,10 @@ pub use detectors::{
 };
 pub use exact_policy::{exact_claim_eligible, exact_claim_eligible_parts};
 pub use fragment::{
-    fragment_behavior, fragment_input_projections, free_input_cids, recognized_fragment_contracts,
-    synthesize_wrapper, synthesize_wrapper_with_module_strings, Effect, EffectSite, Exit,
-    FragmentContract, FragmentKind, OracleInputProjection, Place, ProofFacts,
+    fragment_behavior, fragment_input_projections, fragment_observes_mixed_exit, free_input_cids,
+    recognized_fragment_contracts, synthesize_wrapper, synthesize_wrapper_with_module_strings,
+    Effect, EffectSite, Exit, FragmentContract, FragmentKind, OracleInputProjection, Place,
+    ProofFacts,
 };
 pub use model::{
     AbstractionHole, AbstractionWitness, ConnectedWitness, Dump, DupPair, EnclosingUnit,

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -391,7 +391,7 @@ fn gate_unit(
     // gate so the gate can consult semantic richness (below).
     let value_start = unit_timer.start();
     let (
-        value,
+        mut value,
         lits,
         returns,
         anchors,
@@ -407,6 +407,9 @@ fn gate_unit(
     } else {
         nose_normalize::value_fingerprint_lits_anchors_laws(ctx.il, root, ctx.interner)
     };
+    if let Some(kind) = fragment_kind {
+        crate::fragment::bind_fragment_control_identity(ctx.il, root, kind, &mut value);
+    }
     let value_ms = UnitTimer::elapsed(value_start);
 
     // Size gate. A short unit normally isn't a meaningful clone — EXCEPT a

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -322,6 +322,17 @@ fn exact_safe_for_unit(ctx: &UnitExtractCtx<'_>, root: NodeId, exact_fragment: b
             }))
 }
 
+fn bind_optional_fragment_control_identity(
+    il: &Il,
+    root: NodeId,
+    fragment_kind: Option<FragmentKind>,
+    value: &mut Vec<u64>,
+) {
+    if let Some(kind) = fragment_kind {
+        crate::fragment::bind_fragment_control_identity(il, root, kind, value);
+    }
+}
+
 fn gate_unit(
     ctx: &UnitExtractCtx<'_>,
     unit_root: UnitRoot,
@@ -407,9 +418,7 @@ fn gate_unit(
     } else {
         nose_normalize::value_fingerprint_lits_anchors_laws(ctx.il, root, ctx.interner)
     };
-    if let Some(kind) = fragment_kind {
-        crate::fragment::bind_fragment_control_identity(ctx.il, root, kind, &mut value);
-    }
+    bind_optional_fragment_control_identity(ctx.il, root, fragment_kind, &mut value);
     let value_ms = UnitTimer::elapsed(value_start);
 
     // Size gate. A short unit normally isn't a meaningful clone — EXCEPT a

--- a/crates/nose-detect/src/units/product.rs
+++ b/crates/nose-detect/src/units/product.rs
@@ -189,7 +189,7 @@ pub fn default_product_oracle_fragment_candidates(
         // The extraction bundle records only whether a pointer-length contract fired. The Lab
         // needs the actual coordinates, so rebuild this offline-only fragment fingerprint once
         // and assert it is the same product value before translating its coordinates.
-        let (value, contracts) = match value_context.as_ref() {
+        let (mut value, contracts) = match value_context.as_ref() {
             Some(context) => nose_normalize::value_fingerprint_and_contracts_with_context(
                 normalized_il,
                 unit_root.root,
@@ -202,6 +202,12 @@ pub fn default_product_oracle_fragment_candidates(
                 interner,
             ),
         };
+        crate::fragment::bind_fragment_control_identity(
+            normalized_il,
+            unit_root.root,
+            fragment_kind,
+            &mut value,
+        );
         let product_admission = pre_rejection
             .or_else(|| {
                 post_value_fingerprint_rejection(

--- a/crates/nose-detect/src/units/product.rs
+++ b/crates/nose-detect/src/units/product.rs
@@ -189,19 +189,12 @@ pub fn default_product_oracle_fragment_candidates(
         // The extraction bundle records only whether a pointer-length contract fired. The Lab
         // needs the actual coordinates, so rebuild this offline-only fragment fingerprint once
         // and assert it is the same product value before translating its coordinates.
-        let (mut value, contracts) = match value_context.as_ref() {
-            Some(context) => nose_normalize::value_fingerprint_and_contracts_with_context(
-                normalized_il,
-                unit_root.root,
-                interner,
-                context,
-            ),
-            None => nose_normalize::value_fingerprint_and_contracts(
-                normalized_il,
-                unit_root.root,
-                interner,
-            ),
-        };
+        let (mut value, contracts) = offline_fragment_fingerprint(
+            normalized_il,
+            unit_root.root,
+            interner,
+            value_context.as_ref(),
+        );
         crate::fragment::bind_fragment_control_identity(
             normalized_il,
             unit_root.root,
@@ -232,6 +225,20 @@ pub fn default_product_oracle_fragment_candidates(
         });
     }
     fragments
+}
+
+fn offline_fragment_fingerprint(
+    il: &Il,
+    root: NodeId,
+    interner: &Interner,
+    context: Option<&nose_normalize::ValueFingerprintContext>,
+) -> (Vec<u64>, Vec<(u32, u32)>) {
+    match context {
+        Some(context) => nose_normalize::value_fingerprint_and_contracts_with_context(
+            il, root, interner, context,
+        ),
+        None => nose_normalize::value_fingerprint_and_contracts(il, root, interner),
+    }
 }
 
 fn translate_fragment_contracts(

--- a/crates/nose-detect/src/units/tests/extraction.rs
+++ b/crates/nose-detect/src/units/tests/extraction.rs
@@ -358,6 +358,41 @@ fn oracle_fragment_candidates_retain_current_product_rejections() {
 }
 
 #[test]
+fn mixed_exit_fragment_is_distinct_from_its_enclosing_function() {
+    let interner = Interner::new();
+    let source = r#"
+function tokenizer(src: string) {
+  if (src === 'name') {
+    return src + '!';
+  }
+}
+"#;
+    let raw = nose_frontend::lower_source(
+        FileId(0),
+        "mixed-exit.ts",
+        source.as_bytes(),
+        Lang::TypeScript,
+        &interner,
+    )
+    .expect("lower TypeScript source");
+    let units = crate::units_of_file(&raw, &interner, &crate::DetectOptions::default());
+    let function = units
+        .iter()
+        .find(|unit| unit.kind == UnitKind::Function)
+        .expect("whole function");
+    let fragment = units
+        .iter()
+        .find(|unit| unit.fragment_kind == Some(FragmentKind::ConditionalGuard))
+        .expect("mixed-exit conditional fragment");
+
+    assert!(function.exact_safe && fragment.exact_safe);
+    assert_ne!(
+        function.value, fragment.value,
+        "fragment fallthrough is not whole-function completion"
+    );
+}
+
+#[test]
 fn exact_fragment_collector_does_not_enter_lambda_bodies() {
     let interner = Interner::new();
     let fragments = lowered_fragment_units(

--- a/crates/nose-normalize/src/interp.rs
+++ b/crates/nose-normalize/src/interp.rs
@@ -164,6 +164,7 @@ type R<T> = Result<T, Unsupported>;
 enum Flow {
     Normal,
     Ret(Value),
+    Throw,
     Break,
     Continue,
     /// A type error in a CONDITION (an `Err` value used as an if/loop/ternary test). It
@@ -187,6 +188,7 @@ enum Flow {
 pub enum UnitExit {
     Fallthrough,
     Return,
+    Throw,
     Error,
 }
 
@@ -513,6 +515,7 @@ fn run_unit_once(
     };
     let (ret, exit) = match it.exec(body, &mut env) {
         Ok(Flow::Ret(v)) => (v, UnitExit::Return),
+        Ok(Flow::Throw) => (Value::Err, UnitExit::Throw),
         Ok(Flow::Err) => (Value::Err, UnitExit::Error),
         Ok(_) => (Value::Null, UnitExit::Fallthrough),
         Err(blocker) => return (Err(blocker), it.explore),

--- a/crates/nose-normalize/src/interp/calls.rs
+++ b/crates/nose-normalize/src/interp/calls.rs
@@ -250,7 +250,7 @@ impl<'a> Interp<'a> {
         let result = self.exec(body, &mut fenv);
         match result? {
             Flow::Ret(v) => Ok(v),
-            Flow::Err => Ok(Value::Err),
+            Flow::Throw | Flow::Err => Ok(Value::Err),
             _ => Ok(Value::Null),
         }
     }

--- a/crates/nose-normalize/src/interp/exec.rs
+++ b/crates/nose-normalize/src/interp/exec.rs
@@ -58,7 +58,7 @@ impl<'a> Interp<'a> {
                 if let Some(&e) = self.il.children(node).first() {
                     self.eval(e, env)?;
                 }
-                Ok(Flow::Err)
+                Ok(Flow::Throw)
             }
             NodeKind::If => {
                 let kids = self.il.children(node).to_vec();
@@ -182,7 +182,7 @@ impl<'a> Interp<'a> {
             return Err(Unsupported::protocol("protocol.exception-handler-shape"));
         }
         match self.exec(kids[0], env)? {
-            Flow::Err => self.exec(kids[1], env),
+            Flow::Throw | Flow::Err => self.exec(kids[1], env),
             other => Ok(other),
         }
     }

--- a/crates/nose-normalize/src/interp/hof.rs
+++ b/crates/nose-normalize/src/interp/hof.rs
@@ -150,7 +150,7 @@ impl<'a> Interp<'a> {
             | NodeKind::Break
             | NodeKind::Continue => match self.exec(body, &mut local)? {
                 Flow::Ret(v) => Ok(v),
-                Flow::Err => Ok(Value::Err),
+                Flow::Throw | Flow::Err => Ok(Value::Err),
                 Flow::Normal => Ok(Value::Null),
                 Flow::Break | Flow::Continue => {
                     Err(Unsupported::protocol("protocol.lambda-nonlocal-control"))

--- a/crates/nose-normalize/src/interp/tests/state.rs
+++ b/crates/nose-normalize/src/interp/tests/state.rs
@@ -226,7 +226,7 @@ fn foreach_iterable_err_stops_execution() {
     assert_eq!(run_foreach_with_iterable_err(), Some(Value::Err));
 }
 
-fn run_throw_then_return() -> Value {
+fn run_throw_then_return() -> (Value, UnitExit) {
     let sp = Span::synthetic(FileId(0));
     let mut b = IlBuilder::new(FileId(0));
     let thrown = b.add(NodeKind::Lit, Payload::LitStr(0xBAD), sp, &[]);
@@ -244,12 +244,14 @@ fn run_throw_then_return() -> Value {
         Vec::new(),
         Vec::new(),
     );
-    run_admitted_unit(il, func, &[]).expect("run_unit").ret
+    let interner = Interner::new();
+    let (behavior, exit) = run_unit_observing_exit(&il, &interner, func, &[]).expect("run_unit");
+    (behavior.ret, exit)
 }
 
 #[test]
 fn throw_is_err_behavior_and_stops_execution() {
-    assert_eq!(run_throw_then_return(), Value::Err);
+    assert_eq!(run_throw_then_return(), (Value::Err, UnitExit::Throw));
 }
 
 fn add_self_field(

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -171,10 +171,12 @@ runs every corpus repository through:
 target/release/nose verify bench/repos/<repo> --max-violations 0
 ```
 
-The runner is `scripts/corpus-verify-nightly.sh`. It keeps a per-repository log and deterministic
-TSV, Markdown, and JSON evidence. The merge job rejects a missing or overlapping shard, missing
-artifact, wrong pin, per-repository timeout, hard false merge, or canon-preservation change.
-Every shard and merged artifact is uploaded on success as well as failure. Symbolic-trace
+The runner is `scripts/corpus-verify-nightly.sh`. It keeps per-repository diagnostics separately
+from the byte-deterministic TSV, Markdown, repository selection, and JSON evidence artifact. The
+merge job rejects an incomplete, missing, or overlapping shard, contradictory status/exit row,
+missing artifact, wrong pin, per-repository timeout, hard false merge, or canon-preservation
+change. Every shard evidence artifact, diagnostic artifact, and merged artifact is uploaded on
+success as well as failure. Symbolic-trace
 disagreements stay advisory, but all per-repository deltas from the official v0.19.0 baseline are
 retained instead of being reduced to a total. The weekly deep job separately runs source-runtime,
 metamorphic equivalence, and multi-seed falsification campaigns; manual `release` mode requires

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -162,27 +162,28 @@ project (that user-facing guide is [continuous integration](continuous-integrati
 
 ### Nightly pinned-corpus verify — the soundness moat
 
-The scheduled `.github/workflows/corpus-verify.yml` gate guards soundness. Every night, and
-on manual `workflow_dispatch`, it reconstructs the pinned benchmark corpus with
-`bench/setup_repos.sh`, verifies the prune manifest, builds `target/release/nose`, and runs
-every corpus repository through:
+The scheduled `.github/workflows/corpus-verify.yml` gate guards soundness. Every night, and in
+manual `nightly` or `release` mode, it partitions the pinned benchmark corpus into four jobs,
+reconstructs each exact subset with `bench/setup_repos.sh`, builds `target/release/nose`, and
+runs every corpus repository through:
 
 ```sh
 target/release/nose verify bench/repos/<repo> --max-violations 0
 ```
 
-The runner is `scripts/corpus-verify-nightly.sh`. It shards by repository, keeps a per-repo
-log under `target/corpus-verify-logs/`, writes a Markdown summary to the GitHub step summary,
-and exits non-zero if any repo reports a hard false merge or a canon-preservation change.
-Symbolic-trace disagreements stay advisory: the summary counts them, but they do not fail the
-job. On failure the workflow uploads `target/corpus-verify-logs` as the `corpus-verify-logs`
-artifact so triage starts from the failing repo output. It caches `bench/repos` with a key
-derived from the pinned corpus manifest and prune scripts; a cold run still works because
-`bench/setup_repos.sh` removes unpinned local entries, then reconstructs any missing or
-drifted checkout. For a local spot check:
+The runner is `scripts/corpus-verify-nightly.sh`. It keeps a per-repository log and deterministic
+TSV, Markdown, and JSON evidence. The merge job rejects a missing or overlapping shard, missing
+artifact, wrong pin, per-repository timeout, hard false merge, or canon-preservation change.
+Every shard and merged artifact is uploaded on success as well as failure. Symbolic-trace
+disagreements stay advisory, but all per-repository deltas from the official v0.19.0 baseline are
+retained instead of being reduced to a total. The weekly deep job separately runs source-runtime,
+metamorphic equivalence, and multi-seed falsification campaigns; manual `release` mode requires
+that deep evidence and the full nightly evidence to belong to the same commit. See
+[Soundness Lab](soundness-lab.md#ci-nightly-deep-and-release-gates-862) for the complete contract.
+For a local spot check:
 
 ```sh
-./scripts/corpus-verify-nightly.sh --repo arrow --repo click --jobs 2
+./scripts/corpus-verify-nightly.sh --repo arrow --repo click --jobs 2 --timeout-seconds 900
 ```
 
 ### External review bots

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -333,10 +333,12 @@ safe merely because a dependency edge was missing from the selector.
 The nightly lane deterministically partitions all 120 pinned repositories into four GitHub
 matrix shards. Every repository has a per-repository timeout, and the merge step requires every
 pin exactly once. A missing checkout, missing shard artifact, wrong commit, timeout, nonzero exit,
-false merge, or canon-preservation change remains red. Raw logs and summaries are uploaded on
-success as well as failure. Timing is not part of `summary.tsv`, status rows, or evidence, so
-repeating the same binary and commits with different repository parallelism produces the same
-bytes. Advisory disagreements remain non-blocking, but the baseline snapshot
+false merge, or canon-preservation change remains red. Each shard uploads a byte-deterministic
+evidence artifact (`evidence.json`, repository selection, TSV, and Markdown) separately from its
+build, setup, and per-repository diagnostic logs; both artifacts are retained on success and
+failure. Timing is not part of the deterministic artifact, so repeating the same binary and
+commits with different repository parallelism produces the same bytes. Advisory disagreements
+remain non-blocking, but the baseline snapshot
 [`nightly-advisory-baseline.v1.json`](../bench/soundness/0.20.0/nightly-advisory-baseline.v1.json) records
 the official v0.19.0 count for every repository, and the merged artifact reports all 120
 before/current/delta rows, including unchanged rows.
@@ -346,7 +348,9 @@ equivalence suite, and three fixed-seed distinguishing-input searches. Manual `r
 both full nightly and deep lanes at the same commit, then emits one deterministic report containing
 hard gates, official-v0.19.0 and candidate risk-weighted coverage, every language floor, formal
 theorem/precondition/product-surface coverage, the guarded Tier-A perimeter, and the complete
-advisory diff. It cannot compose evidence from different commits.
+advisory diff. It cannot compose evidence from different commits, accept a missing or extra deep
+check, or release a commit whose `crates` tree differs from the checked binding. A failed composer
+still uploads its log and a failure summary.
 
 The workflow and aggregation contract can be checked without the 120-repository corpus:
 
@@ -356,27 +360,32 @@ python3 scripts/soundness-lab-gate.py self-test
 python3 scripts/soundness-lab-gate.py check
 ```
 
-The self-tests inject a false merge, canon violation, coverage regression, unregistered claim,
-unguarded Tier-A cell, and generic attribution return, and require all six to fail closed. The
-runner separately injects missing repositories, changed pins, timeouts, and aggregation-order
-changes. The release workflow is intentionally manual: ordinary nightly evidence is useful by
-itself, while a release decision additionally requires a successful same-commit deep campaign.
+The self-tests inject false merges, canon violations, coverage regressions, unregistered claims,
+unguarded Tier-A cells, generic attribution returns, incomplete shards, contradictory exit/status
+rows, and missing/empty/extra deep checks, and require all to fail closed. The runner separately
+injects missing repositories, changed pins, timeouts, and aggregation-order changes. The release
+workflow is intentionally manual: ordinary nightly evidence is useful by itself, while a release
+decision additionally requires a successful same-commit deep campaign.
 
 The first full candidate replay caught a real boundary error: a whole function could share an
 exact fingerprint with a conditional fragment that sometimes returns or throws and otherwise
 falls through into its enclosing function. The fragment now binds that mixed terminal-control
-coordinate into both product extraction and the independent audit fingerprint. A focused
-TypeScript regression and the five affected pinned repositories preserve the distinction; the
-gate is therefore recording a defect it found, not merely checking synthetic mutations.
+coordinate into product extraction. The audit oracle independently retains observed terminal
+control, including a distinct throw channel, so deleting the product tag is itself detected. A
+focused TypeScript regression, a tag-removal mutation test, and the affected pinned repositories
+preserve the distinction; the gate is therefore recording a defect it found, not merely checking
+synthetic mutations.
 
 The historical #859 expansion receipt remains bound to the implementation and performance run
 that completed that issue. The #862
 [`release-binding-862.v1.json`](../bench/soundness/0.20.0/release-binding-862.v1.json) separately
-binds the current crates tree, binary, replayed overlay, falsification output, and Type-4 blind
-receipt, while proving that all frozen pair decisions and coverage aggregates are unchanged. A
-fresh nine-iteration query run over the seven-repository regression frontier uses the published
-v0.19.0 arm64 binary as its baseline. After subtracting a same-binary control, the aggregate
-runtime delta is `+1.34%`, within the `5%` gate; the compact
+binds the current crates tree, binary, replayed overlay, falsification output, Type-4 blind receipt,
+and a candidate-generated exclusion-attribution census, while proving that all frozen pair
+decisions and coverage aggregates are unchanged. The candidate census covers 13,790 units and
+attributes every one of its 11,178 exclusions to a concrete classification and capability; generic
+or unattributed exclusions remain zero. A fresh nine-iteration query run over the seven-repository
+regression frontier uses the published v0.19.0 arm64 binary as its baseline. After subtracting a
+same-binary control, the aggregate runtime delta is `+1.63%`, within the `5%` gate; the compact
 [`performance receipt`](../bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json) records
 both raw-run hashes and the exact corpus and binary identities.
 
@@ -409,6 +418,25 @@ python3 scripts/check-soundness-scorecard.py --self-test
 python3 scripts/check-soundness-scorecard.py \
   --baseline bench/soundness/0.19.0 \
   --reproduce target/soundness-lab/v0.19.0
+```
+
+Reproduce the compact current-candidate attribution receipt from the exact source commit and
+binary recorded in `release-binding-862.v1.json`:
+
+```sh
+candidate_commit=a75c3d8c924513d59e6ae4a97941e6241f4ca01e
+candidate_binary=target/release/nose
+candidate_binary_sha256="$(shasum -a 256 "$candidate_binary" | awk '{print $1}')"
+
+RAYON_NUM_THREADS=1 "$candidate_binary" verify crates \
+  --max-violations 0 \
+  --exclusion-census target/soundness-lab/current-exclusions.json
+python3 scripts/soundness_exclusions.py \
+  --summarize-current \
+  --census target/soundness-lab/current-exclusions.json \
+  --source-commit "$candidate_commit" \
+  --binary-sha256 "$candidate_binary_sha256" \
+  --output target/soundness-lab/current-exclusion-attribution.json
 ```
 
 The runner checks each repository HEAD, validates the checked pruned-corpus

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -381,8 +381,8 @@ that completed that issue. The #862
 [`release-binding-862.v1.json`](../bench/soundness/0.20.0/release-binding-862.v1.json) separately
 binds the current crates tree, binary, replayed overlay, falsification output, Type-4 blind receipt,
 and a candidate-generated exclusion-attribution census, while proving that all frozen pair
-decisions and coverage aggregates are unchanged. The candidate census covers 13,790 units and
-attributes every one of its 11,178 exclusions to a concrete classification and capability; generic
+decisions and coverage aggregates are unchanged. The candidate census covers 13,794 units and
+attributes every one of its 11,182 exclusions to a concrete classification and capability; generic
 or unattributed exclusions remain zero. A fresh nine-iteration query run over the seven-repository
 regression frontier uses the published v0.19.0 arm64 binary as its baseline. After subtracting a
 same-binary control, the aggregate runtime delta is `+1.63%`, within the `5%` gate; the compact
@@ -424,7 +424,7 @@ Reproduce the compact current-candidate attribution receipt from the exact sourc
 binary recorded in `release-binding-862.v1.json`:
 
 ```sh
-candidate_commit=a75c3d8c924513d59e6ae4a97941e6241f4ca01e
+candidate_commit=7c459eb4a65d9cb3ccc301e674fc3687a263ba6b
 candidate_binary=target/release/nose
 candidate_binary_sha256="$(shasum -a 256 "$candidate_binary" | awk '{print $1}')"
 

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -321,6 +321,54 @@ parsed color, number/unit, box, and query-order cores, while a named browser/cas
 is linked to the executable declarative counterexamples. CI still treats `sorry`, stale Rust
 symbols or markers, and unused Lean proof hints as failures.
 
+## CI, nightly, deep, and release gates (#862)
+
+The Lab reuses the producers above in four deliberately different lanes. A PR that touches the
+semantic kernel, proof registry, Type-4 evidence, or Lab scripts gets a focused workflow. Its
+artifact indexes the registered claims touched by the diff, while the gate conservatively runs
+the complete formal registry and Lean proofs, scorecard, source-runtime calibration, Tier-A
+perimeter, and executable equivalence battery. This avoids a changed shared rule being declared
+safe merely because a dependency edge was missing from the selector.
+
+The nightly lane deterministically partitions all 120 pinned repositories into four GitHub
+matrix shards. Every repository has a per-repository timeout, and the merge step requires every
+pin exactly once. A missing checkout, missing shard artifact, wrong commit, timeout, nonzero exit,
+false merge, or canon-preservation change remains red. Raw logs and summaries are uploaded on
+success as well as failure. Timing is not part of `summary.tsv`, status rows, or evidence, so
+repeating the same binary and commits with different repository parallelism produces the same
+bytes. Advisory disagreements remain non-blocking, but the baseline snapshot
+[`nightly-advisory-baseline.v1.json`](../bench/soundness/0.20.0/nightly-advisory-baseline.v1.json) records
+the official v0.19.0 count for every repository, and the merged artifact reports all 120
+before/current/delta rows, including unchanged rows.
+
+A separate weekly deep lane runs the independent Python/Node calibration, the full metamorphic
+equivalence suite, and three fixed-seed distinguishing-input searches. Manual `release` mode runs
+both full nightly and deep lanes at the same commit, then emits one deterministic report containing
+hard gates, official-v0.19.0 and candidate risk-weighted coverage, every language floor, formal
+theorem/precondition/product-surface coverage, the guarded Tier-A perimeter, and the complete
+advisory diff. It cannot compose evidence from different commits.
+
+The workflow and aggregation contract can be checked without the 120-repository corpus:
+
+```sh
+./scripts/corpus-verify-nightly.sh --self-test
+python3 scripts/soundness-lab-gate.py self-test
+python3 scripts/soundness-lab-gate.py check
+```
+
+The self-tests inject a false merge, canon violation, coverage regression, unregistered claim,
+unguarded Tier-A cell, and generic attribution return, and require all six to fail closed. The
+runner separately injects missing repositories, changed pins, timeouts, and aggregation-order
+changes. The release workflow is intentionally manual: ordinary nightly evidence is useful by
+itself, while a release decision additionally requires a successful same-commit deep campaign.
+
+The first full candidate replay caught a real boundary error: a whole function could share an
+exact fingerprint with a conditional fragment that sometimes returns or throws and otherwise
+falls through into its enclosing function. The fragment now binds that mixed terminal-control
+coordinate into both product extraction and the independent audit fingerprint. A focused
+TypeScript regression and the five affected pinned repositories preserve the distinction; the
+gate is therefore recording a defect it found, not merely checking synthetic mutations.
+
 ## Reproduce and validate
 
 Use the published binary, the exact release source tree, and all pinned
@@ -353,11 +401,11 @@ python3 scripts/check-soundness-scorecard.py \
 ```
 
 The runner checks each repository HEAD, validates the checked pruned-corpus
-digest, and writes `evidence.json` binding those identities and `summary.tsv`
+digest, and writes v2 `evidence.json` binding those identities and deterministic `summary.tsv`
 to the actual binary hash. Missing repositories, changed pins or source bytes,
 the wrong binary, hard false merges, canon violations, artifact drift, or a
-non-release-tree report fail the check. Timing is omitted from the canonical
-120-repository result; statuses, hard counts, and advisory counts are retained.
+non-release-tree report fail the check. Timing is omitted from every archived
+aggregation file; statuses, hard counts, and advisory counts are retained.
 The measured 1-thread and 4-thread corpus results have the same canonical hash,
 zero hard failures, and 4,756 advisory disagreements.
 

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -369,6 +369,17 @@ coordinate into both product extraction and the independent audit fingerprint. A
 TypeScript regression and the five affected pinned repositories preserve the distinction; the
 gate is therefore recording a defect it found, not merely checking synthetic mutations.
 
+The historical #859 expansion receipt remains bound to the implementation and performance run
+that completed that issue. The #862
+[`release-binding-862.v1.json`](../bench/soundness/0.20.0/release-binding-862.v1.json) separately
+binds the current crates tree, binary, replayed overlay, falsification output, and Type-4 blind
+receipt, while proving that all frozen pair decisions and coverage aggregates are unchanged. A
+fresh nine-iteration query run over the seven-repository regression frontier uses the published
+v0.19.0 arm64 binary as its baseline. After subtracting a same-binary control, the aggregate
+runtime delta is `+1.34%`, within the `5%` gate; the compact
+[`performance receipt`](../bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json) records
+both raw-run hashes and the exact corpus and binary identities.
+
 ## Reproduce and validate
 
 Use the published binary, the exact release source tree, and all pinned

--- a/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
+++ b/formal/obligations/detect/fragment/wrapper_synthesis/meta.toml
@@ -22,17 +22,31 @@ status = "empirical"
 summary = "The copied fragment body and synthesized root must stay in bounds and preserve the selected behavior sinks."
 evidence = ["crates/nose-detect/src/fragment/oracle/tests.rs"]
 
+[preconditions.mixed_exit_identity]
+kind = "runtime"
+status = "empirical"
+summary = "A fallthrough fragment that may return or throw carries a fragment-only control coordinate, so it cannot collide with a whole function that intentionally erases that distinction."
+evidence = ["crates/nose-detect/src/units/tests/extraction.rs#mixed_exit_fragment_is_distinct_from_its_enclosing_function"]
+
 [product]
 surface = "verification-boundary"
 guarantee = "Bounds behavioral verification to fragments satisfying the recorded contract."
 
 [evidence]
-executable_tests = ["crates/nose-detect/src/fragment/oracle/tests.rs"]
+executable_tests = [
+  "crates/nose-detect/src/fragment/oracle/tests.rs",
+  "crates/nose-detect/src/units/tests/extraction.rs#mixed_exit_fragment_is_distinct_from_its_enclosing_function",
+]
 counterexamples = []
 
 [rust]
-files = ["crates/nose-detect/src/fragment/oracle.rs"]
-symbols = ["fragment_behavior", "synthesize_wrapper", "run_unit"]
+files = [
+  "crates/nose-detect/src/fragment.rs",
+  "crates/nose-detect/src/fragment/oracle.rs",
+  "crates/nose-detect/src/units.rs",
+  "crates/nose-detect/src/units/product.rs",
+]
+symbols = ["fragment_behavior", "fragment_observes_mixed_exit", "synthesize_wrapper", "run_unit"]
 
 [lean]
 proof = "Proof.lean"

--- a/scripts/check-soundness-scorecard.py
+++ b/scripts/check-soundness-scorecard.py
@@ -1265,11 +1265,13 @@ def verify_reproduction(path: Path, manifest: dict[str, Any]) -> None:
     if not summary_path.is_file():
         raise ValueError(f"120-repository summary missing: {summary_path}")
     lines = summary_path.read_text().splitlines()
-    expected_header = "repo\tstatus\texit_code\tfalse_merges\tcanon_changes\tadvisory\tseconds"
-    if not lines or lines[0] != expected_header:
+    legacy_header = "repo\tstatus\texit_code\tfalse_merges\tcanon_changes\tadvisory\tseconds"
+    deterministic_header = "repo\tstatus\texit_code\tfalse_merges\tcanon_changes\tadvisory"
+    if not lines or lines[0] not in {legacy_header, deterministic_header}:
         raise ValueError("120-repository summary schema changed")
     rows = [line.split("\t") for line in lines[1:] if line]
-    if any(len(row) != 7 for row in rows):
+    expected_width = 7 if lines[0] == legacy_header else 6
+    if any(len(row) != expected_width for row in rows):
         raise ValueError("120-repository summary row is malformed")
     corpus = load(ROOT / manifest["corpus"]["manifest"])
     expected_repositories = sorted(
@@ -1294,7 +1296,7 @@ def verify_reproduction(path: Path, manifest: dict[str, Any]) -> None:
     evidence = load(evidence_path)
     corpus_path = ROOT / manifest["corpus"]["manifest"]
     prune_path = ROOT / manifest["corpus"]["prune_manifest"]
-    expected_evidence = {
+    expected_v1 = {
         "schema": "nose-corpus-verify-evidence/v1",
         "complete": True,
         "nose": {"sha256": OFFICIAL_BINARY_SHA256, "version": "nose 0.19.0"},
@@ -1305,7 +1307,30 @@ def verify_reproduction(path: Path, manifest: dict[str, Any]) -> None:
         "summary_sha256": sha256_file(summary_path),
         "canonical_result_sha256": canonical_sha,
     }
-    if evidence != expected_evidence:
+    expected_results = [
+        {
+            "id": row[0],
+            "status": row[1],
+            "exit_code": int(row[2]),
+            "false_merges": int(row[3]),
+            "canon_changes": int(row[4]),
+            "advisory": int(row[5]),
+        }
+        for row in sorted(rows)
+    ]
+    expected_v2 = {
+        **expected_v1,
+        "schema": "nose-corpus-verify-evidence/v2",
+        "results": expected_results,
+        "totals": {
+            "repositories": len(expected_results),
+            "failed_repositories": 0,
+            "false_merges": 0,
+            "canon_changes": 0,
+            "advisory": sum(row["advisory"] for row in expected_results),
+        },
+    }
+    if evidence not in (expected_v1, expected_v2):
         raise ValueError("reproduction evidence is not bound to the official binary and pinned corpus")
 
 

--- a/scripts/check-soundness-scorecard.py
+++ b/scripts/check-soundness-scorecard.py
@@ -23,6 +23,7 @@ COHORT_SCHEMA = "nose-soundness-cohort/v1"
 OVERLAY_SCHEMA = "nose-soundness-scorecard-overlay/v2"
 EXPANSION_SCHEMA = "nose-soundness-oracle-expansion/v1"
 PERFORMANCE_SCHEMA = "nose.issue-859.performance/v1"
+RELEASE_BINDING_SCHEMA = "nose-soundness-release-binding/v1"
 CLAIM_ID = "nose.strict-exact.value-fingerprint/v0.19.0"
 PAIR_CAP = 8
 PPM = 1_000_000
@@ -835,8 +836,8 @@ def verify_expansion_receipt(
     implementation_tree = require_git_oid(
         receipt.get("implementation_crates_tree"), "oracle expansion crates tree"
     )
-    if git_rev_parse("HEAD:crates") != implementation_tree:
-        raise ValueError("checked-out product crates do not match the measured implementation")
+    if git_rev_parse(f"{receipt['implementation_source_sha']}:crates") != implementation_tree:
+        raise ValueError("oracle expansion source does not match its measured crates tree")
 
     frozen_contract = receipt.get("frozen_contract", {})
     expected_contract = {
@@ -965,6 +966,151 @@ def verify_expansion_receipt(
         or any(row.get("baseline_source_sha") != receipt["release_tree"] for row in entries)
     ):
         raise ValueError("oracle expansion expected-drift manifest changed")
+
+
+def verify_release_binding(
+    frozen: dict[str, Any], binding_path: Path
+) -> dict[str, Any]:
+    binding = load(binding_path)
+    if (
+        binding.get("schema") != RELEASE_BINDING_SCHEMA
+        or binding.get("issue") != 862
+        or binding.get("parent_issue") != 855
+        or binding.get("release_tree") != scorecard_repo_pin(frozen)
+    ):
+        raise ValueError("release binding has the wrong identity")
+
+    implementation = binding.get("implementation", {})
+    source = require_git_oid(implementation.get("source_sha"), "release binding source")
+    crates_tree = require_git_oid(
+        implementation.get("crates_tree"), "release binding crates tree"
+    )
+    if git_rev_parse(f"{source}:crates") != crates_tree:
+        raise ValueError("release binding source does not match its crates tree")
+    if git_rev_parse("HEAD:crates") != crates_tree:
+        raise ValueError("checked-out product crates do not match the release binding")
+    require_sha256(implementation.get("binary_sha256"), "release binding binary")
+    require_sha256(implementation.get("raw_units_sha256"), "release binding raw units")
+
+    artifacts = binding.get("artifacts", {})
+    loaded: dict[str, Path] = {}
+    for name in (
+        "blind_attack",
+        "overlay",
+        "falsification",
+        "historical_overlay",
+        "expansion_receipt",
+        "performance",
+    ):
+        artifact = artifacts.get(name, {})
+        path = checked_artifact(binding_path, artifact.get("path"))
+        if sha256_file(path) != require_sha256(
+            artifact.get("sha256"), f"release binding {name}"
+        ):
+            raise ValueError(f"release binding {name} hash drifted")
+        loaded[name] = path
+
+    overlay = load(loaded["overlay"])
+    historical = load(loaded["historical_overlay"])
+    verify_overlay(frozen, overlay)
+    verify_overlay(frozen, historical)
+
+    def decision(value: dict[str, Any]) -> list[tuple[str, str, str]]:
+        return [
+            (row["pair_id"], row["baseline_status"], row["candidate_status"])
+            for row in value["pair_ledger"]
+        ]
+
+    if (
+        overlay["summary"] != historical["summary"]
+        or overlay["gates"] != historical["gates"]
+        or decision(overlay) != decision(historical)
+        or binding.get("continuity", {}).get("score_and_pair_status_unchanged") is not True
+    ):
+        raise ValueError("release binding changed the frozen score or pair decisions")
+
+    measured_falsification, measured_completeness = parse_falsification(
+        loaded["falsification"]
+    )
+    measured_completeness.pop("max_violations")
+    if (
+        binding.get("falsification") != measured_falsification
+        or binding.get("completeness") != measured_completeness
+    ):
+        raise ValueError("release binding falsification evidence drifted")
+
+    summary = overlay["summary"]
+    gates = overlay["gates"]
+    expected_result = {
+        "baseline_verified_pair_regressions": gates["baseline_verified_pair_regressions"],
+        "candidate_cohort_sha256": overlay["candidate_cohort_sha256"],
+        "denominator_unchanged": gates["denominator_unchanged"],
+        "exact_unsafe_pair_mass": summary["exact_unsafe_pair_mass"],
+        "gate_passed": gates["passed"],
+        "language_regressions": gates["language_regressions"],
+        "macro_ppm": summary["macro_ppm"],
+        "pair_micro_ppm": summary["pair_micro_ppm"],
+        "release_target_met": gates["release_target_met"],
+        "verified_pair_mass": summary["verified_pair_mass"],
+    }
+    if binding.get("result") != expected_result or not gates["passed"]:
+        raise ValueError("release binding result does not match its overlay")
+
+    blind = load(loaded["blind_attack"])
+    blind_gate = blind.get("hard_gate", {})
+    if (
+        blind.get("product_crates_tree") != crates_tree
+        or blind_gate.get("gate_passed") is not True
+        or blind_gate.get("false_merges") != 0
+        or blind_gate.get("canon_preservation_violations") != 0
+    ):
+        raise ValueError("release binding Type-4 blind attack failed or drifted")
+
+    performance = load(loaded["performance"])
+    baseline = performance.get("baseline", {})
+    candidate = performance.get("candidate", {})
+    if (
+        performance.get("schema") != "nose.issue-862.performance/v1"
+        or performance.get("issue") != 862
+        or performance.get("parent_issue") != 855
+        or baseline.get("source_sha") != binding["release_tree"]
+        or baseline.get("binary_sha256") != OFFICIAL_BINARY_SHA256
+        or candidate.get("source_sha") != source
+        or candidate.get("crates_tree") != crates_tree
+        or candidate.get("binary_sha256") != implementation["binary_sha256"]
+    ):
+        raise ValueError("release performance provenance drifted")
+    for side in (baseline, candidate):
+        require_sha256(side.get("binary_code_sha256"), "release performance code identity")
+    expected_repositories = [
+        "alamofire", "guava", "hugo", "netty", "rxjava", "sqlalchemy", "sympy"
+    ]
+    corpus = performance.get("corpus", {})
+    if corpus.get("repositories") != expected_repositories:
+        raise ValueError("release performance corpus changed")
+    for key, value in corpus.items():
+        if key.endswith("sha256"):
+            require_sha256(value, f"release performance corpus {key}")
+    measurement = performance.get("measurement", {})
+    for key in ("primary_raw_sha256", "control_raw_sha256"):
+        require_sha256(measurement.get(key), f"release performance {key}")
+    baseline_ms = measurement.get("aggregate_baseline_median_ms", 0.0)
+    raw_delta = measurement.get("aggregate_current_median_ms", 0.0) - baseline_ms
+    adjusted = raw_delta - measurement.get("control_delta_ms", math.inf)
+    adjusted_pct = adjusted / baseline_ms * 100.0 if baseline_ms > 0 else math.inf
+    performance_gate = performance.get("gate", {})
+    limit = performance_gate.get("adjusted_delta_pct_limit", -math.inf)
+    if (
+        measurement.get("iterations", 0) < 9
+        or measurement.get("warmups", 0) < 2
+        or not math.isclose(raw_delta, measurement.get("aggregate_raw_delta_ms", math.inf))
+        or not math.isclose(adjusted, measurement.get("adjusted_delta_ms", math.inf))
+        or not math.isclose(adjusted_pct, measurement.get("adjusted_delta_pct", math.inf))
+        or adjusted_pct >= limit
+        or performance_gate.get("passed") is not True
+    ):
+        raise ValueError("release performance gate failed or drifted")
+    return overlay
 
 
 def verify_cohort(cohort: dict[str, Any]) -> None:
@@ -1429,6 +1575,9 @@ def self_test() -> None:
                         raise
                 else:
                     raise AssertionError("tampered expansion aggregate passed replay")
+            release_binding = ROOT / "bench/soundness/0.20.0/release-binding-862.v1.json"
+            if release_binding.is_file():
+                verify_release_binding(scorecard, release_binding)
     print("ok soundness scorecard self-test")
 
 
@@ -1511,6 +1660,9 @@ def main() -> int:
         if expansion_overlay.is_file():
             verify_expansion_receipt(scorecard, expansion_overlay, expansion_receipt)
             expansion_summary = load(expansion_overlay)["summary"]
+        release_binding = ROOT / "bench/soundness/0.20.0/release-binding-862.v1.json"
+        if release_binding.is_file():
+            expansion_summary = verify_release_binding(scorecard, release_binding)["summary"]
         if args.reproduce:
             verify_reproduction(args.reproduce.resolve(), manifest)
         summary = scorecard["summary"]

--- a/scripts/check-soundness-scorecard.py
+++ b/scripts/check-soundness-scorecard.py
@@ -24,6 +24,7 @@ OVERLAY_SCHEMA = "nose-soundness-scorecard-overlay/v2"
 EXPANSION_SCHEMA = "nose-soundness-oracle-expansion/v1"
 PERFORMANCE_SCHEMA = "nose.issue-859.performance/v1"
 RELEASE_BINDING_SCHEMA = "nose-soundness-release-binding/v1"
+CURRENT_EXCLUSION_SCHEMA = "nose-soundness-current-exclusion-attribution/v1"
 CLAIM_ID = "nose.strict-exact.value-fingerprint/v0.19.0"
 PAIR_CAP = 8
 PPM = 1_000_000
@@ -969,7 +970,7 @@ def verify_expansion_receipt(
 
 
 def verify_release_binding(
-    frozen: dict[str, Any], binding_path: Path
+    frozen: dict[str, Any], binding_path: Path, release_commit: str | None = None
 ) -> dict[str, Any]:
     binding = load(binding_path)
     if (
@@ -987,8 +988,10 @@ def verify_release_binding(
     )
     if git_rev_parse(f"{source}:crates") != crates_tree:
         raise ValueError("release binding source does not match its crates tree")
-    if git_rev_parse("HEAD:crates") != crates_tree:
-        raise ValueError("checked-out product crates do not match the release binding")
+    if release_commit is not None:
+        candidate = require_git_oid(release_commit, "release candidate commit")
+        if git_rev_parse(f"{candidate}:crates") != crates_tree:
+            raise ValueError("release candidate product crates do not match the release binding")
     require_sha256(implementation.get("binary_sha256"), "release binding binary")
     require_sha256(implementation.get("raw_units_sha256"), "release binding raw units")
 
@@ -996,6 +999,7 @@ def verify_release_binding(
     loaded: dict[str, Path] = {}
     for name in (
         "blind_attack",
+        "current_exclusion_attribution",
         "overlay",
         "falsification",
         "historical_overlay",
@@ -1009,6 +1013,35 @@ def verify_release_binding(
         ):
             raise ValueError(f"release binding {name} hash drifted")
         loaded[name] = path
+
+    attribution = load(loaded["current_exclusion_attribution"])
+    attribution_summary = attribution.get("summary", {})
+    if (
+        attribution.get("schema") != CURRENT_EXCLUSION_SCHEMA
+        or attribution.get("issue") != 862
+        or attribution.get("parent_issue") != 855
+        or attribution.get("source_sha") != source
+        or attribution.get("crates_tree") != crates_tree
+        or attribution.get("binary_sha256") != implementation["binary_sha256"]
+        or attribution.get("raw_census", {}).get("schema")
+        != "nose-oracle-exclusion-census/v2"
+    ):
+        raise ValueError("current exclusion attribution provenance drifted")
+    require_sha256(
+        attribution.get("raw_census", {}).get("sha256"),
+        "current exclusion attribution raw census",
+    )
+    if (
+        attribution_summary.get("generic_unattributed_exclusions") != 0
+        or attribution_summary.get("total_units")
+        != attribution_summary.get("interpretable_units", -1)
+        + attribution_summary.get("excluded_units", -1)
+        or sum(attribution_summary.get("by_classification", {}).values())
+        != attribution_summary.get("excluded_units")
+        or sum(attribution_summary.get("by_capability", {}).values())
+        != attribution_summary.get("excluded_units")
+    ):
+        raise ValueError("current exclusion attribution counts are inconsistent")
 
     overlay = load(loaded["overlay"])
     historical = load(loaded["historical_overlay"])
@@ -1633,6 +1666,10 @@ def main() -> int:
     parser.add_argument("--query", type=Path)
     parser.add_argument("--source-root", type=Path)
     parser.add_argument("--repo-pin", default=OFFICIAL_RELEASE_COMMIT)
+    parser.add_argument(
+        "--release-commit",
+        help="also require this release candidate commit's crates tree to match the binding",
+    )
     args = parser.parse_args()
     try:
         if args.self_test:
@@ -1662,7 +1699,9 @@ def main() -> int:
             expansion_summary = load(expansion_overlay)["summary"]
         release_binding = ROOT / "bench/soundness/0.20.0/release-binding-862.v1.json"
         if release_binding.is_file():
-            expansion_summary = verify_release_binding(scorecard, release_binding)["summary"]
+            expansion_summary = verify_release_binding(
+                scorecard, release_binding, args.release_commit
+            )["summary"]
         if args.reproduce:
             verify_reproduction(args.reproduce.resolve(), manifest)
         summary = scorecard["summary"]

--- a/scripts/corpus-verify-nightly.sh
+++ b/scripts/corpus-verify-nightly.sh
@@ -14,11 +14,14 @@ Options:
   --nose PATH        nose binary to run (default: target/release/nose, then cargo run)
   --expected-nose-sha256 HEX
                      fail before the run unless the explicit binary has this SHA-256
+  --source-commit HEX bind evidence to the producing source commit
   --corpus-manifest FILE
                      pinned repository manifest (default: bench/goldens/corpus.json)
   --repos-root DIR  checked-out pinned corpus root (default: bench/repos)
   --logs-dir DIR    per-repo log/output directory (default: target/corpus-verify-logs)
   --jobs N          repository-level parallelism (default: nproc/sysctl, capped at 6)
+  --timeout-seconds N
+                     fail a repository that exceeds this wall-clock limit (default: 900)
   --repo ID         run only one corpus repo id; may be repeated
   --self-test       run a fake-nose harness that proves pass/fail/advisory aggregation
   -h, --help        show this help
@@ -64,13 +67,13 @@ if [[ "${1:-}" == "__run_repo" ]]; then
     repos_root="$3"
     logs_dir="$4"
     status_dir="$5"
-    repo_id="$6"
-    expected_commit="$7"
+    timeout_seconds="$6"
+    repo_id="$7"
+    expected_commit="$8"
     repo_dir="$repos_root/$repo_id"
     log="$logs_dir/$repo_id.log"
     status_file="$status_dir/$repo_id.tsv"
 
-    started="$(date +%s)"
     mkdir -p "$logs_dir" "$status_dir"
 
     if [[ ! -d "$repo_dir" ]]; then
@@ -78,8 +81,8 @@ if [[ "${1:-}" == "__run_repo" ]]; then
             echo "missing pinned corpus repo: $repo_dir"
             echo "run bench/setup_repos.sh before corpus verify"
         } >"$log"
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-            "$repo_id" "fail" "127" "0" "0" "0" "0" >"$status_file"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$repo_id" "fail" "127" "0" "0" "0" >"$status_file"
         exit 0
     fi
 
@@ -91,31 +94,54 @@ if [[ "${1:-}" == "__run_repo" ]]; then
             echo "observed: ${observed_commit:-not-a-git-checkout}"
             echo "run bench/setup_repos.sh before corpus verify"
         } >"$log"
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-            "$repo_id" "fail" "126" "0" "0" "0" "0" >"$status_file"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$repo_id" "fail" "126" "0" "0" "0" >"$status_file"
         exit 0
     fi
 
-    set +e
+    command=("$nose" verify "$repo_dir" --max-violations 0)
     if [[ "$nose" == "__cargo_run__" ]]; then
-        cargo run --quiet -p nose-cli -- verify "$repo_dir" --max-violations 0 >"$log" 2>&1
-    else
-        "$nose" verify "$repo_dir" --max-violations 0 >"$log" 2>&1
+        command=(cargo run --quiet -p nose-cli -- verify "$repo_dir" --max-violations 0)
     fi
+    set +e
+    python3 - "$timeout_seconds" "$log" "${command[@]}" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+log_name = sys.argv[2]
+command = sys.argv[3:]
+with open(log_name, "wb") as log:
+    process = subprocess.Popen(
+        command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True
+    )
+    try:
+        code = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+        log.write(f"\ncorpus verify timeout after {timeout} seconds\n".encode())
+        code = 124
+raise SystemExit(code)
+PY
     code=$?
     set -e
 
-    finished="$(date +%s)"
-    elapsed=$((finished - started))
     false_merges="$(parse_count '\[!\] ([0-9]+) VIOLATION\(S\)' "$log")"
     canon_changes="$(parse_count '\[!\] ([0-9]+) unit\(s\) whose behavior CHANGED' "$log")"
-    advisory="$(parse_count 'advisory \(symbolic-trace disagreements.*\): ([0-9]+)' "$log")"
+    advisory="$(parse_count 'advisory \([^)]*disagreements[^)]*\): ([0-9]+)' "$log")"
     status="pass"
     if [[ "$code" -ne 0 || "$false_merges" -ne 0 || "$canon_changes" -ne 0 ]]; then
         status="fail"
     fi
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$repo_id" "$status" "$code" "$false_merges" "$canon_changes" "$advisory" "$elapsed" \
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$repo_id" "$status" "$code" "$false_merges" "$canon_changes" "$advisory" \
         >"$status_file"
     exit 0
 fi
@@ -172,6 +198,9 @@ GATE: 0 <= 0 false merges - OK
 LOG
     ;;
   black)
+    if [[ "${NOSE_CORPUS_SELF_TEST_SLEEP:-0}" == "1" ]]; then
+      sleep 2
+    fi
     cat <<'LOG'
 === value-graph oracle (soundness + completeness) ===
 
@@ -227,6 +256,76 @@ EOF
     grep -q 'advisory symbolic-trace disagreements: 2' "$tmp/out"
     grep -q 'black' "$tmp/logs/summary.md"
     grep -q 'arrow' "$tmp/logs/summary.md"
+    cp -R "$tmp/logs" "$tmp/logs-first"
+    set +e
+    "$script_path" \
+        --nose "$fake_nose" \
+        --corpus-manifest "$tmp/corpus.json" \
+        --repos-root "$tmp/repos" \
+        --logs-dir "$tmp/logs" \
+        --jobs 1 \
+        >"$tmp/repeat-out" 2>&1
+    code=$?
+    set -e
+    [[ "$code" -eq 1 ]] || {
+        cat "$tmp/repeat-out" >&2
+        echo "self-test expected repeated aggregate failure, got exit $code" >&2
+        exit 1
+    }
+    diff -ru "$tmp/logs-first" "$tmp/logs"
+
+    rm -rf "$tmp/repos/black"
+    set +e
+    "$script_path" \
+        --nose "$fake_nose" \
+        --corpus-manifest "$tmp/corpus.json" \
+        --repos-root "$tmp/repos" \
+        --logs-dir "$tmp/missing-logs" \
+        --repo black \
+        >"$tmp/missing-out" 2>&1
+    code=$?
+    set -e
+    [[ "$code" -eq 1 ]] || {
+        cat "$tmp/missing-out" >&2
+        echo "self-test expected missing repository failure, got exit $code" >&2
+        exit 1
+    }
+    grep -q 'missing pinned corpus repo' "$tmp/missing-logs/black.log"
+
+    git -C "$tmp/repos" clone -q "$tmp/repos/arrow" black
+    black_commit="$(git -C "$tmp/repos/black" rev-parse HEAD)"
+    python3 - "$tmp/corpus.json" "$black_commit" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+value = json.loads(path.read_text())
+for repository in value["repositories"]:
+    if repository["id"] == "black":
+        repository["commit"] = sys.argv[2]
+path.write_text(json.dumps(value) + "\n")
+PY
+    set +e
+    NOSE_CORPUS_SELF_TEST_SLEEP=1 "$script_path" \
+        --nose "$fake_nose" \
+        --corpus-manifest "$tmp/corpus.json" \
+        --repos-root "$tmp/repos" \
+        --logs-dir "$tmp/timeout-logs" \
+        --timeout-seconds 1 \
+        --repo black \
+        >"$tmp/timeout-out" 2>&1
+    code=$?
+    set -e
+    [[ "$code" -eq 1 ]] || {
+        cat "$tmp/timeout-out" >&2
+        echo "self-test expected timeout failure, got exit $code" >&2
+        exit 1
+    }
+    grep -q 'timeout after 1 seconds' "$tmp/timeout-logs/black.log"
+
+    rm -rf "$tmp/repos/black"
+    git -C "$tmp/repos" clone -q "$tmp/repos/arrow" black
     git -C "$tmp/repos/arrow" \
         -c user.name='nose corpus self-test' \
         -c user.email='nose-corpus-self-test@example.invalid' \
@@ -253,10 +352,12 @@ EOF
 
 nose=""
 expected_nose_sha256=""
+source_commit=""
 corpus_manifest="bench/goldens/corpus.json"
 repos_root="bench/repos"
 logs_dir="target/corpus-verify-logs"
 jobs="${NOSE_CORPUS_VERIFY_JOBS:-$(default_jobs)}"
+timeout_seconds="${NOSE_CORPUS_VERIFY_TIMEOUT_SECONDS:-900}"
 repo_filters=()
 
 while [[ $# -gt 0 ]]; do
@@ -267,6 +368,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --expected-nose-sha256)
             expected_nose_sha256="${2:?missing value for --expected-nose-sha256}"
+            shift 2
+            ;;
+        --source-commit)
+            source_commit="${2:?missing value for --source-commit}"
             shift 2
             ;;
         --corpus-manifest)
@@ -283,6 +388,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --jobs)
             jobs="${2:?missing value for --jobs}"
+            shift 2
+            ;;
+        --timeout-seconds)
+            timeout_seconds="${2:?missing value for --timeout-seconds}"
             shift 2
             ;;
         --repo)
@@ -309,10 +418,27 @@ done
     echo "--jobs must be a positive integer, got: $jobs" >&2
     exit 2
 }
+[[ "$timeout_seconds" =~ ^[0-9]+$ && "$timeout_seconds" -gt 0 ]] || {
+    echo "--timeout-seconds must be a positive integer, got: $timeout_seconds" >&2
+    exit 2
+}
 [[ -z "$expected_nose_sha256" || "$expected_nose_sha256" =~ ^[0-9a-f]{64}$ ]] || {
     echo "--expected-nose-sha256 must be 64 lowercase hex characters" >&2
     exit 2
 }
+[[ -z "$source_commit" || "$source_commit" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "--source-commit must be 40 lowercase hex characters" >&2
+    exit 2
+}
+if [[ -n "$source_commit" ]]; then
+    observed_source_commit="$(git rev-parse HEAD 2>/dev/null || true)"
+    if [[ "$observed_source_commit" != "$source_commit" ]]; then
+        echo "source commit mismatch" >&2
+        echo "expected: $source_commit" >&2
+        echo "observed: ${observed_source_commit:-not-a-git-checkout}" >&2
+        exit 2
+    fi
+fi
 [[ -f "$corpus_manifest" ]] || {
     echo "corpus manifest does not exist: $corpus_manifest" >&2
     exit 2
@@ -394,6 +520,7 @@ if [[ "${#repo_filters[@]}" -eq 0 && "$corpus_manifest_absolute" == "$default_co
 fi
 
 xargs -n 2 -P "$jobs" "$0" __run_repo "$nose" "$repos_root" "$logs_dir" "$logs_dir/status" \
+    "$timeout_seconds" \
     <"$repo_list"
 if [[ "$prune_verified" == "true" ]]; then
     python3 bench/prune_corpus.py --repos-root "$repos_root" --check-manifest
@@ -401,7 +528,7 @@ fi
 
 summary_tsv="$logs_dir/summary.tsv"
 {
-    printf 'repo\tstatus\texit_code\tfalse_merges\tcanon_changes\tadvisory\tseconds\n'
+    printf 'repo\tstatus\texit_code\tfalse_merges\tcanon_changes\tadvisory\n'
     LC_ALL=C sort "$logs_dir"/status/*.tsv
 } >"$summary_tsv"
 
@@ -412,13 +539,12 @@ totals="$(
         false_merges += $4
         canon_changes += $5
         advisory += $6
-        seconds += $7
     }
     END {
-        printf "%d\t%d\t%d\t%d\t%d\t%d", repos, failed, false_merges, canon_changes, advisory, seconds
+        printf "%d\t%d\t%d\t%d\t%d", repos, failed, false_merges, canon_changes, advisory
     }' "$summary_tsv"
 )"
-IFS=$'\t' read -r total_repos failed_repos total_false total_canon total_advisory total_seconds <<<"$totals"
+IFS=$'\t' read -r total_repos failed_repos total_false total_canon total_advisory <<<"$totals"
 
 python3 - \
     "$logs_dir/evidence.json" \
@@ -426,6 +552,7 @@ python3 - \
     "$repos_root" \
     "$nose_sha256" \
     "$nose_version" \
+    "$source_commit" \
     "$corpus_manifest" \
     "bench/labels/prune_manifest.json" \
     "$prune_verified" \
@@ -446,7 +573,7 @@ def sha256_file(path: Path) -> str:
 
 
 (
-    output_name, repo_list_name, repos_root_name, nose_sha256, nose_version,
+    output_name, repo_list_name, repos_root_name, nose_sha256, nose_version, source_commit,
     corpus_manifest_name, prune_manifest_name, prune_verified, summary_name,
 ) = sys.argv[1:]
 repo_list = Path(repo_list_name)
@@ -469,11 +596,22 @@ for line in repo_list.read_text().splitlines():
     })
 
 summary_rows = [line.split("\t") for line in summary.read_text().splitlines()[1:] if line]
-canonical = ("\n".join(sorted("\t".join(row[:6]) for row in summary_rows)) + "\n").encode()
+canonical = ("\n".join(sorted("\t".join(row) for row in summary_rows)) + "\n").encode()
 complete = prune_verified == "true"
 prune = json.loads(prune_manifest.read_text()) if complete else None
+results = [
+    {
+        "id": row[0],
+        "status": row[1],
+        "exit_code": int(row[2]),
+        "false_merges": int(row[3]),
+        "canon_changes": int(row[4]),
+        "advisory": int(row[5]),
+    }
+    for row in sorted(summary_rows)
+]
 evidence = {
-    "schema": "nose-corpus-verify-evidence/v1",
+    "schema": "nose-corpus-verify-evidence/v2",
     "complete": complete,
     "nose": {"sha256": nose_sha256 or None, "version": nose_version or None},
     "corpus_manifest_sha256": sha256_file(corpus_manifest),
@@ -482,9 +620,19 @@ evidence = {
         prune["corpus_digest_after_prune"]["hex"] if prune is not None else None
     ),
     "repositories": sorted(repositories, key=lambda row: row["id"]),
+    "results": results,
+    "totals": {
+        "repositories": len(results),
+        "failed_repositories": sum(row["status"] != "pass" for row in results),
+        "false_merges": sum(row["false_merges"] for row in results),
+        "canon_changes": sum(row["canon_changes"] for row in results),
+        "advisory": sum(row["advisory"] for row in results),
+    },
     "summary_sha256": sha256_file(summary),
     "canonical_result_sha256": hashlib.sha256(canonical).hexdigest(),
 }
+if source_commit:
+    evidence["source_commit"] = source_commit
 Path(output_name).write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
 PY
 
@@ -497,12 +645,11 @@ summary_md="$logs_dir/summary.md"
     echo "- hard false merges: $total_false"
     echo "- canon-preservation changes: $total_canon"
     echo "- advisory symbolic-trace disagreements: $total_advisory"
-    echo "- summed repo seconds: $total_seconds"
     echo
-    echo "| repo | status | false merges | canon changes | advisory | seconds |"
-    echo "|---|---:|---:|---:|---:|---:|"
+    echo "| repo | status | false merges | canon changes | advisory |"
+    echo "|---|---:|---:|---:|---:|"
     awk -F '\t' 'NR > 1 {
-        printf "| %s | %s | %s | %s | %s | %s |\n", $1, $2, $4, $5, $6, $7
+        printf "| %s | %s | %s | %s | %s |\n", $1, $2, $4, $5, $6
     }' "$summary_tsv"
 } >"$summary_md"
 

--- a/scripts/corpus-verify-nightly.sh
+++ b/scripts/corpus-verify-nightly.sh
@@ -256,6 +256,19 @@ EOF
     grep -q 'advisory symbolic-trace disagreements: 2' "$tmp/out"
     grep -q 'black' "$tmp/logs/summary.md"
     grep -q 'arrow' "$tmp/logs/summary.md"
+    python3 - "$tmp/logs/evidence.json" <<'PY'
+import json
+import sys
+
+evidence = json.load(open(sys.argv[1], encoding="utf-8"))
+assert evidence["complete"] is True
+assert evidence["full_corpus"] is False
+assert all(
+    (row["status"] == "pass")
+    == (row["exit_code"] == 0 and row["false_merges"] == 0 and row["canon_changes"] == 0)
+    for row in evidence["results"]
+)
+PY
     cp -R "$tmp/logs" "$tmp/logs-first"
     set +e
     "$script_path" \
@@ -597,8 +610,8 @@ for line in repo_list.read_text().splitlines():
 
 summary_rows = [line.split("\t") for line in summary.read_text().splitlines()[1:] if line]
 canonical = ("\n".join(sorted("\t".join(row) for row in summary_rows)) + "\n").encode()
-complete = prune_verified == "true"
-prune = json.loads(prune_manifest.read_text()) if complete else None
+full_corpus = prune_verified == "true"
+prune = json.loads(prune_manifest.read_text()) if full_corpus else None
 results = [
     {
         "id": row[0],
@@ -612,10 +625,13 @@ results = [
 ]
 evidence = {
     "schema": "nose-corpus-verify-evidence/v2",
-    "complete": complete,
+    # Reaching this writer means every selected repository produced exactly one status row.
+    # A failed repository is still a complete shard and remains red through its row/totals.
+    "complete": True,
+    "full_corpus": full_corpus,
     "nose": {"sha256": nose_sha256 or None, "version": nose_version or None},
     "corpus_manifest_sha256": sha256_file(corpus_manifest),
-    "prune_manifest_sha256": sha256_file(prune_manifest) if complete else None,
+    "prune_manifest_sha256": sha256_file(prune_manifest) if full_corpus else None,
     "pruned_corpus_digest_sha256": (
         prune["corpus_digest_after_prune"]["hex"] if prune is not None else None
     ),

--- a/scripts/soundness-lab-gate.py
+++ b/scripts/soundness-lab-gate.py
@@ -29,6 +29,11 @@ FORMAL = ROOT / "formal/obligations"
 WORKFLOW = ROOT / ".github/workflows/corpus-verify.yml"
 ADVISORY_BASELINE = CURRENT / "nightly-advisory-baseline.v1.json"
 PERFORMANCE = ROOT / "bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json"
+DEEP_CHECKS = {
+    "source_runtime_calibration",
+    "metamorphic_equivalence",
+    "multi_seed_falsification",
+}
 
 
 class GateError(ValueError):
@@ -154,6 +159,7 @@ def static_snapshot() -> dict[str, Any]:
     baseline = load(BASELINE / "scorecard.v1.json")
     overlay = load(CURRENT / "release-overlay-862.v1.json")
     receipt = load(CURRENT / "release-binding-862.v1.json")
+    attribution = load(CURRENT / "current-exclusion-attribution-862.v1.json")
     blind = load(TYPE4 / "blind_attack.v1.json")
     performance = load(PERFORMANCE)
     return {
@@ -176,11 +182,7 @@ def static_snapshot() -> dict[str, Any]:
         },
         "formal": formal_coverage(),
         "type4": type4_coverage(),
-        "attribution": {
-            "generic_unattributed_exclusions": manifest["exclusion_attribution"][
-                "generic_unattributed_exclusions"
-            ]
-        },
+        "attribution": attribution["summary"],
     }
 
 
@@ -246,6 +248,8 @@ def shard_plan(count: int) -> list[dict[str, Any]]:
 def validate_shard_evidence(evidence: dict[str, Any]) -> None:
     if evidence.get("schema") != "nose-corpus-verify-evidence/v2":
         raise GateError("nightly shard has an unsupported evidence schema")
+    if evidence.get("complete") is not True:
+        raise GateError("nightly shard is incomplete")
     results = evidence.get("results")
     repositories = evidence.get("repositories")
     if not isinstance(results, list) or not isinstance(repositories, list):
@@ -258,6 +262,14 @@ def validate_shard_evidence(evidence: dict[str, Any]) -> None:
         raise GateError("nightly shard contains duplicate repositories")
     if set(result_ids) != set(repository_ids):
         raise GateError("nightly shard identities and results disagree")
+    for row in results:
+        hard_pass = (
+            row.get("exit_code") == 0
+            and row.get("false_merges") == 0
+            and row.get("canon_changes") == 0
+        )
+        if (row.get("status") == "pass") != hard_pass:
+            raise GateError(f"nightly shard status contradicts exit evidence: {row.get('id')}")
     expected_totals = {
         "repositories": len(results),
         "failed_repositories": sum(row["status"] != "pass" for row in results),
@@ -282,6 +294,16 @@ def advisory_baseline(path: Path = ADVISORY_BASELINE) -> dict[str, Any]:
         raise GateError("advisory baseline does not cover the pinned corpus")
     if value.get("total") != sum(row["advisory"] for row in rows):
         raise GateError("advisory baseline total is inconsistent")
+    snapshot = static_snapshot()
+    source = value.get("source", {})
+    expected = snapshot["official_baseline"]
+    if (
+        source.get("version") != expected["version"]
+        or source.get("binary_sha256") != expected["published_binary_sha256"]
+        or source.get("corpus_manifest_sha256") != sha256(CORPUS)
+        or value.get("total") != expected["corpus"]["advisory_disagreements"]
+    ):
+        raise GateError("advisory baseline provenance drifted from official v0.19.0")
     return value
 
 
@@ -423,15 +445,44 @@ def language_floors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
-def release_report(corpus: dict[str, Any], deep: dict[str, Any], commit: str) -> dict[str, Any]:
-    snapshot = static_snapshot()
-    validate_snapshot(snapshot, corpus)
+def validate_deep_evidence(deep: dict[str, Any], commit: str) -> None:
     if deep.get("schema") != "nose-soundness-deep-evidence/v1":
         raise GateError("deep campaign evidence schema changed")
+    checks = deep.get("checks")
+    if (
+        deep.get("source_commit") != commit
+        or not isinstance(checks, dict)
+        or set(checks) != DEEP_CHECKS
+        or any(value is not True for value in checks.values())
+    ):
+        raise GateError("deep campaign is missing, failed, malformed, or belongs to another commit")
+
+
+def verify_release_commit_binding(commit: str) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/check-soundness-scorecard.py"),
+            "--release-commit",
+            commit,
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise GateError(f"release binding verification failed: {detail}")
+
+
+def release_report(corpus: dict[str, Any], deep: dict[str, Any], commit: str) -> dict[str, Any]:
+    verify_release_commit_binding(commit)
+    snapshot = static_snapshot()
+    validate_snapshot(snapshot, corpus)
     if corpus.get("source_commit") != commit:
         raise GateError("nightly corpus evidence belongs to another source commit")
-    if deep.get("source_commit") != commit or not all(deep.get("checks", {}).values()):
-        raise GateError("deep campaign is missing, failed, or belongs to another commit")
+    validate_deep_evidence(deep, commit)
     return {
         "schema": "nose-soundness-release-gate/v1",
         "source_commit": commit,
@@ -626,6 +677,64 @@ def self_test() -> None:
             pass
         else:
             raise AssertionError(f"self-test mutation escaped: {label}")
+    valid_shard = {
+        "schema": "nose-corpus-verify-evidence/v2",
+        "complete": True,
+        "nose": {"sha256": "0" * 64, "version": "nose 0.20.0"},
+        "repositories": [{"id": "fixture"}],
+        "results": [
+            {
+                "id": "fixture",
+                "status": "pass",
+                "exit_code": 0,
+                "false_merges": 0,
+                "canon_changes": 0,
+                "advisory": 0,
+            }
+        ],
+        "totals": {
+            "repositories": 1,
+            "failed_repositories": 0,
+            "false_merges": 0,
+            "canon_changes": 0,
+            "advisory": 0,
+        },
+    }
+    validate_shard_evidence(valid_shard)
+    shard_mutations = (
+        ("incomplete shard", lambda item: item.update(complete=False)),
+        ("pass with nonzero exit", lambda item: item["results"][0].update(exit_code=1)),
+        ("failure with zero exit", lambda item: item["results"][0].update(status="fail")),
+    )
+    for label, mutate in shard_mutations:
+        changed = copy.deepcopy(valid_shard)
+        mutate(changed)
+        try:
+            validate_shard_evidence(changed)
+        except GateError:
+            pass
+        else:
+            raise AssertionError(f"self-test mutation escaped: {label}")
+    valid_deep = {
+        "schema": "nose-soundness-deep-evidence/v1",
+        "source_commit": "0" * 40,
+        "checks": {key: True for key in DEEP_CHECKS},
+    }
+    validate_deep_evidence(valid_deep, "0" * 40)
+    deep_mutations = (
+        ("missing deep check", lambda item: item["checks"].pop("metamorphic_equivalence")),
+        ("empty deep checks", lambda item: item.update(checks={})),
+        ("extra deep check", lambda item: item["checks"].update(extra=True)),
+    )
+    for label, mutate in deep_mutations:
+        changed = copy.deepcopy(valid_deep)
+        mutate(changed)
+        try:
+            validate_deep_evidence(changed, "0" * 40)
+        except GateError:
+            pass
+        else:
+            raise AssertionError(f"self-test mutation escaped: {label}")
     first = canonical(snapshot)
     second = canonical(static_snapshot())
     if first != second:
@@ -635,7 +744,7 @@ def self_test() -> None:
     if sorted(ids) != sorted(row["id"] for row in corpus_rows()) or len(ids) != len(set(ids)):
         raise AssertionError("shard plan did not cover every pinned repository exactly once")
     check_workflow()
-    print("Soundness Lab gate self-test: six fail-closed mutations rejected")
+    print("Soundness Lab gate self-test: fail-closed mutations rejected")
 
 
 def main() -> int:

--- a/scripts/soundness-lab-gate.py
+++ b/scripts/soundness-lab-gate.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import hashlib
 import json
+import math
 import re
 import subprocess
 import sys
@@ -27,6 +28,7 @@ TYPE4 = ROOT / "bench/type4"
 FORMAL = ROOT / "formal/obligations"
 WORKFLOW = ROOT / ".github/workflows/corpus-verify.yml"
 ADVISORY_BASELINE = CURRENT / "nightly-advisory-baseline.v1.json"
+PERFORMANCE = ROOT / "bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json"
 
 
 class GateError(ValueError):
@@ -150,9 +152,10 @@ def type4_coverage() -> dict[str, Any]:
 def static_snapshot() -> dict[str, Any]:
     manifest = load(BASELINE / "manifest.v1.json")
     baseline = load(BASELINE / "scorecard.v1.json")
-    overlay = load(CURRENT / "oracle-expansion-overlay.v2.json")
-    receipt = load(CURRENT / "oracle-expansion-859.v1.json")
+    overlay = load(CURRENT / "release-overlay-862.v1.json")
+    receipt = load(CURRENT / "release-binding-862.v1.json")
     blind = load(TYPE4 / "blind_attack.v1.json")
+    performance = load(PERFORMANCE)
     return {
         "official_baseline": {
             "version": manifest["baseline"],
@@ -166,6 +169,10 @@ def static_snapshot() -> dict[str, Any]:
             "coverage_gates": overlay["gates"],
             "focused_falsification": receipt["falsification"],
             "blind_attack": blind["hard_gate"],
+            "performance": {
+                "gate": performance["gate"],
+                "measurement": performance["measurement"],
+            },
         },
         "formal": formal_coverage(),
         "type4": type4_coverage(),
@@ -206,6 +213,13 @@ def validate_snapshot(snapshot: dict[str, Any], corpus: dict[str, Any] | None = 
         )
         if canon:
             errors.append(f"{label} has a canon-preservation violation")
+    performance = candidate["performance"]
+    if (
+        performance["gate"].get("passed") is not True
+        or performance["measurement"].get("adjusted_delta_pct", math.inf)
+        >= performance["gate"].get("adjusted_delta_pct_limit", -math.inf)
+    ):
+        errors.append("official-v0.19.0 performance gate failed")
     if corpus is not None:
         totals = corpus.get("totals", {})
         if not corpus.get("complete"):
@@ -435,6 +449,7 @@ def release_report(corpus: dict[str, Any], deep: dict[str, Any], commit: str) ->
             ),
         },
         "risk_weighted_coverage": snapshot["candidate"]["risk_weighted_coverage"],
+        "performance": snapshot["candidate"]["performance"],
         "language_floors": language_floors(snapshot),
         "proof_coverage": {
             key: snapshot["formal"][key]
@@ -460,6 +475,7 @@ def markdown_summary(report: dict[str, Any]) -> str:
         )
     coverage = report["risk_weighted_coverage"]
     proof = report["proof_coverage"]
+    performance = report["performance"]["measurement"]
     return (
         "## Soundness Lab 0.20 release gate\n\n"
         f"- result: **{'PASS' if report['gate_passed'] else 'FAIL'}**\n"
@@ -467,6 +483,7 @@ def markdown_summary(report: dict[str, Any]) -> str:
         f"- risk-weighted coverage: {coverage['macro_ppm'] / 10000:.2f}% "
         f"(target {coverage['release_target_ppm'] / 10000:.2f}%)\n"
         f"- frozen verified pairs: {coverage['verified_pair_mass']}/{coverage['baseline_pair_mass']}\n"
+        f"- official-v0.19.0 adjusted runtime delta: {performance['adjusted_delta_pct']:+.2f}%\n"
         f"- proof coverage: {proof['theorems']}\n"
         f"- precondition coverage: {proof['preconditions']}\n"
     )

--- a/scripts/soundness-lab-gate.py
+++ b/scripts/soundness-lab-gate.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env python3
+"""Compose existing Soundness Lab evidence into CI, nightly, and release gates."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - CI and supported local Python provide it.
+    tomllib = None  # type: ignore[assignment]
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "bench/goldens/corpus.json"
+BASELINE = ROOT / "bench/soundness/0.19.0"
+CURRENT = ROOT / "bench/soundness/0.20.0"
+TYPE4 = ROOT / "bench/type4"
+FORMAL = ROOT / "formal/obligations"
+WORKFLOW = ROOT / ".github/workflows/corpus-verify.yml"
+ADVISORY_BASELINE = CURRENT / "nightly-advisory-baseline.v1.json"
+
+
+class GateError(ValueError):
+    pass
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except FileNotFoundError as error:
+        raise GateError(f"required artifact is missing: {path.relative_to(ROOT)}") from error
+    except json.JSONDecodeError as error:
+        raise GateError(f"invalid JSON artifact {path.relative_to(ROOT)}: {error}") from error
+    if not isinstance(value, dict):
+        raise GateError(f"artifact root must be an object: {path.relative_to(ROOT)}")
+    return value
+
+
+def canonical(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def corpus_rows() -> list[dict[str, Any]]:
+    rows = load(CORPUS).get("repositories")
+    if not isinstance(rows, list) or not rows:
+        raise GateError("pinned corpus manifest has no repositories")
+    return sorted(rows, key=lambda row: row["id"])
+
+
+def formal_coverage() -> dict[str, Any]:
+    if tomllib is None:
+        raise GateError("Python tomllib is required to read formal claim metadata")
+    theorem: Counter[str] = Counter()
+    preconditions: Counter[str] = Counter()
+    surfaces: Counter[str] = Counter()
+    claims: dict[str, set[str]] = {}
+    claim_files: dict[str, set[str]] = {}
+    obligations: list[dict[str, Any]] = []
+    for meta_path in sorted(FORMAL.rglob("meta.toml")):
+        meta = tomllib.loads(meta_path.read_text())
+        claim = meta.get("claim", {}).get("id")
+        obligation_id = meta.get("id")
+        if not isinstance(claim, str) or not isinstance(obligation_id, str):
+            raise GateError(f"claim metadata missing in {meta_path.relative_to(ROOT)}")
+        if claim in claims:
+            raise GateError(f"duplicate formal claim: {claim}")
+        rust_files = set(meta.get("rust", {}).get("files", []))
+        claims[claim] = rust_files
+        proof = meta.get("lean", {}).get("proof")
+        evidence_files = {
+            reference.partition("#")[0]
+            for field in ("executable_tests", "counterexamples")
+            for reference in meta.get("evidence", {}).get(field, [])
+        }
+        for precondition in meta.get("preconditions", {}).values():
+            if isinstance(precondition, dict):
+                evidence_files.update(
+                    reference.partition("#")[0]
+                    for reference in precondition.get("evidence", [])
+                )
+        claim_files[claim] = {
+            str(meta_path.relative_to(ROOT)),
+            *rust_files,
+            *evidence_files,
+            *([str((meta_path.parent / proof).relative_to(ROOT))] if proof else []),
+        }
+        theorem[str(meta.get("theorem", {}).get("status", "missing"))] += 1
+        surfaces[str(meta.get("product", {}).get("surface", "missing"))] += 1
+        for item in meta.get("preconditions", {}).values():
+            if isinstance(item, dict):
+                preconditions[str(item.get("status", "missing"))] += 1
+        obligations.append({"id": obligation_id, "claim": claim})
+
+    markers: dict[str, set[str]] = {}
+    marker_re = re.compile(r"\bproof-claim:\s*(nose\.claim\.[a-z0-9_.-]+)\b")
+    for source in sorted((ROOT / "crates").rglob("*.rs")):
+        rel = str(source.relative_to(ROOT))
+        for match in marker_re.finditer(source.read_text(encoding="utf-8")):
+            markers.setdefault(match.group(1), set()).add(rel)
+    unregistered = sorted(set(markers) - set(claims))
+    unlisted = sorted(
+        f"{claim}:{path}"
+        for claim, paths in markers.items()
+        if claim in claims
+        for path in paths - claims[claim]
+    )
+    return {
+        "obligations": len(obligations),
+        "theorems": dict(sorted(theorem.items())),
+        "preconditions": dict(sorted(preconditions.items())),
+        "product_surfaces": dict(sorted(surfaces.items())),
+        "unregistered_claims": unregistered,
+        "unlisted_claim_markers": unlisted,
+        "claim_files": {key: sorted(value) for key, value in sorted(claim_files.items())},
+    }
+
+
+def type4_coverage() -> dict[str, Any]:
+    sys.path.insert(0, str(TYPE4))
+    import axis_claim_gate as gate  # type: ignore[import-not-found]
+
+    registry = gate.load(gate.REGISTRY)
+    summary = gate.validate(
+        registry,
+        gate.load(gate.EVIDENCE),
+        gate.load(gate.BLIND_RECEIPT),
+        gate.load(gate.DECLARATIVE_MATRIX),
+    )
+    return {
+        "axes": summary["axes"],
+        "exact_cells": summary["cells"],
+        "closed_cells": summary["closed_cells"],
+        "unguarded_tier_a_cells": [],
+    }
+
+
+def static_snapshot() -> dict[str, Any]:
+    manifest = load(BASELINE / "manifest.v1.json")
+    baseline = load(BASELINE / "scorecard.v1.json")
+    overlay = load(CURRENT / "oracle-expansion-overlay.v2.json")
+    receipt = load(CURRENT / "oracle-expansion-859.v1.json")
+    blind = load(TYPE4 / "blind_attack.v1.json")
+    return {
+        "official_baseline": {
+            "version": manifest["baseline"],
+            "source_commit": manifest["source"]["release_commit"],
+            "published_binary_sha256": manifest["published_asset_identity"]["binary_sha256"],
+            "corpus": manifest["corpus"],
+            "risk_weighted_coverage": baseline["summary"],
+        },
+        "candidate": {
+            "risk_weighted_coverage": overlay["summary"],
+            "coverage_gates": overlay["gates"],
+            "focused_falsification": receipt["falsification"],
+            "blind_attack": blind["hard_gate"],
+        },
+        "formal": formal_coverage(),
+        "type4": type4_coverage(),
+        "attribution": {
+            "generic_unattributed_exclusions": manifest["exclusion_attribution"][
+                "generic_unattributed_exclusions"
+            ]
+        },
+    }
+
+
+def validate_snapshot(snapshot: dict[str, Any], corpus: dict[str, Any] | None = None) -> None:
+    errors: list[str] = []
+    baseline = snapshot["official_baseline"]["risk_weighted_coverage"]
+    candidate = snapshot["candidate"]
+    coverage = candidate["risk_weighted_coverage"]
+    gates = candidate["coverage_gates"]
+    if not gates.get("passed") or not gates.get("release_target_met"):
+        errors.append("risk-weighted coverage regression or release target failure")
+    for language, floor in baseline["by_language"].items():
+        current = coverage.get("by_language", {}).get(language)
+        if not current or current["macro_ppm"] < floor["macro_ppm"]:
+            errors.append(f"language coverage floor regressed: {language}")
+    if snapshot["formal"]["unregistered_claims"]:
+        errors.append("unregistered soundness-bearing claim")
+    if snapshot["formal"]["unlisted_claim_markers"]:
+        errors.append("claim marker is outside its registered source set")
+    if snapshot["type4"]["unguarded_tier_a_cells"]:
+        errors.append("unguarded Tier-A exact cell")
+    if snapshot["attribution"]["generic_unattributed_exclusions"]:
+        errors.append("generic/unattributed exclusion returned")
+    for label in ("focused_falsification", "blind_attack"):
+        evidence = candidate[label]
+        if evidence.get("false_merges", 0):
+            errors.append(f"{label} has a hard false merge")
+        canon = evidence.get(
+            "canon_preservation_violations", evidence.get("canon_changes", 0)
+        )
+        if canon:
+            errors.append(f"{label} has a canon-preservation violation")
+    if corpus is not None:
+        totals = corpus.get("totals", {})
+        if not corpus.get("complete"):
+            errors.append("nightly corpus evidence is incomplete")
+        if totals.get("failed_repositories", 0):
+            errors.append("nightly corpus has failed or timed-out repositories")
+        if totals.get("false_merges", 0):
+            errors.append("nightly corpus has a hard false merge")
+        if totals.get("canon_changes", 0):
+            errors.append("nightly corpus has a canon-preservation violation")
+    if errors:
+        raise GateError("; ".join(errors))
+
+
+def shard_plan(count: int) -> list[dict[str, Any]]:
+    if count < 1:
+        raise GateError("shard count must be positive")
+    shards = [{"id": str(index + 1), "repos": []} for index in range(count)]
+    for index, row in enumerate(corpus_rows()):
+        shards[index % count]["repos"].append(row["id"])
+    return shards
+
+
+def validate_shard_evidence(evidence: dict[str, Any]) -> None:
+    if evidence.get("schema") != "nose-corpus-verify-evidence/v2":
+        raise GateError("nightly shard has an unsupported evidence schema")
+    results = evidence.get("results")
+    repositories = evidence.get("repositories")
+    if not isinstance(results, list) or not isinstance(repositories, list):
+        raise GateError("nightly shard is missing repository results")
+    result_ids = [row["id"] for row in results]
+    repository_ids = [row["id"] for row in repositories]
+    if len(result_ids) != len(set(result_ids)) or len(repository_ids) != len(
+        set(repository_ids)
+    ):
+        raise GateError("nightly shard contains duplicate repositories")
+    if set(result_ids) != set(repository_ids):
+        raise GateError("nightly shard identities and results disagree")
+    expected_totals = {
+        "repositories": len(results),
+        "failed_repositories": sum(row["status"] != "pass" for row in results),
+        "false_merges": sum(row["false_merges"] for row in results),
+        "canon_changes": sum(row["canon_changes"] for row in results),
+        "advisory": sum(row["advisory"] for row in results),
+    }
+    if evidence.get("totals") != expected_totals:
+        raise GateError("nightly shard totals do not match repository results")
+    nose = evidence.get("nose", {})
+    if not nose.get("sha256") or not nose.get("version"):
+        raise GateError("nightly shard is not bound to an explicit nose binary")
+
+
+def advisory_baseline(path: Path = ADVISORY_BASELINE) -> dict[str, Any]:
+    value = load(path)
+    if value.get("schema") != "nose-corpus-advisory-baseline/v1":
+        raise GateError("advisory baseline schema changed")
+    rows = value.get("repositories", [])
+    ids = [row["id"] for row in rows]
+    if len(ids) != len(set(ids)) or set(ids) != {row["id"] for row in corpus_rows()}:
+        raise GateError("advisory baseline does not cover the pinned corpus")
+    if value.get("total") != sum(row["advisory"] for row in rows):
+        raise GateError("advisory baseline total is inconsistent")
+    return value
+
+
+def freeze_advisory_baseline(evidence_path: Path, output: Path) -> None:
+    evidence = load(evidence_path)
+    validate_shard_evidence(evidence)
+    snapshot = static_snapshot()
+    expected_sha = snapshot["official_baseline"]["published_binary_sha256"]
+    if not evidence.get("complete") or evidence.get("nose", {}).get("sha256") != expected_sha:
+        raise GateError("advisory baseline requires a complete official v0.19.0 binary replay")
+    results = sorted(evidence["results"], key=lambda row: row["id"])
+    expected = {row["id"] for row in corpus_rows()}
+    if {row["id"] for row in results} != expected:
+        raise GateError("advisory baseline replay did not cover the exact pinned corpus")
+    if any(
+        row["status"] != "pass" or row["exit_code"] or row["false_merges"] or row["canon_changes"]
+        for row in results
+    ):
+        raise GateError("official advisory baseline replay failed a hard gate")
+    value = {
+        "schema": "nose-corpus-advisory-baseline/v1",
+        "source": {
+            "version": "0.19.0",
+            "binary_sha256": expected_sha,
+            "corpus_manifest_sha256": sha256(CORPUS),
+        },
+        "repositories": [
+            {"id": row["id"], "advisory": row["advisory"]} for row in results
+        ],
+        "total": sum(row["advisory"] for row in results),
+    }
+    official_total = snapshot["official_baseline"]["corpus"]["advisory_disagreements"]
+    if value["total"] != official_total:
+        raise GateError(
+            f"official advisory total changed: expected {official_total}, got {value['total']}"
+        )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical(value))
+
+
+def merge_shards(inputs: Path, baseline_path: Path) -> dict[str, Any]:
+    paths = sorted(inputs.rglob("evidence.json"))
+    if not paths:
+        raise GateError(f"no shard evidence found under {inputs}")
+    shards = [load(path) for path in paths]
+    for shard in shards:
+        validate_shard_evidence(shard)
+    results = [row for shard in shards for row in shard["results"]]
+    repositories = [row for shard in shards for row in shard["repositories"]]
+    expected = {row["id"]: row["commit"] for row in corpus_rows()}
+    ids = [row["id"] for row in results]
+    if len(ids) != len(set(ids)):
+        raise GateError("nightly shards overlap")
+    if set(ids) != set(expected):
+        missing = sorted(set(expected) - set(ids))
+        extra = sorted(set(ids) - set(expected))
+        raise GateError(f"nightly shard coverage mismatch: missing={missing}, extra={extra}")
+    by_repository = {row["id"]: row for row in repositories}
+    for repo_id, commit in expected.items():
+        observed = by_repository.get(repo_id)
+        if not observed or observed.get("expected_commit") != commit or observed.get(
+            "observed_commit"
+        ) != commit:
+            raise GateError(f"nightly repository pin mismatch: {repo_id}")
+    nose_identities = {json.dumps(shard["nose"], sort_keys=True) for shard in shards}
+    if len(nose_identities) != 1:
+        raise GateError("nightly shards used different nose binaries")
+    manifest_hashes = {shard["corpus_manifest_sha256"] for shard in shards}
+    if manifest_hashes != {sha256(CORPUS)}:
+        raise GateError("nightly shards used a different corpus manifest")
+    source_commits = {shard.get("source_commit") for shard in shards}
+    if len(source_commits) != 1 or not re.fullmatch(
+        r"[0-9a-f]{40}", next(iter(source_commits), "") or ""
+    ):
+        raise GateError("nightly shards belong to different source commits")
+
+    results = sorted(results, key=lambda row: row["id"])
+    baseline = advisory_baseline(baseline_path)
+    before = {row["id"]: row["advisory"] for row in baseline["repositories"]}
+    advisory_diff = [
+        {
+            "id": row["id"],
+            "baseline": before[row["id"]],
+            "candidate": row["advisory"],
+            "delta": row["advisory"] - before[row["id"]],
+        }
+        for row in results
+    ]
+    totals = {
+        "repositories": len(results),
+        "failed_repositories": sum(row["status"] != "pass" for row in results),
+        "false_merges": sum(row["false_merges"] for row in results),
+        "canon_changes": sum(row["canon_changes"] for row in results),
+        "advisory": sum(row["advisory"] for row in results),
+    }
+    merged = {
+        "schema": "nose-corpus-verify-merged/v1",
+        "complete": True,
+        "nose": shards[0]["nose"],
+        "source_commit": shards[0].get("source_commit"),
+        "corpus_manifest_sha256": sha256(CORPUS),
+        "repositories": sorted(repositories, key=lambda row: row["id"]),
+        "results": results,
+        "totals": totals,
+        "canonical_result_sha256": hashlib.sha256(
+            ("\n".join(
+                "\t".join(
+                    str(row[key])
+                    for key in (
+                        "id", "status", "exit_code", "false_merges", "canon_changes", "advisory"
+                    )
+                )
+                for row in results
+            ) + "\n").encode()
+        ).hexdigest(),
+        "advisory": {
+            "blocking": False,
+            "baseline_total": baseline["total"],
+            "candidate_total": totals["advisory"],
+            "delta": totals["advisory"] - baseline["total"],
+            "per_repository_diff": advisory_diff,
+        },
+    }
+    validate_snapshot(static_snapshot(), merged)
+    return merged
+
+
+def language_floors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    baseline = snapshot["official_baseline"]["risk_weighted_coverage"]["by_language"]
+    current = snapshot["candidate"]["risk_weighted_coverage"]["by_language"]
+    return [
+        {
+            "language": language,
+            "baseline_macro_ppm": baseline[language]["macro_ppm"],
+            "candidate_macro_ppm": current[language]["macro_ppm"],
+            "passed": current[language]["macro_ppm"] >= baseline[language]["macro_ppm"],
+        }
+        for language in sorted(baseline)
+    ]
+
+
+def release_report(corpus: dict[str, Any], deep: dict[str, Any], commit: str) -> dict[str, Any]:
+    snapshot = static_snapshot()
+    validate_snapshot(snapshot, corpus)
+    if deep.get("schema") != "nose-soundness-deep-evidence/v1":
+        raise GateError("deep campaign evidence schema changed")
+    if corpus.get("source_commit") != commit:
+        raise GateError("nightly corpus evidence belongs to another source commit")
+    if deep.get("source_commit") != commit or not all(deep.get("checks", {}).values()):
+        raise GateError("deep campaign is missing, failed, or belongs to another commit")
+    return {
+        "schema": "nose-soundness-release-gate/v1",
+        "source_commit": commit,
+        "gate_passed": True,
+        "official_baseline": snapshot["official_baseline"],
+        "hard_gates": {
+            "pinned_corpus": corpus["totals"],
+            "focused_falsification": snapshot["candidate"]["focused_falsification"],
+            "blind_attack": snapshot["candidate"]["blind_attack"],
+            "deep_campaign": deep["checks"],
+            "registered_claims": not snapshot["formal"]["unregistered_claims"],
+            "guarded_tier_a_cells": not snapshot["type4"]["unguarded_tier_a_cells"],
+            "attributed_exclusions": (
+                snapshot["attribution"]["generic_unattributed_exclusions"] == 0
+            ),
+        },
+        "risk_weighted_coverage": snapshot["candidate"]["risk_weighted_coverage"],
+        "language_floors": language_floors(snapshot),
+        "proof_coverage": {
+            key: snapshot["formal"][key]
+            for key in ("obligations", "theorems", "preconditions", "product_surfaces")
+        },
+        "type4_claim_perimeter": snapshot["type4"],
+        "advisory": corpus["advisory"],
+    }
+
+
+def markdown_summary(report: dict[str, Any]) -> str:
+    if report["schema"] == "nose-corpus-verify-merged/v1":
+        totals = report["totals"]
+        advisory = report["advisory"]
+        return (
+            "## Soundness Lab nightly\n\n"
+            f"- pinned repositories: {totals['repositories']}\n"
+            f"- failed / false merges / canon violations: "
+            f"{totals['failed_repositories']} / {totals['false_merges']} / {totals['canon_changes']}\n"
+            f"- advisory disagreements: {advisory['candidate_total']} "
+            f"({advisory['delta']:+d}, non-blocking)\n"
+            f"- deterministic result: `{report['canonical_result_sha256']}`\n"
+        )
+    coverage = report["risk_weighted_coverage"]
+    proof = report["proof_coverage"]
+    return (
+        "## Soundness Lab 0.20 release gate\n\n"
+        f"- result: **{'PASS' if report['gate_passed'] else 'FAIL'}**\n"
+        f"- official baseline: v{report['official_baseline']['version']}\n"
+        f"- risk-weighted coverage: {coverage['macro_ppm'] / 10000:.2f}% "
+        f"(target {coverage['release_target_ppm'] / 10000:.2f}%)\n"
+        f"- frozen verified pairs: {coverage['verified_pair_mass']}/{coverage['baseline_pair_mass']}\n"
+        f"- proof coverage: {proof['theorems']}\n"
+        f"- precondition coverage: {proof['preconditions']}\n"
+    )
+
+
+def write_report(value: dict[str, Any], output: Path, markdown: Path | None) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical(value))
+    if markdown:
+        markdown.parent.mkdir(parents=True, exist_ok=True)
+        markdown.write_text(markdown_summary(value))
+
+
+def write_deep_evidence(args: argparse.Namespace) -> None:
+    checks = {
+        "source_runtime_calibration": args.domain == "success",
+        "metamorphic_equivalence": args.equivalence == "success",
+        "multi_seed_falsification": args.falsification == "success",
+    }
+    value = {
+        "schema": "nose-soundness-deep-evidence/v1",
+        "source_commit": args.commit,
+        "checks": checks,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(canonical(value))
+
+
+def pr_plan(base: str, output: Path, markdown: Path) -> None:
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise GateError(f"cannot diff PR base {base}: {completed.stderr.strip()}")
+    changed = sorted(line for line in completed.stdout.splitlines() if line)
+    formal = formal_coverage()
+    touched = [
+        claim
+        for claim, files in formal["claim_files"].items()
+        if set(files) & set(changed)
+    ]
+    value = {
+        "schema": "nose-soundness-pr-plan/v1",
+        "base": base,
+        "changed_files": changed,
+        "touched_claims": sorted(touched),
+        "checks": [
+            "formal-registry-and-proofs",
+            "risk-weighted-scorecard",
+            "Tier-A-axis-language-perimeter",
+            "source-runtime-calibration",
+            "focused-equivalence-battery",
+        ],
+        "selection": "All Soundness Lab checks run conservatively; touched claims are the review index.",
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical(value))
+    lines = ["## Soundness Lab PR plan", "", f"- changed files: {len(changed)}"]
+    lines.append(f"- touched registered claims: {len(touched)}")
+    lines.extend(f"  - `{claim}`" for claim in sorted(touched))
+    markdown.write_text("\n".join(lines) + "\n")
+
+
+def check_workflow() -> None:
+    try:
+        text = WORKFLOW.read_text()
+    except FileNotFoundError as error:
+        raise GateError("Soundness Lab workflow is missing") from error
+    required = (
+        "pull_request:",
+        'cron: "17 18 * * *"',
+        'cron: "43 17 * * 0"',
+        "plan-nightly:",
+        "nightly-shard:",
+        "merge-nightly:",
+        "deep-campaign:",
+        "release-gate:",
+        "if-no-files-found: error",
+        "failure() || cancelled() || success()",
+        '--source-commit "${{ github.sha }}"',
+        "corpus-verify-nightly.sh --self-test",
+        "check-soundness-scorecard.py --self-test",
+        "check-formal-obligations.py --self-test",
+        "check_axis_language_claims.py --self-test",
+        "soundness_exclusions.py --self-test",
+    )
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise GateError(f"Soundness Lab workflow contract is incomplete: {missing}")
+
+
+def self_test() -> None:
+    snapshot = static_snapshot()
+    empty_corpus = {
+        "complete": True,
+        "totals": {
+            "repositories": 1,
+            "failed_repositories": 0,
+            "false_merges": 0,
+            "canon_changes": 0,
+            "advisory": 1,
+        },
+    }
+    validate_snapshot(snapshot, empty_corpus)
+    mutations = (
+        ("false merge", lambda item: item["totals"].update(false_merges=1), "corpus"),
+        ("canon violation", lambda item: item["totals"].update(canon_changes=1), "corpus"),
+        (
+            "coverage regression",
+            lambda item: item["candidate"]["coverage_gates"].update(passed=False),
+            "snapshot",
+        ),
+        (
+            "unregistered claim",
+            lambda item: item["formal"]["unregistered_claims"].append("nose.claim.mutant"),
+            "snapshot",
+        ),
+        (
+            "unguarded Tier-A cell",
+            lambda item: item["type4"]["unguarded_tier_a_cells"].append("mutant/rust"),
+            "snapshot",
+        ),
+        (
+            "generic attribution",
+            lambda item: item["attribution"].update(generic_unattributed_exclusions=1),
+            "snapshot",
+        ),
+    )
+    for label, mutate, target in mutations:
+        changed_snapshot = copy.deepcopy(snapshot)
+        changed_corpus = copy.deepcopy(empty_corpus)
+        mutate(changed_corpus if target == "corpus" else changed_snapshot)
+        try:
+            validate_snapshot(changed_snapshot, changed_corpus)
+        except GateError:
+            pass
+        else:
+            raise AssertionError(f"self-test mutation escaped: {label}")
+    first = canonical(snapshot)
+    second = canonical(static_snapshot())
+    if first != second:
+        raise AssertionError("same-source static release evidence is not byte-deterministic")
+    plan = shard_plan(7)
+    ids = [repo for shard in plan for repo in shard["repos"]]
+    if sorted(ids) != sorted(row["id"] for row in corpus_rows()) or len(ids) != len(set(ids)):
+        raise AssertionError("shard plan did not cover every pinned repository exactly once")
+    check_workflow()
+    print("Soundness Lab gate self-test: six fail-closed mutations rejected")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("self-test")
+    plan = sub.add_parser("plan-shards")
+    plan.add_argument("--count", type=int, default=4)
+    merge = sub.add_parser("merge-nightly")
+    merge.add_argument("--inputs", type=Path, required=True)
+    merge.add_argument("--advisory-baseline", type=Path, default=ADVISORY_BASELINE)
+    merge.add_argument("--output", type=Path, required=True)
+    merge.add_argument("--markdown", type=Path)
+    freeze_advisory = sub.add_parser("freeze-advisory-baseline")
+    freeze_advisory.add_argument("--evidence", type=Path, required=True)
+    freeze_advisory.add_argument("--output", type=Path, default=ADVISORY_BASELINE)
+    release = sub.add_parser("release")
+    release.add_argument("--corpus", type=Path, required=True)
+    release.add_argument("--deep", type=Path, required=True)
+    release.add_argument("--commit", required=True)
+    release.add_argument("--output", type=Path, required=True)
+    release.add_argument("--markdown", type=Path)
+    deep = sub.add_parser("deep-evidence")
+    deep.add_argument("--commit", required=True)
+    deep.add_argument("--domain", required=True)
+    deep.add_argument("--equivalence", required=True)
+    deep.add_argument("--falsification", required=True)
+    deep.add_argument("--output", type=Path, required=True)
+    pr = sub.add_parser("pr-plan")
+    pr.add_argument("--base", required=True)
+    pr.add_argument("--output", type=Path, required=True)
+    pr.add_argument("--markdown", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == "check":
+            snapshot = static_snapshot()
+            validate_snapshot(snapshot)
+            check_workflow()
+            print(
+                "Soundness Lab static gate: "
+                f"{snapshot['formal']['obligations']} obligations, "
+                f"{snapshot['type4']['exact_cells']} guarded Tier-A cells"
+            )
+        elif args.command == "self-test":
+            self_test()
+        elif args.command == "plan-shards":
+            print(json.dumps(shard_plan(args.count), separators=(",", ":")))
+        elif args.command == "merge-nightly":
+            report = merge_shards(args.inputs, args.advisory_baseline)
+            write_report(report, args.output, args.markdown)
+        elif args.command == "freeze-advisory-baseline":
+            freeze_advisory_baseline(args.evidence, args.output)
+        elif args.command == "release":
+            report = release_report(load(args.corpus), load(args.deep), args.commit)
+            write_report(report, args.output, args.markdown)
+        elif args.command == "deep-evidence":
+            write_deep_evidence(args)
+        elif args.command == "pr-plan":
+            pr_plan(args.base, args.output, args.markdown)
+    except (GateError, KeyError, OSError, TypeError, subprocess.SubprocessError) as error:
+        print(f"Soundness Lab gate failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/soundness_exclusions.py
+++ b/scripts/soundness_exclusions.py
@@ -20,6 +20,7 @@ RAW_SCHEMA = "nose-oracle-exclusion-census/v2"
 LEDGER_SCHEMA = "nose-soundness-exclusion-ledger/v2"
 CORPUS_SCHEMA = "nose-claimable-mass-census/v2"
 PRIORITY_SCHEMA = "nose-interpreter-priority/v2"
+CURRENT_ATTRIBUTION_SCHEMA = "nose-soundness-current-exclusion-attribution/v1"
 RELEASE_COMMIT = "0985e6963c58d5a97e523bc532b88aa5e34f2ef9"
 CRATES_TREE = "f57b078517fcd114657dfb90a2b72f44bfb6cafb"
 REPORT_SHA256 = "149abb80c7ffb790d3fc0fbc2ad910add776d768ecf2961ee4321239f935d9c9"
@@ -203,6 +204,67 @@ def validate_raw(raw: dict[str, Any]) -> None:
     expected_priority = priority_rows(units, raw["claimable_family_cap"])
     if expected_priority != raw["priority"]:
         raise ValueError("priority aggregate does not match claimable unit rows")
+
+
+def current_attribution_receipt(
+    raw: dict[str, Any],
+    raw_sha256: str,
+    source_commit: str,
+    crates_tree: str,
+    binary_sha256: str,
+) -> dict[str, Any]:
+    """Compact a fully validated candidate census without checking in every unit row."""
+    validate_raw(raw)
+    excluded = [unit for unit in raw["units"] if unit["reason"] != "interpretable"]
+    classifications = Counter(unit["classification"] for unit in excluded)
+    capabilities = Counter(
+        unit["first_blocker"]["capability_id"]
+        for unit in excluded
+        if unit.get("first_blocker")
+    )
+    return {
+        "schema": CURRENT_ATTRIBUTION_SCHEMA,
+        "issue": 862,
+        "parent_issue": 855,
+        "source_sha": source_commit,
+        "crates_tree": crates_tree,
+        "binary_sha256": binary_sha256,
+        "raw_census": {
+            "schema": RAW_SCHEMA,
+            "sha256": raw_sha256,
+        },
+        "summary": {
+            "total_units": raw["units_total"],
+            "interpretable_units": raw["interpretable_units"],
+            "excluded_units": len(excluded),
+            "generic_unattributed_exclusions": raw["generic_unattributed_exclusions"],
+            "by_classification": dict(sorted(classifications.items())),
+            "by_capability": dict(sorted(capabilities.items())),
+        },
+    }
+
+
+def summarize_current(
+    census: Path, source_commit: str, binary_sha256: str, output: Path
+) -> None:
+    if len(source_commit) != 40 or any(char not in "0123456789abcdef" for char in source_commit):
+        raise ValueError("--source-commit must be a full lowercase Git object id")
+    if len(binary_sha256) != 64 or any(char not in "0123456789abcdef" for char in binary_sha256):
+        raise ValueError("--binary-sha256 must be 64 lowercase hex characters")
+    observed = subprocess.check_output(
+        ["git", "rev-parse", "--verify", f"{source_commit}^{{commit}}"],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+    if observed != source_commit:
+        raise ValueError("--source-commit did not resolve exactly")
+    crates_tree = subprocess.check_output(
+        ["git", "rev-parse", f"{source_commit}:crates"], cwd=ROOT, text=True
+    ).strip()
+    receipt = current_attribution_receipt(
+        load(census), sha256_file(census), source_commit, crates_tree, binary_sha256
+    )
+    write(output, receipt)
 
 
 def parse_loc(loc: str) -> tuple[str, int]:
@@ -776,6 +838,29 @@ def self_test() -> None:
         pass
     else:
         raise AssertionError("missing blocker was accepted")
+    valid_raw = {
+        "schema": RAW_SCHEMA,
+        "units_total": 2,
+        "interpretable_units": 1,
+        "generic_unattributed_exclusions": 0,
+        "claimable_family_cap": PAIR_CAP,
+        "merge_pairs": count_pairs(iter(units)),
+        "claimable_merge_pairs": count_pairs(iter(units)),
+        "priority": before,
+        "units": units,
+    }
+    receipt = current_attribution_receipt(
+        valid_raw, "1" * 64, "2" * 40, "3" * 40, "4" * 64
+    )
+    if receipt["summary"] != {
+        "total_units": 2,
+        "interpretable_units": 1,
+        "excluded_units": 1,
+        "generic_unattributed_exclusions": 0,
+        "by_classification": {"missing-oracle-support": 1},
+        "by_capability": {"il.test": 1},
+    }:
+        raise AssertionError("current attribution receipt did not preserve validated counts")
     with tempfile.TemporaryDirectory() as tmp:
         first = Path(tmp) / "first"
         peer = Path(tmp) / "peer"
@@ -861,6 +946,7 @@ def main() -> None:
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--freeze-baseline", action="store_true")
     parser.add_argument("--freeze-corpus", action="store_true")
+    parser.add_argument("--summarize-current", action="store_true")
     parser.add_argument("--census", type=Path)
     parser.add_argument("--census-peer", type=Path)
     parser.add_argument("--report", type=Path)
@@ -868,10 +954,21 @@ def main() -> None:
     parser.add_argument("--source-root", type=Path)
     parser.add_argument("--raw-dir", type=Path)
     parser.add_argument("--evidence", type=Path)
+    parser.add_argument("--source-commit")
+    parser.add_argument("--binary-sha256")
+    parser.add_argument("--output", type=Path)
     parser.add_argument("--baseline", type=Path, default=BASELINE)
     args = parser.parse_args()
     if args.self_test:
         self_test()
+        return
+    if args.summarize_current:
+        if not all((args.census, args.source_commit, args.binary_sha256, args.output)):
+            parser.error(
+                "--summarize-current requires --census, --source-commit, "
+                "--binary-sha256, and --output"
+            )
+        summarize_current(args.census, args.source_commit, args.binary_sha256, args.output)
         return
     if args.freeze_baseline:
         if not all((


### PR DESCRIPTION
Closes #862

## Summary

- add focused PR, deterministic nightly, deep-campaign, and 0.20 release gates with artifacts preserved on success and failure
- fail closed on missing or inconsistent shards, incomplete corpus evidence, coverage regressions, unregistered claims, and generic exclusion attribution
- fix mixed-exit exact fingerprints and separate explicit throws from interpreter errors after full-corpus false merges exposed both boundaries
- bind current exclusion evidence and release performance to the candidate tree and official v0.19.0 binary

## Validation

- ./scripts/check-ci-local.sh --fast
- full pinned corpus: 120/120 repositories, 0 false merges, 0 canon violations
- Type-4 blind attack: 54 exact groups, 0 false merges, 0 canon violations
- release equivalence: 430/430 tests and three fixed falsification seeds
- release gate: PASS; risk-weighted coverage 45.76% (target 42.50%); adjusted runtime delta +1.63% versus official v0.19.0

## Review

One parallel round of three independent reviews was completed for #862. Their actionable findings were applied once; no repeat review was requested.