### PR TITLE
Bind Soundness Lab evidence to the merged commit

### DIFF
--- a/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json
@@ -9,7 +9,7 @@
     "binary_code_sha256": "9b8760574a86cefd36a670d70f46f4ac2a80ba18f5b0a09b5a9dee9d74b8690d",
     "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
     "crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
-    "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b"
+    "source_sha": "6223233e5e72f73426b74f8df7ec445b85362eed"
   },
   "corpus": {
     "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",

--- a/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
+++ b/bench/soundness/0.20.0/current-exclusion-attribution-862.v1.json
@@ -8,7 +8,7 @@
     "sha256": "6d6137b6fe831b5657500c0f4fec77b77c0a6a26d20d6ae76defbcae765f1a1f"
   },
   "schema": "nose-soundness-current-exclusion-attribution/v1",
-  "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b",
+  "source_sha": "6223233e5e72f73426b74f8df7ec445b85362eed",
   "summary": {
     "by_capability": {
       "budget.oracle-cost": 1,

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -6,7 +6,7 @@
     },
     "current_exclusion_attribution": {
       "path": "current-exclusion-attribution-862.v1.json",
-      "sha256": "57774fad7159f6038624e5ec4f2683e7107a863de6eca0bb70259ec400d6045a"
+      "sha256": "c85f06891a8676cdab5edc87d60893e38cc125aabedce1d1939271278377bb24"
     },
     "expansion_receipt": {
       "path": "oracle-expansion-859.v1.json",
@@ -26,7 +26,7 @@
     },
     "performance": {
       "path": "../../recall_loss/issue-862-official-v0.19.0-performance-2026-07-18.v1.json",
-      "sha256": "b5cc9acbd0657cf1c215c4a2367477e1e12e02b41e0d16925c51c0fbea8f5386"
+      "sha256": "2ec164529b51f4fc5b8e80584129a191bf20c8e44bed01474c27a51017fcf1a0"
     }
   },
   "completeness": {
@@ -56,7 +56,7 @@
     "binary_sha256": "b94b2fa9a5b8d52c972340e530a9c7e956819cf5df97980cdc387bae5f7fe64f",
     "crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
     "raw_units_sha256": "ddbf5e83f194a28f5607a1eb4c15523c0d448d877fc834968d39f8c9ecc41341",
-    "source_sha": "7c459eb4a65d9cb3ccc301e674fc3687a263ba6b"
+    "source_sha": "6223233e5e72f73426b74f8df7ec445b85362eed"
   },
   "issue": 862,
   "parent_issue": 855,

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -424,7 +424,7 @@ Reproduce the compact current-candidate attribution receipt from the exact sourc
 binary recorded in `release-binding-862.v1.json`:
 
 ```sh
-candidate_commit=7c459eb4a65d9cb3ccc301e674fc3687a263ba6b
+candidate_commit=6223233e5e72f73426b74f8df7ec445b85362eed
 candidate_binary=target/release/nose
 candidate_binary_sha256="$(shasum -a 256 "$candidate_binary" | awk '{print $1}')"
 


### PR DESCRIPTION
Follow-up to #905 and #862.

The #862 release evidence referenced an intermediate branch commit whose crates tree is byte-for-byte identical to merge commit 6223233e, but that intermediate object is unavailable in a clean squash-merged main checkout. This made the main scorecard self-test fail while the PR checkout passed.

This PR changes only provenance metadata and the documented reproduction commit:
- rebind the current exclusion, performance, and release receipts to 6223233e
- refresh the two affected artifact hashes
- preserve the exact crates tree 85befdaa7e960a4762c9baade4fcdad372f005da and all measured results

Focused validation:
- soundness scorecard self-test
- scorecard with release candidate binding
- JSON and diff validation
- documentation checks

No additional review round is requested, per the one-round review constraint for #862.