### PR TITLE
perf(query): eliminate repeated default-surface identity work

### DIFF
--- a/bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json
@@ -1,0 +1,124 @@
+{
+  "artifacts": {
+    "all120_control_r3_sha256": "df2fd999cb7fa6dd8f23957771a7d8513b2929866f530e367bdc1f565fb39b88",
+    "all120_primary_r3_sha256": "40c5cbab8d35aa259371d29553c1c0355590d730212eb18365c8bf3f793daeb9",
+    "focused18_control_r21_sha256": "85df47e2b2669ada888e9b84051fe7d7d87ce4ad8d0524b4fd96511374af9e40",
+    "focused18_primary_r21_sha256": "1f72f3da5e9b4f6ade160ae6c2cd4617a38e608512452e63e4756c7bdc32e397",
+    "focused33_control_r9_sha256": "86294885619feda1c2397a1773b272ca18b05bfaed1ecb4750737478a2b16eab",
+    "focused33_primary_r9_sha256": "a4188eba28259d77f630444013bc3bf76e8c3e43adbfe1fb9eb1911824451dc2",
+    "focused9_control_r40_sha256": "a3e615b896b9520604ddcd19ed60e2a0e6390746179513c1ab5541e9f987fb63",
+    "focused9_primary_r40_sha256": "a539b07ede84b3531b28623a4b84278fe5225ad1c4327c5331a9d5e191fc948a",
+    "final_checker_status_sha256": "021b949bd1a9a3b4fef512af268f683e799e7b2103f21ec857c21db165a8b8f2",
+    "pre_post_all120_output_sha256": "124f972fa54cd58710d5503673e0a1d0b32ffd71e5fa38889557aadbbecbd7c8",
+    "semantic_smoke_focused_sha256": "c32658ab8fc9adbf230f40c25ad4bab2cb5a28095415090e46bfcba24e39cd38",
+    "semantic_smoke_primary_sha256": "6ec2c77834f7714738183511ee452c9c284af35cd2f5bfbb0c8cc82bf6767c3b",
+    "semantic_smoke_summary_sha256": "ec9728da3960f8635b009d8bc59d12a9857c79607ee474ce20af02424737f37c"
+  },
+  "baseline": {
+    "binary_code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+    "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+    "source_sha": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+    "version": "v0.19.0"
+  },
+  "candidate": {
+    "binary_code_sha256": "e8f592a00519b27d1bd4ff4a52911806c1180e8f9a72be68232157adca7dc63f",
+    "binary_sha256": "111c6507dd028a194c000fbc279e05e6b9b2899552a9dca7f56a15d23c5ad38c",
+    "source_sha": "8c37b8f9c75b9543dc746e3eb6b9b18209810059"
+  },
+  "corpus": {
+    "corpus_manifest_sha256": "87b3defc02c87e53f5ce20d10b68afdbc7190a6db5d5bfdb6b655b305bbc7ba8",
+    "corpus_state_sha256": "781b5c5082c5ddf03cf5a3b3622eb4944bd2389b233e8a593b08f54e96ef6eda",
+    "expected_corpus_state_sha256": "b28d7245aa34d7e0320d0c80ef988803ba6acb65b63eaf1bae6d7ac840b168e0",
+    "prune_manifest_sha256": "c22f34d3ab4da9b89b5938140bbfdf7664178b3b7b57e5ea3937ba0bb47c2980",
+    "repositories": 120
+  },
+  "escalation": [
+    {
+      "iterations": 3,
+      "repositories": 120
+    },
+    {
+      "iterations": 9,
+      "repositories": 33
+    },
+    {
+      "iterations": 21,
+      "repositories": 18
+    },
+    {
+      "iterations": 40,
+      "repositories": 9
+    }
+  ],
+  "follow_up": {
+    "frontend": "https://github.com/corca-ai/nose/issues/907",
+    "normalization": "https://github.com/corca-ai/nose/issues/908"
+  },
+  "gate": {
+    "aggregate_control_adjusted_delta_pct_limit": 5.0,
+    "aggregate_passed": true,
+    "default_query_regressions_removed": true,
+    "final_checker_status": "split-independent-residuals",
+    "semantic_smoke_passed": true
+  },
+  "issue": 892,
+  "measurement": {
+    "all120_r3": {
+      "adjusted_delta_ms": -247.1176718827337,
+      "adjusted_delta_pct": -0.690817460034696,
+      "aggregate_baseline_median_ms": 35752.501708688214,
+      "aggregate_current_median_ms": 35438.88137477916,
+      "control_delta_ms": -66.50266202632338,
+      "raw_delta_ms": -313.6203339090571,
+      "raw_delta_pct": -0.8771982908061625
+    },
+    "command": "nose query <repo> all top=0 --format json",
+    "focused9_r40": {
+      "adjusted_delta_ms": -16.153500822838396,
+      "adjusted_delta_pct": -0.23344612168502538,
+      "aggregate_baseline_median_ms": 6806.019897107035,
+      "aggregate_current_median_ms": 6760.2532703313045,
+      "control_delta_ms": -29.613125952892005,
+      "raw_delta_ms": -45.7666267757304,
+      "raw_delta_pct": -0.6724433291061044
+    },
+    "remaining_independent_signals": [
+      {
+        "adjusted_delta_ms": 5.55,
+        "adjusted_delta_pct": 6.52,
+        "repo": "etcd",
+        "stage": "lower"
+      },
+      {
+        "adjusted_delta_ms": 5.9,
+        "adjusted_delta_pct": 10.55,
+        "repo": "etcd",
+        "stage": "parse+lower"
+      },
+      {
+        "adjusted_delta_ms": 26.5,
+        "adjusted_delta_pct": 7.39,
+        "repo": "guava",
+        "stage": "normalize+extract"
+      },
+      {
+        "adjusted_delta_ms": 7.05,
+        "adjusted_delta_pct": 6.39,
+        "repo": "minio",
+        "stage": "normalize+extract"
+      }
+    ]
+  },
+  "output_invariance": {
+    "all120_family_count_order_surface_metadata_and_bytes_identical": true,
+    "baseline_binary_sha256": "7fed6a7cfa374031f950cbfedb04124d8868baa0a6c1eabf2e7685e5429edf87",
+    "baseline_source_sha": "963af51f38e1a9004f8aed3a0bd0d3ab1648e353",
+    "candidate_binary_sha256": "111c6507dd028a194c000fbc279e05e6b9b2899552a9dca7f56a15d23c5ad38c",
+    "repositories": 120
+  },
+  "root_cause": {
+    "description": "Default-surface checks recomputed sorted whole-family identities in opportunity grouping, gating, and rendering after the #842/#843 surface split.",
+    "fix": "Use stable in-process family handles for surface membership and decide default slices while constructing direct fold edges, removing the redundant full-family pass."
+  },
+  "schema": "nose.issue-892.performance/v1"
+}

--- a/crates/nose-cli/src/main_tests/query_family.rs
+++ b/crates/nose-cli/src/main_tests/query_family.rs
@@ -58,8 +58,8 @@ fn compiled_css_pipeline_demotes_source_plus_outputs_but_not_cross_source() {
     let ov = SurfaceOverrides {
         generated_sources: gen.clone(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     assert_eq!(effective_surface(&pipe, &ov), "generated");
     assert!(
@@ -104,8 +104,8 @@ fn partial_jazzy_provenance_keeps_the_family_on_its_ranked_surface() {
         ]
         .into_iter()
         .collect(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     assert_eq!(effective_surface(&family, &overrides), "default");
     assert!(is_default_report_family(&family, &overrides));
@@ -126,8 +126,8 @@ fn jazzy_surface_classification_preserves_the_opportunity_fold_input() {
         ]
         .into_iter()
         .collect(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     assert_eq!(effective_surface(&family, &overrides), "generated");
     assert!(
@@ -146,8 +146,8 @@ fn query_family_json_carries_fold_navigation() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     // The primary lists the slice ids it subsumes (navigable id= handles).
     let ja = query_family_json(&a, &ov, &opp, false, None, None);
@@ -195,8 +195,8 @@ fn query_family_json_carries_proof_depth() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     let empty = OpportunityGroups::default();
     // Exact channel: how much is proven identical (the shared value-multiset size).
@@ -230,8 +230,8 @@ fn query_family_json_carries_raw_detector_metrics() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
-        declaration_run_ids: rustc_hash::FxHashSet::default(),
-        declaration_only_type_contract_ids: rustc_hash::FxHashSet::default(),
+        declaration_run_families: rustc_hash::FxHashSet::default(),
+        declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
     let empty = OpportunityGroups::default();
     let mut f = fam(2, 3, &[Some("a"), Some("b"), Some("c")]);

--- a/crates/nose-cli/src/main_tests/query_family/accepted_coverage.rs
+++ b/crates/nose-cli/src/main_tests/query_family/accepted_coverage.rs
@@ -54,10 +54,9 @@ fn overlapping_slices_fold_under_their_primary() {
 fn a_slice_stays_visible_when_its_primary_leaves_the_default_surface() {
     let primary = fam_at(&[("docs/a.html", 100, 130), ("docs/b.html", 50, 70)]);
     let slice = fam_at(&[("docs/a.html", 105, 128), ("docs/b.html", 52, 66)]);
-    let mut groups = OpportunityGroups::from_ranked(&[&primary, &slice]);
-    let default_ids = [baseline::family_id(&slice)].into_iter().collect();
-
-    groups.restrict_default_slices_to(&default_ids);
+    let groups = OpportunityGroups::from_ranked_with_default(&[&primary, &slice], |family| {
+        std::ptr::eq(family, &slice)
+    });
 
     assert!(
         groups.is_slice(&slice),

--- a/crates/nose-cli/src/query_commands.rs
+++ b/crates/nose-cli/src/query_commands.rs
@@ -1,4 +1,3 @@
-use crate::baseline;
 use crate::baseline_comparison::BaselineComparison;
 use crate::cli_args::{Cmd, QueryArgs, ScopeFilter};
 use crate::divergence;
@@ -192,14 +191,9 @@ fn query_opportunities(
         .iter()
         .filter(|f| is_default_opportunity_family(f, overrides))
         .collect();
-    let mut groups = OpportunityGroups::from_ranked(&default_fams);
-    let default_ids = families
-        .iter()
-        .filter(|family| is_default_report_family(family, overrides))
-        .map(baseline::family_id)
-        .collect();
-    groups.restrict_default_slices_to(&default_ids);
-    groups
+    OpportunityGroups::from_ranked_with_default(&default_fams, |family| {
+        is_default_report_family(family, overrides)
+    })
 }
 
 fn discard_accepted_coverage(families: &mut [nose_detect::RefactorFamily]) {

--- a/crates/nose-cli/src/query_opportunities.rs
+++ b/crates/nose-cli/src/query_opportunities.rs
@@ -47,7 +47,18 @@ impl OpportunityGroups {
     /// policy. Requiring direct obligation coverage prevents partial overlap or
     /// an A-B-C bridge from hiding accepted endpoints the primary does not
     /// represent.
+    #[cfg(test)]
     pub(crate) fn from_ranked(families: &[&nose_detect::RefactorFamily]) -> Self {
+        Self::from_ranked_with_default(families, |_| true)
+    }
+
+    /// Build the stable all-surface fold forest and, while the direct endpoints are already
+    /// known, decide which edges may also fold on the default surface. Computing that decision
+    /// here avoids a second full-family identity pass after the graph has been built (#892).
+    pub(crate) fn from_ranked_with_default(
+        families: &[&nose_detect::RefactorFamily],
+        is_default: impl Fn(&nose_detect::RefactorFamily) -> bool,
+    ) -> Self {
         // A file listing implausibly many families would make candidate
         // generation quadratic; skip it rather than risk query speed.
         const PER_FILE_CAP: usize = 200;
@@ -142,30 +153,17 @@ impl OpportunityGroups {
         }
         let mut groups = Self::default();
         for (i, primary) in primary_index.into_iter().enumerate() {
-            if let Some(primary) = primary {
-                let primary = baseline::family_id(families[primary]);
+            if let Some(primary_index) = primary {
+                let primary = baseline::family_id(families[primary_index]);
                 let slice = baseline::family_id(families[i]);
+                if is_default(families[i]) && is_default(families[primary_index]) {
+                    groups.default_slices.insert(slice.clone());
+                }
                 groups.primary_of.insert(slice.clone(), primary.clone());
                 groups.slices_of.entry(primary).or_default().push(slice);
             }
         }
         groups
-            .default_slices
-            .extend(groups.primary_of.keys().cloned());
-        groups
-    }
-
-    /// Restrict default-view folds to edges whose slice and direct suppressor
-    /// both remain on the default surface. The unrestricted maps continue to
-    /// describe the stable `all` view and its JSON navigation.
-    pub(crate) fn restrict_default_slices_to(&mut self, default_ids: &FxHashSet<String>) {
-        self.default_slices.retain(|slice| {
-            default_ids.contains(slice)
-                && self
-                    .primary_of
-                    .get(slice)
-                    .is_some_and(|primary| default_ids.contains(primary))
-        });
     }
 
     pub(crate) fn is_slice(&self, family: &nose_detect::RefactorFamily) -> bool {

--- a/crates/nose-cli/src/query_output.rs
+++ b/crates/nose-cli/src/query_output.rs
@@ -302,17 +302,13 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-            declaration_run_ids: Default::default(),
-            declaration_only_type_contract_ids: Default::default(),
+            declaration_run_families: Default::default(),
+            declaration_only_type_contract_families: Default::default(),
         };
         let ranked: Vec<_> = families.iter().collect();
-        let mut groups = OpportunityGroups::from_ranked(&ranked);
-        let default_ids = families
-            .iter()
-            .filter(|family| is_default_report_family(family, &overrides))
-            .map(baseline::family_id)
-            .collect();
-        groups.restrict_default_slices_to(&default_ids);
+        let groups = OpportunityGroups::from_ranked_with_default(&ranked, |family| {
+            is_default_report_family(family, &overrides)
+        });
         let filters = [
             ("surface=default", QOp::Eq, "default", false),
             ("surface~default", QOp::Has, "default", false),

--- a/crates/nose-cli/src/surfaces.rs
+++ b/crates/nose-cli/src/surfaces.rs
@@ -35,9 +35,21 @@ pub(crate) fn classify_surface_overrides(
     SurfaceOverrides {
         generated_sources: generated.sources,
         additional_generated_surface_sources: generated.additional_surface_sources,
-        declaration_run_ids: declaration_run_ids(families),
-        declaration_only_type_contract_ids: declaration_only_type_contract_ids(families),
+        declaration_run_families: declaration_run_families(families),
+        declaration_only_type_contract_families: declaration_only_type_contract_families(families),
     }
+}
+
+/// Process-local identity for a ranked family.
+///
+/// Surface overrides live only as long as the query's family vector. The location buffer is
+/// not resized after classification, so its address and length remain stable even if the outer
+/// family vector is sorted. This avoids repeatedly sorting and hashing every location merely to
+/// ask whether an already-classified family has a presentation override (#892).
+type FamilyHandle = (usize, usize);
+
+fn family_handle(family: &nose_detect::RefactorFamily) -> FamilyHandle {
+    (family.locations.as_ptr() as usize, family.locations.len())
 }
 
 /// The mechanically-decidable non-actionable classes (design.md §2b: the
@@ -51,14 +63,14 @@ pub(crate) struct SurfaceOverrides {
     /// files deliberately do not set `Loc::looks_generated`, which has semantic effects on
     /// helper selection and folding beyond presentation (#842).
     pub(crate) additional_generated_surface_sources: FxHashSet<String>,
-    /// Family ids whose every member span is provably only import/include/
+    /// Families whose every member span is provably only import/include/
     /// use/re-export declarations — duplication the language mandates per
     /// file, with no extraction action to take.
-    pub(crate) declaration_run_ids: FxHashSet<String>,
-    /// Family ids whose every member carries the complete, already-lowered
+    pub(crate) declaration_run_families: FxHashSet<FamilyHandle>,
+    /// Families whose every member carries the complete, already-lowered
     /// declaration-only type-contract proof frozen by #841. This consumes only
     /// language-neutral `UnitOrigin` facets; missing or mixed evidence fails open.
-    pub(crate) declaration_only_type_contract_ids: FxHashSet<String>,
+    pub(crate) declaration_only_type_contract_families: FxHashSet<FamilyHandle>,
 }
 
 /// The surface an integration should treat this family as: the ranked
@@ -130,8 +142,8 @@ fn family_declaration_run(
     overrides: &SurfaceOverrides,
 ) -> bool {
     overrides
-        .declaration_run_ids
-        .contains(&crate::baseline::family_id(family))
+        .declaration_run_families
+        .contains(&family_handle(family))
 }
 
 fn family_declaration_only_type_contract(
@@ -139,8 +151,8 @@ fn family_declaration_only_type_contract(
     overrides: &SurfaceOverrides,
 ) -> bool {
     overrides
-        .declaration_only_type_contract_ids
-        .contains(&crate::baseline::family_id(family))
+        .declaration_only_type_contract_families
+        .contains(&family_handle(family))
 }
 
 /// Apply the typed product form of `declaration-only-type.v1` frozen by #841.
@@ -155,13 +167,13 @@ fn family_declaration_only_type_contract(
 /// disqualifiers. Because every condition is positive and all-member, unknown,
 /// partial, mixed, default-body, extension, enum, and schema origins remain on
 /// their ranked surface.
-fn declaration_only_type_contract_ids(
+fn declaration_only_type_contract_families(
     families: &[nose_detect::RefactorFamily],
-) -> FxHashSet<String> {
+) -> FxHashSet<FamilyHandle> {
     families
         .iter()
         .filter(|family| is_declaration_only_type_contract(family))
-        .map(crate::baseline::family_id)
+        .map(family_handle)
         .collect()
 }
 
@@ -223,7 +235,7 @@ fn is_declaration_only_type_contract(family: &nose_detect::RefactorFamily) -> bo
 /// statement keeps the family on its ranked surface. Misclassifying a real
 /// finding is the error class this guards against; missing an import run is
 /// only a ranking nuisance.
-fn declaration_run_ids(families: &[nose_detect::RefactorFamily]) -> FxHashSet<String> {
+fn declaration_run_families(families: &[nose_detect::RefactorFamily]) -> FxHashSet<FamilyHandle> {
     // Three passes (coevo s4 perf packet): a cheap serial prescreen picks the
     // candidate families, the unique candidate files parse in PARALLEL (the
     // serial per-file AST parse cost +29% wall on sympy), and the final pass
@@ -267,7 +279,7 @@ fn declaration_run_ids(families: &[nose_detect::RefactorFamily]) -> FxHashSet<St
                 .iter()
                 .all(|l| declaration_run_span(l, &mut lines, &facts))
         })
-        .map(|f| crate::baseline::family_id(f))
+        .map(|f| family_handle(f))
         .collect()
 }
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -189,6 +189,7 @@ fundamentals; the rest is grouped by area.
 - [0.17.0 release evidence](release-evidence-0.17.0.md) — the hazard refresh, all-corpus query-regression, recall-loss gate, and profiling notes for the 0.17.0 release candidate.
 - [0.17.0 post-release runtime triage](runtime-triage-0.17.0.md) — focused follow-up on the largest release-candidate query-runtime regressions, including the `arrow` hot-path fix and remaining no-family-growth follow-ups.
 - [20-optimization runtime pass](runtime-performance-20-optimizations-2026-07-02.md) — the post-0.17.0 profile-guided optimization sequence, all-120-repo before/after run, focused recheck, and noise-aware interpretation.
+- [default-query performance closeout](runtime-performance-issue-892-2026-07-18.md) — #892's output-preserving surface-membership optimization, official-v0.19.0 all-120/r40 measurements, semantic smoke, and bounded independent residual split.
 - [experiments](experiments.md) — the measured log of what was tried and what happened.
 
 ### Field evidence & audits

--- a/docs/runtime-performance-issue-892-2026-07-18.md
+++ b/docs/runtime-performance-issue-892-2026-07-18.md
@@ -1,0 +1,102 @@
+# Default-query performance closeout for #892
+
+Generated on 2026-07-18. The
+[durable #892 performance artifact](../bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json) binds
+the measurements and binary identities below.
+The reusable measurement contract is documented in [runtime triage](runtime-triage.md).
+
+## Outcome
+
+#892's persistent default-query opportunity and gating regressions are removed without
+changing product output. The all-120 aggregate is `0.88%` faster before control
+adjustment and `0.69%` faster after it. The required semantic regression smoke passes
+with zero output drift and a `2.28%` adjusted aggregate improvement.
+
+The final preregistered r40 check retained three independent pre-query stage owners:
+etcd Go frontend work and Guava/MinIO normalization. They are split to #907 and #908,
+as required by #892's result-dependent rule. They do not block #847 because its frozen
+runtime criterion is the control-adjusted aggregate, which is safely improved here.
+
+## Diagnosis and implementation
+
+Sampling Alamofire before editing showed `family_key` dominating the new query path.
+The #842/#843 surface split repeatedly sorted and hashed every family location while:
+
+- deciding whether a family was default-actionable;
+- rebuilding the set of default family identities after opportunity grouping;
+- checking effective surfaces during gating and rendering.
+
+The fix uses a process-local `(locations pointer, length)` family handle for surface
+override membership. These handles remain stable while the location vectors live, even
+when the outer family vector is sorted. `OpportunityGroups` now also decides default
+slices when it creates direct fold edges, eliminating the second full-family identity
+pass. Stable serialized family IDs remain the authority at process boundaries.
+
+Post-change sampling reduced `family_key` top-stack samples from 78 to 29; the remaining
+calls are the direct fold-edge IDs that product output requires.
+
+## Product measurements
+
+The baseline is the published v0.19.0 arm64 macOS binary at source
+`0985e6963c58d5a97e523bc532b88aa5e34f2ef9`. Its file SHA-256 is
+`0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3`.
+The candidate source is `8c37b8f9c75b9543dc746e3eb6b9b18209810059`; its binary SHA-256 is
+`111c6507dd028a194c000fbc279e05e6b9b2899552a9dca7f56a15d23c5ad38c`.
+
+| Scope | Baseline | Candidate | Raw delta | Control-adjusted delta |
+| --- | ---: | ---: | ---: | ---: |
+| all 120, r3 | 35,752.50 ms | 35,438.88 ms | -313.62 ms / -0.88% | -247.12 ms / -0.69% |
+| final 9, r40 | 6,806.02 ms | 6,760.25 ms | -45.77 ms / -0.67% | -16.15 ms / -0.23% |
+
+The original seven-repository r9 replay also showed the intended path improvement:
+
+| Repository | `query_opp` v0.19.0 → candidate | `query_gate` v0.19.0 → candidate |
+| --- | ---: | ---: |
+| Alamofire | 47.4 → 34.5 ms | 24.1 → 14.8 ms |
+| Guava | 5.8 → 2.8 ms | 7.0 → 4.0 ms |
+| Netty | 6.8 → 3.6 ms | 7.4 → 5.1 ms |
+| RxJava | 10.6 → 6.7 ms | 8.6 → 5.0 ms |
+| SQLAlchemy | 3.4 → 1.5 ms | 5.2 → 3.4 ms |
+| SymPy | 3.5 → 1.6 ms | 5.1 → 3.2 ms |
+
+The established escalation was applied once at each depth: all-120 r3, 33-repository
+r9, 18-repository r21, and 9-repository r40. No threshold was changed.
+
+## Output and semantic safety
+
+A separately built pre-fix binary from `963af51f38e1a9004f8aed3a0bd0d3ab1648e353`
+was compared directly with the fixed binary across all 120 repositories. Every family
+count, order, surface count, metadata byte, output byte count, and SHA-256 matched.
+This isolates #892's zero output drift from intentional v0.19.0-to-main changes.
+
+`scripts/semantic-regression-smoke.sh --force` compared the same two binaries on the
+seven-language pinned smoke corpus. It passed after the standard focused rerun:
+
+- aggregate: 580.38 → 575.69 ms;
+- control-adjusted: -13.23 ms / -2.28%;
+- output drift: zero declared, zero unexpected;
+- Ruby scaling: within threshold, exponent 0.69 against the 1.35 limit.
+
+The implementation also passed:
+
+- `cargo test --workspace --all-targets`;
+- `cargo clippy --workspace --all-targets -- -D warnings`;
+- `cargo fmt --all -- --check`;
+- `scripts/check-docs.sh`;
+- the focused query-family, generated-surface, and declaration-surface tests.
+
+## Independent residuals
+
+The unchanged 5% / 5 ms checker retained four r40 stage rows:
+
+| Owner | Stage | Raw delta | Control-adjusted delta | Follow-up |
+| --- | --- | ---: | ---: | --- |
+| etcd | lower | +2.50 ms | +5.55 ms / +6.52% | #907 |
+| etcd | parse+lower | +2.55 ms | +5.90 ms / +10.55% | #907 |
+| Guava | normalize+extract | +19.30 ms | +26.50 ms / +7.39% | #908 |
+| MinIO | normalize+extract | +3.20 ms | +7.05 ms / +6.39% | #908 |
+
+These execute before the query classification changed by #892. The Go frontend was
+untouched by this fix, while normalization grew materially after v0.19.0 in #900 and
+#859. The split therefore follows the issue's explicit independent-cause rule rather
+than broadening one query optimization into unrelated frontend and semantic work.


### PR DESCRIPTION
## Summary

- replace repeated sorted whole-family identity hashing in default-surface membership with stable process-local family handles
- decide default opportunity slices while constructing direct fold edges, removing the second full-family scan
- record official-v0.19.0 all-120 and focused r3→r9→r21→r40 evidence plus a pre/post all-120 byte-identity replay

## Outcome

- all-120 aggregate: -0.88% raw, -0.69% after same-binary control adjustment
- original persistent `query_opp`/`query_gate` signals removed
- semantic regression smoke: pass, -2.28% adjusted, zero output drift
- pre-fix main vs fixed: 120/120 output hashes and family/surface metadata identical

The final r40 retained independent pre-query owners in the unchanged Go frontend and post-v0.19 normalization expansion. Per #892's explicit result-dependent split rule, those are bounded in #907 and #908 and do not block #847's aggregate runtime criterion.

## Validation

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-docs.sh`
- `scripts/semantic-regression-smoke.sh --force`
- all-120 output identity replay

Closes #892
