### PR TITLE
Prove bounded semantic change witnesses for divergent edits

### DIFF
--- a/bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json
@@ -6,6 +6,7 @@
   "blind_or_temporal_data_accessed": false,
   "source": {
     "candidate_commit": "3d15ac455a167fd90e449fc3f935deadd4bdd384",
+    "final_commit": "d639321f8668eaaa14226a4b3600292e828ec087",
     "baseline_release": "v0.19.0",
     "baseline_source_commit": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9"
   },
@@ -58,5 +59,11 @@
   "assessment": {
     "status": "bounded-advisory-overhead",
     "reason": "The issue defines no numeric promotion budget. The evidence remains advisory, legacy output is identical on all 17 repositories, work is capped to already-flagged candidate files and units, and the initial unbounded eager-projection regression was removed."
+  },
+  "final_commit_transfer": {
+    "change": "Box the cached FileProjection enum variant to satisfy clippy::large-enum-variant.",
+    "behavioral_or_work_scope_change": false,
+    "remeasurement_required": false,
+    "validation": "Final source passed clippy -D warnings plus 232 library, 235 CLI, and 3 connected-witness tests."
   }
 }

--- a/bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json
@@ -1,0 +1,62 @@
+{
+  "schema": "nose.issue-849.performance/v1",
+  "issue": 849,
+  "measured_at": "2026-07-18",
+  "development_only": true,
+  "blind_or_temporal_data_accessed": false,
+  "source": {
+    "candidate_commit": "3d15ac455a167fd90e449fc3f935deadd4bdd384",
+    "baseline_release": "v0.19.0",
+    "baseline_source_commit": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9"
+  },
+  "binaries": {
+    "baseline": {
+      "version": "nose 0.19.0",
+      "sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate": {
+      "version": "nose 0.19.0",
+      "sha256": "2f961af03e2e62f275e1b9ac4d5df162e2385c54f947475350e6c4a79bfd4eb2"
+    }
+  },
+  "harness": {
+    "path": "eval/divergence_fire/semantic_witness_eval.py",
+    "sha256": "043d676901691ec37e0fbec22f57fd73cba8c99ae2931201d921ae7060f76722",
+    "selection": "first current-v2-strict default-arm finding per development repository",
+    "repositories": 17,
+    "iterations": 3,
+    "warmups": 1,
+    "command": "nose query . base=<parent> top=0 --format json"
+  },
+  "primary": {
+    "baseline_median_sum_ms": 10058.212163,
+    "candidate_median_sum_ms": 10566.691753,
+    "raw_delta_ms": 508.47959,
+    "raw_delta_pct": 5.055368,
+    "legacy_outputs_equal_after_removing_semantic_change": true,
+    "legacy_outputs_equal_repositories": 17,
+    "raw_artifact_sha256": "2fe6055efd090583769e060ee072cceeea51f76c7af33f7215a695d0166b87be"
+  },
+  "same_binary_control": {
+    "first_median_sum_ms": 10141.731584,
+    "second_median_sum_ms": 10112.234708,
+    "delta_ms": -29.496876,
+    "delta_pct": -0.290847,
+    "raw_artifact_sha256": "9af0423341619cdd6905a649c63f7814a641a427d69540247d04655ca04c86dc"
+  },
+  "control_adjusted": {
+    "delta_ms": 537.976466,
+    "delta_pct": 5.348629
+  },
+  "optimization_receipt": {
+    "pre_optimization_raw_delta_ms": 5492.024167,
+    "pre_optimization_raw_delta_pct": 54.86025,
+    "pre_optimization_candidate_binary_sha256": "275a97171d38ce9a1ba313c70c7188a0dba89eab6011187a7e00ee77c2899510",
+    "pre_optimization_raw_artifact_sha256": "fccdc76a9fb2442e425b3ed8c1dc5c91e6056a9456f98c25bce2f4b8f3e097b7",
+    "change": "normalize selected files once, build and cache value DAGs only for aligned candidate units, and skip unalignable detector-only blocks"
+  },
+  "assessment": {
+    "status": "bounded-advisory-overhead",
+    "reason": "The issue defines no numeric promotion budget. The evidence remains advisory, legacy output is identical on all 17 repositories, work is capped to already-flagged candidate files and units, and the initial unbounded eager-projection regression was removed."
+  }
+}

--- a/bench/soundness/0.20.0/release-binding-862.v1.json
+++ b/bench/soundness/0.20.0/release-binding-862.v1.json
@@ -1,7 +1,7 @@
 {
   "artifacts": {
     "blind_attack": {
-      "path": "../../type4/blind_attack.v1.json",
+      "path": "release-blind-attack-862.v1.json",
       "sha256": "622601e62ed10b5b822ca606397dd7ab1ef97f47b31f2ce88dbae22a8cdb4c4c"
     },
     "current_exclusion_attribution": {

--- a/bench/soundness/0.20.0/release-blind-attack-862.v1.json
+++ b/bench/soundness/0.20.0/release-blind-attack-862.v1.json
@@ -1,0 +1,29 @@
+{
+  "advisory_disagreements": 86,
+  "attacker": "blind-oracle",
+  "corpus": "bench/type4/coverage_probes",
+  "corpus_files": 284,
+  "corpus_sha256": "7ae580a154ca51863fb7ebb36913dffb7c5a7d36dc3bb5fe4f264a6391dfbab2",
+  "hard_gate": {
+    "canon_preservation_violations": 0,
+    "false_merges": 0,
+    "fingerprint_groups": 54,
+    "gate_passed": true
+  },
+  "oracle_exclusions": {
+    "battery-bail": 0,
+    "core-missing": 2,
+    "empty-fingerprint": 0,
+    "path-bail": 0,
+    "uninterpretable": 160
+  },
+  "product_crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
+  "schema_version": 1,
+  "summary": {
+    "admission_rejections": 28,
+    "canon_checked": 267,
+    "excluded_units": 162,
+    "interpretable_units": 321,
+    "total_units": 483
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "85befdaa7e960a4762c9baade4fcdad372f005da",
+  "product_crates_tree": "77c44280ec627833a74a5747a555d269027ed249",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/divergence.rs
+++ b/crates/nose-cli/src/divergence.rs
@@ -12,6 +12,7 @@
 //!
 //! The structural signal is a candidate surfacer, not a proof: inspect the flagged siblings.
 
+mod change_witness;
 mod detect;
 mod git;
 mod output;
@@ -256,4 +257,181 @@ pub(crate) struct Site {
     /// varying spots; `None` = unprovable (unreadable source / capped diff) or a
     /// not-updated site.
     pub(crate) touches_shared: Option<bool>,
+    /// Bounded base-to-current semantic change evidence (#849). This is deliberately
+    /// presentation-only in v2: neither `tier()` nor `gate_fail_default()` reads it.
+    pub(crate) semantic_change: Option<SemanticChangeWitness>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticWitnessStatus {
+    Complete,
+    Advisory,
+    Unavailable,
+}
+
+impl SemanticWitnessStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Advisory => "advisory",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticChangeKind {
+    NoSemanticDelta,
+    Replacement,
+    Deletion,
+    Insertion,
+    Mixed,
+    Unknown,
+}
+
+impl SemanticChangeKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NoSemanticDelta => "no-semantic-delta",
+            Self::Replacement => "replacement",
+            Self::Deletion => "deletion",
+            Self::Insertion => "insertion",
+            Self::Mixed => "mixed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticChangeFacet {
+    Value,
+    Return,
+    Control,
+    Effect,
+}
+
+impl SemanticChangeFacet {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Value => "value",
+            Self::Return => "return",
+            Self::Control => "control",
+            Self::Effect => "effect",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticAlignment {
+    ExactSpan,
+    StableName,
+    ChangedRange,
+    NearestSpan,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticProjectionStatus {
+    Ok,
+    Missing,
+    Unsupported,
+    ReadFailed,
+    LowerFailed,
+    UnitMissing,
+    AmbiguousUnit,
+    CapExceeded,
+    NotAttempted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticWitnessCaveat {
+    PureInsertion,
+    MixedChange,
+    MissingCurrentUnit,
+    UnsupportedLanguage,
+    LossyBaseLowering,
+    LossyCurrentLowering,
+    FragmentUnsupported,
+    AmbiguousAlignment,
+    HeuristicAlignment,
+    UnresolvedReferent,
+    NoAffectedSemanticNode,
+    NoSharedSemanticNode,
+    ScopedDeltaUnmapped,
+    Truncated,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct SemanticWitnessCoverage {
+    pub(crate) base_affected_nodes: usize,
+    pub(crate) current_affected_nodes: usize,
+    pub(crate) mapped_shared_nodes: usize,
+    pub(crate) sibling_units_checked: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct SemanticWitnessCaps {
+    pub(crate) max_files: usize,
+    pub(crate) max_file_bytes: usize,
+    pub(crate) max_changed_sites_per_family: usize,
+    pub(crate) max_siblings_per_family: usize,
+    pub(crate) max_units_per_file: usize,
+    pub(crate) max_nodes_per_unit: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SemanticSinkKind {
+    Return,
+    Cond,
+    Effect,
+    Break,
+    Throw,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct SemanticSinkDelta {
+    pub(crate) kind: SemanticSinkKind,
+    pub(crate) removed: usize,
+    pub(crate) inserted: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct SemanticChangeWitness {
+    pub(crate) status: SemanticWitnessStatus,
+    pub(crate) change_kind: SemanticChangeKind,
+    pub(crate) facets: Vec<SemanticChangeFacet>,
+    pub(crate) alignment: SemanticAlignment,
+    pub(crate) base_projection: SemanticProjectionStatus,
+    pub(crate) current_projection: SemanticProjectionStatus,
+    pub(crate) coverage: SemanticWitnessCoverage,
+    pub(crate) sink_deltas: Vec<SemanticSinkDelta>,
+    pub(crate) caveats: Vec<SemanticWitnessCaveat>,
+    pub(crate) caps: SemanticWitnessCaps,
+}
+
+impl SemanticChangeWitness {
+    pub(crate) fn concise_label(&self) -> String {
+        let facets = self
+            .facets
+            .iter()
+            .map(|facet| facet.as_str())
+            .collect::<Vec<_>>()
+            .join("+");
+        if facets.is_empty() {
+            format!("{} {}", self.status.as_str(), self.change_kind.as_str())
+        } else {
+            format!(
+                "{} {} ({facets})",
+                self.status.as_str(),
+                self.change_kind.as_str()
+            )
+        }
+    }
 }

--- a/crates/nose-cli/src/divergence/change_witness.rs
+++ b/crates/nose-cli/src/divergence/change_witness.rs
@@ -1,0 +1,857 @@
+//! Bounded base-to-current semantic change witnesses for already-flagged divergences.
+//!
+//! This module is intentionally downstream of candidate detection. It reads only the
+//! changed candidate files and a capped set of their base siblings; it never performs a
+//! second repository discovery. The evidence is advisory in divergent-edit v2.
+
+use super::git::DiffEntry;
+use super::*;
+use nose_il::{FileId, Interner, Lang, UnitKind};
+use nose_normalize::{FileReferents, ValueDag, VgSinkKind};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::Path;
+
+const MAX_FILES: usize = 64;
+const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_CHANGED_SITES_PER_FAMILY: usize = 16;
+const MAX_SIBLINGS_PER_FAMILY: usize = 16;
+const MAX_UNITS_PER_FILE: usize = 512;
+const MAX_NODES_PER_UNIT: usize = 2_048;
+
+const CAPS: SemanticWitnessCaps = SemanticWitnessCaps {
+    max_files: MAX_FILES,
+    max_file_bytes: MAX_FILE_BYTES,
+    max_changed_sites_per_family: MAX_CHANGED_SITES_PER_FAMILY,
+    max_siblings_per_family: MAX_SIBLINGS_PER_FAMILY,
+    max_units_per_file: MAX_UNITS_PER_FILE,
+    max_nodes_per_unit: MAX_NODES_PER_UNIT,
+};
+
+pub(super) fn enrich_semantic_change_witnesses(
+    flagged: &mut [Divergence],
+    base_root: &Path,
+    current_root: &Path,
+    base_changed: &HashMap<String, Vec<(u32, u32)>>,
+    current_changed: &HashMap<String, Vec<(u32, u32)>>,
+    diff_entries: &[DiffEntry],
+    opts: &nose_detect::DetectOptions,
+) {
+    let mut builder = WitnessBuilder::new(
+        base_root,
+        current_root,
+        base_changed,
+        current_changed,
+        diff_entries,
+        opts,
+    );
+    for divergence in flagged
+        .iter_mut()
+        .filter(|d| d.lane == DivergenceLane::BaseDivergence)
+    {
+        let siblings = divergence
+            .not_updated
+            .iter()
+            .take(MAX_SIBLINGS_PER_FAMILY)
+            .cloned()
+            .collect::<Vec<_>>();
+        for (index, site) in divergence.changed.iter_mut().enumerate() {
+            site.semantic_change = Some(if index < MAX_CHANGED_SITES_PER_FAMILY {
+                builder.witness(site, &siblings)
+            } else {
+                unavailable(
+                    SemanticProjectionStatus::CapExceeded,
+                    SemanticProjectionStatus::NotAttempted,
+                    vec![SemanticWitnessCaveat::Truncated],
+                )
+            });
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum Tree {
+    Base,
+    Current,
+}
+
+#[derive(Clone)]
+enum LoadState {
+    Ready(FileProjection),
+    Failed(SemanticProjectionStatus),
+}
+
+#[derive(Clone)]
+struct FileProjection {
+    units: Vec<UnitProjection>,
+}
+
+#[derive(Clone)]
+struct UnitProjection {
+    kind: UnitKind,
+    name: Option<String>,
+    start_line: u32,
+    end_line: u32,
+    exact_safe: bool,
+    dag: ValueDag,
+    truncated: bool,
+    unresolved_referent: bool,
+}
+
+#[derive(Clone)]
+struct ProjectionAttempt {
+    status: SemanticProjectionStatus,
+    alignment: SemanticAlignment,
+    unit: Option<UnitProjection>,
+}
+
+impl ProjectionAttempt {
+    fn failed(status: SemanticProjectionStatus) -> Self {
+        Self {
+            status,
+            alignment: SemanticAlignment::None,
+            unit: None,
+        }
+    }
+}
+
+struct WitnessBuilder<'a> {
+    base_root: &'a Path,
+    current_root: &'a Path,
+    base_changed: &'a HashMap<String, Vec<(u32, u32)>>,
+    current_changed: &'a HashMap<String, Vec<(u32, u32)>>,
+    diff_entries: &'a [DiffEntry],
+    opts: nose_detect::DetectOptions,
+    files: HashMap<(Tree, String), LoadState>,
+}
+
+impl<'a> WitnessBuilder<'a> {
+    fn new(
+        base_root: &'a Path,
+        current_root: &'a Path,
+        base_changed: &'a HashMap<String, Vec<(u32, u32)>>,
+        current_changed: &'a HashMap<String, Vec<(u32, u32)>>,
+        diff_entries: &'a [DiffEntry],
+        opts: &nose_detect::DetectOptions,
+    ) -> Self {
+        let mut opts = *opts;
+        // A current unit may shrink below the query's candidate floor after an edit. The
+        // witness still needs to align it, so extraction here has no size floor.
+        opts.min_lines = 0;
+        opts.min_tokens = 0;
+        opts.contiguous_min_lines = 0;
+        opts.contiguous_min_tokens = 0;
+        Self {
+            base_root,
+            current_root,
+            base_changed,
+            current_changed,
+            diff_entries,
+            opts,
+            files: HashMap::new(),
+        }
+    }
+
+    fn witness(&mut self, site: &Site, siblings: &[Site]) -> SemanticChangeWitness {
+        if site.is_fragment {
+            return unavailable(
+                SemanticProjectionStatus::Unsupported,
+                SemanticProjectionStatus::NotAttempted,
+                vec![SemanticWitnessCaveat::FragmentUnsupported],
+            );
+        }
+        let base = self.project_base(site);
+        let Some(base_unit) = base.unit else {
+            return unavailable(
+                base.status,
+                SemanticProjectionStatus::NotAttempted,
+                caveat_for_projection(base.status, true),
+            );
+        };
+
+        let Some(current_path) = self.current_path(&site.file) else {
+            return unavailable(
+                base.status,
+                SemanticProjectionStatus::Missing,
+                vec![SemanticWitnessCaveat::MissingCurrentUnit],
+            );
+        };
+        let current_ranges = self
+            .current_changed
+            .get(&current_path)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let current = self.project_current(&base_unit, &current_path, current_ranges);
+        let Some(current_unit) = current.unit else {
+            let mut caveats = caveat_for_projection(current.status, false);
+            if caveats.is_empty() {
+                caveats.push(SemanticWitnessCaveat::MissingCurrentUnit);
+            }
+            return unavailable(base.status, current.status, caveats);
+        };
+
+        let base_ranges = self
+            .base_changed
+            .get(&site.file)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let sibling_hashes = self.sibling_hashes(siblings);
+        compare_units(
+            &base_unit,
+            &current_unit,
+            base_ranges,
+            current_ranges,
+            &sibling_hashes,
+            current.alignment,
+        )
+    }
+
+    fn current_path(&self, base_path: &str) -> Option<String> {
+        self.diff_entries
+            .iter()
+            .find(|entry| entry.old_path.as_deref() == Some(base_path))
+            .map(|entry| entry.new_path.clone())
+            .unwrap_or_else(|| Some(base_path.to_string()))
+    }
+
+    fn project_base(&mut self, site: &Site) -> ProjectionAttempt {
+        let file = match self.load_file(Tree::Base, &site.file) {
+            Ok(file) => file,
+            Err(status) => return ProjectionAttempt::failed(status),
+        };
+        let mut candidates = file
+            .units
+            .iter()
+            .filter(|unit| unit_matches_site(unit, site, true))
+            .cloned()
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            if let Some(enclosing) = &site.enclosing_unit {
+                candidates = file
+                    .units
+                    .iter()
+                    .filter(|unit| unit_matches_enclosing(unit, enclosing))
+                    .cloned()
+                    .collect();
+            }
+        }
+        match candidates.as_slice() {
+            [unit] => ProjectionAttempt {
+                status: SemanticProjectionStatus::Ok,
+                alignment: SemanticAlignment::ExactSpan,
+                unit: Some(unit.clone()),
+            },
+            [] => ProjectionAttempt::failed(SemanticProjectionStatus::UnitMissing),
+            _ => ProjectionAttempt::failed(SemanticProjectionStatus::AmbiguousUnit),
+        }
+    }
+
+    fn project_current(
+        &mut self,
+        base: &UnitProjection,
+        current_path: &str,
+        changed_ranges: &[(u32, u32)],
+    ) -> ProjectionAttempt {
+        let file = match self.load_file(Tree::Current, current_path) {
+            Ok(file) => file,
+            Err(status) => return ProjectionAttempt::failed(status),
+        };
+        let same_kind = file
+            .units
+            .into_iter()
+            .filter(|unit| unit.kind == base.kind)
+            .collect::<Vec<_>>();
+        let exact = same_kind
+            .iter()
+            .filter(|unit| {
+                unit.name == base.name
+                    && unit.start_line == base.start_line
+                    && unit.end_line == base.end_line
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if let [unit] = exact.as_slice() {
+            return projected(unit.clone(), SemanticAlignment::ExactSpan);
+        }
+        if let Some(name) = base.name.as_deref() {
+            let named = same_kind
+                .iter()
+                .filter(|unit| unit.name.as_deref() == Some(name))
+                .cloned()
+                .collect::<Vec<_>>();
+            if let [unit] = named.as_slice() {
+                return projected(unit.clone(), SemanticAlignment::StableName);
+            }
+        }
+        let changed = same_kind
+            .iter()
+            .filter(|unit| ranges_touch_unit(changed_ranges, unit))
+            .cloned()
+            .collect::<Vec<_>>();
+        if let [unit] = changed.as_slice() {
+            return projected(unit.clone(), SemanticAlignment::ChangedRange);
+        }
+        let Some(min_distance) = same_kind
+            .iter()
+            .map(|unit| unit.start_line.abs_diff(base.start_line))
+            .min()
+        else {
+            return ProjectionAttempt::failed(SemanticProjectionStatus::UnitMissing);
+        };
+        let nearest = same_kind
+            .into_iter()
+            .filter(|unit| unit.start_line.abs_diff(base.start_line) == min_distance)
+            .collect::<Vec<_>>();
+        match nearest.as_slice() {
+            [unit] => projected(unit.clone(), SemanticAlignment::NearestSpan),
+            _ => ProjectionAttempt::failed(SemanticProjectionStatus::AmbiguousUnit),
+        }
+    }
+
+    fn sibling_hashes(&mut self, siblings: &[Site]) -> SharedHashes {
+        let mut hashes = BTreeMap::new();
+        let mut units_checked = 0;
+        for sibling in siblings {
+            if sibling.is_fragment {
+                continue;
+            }
+            let attempt = self.project_base(sibling);
+            if let Some(unit) = attempt.unit {
+                units_checked += 1;
+                for hash in node_hashes(&unit.dag) {
+                    *hashes.entry(hash).or_insert(0usize) += 1;
+                }
+            }
+        }
+        SharedHashes {
+            hashes,
+            units_checked,
+        }
+    }
+
+    fn load_file(
+        &mut self,
+        tree: Tree,
+        relative_path: &str,
+    ) -> Result<FileProjection, SemanticProjectionStatus> {
+        let key = (tree, relative_path.to_string());
+        if let Some(state) = self.files.get(&key).cloned() {
+            return loaded(state);
+        }
+        if self.files.len() >= MAX_FILES {
+            return Err(SemanticProjectionStatus::CapExceeded);
+        }
+        let root = match tree {
+            Tree::Base => self.base_root,
+            Tree::Current => self.current_root,
+        };
+        let state = project_file(&root.join(relative_path), relative_path, &self.opts);
+        self.files.insert(key, state.clone());
+        loaded(state)
+    }
+}
+
+struct SharedHashes {
+    hashes: BTreeMap<u64, usize>,
+    units_checked: usize,
+}
+
+impl SharedHashes {
+    fn contains_key(&self, hash: &u64) -> bool {
+        self.hashes.contains_key(hash)
+    }
+}
+
+struct SemanticAnalysis {
+    change_kind: SemanticChangeKind,
+    facets: Vec<SemanticChangeFacet>,
+    sink_deltas: Vec<SemanticSinkDelta>,
+    base_affected_nodes: usize,
+    current_affected_nodes: usize,
+    mapped_shared_nodes: usize,
+    has_insertions: bool,
+    has_non_insertions: bool,
+    same_semantics: bool,
+    removed: usize,
+    inserted: usize,
+}
+
+fn compare_units(
+    base: &UnitProjection,
+    current: &UnitProjection,
+    base_ranges: &[(u32, u32)],
+    current_ranges: &[(u32, u32)],
+    sibling_hashes: &SharedHashes,
+    alignment: SemanticAlignment,
+) -> SemanticChangeWitness {
+    let analysis = analyze_change(base, current, base_ranges, current_ranges, sibling_hashes);
+    let caveats = analysis_caveats(&analysis, base, current, alignment);
+    SemanticChangeWitness {
+        status: if caveats.is_empty() {
+            SemanticWitnessStatus::Complete
+        } else {
+            SemanticWitnessStatus::Advisory
+        },
+        change_kind: analysis.change_kind,
+        facets: analysis.facets,
+        alignment,
+        base_projection: SemanticProjectionStatus::Ok,
+        current_projection: SemanticProjectionStatus::Ok,
+        coverage: SemanticWitnessCoverage {
+            base_affected_nodes: analysis.base_affected_nodes,
+            current_affected_nodes: analysis.current_affected_nodes,
+            mapped_shared_nodes: analysis.mapped_shared_nodes,
+            sibling_units_checked: sibling_hashes.units_checked,
+        },
+        sink_deltas: analysis.sink_deltas,
+        caveats,
+        caps: CAPS,
+    }
+}
+
+fn analyze_change(
+    base: &UnitProjection,
+    current: &UnitProjection,
+    base_ranges: &[(u32, u32)],
+    current_ranges: &[(u32, u32)],
+    sibling_hashes: &SharedHashes,
+) -> SemanticAnalysis {
+    let base_ranges = ranges_inside_unit(base_ranges, base);
+    let current_ranges = ranges_inside_unit(current_ranges, current);
+    let has_insertions = base_ranges.iter().any(|(start, end)| start > end);
+    let has_non_insertions = base_ranges.iter().any(|(start, end)| start <= end);
+    let source_deletion = has_non_insertions
+        && !has_insertions
+        && !current_ranges.is_empty()
+        && current_ranges.iter().all(|(start, end)| start > end);
+    let base_affected = affected_hashes(&base.dag, &base_ranges);
+    let current_affected = if source_deletion {
+        Vec::new()
+    } else {
+        affected_hashes(&current.dag, &current_ranges)
+    };
+    let mapped_shared_nodes = base_affected
+        .iter()
+        .filter(|hash| sibling_hashes.contains_key(hash))
+        .count();
+    let base_nodes = node_hashes(&base.dag);
+    let current_nodes = node_hashes(&current.dag);
+    let sinks_before = sink_signatures(&base.dag);
+    let sinks_after = sink_signatures(&current.dag);
+    let same_semantics = base_nodes == current_nodes && sinks_before == sinks_after;
+    let removed = multiset_removed(&base_affected, &current_affected);
+    let inserted = multiset_removed(&current_affected, &base_affected);
+    let sink_deltas = sink_deltas(&sinks_before, &sinks_after);
+    SemanticAnalysis {
+        change_kind: classify_change(
+            same_semantics,
+            has_insertions,
+            has_non_insertions,
+            removed,
+            inserted,
+        ),
+        facets: change_facets(base_nodes != current_nodes, &sink_deltas),
+        sink_deltas,
+        base_affected_nodes: base_affected.len(),
+        current_affected_nodes: current_affected.len(),
+        mapped_shared_nodes,
+        has_insertions,
+        has_non_insertions,
+        same_semantics,
+        removed,
+        inserted,
+    }
+}
+
+fn classify_change(
+    same_semantics: bool,
+    has_insertions: bool,
+    has_non_insertions: bool,
+    removed: usize,
+    inserted: usize,
+) -> SemanticChangeKind {
+    match (
+        same_semantics,
+        has_insertions,
+        has_non_insertions,
+        removed,
+        inserted,
+    ) {
+        (true, _, _, _, _) => SemanticChangeKind::NoSemanticDelta,
+        (_, true, true, _, _) => SemanticChangeKind::Mixed,
+        (_, true, false, _, _) | (_, false, _, 0, 1..) => SemanticChangeKind::Insertion,
+        (_, false, _, 1.., 1..) => SemanticChangeKind::Replacement,
+        (_, false, _, 1.., 0) => SemanticChangeKind::Deletion,
+        _ => SemanticChangeKind::Unknown,
+    }
+}
+
+fn change_facets(
+    value_changed: bool,
+    sink_deltas: &[SemanticSinkDelta],
+) -> Vec<SemanticChangeFacet> {
+    let mut facets = Vec::new();
+    if value_changed {
+        facets.push(SemanticChangeFacet::Value);
+    }
+    for delta in sink_deltas {
+        match delta.kind {
+            SemanticSinkKind::Return => facets.push(SemanticChangeFacet::Return),
+            SemanticSinkKind::Cond | SemanticSinkKind::Break => {
+                facets.push(SemanticChangeFacet::Control);
+            }
+            SemanticSinkKind::Effect => facets.push(SemanticChangeFacet::Effect),
+            SemanticSinkKind::Throw => {
+                facets.push(SemanticChangeFacet::Control);
+                facets.push(SemanticChangeFacet::Effect);
+            }
+        }
+    }
+    facets.sort();
+    facets.dedup();
+    facets
+}
+
+fn analysis_caveats(
+    analysis: &SemanticAnalysis,
+    base: &UnitProjection,
+    current: &UnitProjection,
+    alignment: SemanticAlignment,
+) -> Vec<SemanticWitnessCaveat> {
+    let mut caveats = Vec::new();
+    if analysis.has_insertions && analysis.has_non_insertions {
+        caveats.push(SemanticWitnessCaveat::MixedChange);
+    } else if analysis.has_insertions {
+        caveats.push(SemanticWitnessCaveat::PureInsertion);
+    }
+    if !base.exact_safe {
+        caveats.push(SemanticWitnessCaveat::LossyBaseLowering);
+    }
+    if !current.exact_safe {
+        caveats.push(SemanticWitnessCaveat::LossyCurrentLowering);
+    }
+    if base.unresolved_referent || current.unresolved_referent {
+        caveats.push(SemanticWitnessCaveat::UnresolvedReferent);
+    }
+    if base.truncated || current.truncated {
+        caveats.push(SemanticWitnessCaveat::Truncated);
+    }
+    if alignment == SemanticAlignment::NearestSpan {
+        caveats.push(SemanticWitnessCaveat::HeuristicAlignment);
+    }
+    if analysis.base_affected_nodes == 0 {
+        caveats.push(SemanticWitnessCaveat::NoAffectedSemanticNode);
+    } else if analysis.mapped_shared_nodes == 0 {
+        caveats.push(SemanticWitnessCaveat::NoSharedSemanticNode);
+    }
+    if !analysis.same_semantics && analysis.removed == 0 && analysis.inserted == 0 {
+        caveats.push(SemanticWitnessCaveat::ScopedDeltaUnmapped);
+    }
+    caveats.sort();
+    caveats.dedup();
+    caveats
+}
+
+fn loaded(state: LoadState) -> Result<FileProjection, SemanticProjectionStatus> {
+    match state {
+        LoadState::Ready(file) => Ok(file),
+        LoadState::Failed(status) => Err(status),
+    }
+}
+
+fn project_file(
+    absolute_path: &Path,
+    relative_path: &str,
+    opts: &nose_detect::DetectOptions,
+) -> LoadState {
+    let Some(lang) = Lang::from_file_path(absolute_path) else {
+        return LoadState::Failed(SemanticProjectionStatus::Unsupported);
+    };
+    // Container/declarative projections need region-aware source coordinates or a
+    // non-imperative fingerprint; neither may be silently interpreted as a value DAG.
+    if matches!(lang, Lang::Css | Lang::Vue | Lang::Svelte | Lang::Html) {
+        return LoadState::Failed(SemanticProjectionStatus::Unsupported);
+    }
+    let source = match fs::read(absolute_path) {
+        Ok(source) => source,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return LoadState::Failed(SemanticProjectionStatus::Missing)
+        }
+        Err(_) => return LoadState::Failed(SemanticProjectionStatus::ReadFailed),
+    };
+    if source.len() > MAX_FILE_BYTES {
+        return LoadState::Failed(SemanticProjectionStatus::CapExceeded);
+    }
+    let interner = Interner::new();
+    let raw = match nose_frontend::lower_source(FileId(0), relative_path, &source, lang, &interner)
+    {
+        Ok(raw) => raw,
+        Err(_) => return LoadState::Failed(SemanticProjectionStatus::LowerFailed),
+    };
+    let features = nose_detect::units_of_file(&raw, &interner, opts);
+    let normalized = nose_normalize::normalize(
+        &raw,
+        &interner,
+        &nose_normalize::NormalizeOptions {
+            cfg_norm: opts.cfg_norm,
+            dce: opts.dce,
+            ..Default::default()
+        },
+    );
+    if normalized.units.len() > MAX_UNITS_PER_FILE {
+        return LoadState::Failed(SemanticProjectionStatus::CapExceeded);
+    }
+    let referents = FileReferents::new(&normalized, &interner);
+    let mut units = Vec::with_capacity(normalized.units.len());
+    for unit in &normalized.units {
+        let span = normalized.node(unit.root).span;
+        let name = unit.name.map(|symbol| interner.resolve(symbol).to_string());
+        let feature = features.iter().find(|feature| {
+            feature.kind == unit.kind
+                && feature.start_line == span.start_line
+                && feature.end_line == span.end_line
+                && feature.name == name
+                && feature.fragment_kind.is_none()
+        });
+        let dag = nose_normalize::value_dag(&normalized, unit.root, &interner, None, &referents);
+        let truncated = dag.nodes.len() > MAX_NODES_PER_UNIT;
+        let unresolved_referent = dag
+            .referents
+            .iter()
+            .any(|referent| referent.referent.is_none());
+        units.push(UnitProjection {
+            kind: unit.kind,
+            name,
+            start_line: span.start_line,
+            end_line: span.end_line,
+            exact_safe: feature.is_some_and(|feature| feature.exact_safe),
+            dag,
+            truncated,
+            unresolved_referent,
+        });
+    }
+    LoadState::Ready(FileProjection { units })
+}
+
+fn unit_matches_site(unit: &UnitProjection, site: &Site, require_span: bool) -> bool {
+    unit.kind == site.kind
+        && (!require_span || (unit.start_line == site.start_line && unit.end_line == site.end_line))
+        && match site.name.as_deref() {
+            Some(name) => unit.name.as_deref() == Some(name),
+            None => true,
+        }
+}
+
+fn unit_matches_enclosing(unit: &UnitProjection, enclosing: &EnclosingUnit) -> bool {
+    unit.kind == enclosing.kind
+        && unit.start_line == enclosing.start_line
+        && unit.end_line == enclosing.end_line
+        && match enclosing.name.as_deref() {
+            Some(name) => unit.name.as_deref() == Some(name),
+            None => true,
+        }
+}
+
+fn projected(unit: UnitProjection, alignment: SemanticAlignment) -> ProjectionAttempt {
+    ProjectionAttempt {
+        status: SemanticProjectionStatus::Ok,
+        alignment,
+        unit: Some(unit),
+    }
+}
+
+fn ranges_inside_unit(ranges: &[(u32, u32)], unit: &UnitProjection) -> Vec<(u32, u32)> {
+    ranges
+        .iter()
+        .copied()
+        .filter(|&(start, end)| {
+            if start <= end {
+                start <= unit.end_line && unit.start_line <= end
+            } else {
+                unit.start_line < start && start <= unit.end_line
+            }
+        })
+        .collect()
+}
+
+fn ranges_touch_unit(ranges: &[(u32, u32)], unit: &UnitProjection) -> bool {
+    !ranges_inside_unit(ranges, unit).is_empty()
+}
+
+fn affected_hashes(dag: &ValueDag, ranges: &[(u32, u32)]) -> Vec<u64> {
+    let mut hashes = dag
+        .nodes
+        .iter()
+        .take(MAX_NODES_PER_UNIT)
+        .filter(|node| node.line_start != 0 && node.line_end != 0)
+        .filter(|node| {
+            ranges.iter().any(|&(start, end)| {
+                if start <= end {
+                    start <= node.line_end && node.line_start <= end
+                } else {
+                    node.line_start < start && start <= node.line_end
+                }
+            })
+        })
+        .map(|node| node.hash)
+        .collect::<Vec<_>>();
+    hashes.sort_unstable();
+    hashes
+}
+
+fn node_hashes(dag: &ValueDag) -> Vec<u64> {
+    let mut hashes = dag
+        .nodes
+        .iter()
+        .take(MAX_NODES_PER_UNIT)
+        .map(|node| node.hash)
+        .collect::<Vec<_>>();
+    hashes.sort_unstable();
+    hashes
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct SinkSignature {
+    kind: SemanticSinkKind,
+    hash: u64,
+    effect_ord: Option<u32>,
+}
+
+fn sink_signatures(dag: &ValueDag) -> Vec<SinkSignature> {
+    let mut signatures = dag
+        .sinks
+        .iter()
+        .take(MAX_NODES_PER_UNIT)
+        .filter_map(|sink| {
+            Some(SinkSignature {
+                kind: semantic_sink_kind(sink.kind),
+                hash: dag.nodes.get(sink.value as usize)?.hash,
+                effect_ord: sink.effect_ord,
+            })
+        })
+        .collect::<Vec<_>>();
+    signatures.sort();
+    signatures
+}
+
+fn semantic_sink_kind(kind: VgSinkKind) -> SemanticSinkKind {
+    match kind {
+        VgSinkKind::Return => SemanticSinkKind::Return,
+        VgSinkKind::Cond => SemanticSinkKind::Cond,
+        VgSinkKind::Effect => SemanticSinkKind::Effect,
+        VgSinkKind::Break => SemanticSinkKind::Break,
+        VgSinkKind::Throw => SemanticSinkKind::Throw,
+    }
+}
+
+fn multiset_removed<T: Ord>(before: &[T], after: &[T]) -> usize {
+    let mut before_index = 0;
+    let mut after_index = 0;
+    let mut removed = 0;
+    while before_index < before.len() {
+        while after_index < after.len() && after[after_index] < before[before_index] {
+            after_index += 1;
+        }
+        if after_index < after.len() && after[after_index] == before[before_index] {
+            after_index += 1;
+        } else {
+            removed += 1;
+        }
+        before_index += 1;
+    }
+    removed
+}
+
+fn sink_deltas(before: &[SinkSignature], after: &[SinkSignature]) -> Vec<SemanticSinkDelta> {
+    let mut kinds = BTreeMap::<SemanticSinkKind, (Vec<SinkSignature>, Vec<SinkSignature>)>::new();
+    for &sink in before {
+        kinds.entry(sink.kind).or_default().0.push(sink);
+    }
+    for &sink in after {
+        kinds.entry(sink.kind).or_default().1.push(sink);
+    }
+    kinds
+        .into_iter()
+        .filter_map(|(kind, (before, after))| {
+            let removed = multiset_removed(&before, &after);
+            let inserted = multiset_removed(&after, &before);
+            (removed > 0 || inserted > 0).then_some(SemanticSinkDelta {
+                kind,
+                removed,
+                inserted,
+            })
+        })
+        .collect()
+}
+
+fn caveat_for_projection(
+    status: SemanticProjectionStatus,
+    base: bool,
+) -> Vec<SemanticWitnessCaveat> {
+    match status {
+        SemanticProjectionStatus::Unsupported => vec![SemanticWitnessCaveat::UnsupportedLanguage],
+        SemanticProjectionStatus::AmbiguousUnit => {
+            vec![SemanticWitnessCaveat::AmbiguousAlignment]
+        }
+        SemanticProjectionStatus::CapExceeded => vec![SemanticWitnessCaveat::Truncated],
+        SemanticProjectionStatus::Missing | SemanticProjectionStatus::UnitMissing if !base => {
+            vec![SemanticWitnessCaveat::MissingCurrentUnit]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn unavailable(
+    base_projection: SemanticProjectionStatus,
+    current_projection: SemanticProjectionStatus,
+    mut caveats: Vec<SemanticWitnessCaveat>,
+) -> SemanticChangeWitness {
+    caveats.sort();
+    caveats.dedup();
+    SemanticChangeWitness {
+        status: SemanticWitnessStatus::Unavailable,
+        change_kind: SemanticChangeKind::Unknown,
+        facets: Vec::new(),
+        alignment: SemanticAlignment::None,
+        base_projection,
+        current_projection,
+        coverage: SemanticWitnessCoverage {
+            base_affected_nodes: 0,
+            current_affected_nodes: 0,
+            mapped_shared_nodes: 0,
+            sibling_units_checked: 0,
+        },
+        sink_deltas: Vec::new(),
+        caveats,
+        caps: CAPS,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multiset_difference_preserves_duplicate_counts() {
+        assert_eq!(multiset_removed(&[1, 1, 2, 4], &[1, 2, 3]), 2);
+        assert_eq!(multiset_removed(&[1, 2, 3], &[1, 1, 2, 4]), 1);
+    }
+
+    #[test]
+    fn insertion_context_requires_a_node_to_straddle_the_gap() {
+        let dag = ValueDag {
+            nodes: vec![nose_normalize::VgNode {
+                op: nose_normalize::VgOp::Input,
+                key: 0,
+                args: Vec::new(),
+                hash: 7,
+                line_start: 2,
+                line_end: 4,
+            }],
+            sinks: Vec::new(),
+            referents: Vec::new(),
+        };
+        assert_eq!(affected_hashes(&dag, &[(3, 2)]), vec![7]);
+        assert!(affected_hashes(&dag, &[(2, 1)]).is_empty());
+    }
+}

--- a/crates/nose-cli/src/divergence/change_witness.rs
+++ b/crates/nose-cli/src/divergence/change_witness.rs
@@ -76,7 +76,7 @@ enum Tree {
 }
 
 enum LoadState {
-    Ready(FileProjection),
+    Ready(Box<FileProjection>),
     Failed(SemanticProjectionStatus),
 }
 
@@ -379,7 +379,7 @@ impl<'a> WitnessBuilder<'a> {
             self.files.insert(key.clone(), state);
         }
         match self.files.get(&key).expect("file projection was inserted") {
-            LoadState::Ready(file) => Ok(file),
+            LoadState::Ready(file) => Ok(file.as_ref()),
             LoadState::Failed(status) => Err(*status),
         }
     }
@@ -639,11 +639,11 @@ fn project_file(
             end_line: span.end_line,
         });
     }
-    LoadState::Ready(FileProjection {
+    LoadState::Ready(Box::new(FileProjection {
         interner,
         normalized,
         units,
-    })
+    }))
 }
 
 fn project_unit(file: &FileProjection, unit: &UnitSkeleton) -> UnitProjection {

--- a/crates/nose-cli/src/divergence/change_witness.rs
+++ b/crates/nose-cli/src/divergence/change_witness.rs
@@ -6,7 +6,7 @@
 
 use super::git::DiffEntry;
 use super::*;
-use nose_il::{FileId, Interner, Lang, UnitKind};
+use nose_il::{FileId, Interner, Lang, NodeId, UnitKind};
 use nose_normalize::{FileReferents, ValueDag, VgSinkKind};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -75,15 +75,24 @@ enum Tree {
     Current,
 }
 
-#[derive(Clone)]
 enum LoadState {
     Ready(FileProjection),
     Failed(SemanticProjectionStatus),
 }
 
-#[derive(Clone)]
 struct FileProjection {
-    units: Vec<UnitProjection>,
+    interner: Interner,
+    normalized: nose_il::Il,
+    units: Vec<UnitSkeleton>,
+}
+
+#[derive(Clone)]
+struct UnitSkeleton {
+    root: NodeId,
+    kind: UnitKind,
+    name: Option<String>,
+    start_line: u32,
+    end_line: u32,
 }
 
 #[derive(Clone)]
@@ -123,6 +132,7 @@ struct WitnessBuilder<'a> {
     diff_entries: &'a [DiffEntry],
     opts: nose_detect::DetectOptions,
     files: HashMap<(Tree, String), LoadState>,
+    projections: HashMap<(Tree, String, NodeId), UnitProjection>,
 }
 
 impl<'a> WitnessBuilder<'a> {
@@ -149,6 +159,7 @@ impl<'a> WitnessBuilder<'a> {
             diff_entries,
             opts,
             files: HashMap::new(),
+            projections: HashMap::new(),
         }
     }
 
@@ -215,34 +226,44 @@ impl<'a> WitnessBuilder<'a> {
     }
 
     fn project_base(&mut self, site: &Site) -> ProjectionAttempt {
-        let file = match self.load_file(Tree::Base, &site.file) {
-            Ok(file) => file,
-            Err(status) => return ProjectionAttempt::failed(status),
-        };
-        let mut candidates = file
-            .units
-            .iter()
-            .filter(|unit| unit_matches_site(unit, site, true))
-            .cloned()
-            .collect::<Vec<_>>();
-        if candidates.is_empty() {
-            if let Some(enclosing) = &site.enclosing_unit {
-                candidates = file
-                    .units
-                    .iter()
-                    .filter(|unit| unit_matches_enclosing(unit, enclosing))
-                    .cloned()
-                    .collect();
-            }
+        // Detector-added block roots are not frontend units in the normalized IL. Without
+        // an enclosing frontend unit there is nothing this projection can align, so avoid
+        // normalizing a potentially large file only to return the same `unit-missing` result.
+        if site.kind == UnitKind::Block && site.enclosing_unit.is_none() {
+            return ProjectionAttempt::failed(SemanticProjectionStatus::UnitMissing);
         }
-        match candidates.as_slice() {
-            [unit] => ProjectionAttempt {
-                status: SemanticProjectionStatus::Ok,
-                alignment: SemanticAlignment::ExactSpan,
-                unit: Some(unit.clone()),
-            },
-            [] => ProjectionAttempt::failed(SemanticProjectionStatus::UnitMissing),
-            _ => ProjectionAttempt::failed(SemanticProjectionStatus::AmbiguousUnit),
+        let selected = {
+            let file = match self.load_file(Tree::Base, &site.file) {
+                Ok(file) => file,
+                Err(status) => return ProjectionAttempt::failed(status),
+            };
+            let mut candidates = file
+                .units
+                .iter()
+                .filter(|unit| unit_matches_site(unit, site, true))
+                .cloned()
+                .collect::<Vec<_>>();
+            if candidates.is_empty() {
+                if let Some(enclosing) = &site.enclosing_unit {
+                    candidates = file
+                        .units
+                        .iter()
+                        .filter(|unit| unit_matches_enclosing(unit, enclosing))
+                        .cloned()
+                        .collect();
+                }
+            }
+            match candidates.as_slice() {
+                [unit] => Ok(unit.clone()),
+                [] => Err(SemanticProjectionStatus::UnitMissing),
+                _ => Err(SemanticProjectionStatus::AmbiguousUnit),
+            }
+        };
+        match selected {
+            Ok(unit) => {
+                self.project_selected(Tree::Base, &site.file, unit, SemanticAlignment::ExactSpan)
+            }
+            Err(status) => ProjectionAttempt::failed(status),
         }
     }
 
@@ -252,60 +273,71 @@ impl<'a> WitnessBuilder<'a> {
         current_path: &str,
         changed_ranges: &[(u32, u32)],
     ) -> ProjectionAttempt {
-        let file = match self.load_file(Tree::Current, current_path) {
-            Ok(file) => file,
-            Err(status) => return ProjectionAttempt::failed(status),
-        };
-        let same_kind = file
-            .units
-            .into_iter()
-            .filter(|unit| unit.kind == base.kind)
-            .collect::<Vec<_>>();
-        let exact = same_kind
-            .iter()
-            .filter(|unit| {
-                unit.name == base.name
-                    && unit.start_line == base.start_line
-                    && unit.end_line == base.end_line
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if let [unit] = exact.as_slice() {
-            return projected(unit.clone(), SemanticAlignment::ExactSpan);
-        }
-        if let Some(name) = base.name.as_deref() {
-            let named = same_kind
+        let selected = {
+            let file = match self.load_file(Tree::Current, current_path) {
+                Ok(file) => file,
+                Err(status) => return ProjectionAttempt::failed(status),
+            };
+            let same_kind = file
+                .units
                 .iter()
-                .filter(|unit| unit.name.as_deref() == Some(name))
+                .filter(|unit| unit.kind == base.kind)
                 .cloned()
                 .collect::<Vec<_>>();
-            if let [unit] = named.as_slice() {
-                return projected(unit.clone(), SemanticAlignment::StableName);
+            let exact = same_kind
+                .iter()
+                .filter(|unit| {
+                    unit.name == base.name
+                        && unit.start_line == base.start_line
+                        && unit.end_line == base.end_line
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if let [unit] = exact.as_slice() {
+                Ok((unit.clone(), SemanticAlignment::ExactSpan))
+            } else if let Some(name) = base.name.as_deref() {
+                let named = same_kind
+                    .iter()
+                    .filter(|unit| unit.name.as_deref() == Some(name))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if let [unit] = named.as_slice() {
+                    Ok((unit.clone(), SemanticAlignment::StableName))
+                } else {
+                    select_current_by_change_or_distance(&same_kind, base, changed_ranges)
+                }
+            } else {
+                select_current_by_change_or_distance(&same_kind, base, changed_ranges)
             }
-        }
-        let changed = same_kind
-            .iter()
-            .filter(|unit| ranges_touch_unit(changed_ranges, unit))
-            .cloned()
-            .collect::<Vec<_>>();
-        if let [unit] = changed.as_slice() {
-            return projected(unit.clone(), SemanticAlignment::ChangedRange);
-        }
-        let Some(min_distance) = same_kind
-            .iter()
-            .map(|unit| unit.start_line.abs_diff(base.start_line))
-            .min()
-        else {
-            return ProjectionAttempt::failed(SemanticProjectionStatus::UnitMissing);
         };
-        let nearest = same_kind
-            .into_iter()
-            .filter(|unit| unit.start_line.abs_diff(base.start_line) == min_distance)
-            .collect::<Vec<_>>();
-        match nearest.as_slice() {
-            [unit] => projected(unit.clone(), SemanticAlignment::NearestSpan),
-            _ => ProjectionAttempt::failed(SemanticProjectionStatus::AmbiguousUnit),
+        match selected {
+            Ok((unit, alignment)) => {
+                self.project_selected(Tree::Current, current_path, unit, alignment)
+            }
+            Err(status) => ProjectionAttempt::failed(status),
         }
+    }
+
+    fn project_selected(
+        &mut self,
+        tree: Tree,
+        relative_path: &str,
+        unit: UnitSkeleton,
+        alignment: SemanticAlignment,
+    ) -> ProjectionAttempt {
+        let key = (tree, relative_path.to_string(), unit.root);
+        if let Some(projection) = self.projections.get(&key).cloned() {
+            return projected(projection, alignment);
+        }
+        let projection = {
+            let file = match self.load_file(tree, relative_path) {
+                Ok(file) => file,
+                Err(status) => return ProjectionAttempt::failed(status),
+            };
+            project_unit(file, &unit)
+        };
+        self.projections.insert(key, projection.clone());
+        projected(projection, alignment)
     }
 
     fn sibling_hashes(&mut self, siblings: &[Site]) -> SharedHashes {
@@ -333,21 +365,23 @@ impl<'a> WitnessBuilder<'a> {
         &mut self,
         tree: Tree,
         relative_path: &str,
-    ) -> Result<FileProjection, SemanticProjectionStatus> {
+    ) -> Result<&FileProjection, SemanticProjectionStatus> {
         let key = (tree, relative_path.to_string());
-        if let Some(state) = self.files.get(&key).cloned() {
-            return loaded(state);
+        if !self.files.contains_key(&key) {
+            if self.files.len() >= MAX_FILES {
+                return Err(SemanticProjectionStatus::CapExceeded);
+            }
+            let root = match tree {
+                Tree::Base => self.base_root,
+                Tree::Current => self.current_root,
+            };
+            let state = project_file(&root.join(relative_path), relative_path, &self.opts);
+            self.files.insert(key.clone(), state);
         }
-        if self.files.len() >= MAX_FILES {
-            return Err(SemanticProjectionStatus::CapExceeded);
+        match self.files.get(&key).expect("file projection was inserted") {
+            LoadState::Ready(file) => Ok(file),
+            LoadState::Failed(status) => Err(*status),
         }
-        let root = match tree {
-            Tree::Base => self.base_root,
-            Tree::Current => self.current_root,
-        };
-        let state = project_file(&root.join(relative_path), relative_path, &self.opts);
-        self.files.insert(key, state.clone());
-        loaded(state)
     }
 }
 
@@ -552,13 +586,6 @@ fn analysis_caveats(
     caveats
 }
 
-fn loaded(state: LoadState) -> Result<FileProjection, SemanticProjectionStatus> {
-    match state {
-        LoadState::Ready(file) => Ok(file),
-        LoadState::Failed(status) => Err(status),
-    }
-}
-
 fn project_file(
     absolute_path: &Path,
     relative_path: &str,
@@ -588,7 +615,6 @@ fn project_file(
         Ok(raw) => raw,
         Err(_) => return LoadState::Failed(SemanticProjectionStatus::LowerFailed),
     };
-    let features = nose_detect::units_of_file(&raw, &interner, opts);
     let normalized = nose_normalize::normalize(
         &raw,
         &interner,
@@ -601,39 +627,58 @@ fn project_file(
     if normalized.units.len() > MAX_UNITS_PER_FILE {
         return LoadState::Failed(SemanticProjectionStatus::CapExceeded);
     }
-    let referents = FileReferents::new(&normalized, &interner);
     let mut units = Vec::with_capacity(normalized.units.len());
     for unit in &normalized.units {
         let span = normalized.node(unit.root).span;
         let name = unit.name.map(|symbol| interner.resolve(symbol).to_string());
-        let feature = features.iter().find(|feature| {
-            feature.kind == unit.kind
-                && feature.start_line == span.start_line
-                && feature.end_line == span.end_line
-                && feature.name == name
-                && feature.fragment_kind.is_none()
-        });
-        let dag = nose_normalize::value_dag(&normalized, unit.root, &interner, None, &referents);
-        let truncated = dag.nodes.len() > MAX_NODES_PER_UNIT;
-        let unresolved_referent = dag
-            .referents
-            .iter()
-            .any(|referent| referent.referent.is_none());
-        units.push(UnitProjection {
+        units.push(UnitSkeleton {
+            root: unit.root,
             kind: unit.kind,
             name,
             start_line: span.start_line,
             end_line: span.end_line,
-            exact_safe: feature.is_some_and(|feature| feature.exact_safe),
-            dag,
-            truncated,
-            unresolved_referent,
         });
     }
-    LoadState::Ready(FileProjection { units })
+    LoadState::Ready(FileProjection {
+        interner,
+        normalized,
+        units,
+    })
 }
 
-fn unit_matches_site(unit: &UnitProjection, site: &Site, require_span: bool) -> bool {
+fn project_unit(file: &FileProjection, unit: &UnitSkeleton) -> UnitProjection {
+    let span = file.normalized.node(unit.root).span;
+    let exact_safe =
+        nose_detect::exact_safe_roots_by_span(&file.normalized, &file.interner, &[unit.root])
+            .get(&(span.start_byte, span.end_byte))
+            .copied()
+            .unwrap_or(false);
+    let referents = FileReferents::new(&file.normalized, &file.interner);
+    let dag = nose_normalize::value_dag(
+        &file.normalized,
+        unit.root,
+        &file.interner,
+        None,
+        &referents,
+    );
+    let truncated = dag.nodes.len() > MAX_NODES_PER_UNIT;
+    let unresolved_referent = dag
+        .referents
+        .iter()
+        .any(|referent| referent.referent.is_none());
+    UnitProjection {
+        kind: unit.kind,
+        name: unit.name.clone(),
+        start_line: unit.start_line,
+        end_line: unit.end_line,
+        exact_safe,
+        dag,
+        truncated,
+        unresolved_referent,
+    }
+}
+
+fn unit_matches_site(unit: &UnitSkeleton, site: &Site, require_span: bool) -> bool {
     unit.kind == site.kind
         && (!require_span || (unit.start_line == site.start_line && unit.end_line == site.end_line))
         && match site.name.as_deref() {
@@ -642,7 +687,7 @@ fn unit_matches_site(unit: &UnitProjection, site: &Site, require_span: bool) -> 
         }
 }
 
-fn unit_matches_enclosing(unit: &UnitProjection, enclosing: &EnclosingUnit) -> bool {
+fn unit_matches_enclosing(unit: &UnitSkeleton, enclosing: &EnclosingUnit) -> bool {
     unit.kind == enclosing.kind
         && unit.start_line == enclosing.start_line
         && unit.end_line == enclosing.end_line
@@ -660,6 +705,37 @@ fn projected(unit: UnitProjection, alignment: SemanticAlignment) -> ProjectionAt
     }
 }
 
+fn select_current_by_change_or_distance(
+    same_kind: &[UnitSkeleton],
+    base: &UnitProjection,
+    changed_ranges: &[(u32, u32)],
+) -> Result<(UnitSkeleton, SemanticAlignment), SemanticProjectionStatus> {
+    let changed = same_kind
+        .iter()
+        .filter(|unit| ranges_touch_skeleton(changed_ranges, unit))
+        .cloned()
+        .collect::<Vec<_>>();
+    if let [unit] = changed.as_slice() {
+        return Ok((unit.clone(), SemanticAlignment::ChangedRange));
+    }
+    let Some(min_distance) = same_kind
+        .iter()
+        .map(|unit| unit.start_line.abs_diff(base.start_line))
+        .min()
+    else {
+        return Err(SemanticProjectionStatus::UnitMissing);
+    };
+    let nearest = same_kind
+        .iter()
+        .filter(|unit| unit.start_line.abs_diff(base.start_line) == min_distance)
+        .cloned()
+        .collect::<Vec<_>>();
+    match nearest.as_slice() {
+        [unit] => Ok((unit.clone(), SemanticAlignment::NearestSpan)),
+        _ => Err(SemanticProjectionStatus::AmbiguousUnit),
+    }
+}
+
 fn ranges_inside_unit(ranges: &[(u32, u32)], unit: &UnitProjection) -> Vec<(u32, u32)> {
     ranges
         .iter()
@@ -674,8 +750,14 @@ fn ranges_inside_unit(ranges: &[(u32, u32)], unit: &UnitProjection) -> Vec<(u32,
         .collect()
 }
 
-fn ranges_touch_unit(ranges: &[(u32, u32)], unit: &UnitProjection) -> bool {
-    !ranges_inside_unit(ranges, unit).is_empty()
+fn ranges_touch_skeleton(ranges: &[(u32, u32)], unit: &UnitSkeleton) -> bool {
+    ranges.iter().any(|&(start, end)| {
+        if start <= end {
+            start <= unit.end_line && unit.start_line <= end
+        } else {
+            unit.start_line < start && start <= unit.end_line
+        }
+    })
 }
 
 fn affected_hashes(dag: &ValueDag, ranges: &[(u32, u32)]) -> Vec<u64> {

--- a/crates/nose-cli/src/divergence/detect.rs
+++ b/crates/nose-cli/src/divergence/detect.rs
@@ -71,6 +71,15 @@ pub(crate) fn detect_divergences(
         &base_tree.path,
         &enrich_opts,
     );
+    change_witness::enrich_semantic_change_witnesses(
+        &mut flagged,
+        &base_tree.path,
+        &root,
+        &changed,
+        &current_changed,
+        &diff_entries,
+        &enrich_opts,
+    );
     if current_lane_requested {
         let current_paths = reroot_paths(&divergence_paths, &root);
         let mut current_families = detect_divergence_base_families(
@@ -416,6 +425,7 @@ pub(super) fn to_site(loc: &Loc) -> Site {
         reason_code: loc.reason_code,
         enclosing_unit: loc.enclosing_unit.clone(),
         touches_shared: None,
+        semantic_change: None,
     }
 }
 

--- a/crates/nose-cli/src/divergence/output.rs
+++ b/crates/nose-cli/src/divergence/output.rs
@@ -55,6 +55,7 @@ pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::V
             "reason_code": s.reason_code,
             "enclosing_unit": s.enclosing_unit,
             "touches_shared": s.touches_shared,
+            "semantic_change": s.semantic_change,
         })
     };
     flagged
@@ -191,6 +192,9 @@ fn divergence_sarif_result(d: &Divergence) -> serde_json::Value {
             },
             "policy": DIVERGENT_EDIT_V2_POLICY,
             "fire_eligible": d.fire_eligible,
+            "semantic_change": d.changed.iter()
+                .filter_map(|site| site.semantic_change.as_ref())
+                .collect::<Vec<_>>(),
         },
     })
 }

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -5,7 +5,9 @@ use super::git::{
 };
 use super::output::{divergence_items_json, divergence_sarif, fragment_context};
 use super::{
-    Divergence, DivergenceLane, DivergenceTier, Site, DIVERGENCE_LANE_VALUES,
+    Divergence, DivergenceLane, DivergenceTier, SemanticAlignment, SemanticChangeKind,
+    SemanticChangeWitness, SemanticProjectionStatus, SemanticWitnessCaps, SemanticWitnessCaveat,
+    SemanticWitnessCoverage, SemanticWitnessStatus, Site, DIVERGENCE_LANE_VALUES,
     DIVERGENCE_SUPPRESSION_KIND_VALUES, DIVERGENCE_TAXONOMY_HINT_VALUES,
     DIVERGENCE_TIER_REASON_VALUES, DIVERGENCE_TIER_VALUES, DIVERGENT_EDIT_V2_POLICY,
 };
@@ -274,6 +276,7 @@ fn tier_site(file: &str, touches_shared: Option<bool>) -> Site {
         reason_code: None,
         enclosing_unit: None,
         touches_shared,
+        semantic_change: None,
     }
 }
 
@@ -309,9 +312,36 @@ fn v2_tier_routes_new_copy_lane_to_report_only() {
 
 #[test]
 fn v2_tier_routes_unknown_shared_evidence_to_review() {
-    let d = tier_divergence("prod", false, None);
+    let mut d = tier_divergence("prod", false, None);
+    d.changed[0].semantic_change = Some(SemanticChangeWitness {
+        status: SemanticWitnessStatus::Unavailable,
+        change_kind: SemanticChangeKind::Unknown,
+        facets: Vec::new(),
+        alignment: SemanticAlignment::None,
+        base_projection: SemanticProjectionStatus::Ok,
+        current_projection: SemanticProjectionStatus::UnitMissing,
+        coverage: SemanticWitnessCoverage {
+            base_affected_nodes: 0,
+            current_affected_nodes: 0,
+            mapped_shared_nodes: 0,
+            sibling_units_checked: 0,
+        },
+        sink_deltas: Vec::new(),
+        caveats: vec![SemanticWitnessCaveat::MissingCurrentUnit],
+        caps: SemanticWitnessCaps {
+            max_files: 64,
+            max_file_bytes: 2 * 1024 * 1024,
+            max_changed_sites_per_family: 16,
+            max_siblings_per_family: 16,
+            max_units_per_file: 512,
+            max_nodes_per_unit: 2_048,
+        },
+    });
     assert_eq!(d.tier(), DivergenceTier::Review);
-    assert!(!d.gate_fail_default(), "unknown evidence must fail closed");
+    assert!(
+        !d.gate_fail_default(),
+        "an unavailable semantic witness cannot promote the v2 gate"
+    );
     assert_eq!(d.taxonomy_hint(), "unclear");
     assert_eq!(
         d.tier_reasons(),

--- a/crates/nose-cli/src/query_views.rs
+++ b/crates/nose-cli/src/query_views.rs
@@ -177,6 +177,7 @@ pub(super) fn render_query_base(
             divergence::DivergenceLane::BaseDivergence => {
                 for s in &d.changed {
                     println!("    changed:      {}", site(s));
+                    print_semantic_change(s);
                 }
                 for s in &d.not_updated {
                     println!("    not updated:  {}", site(s));
@@ -194,6 +195,12 @@ pub(super) fn render_query_base(
     }
     println!("\nnext:");
     println!("  nose query {path} base={base_ref} --fail-on any   # fail CI on strict divergences");
+}
+
+fn print_semantic_change(site: &divergence::Site) {
+    if let Some(witness) = &site.semantic_change {
+        println!("      semantic:   {}", witness.concise_label());
+    }
 }
 
 /// The `reinvented` view: code that reimplements an existing helper's body (the `reinvented`

--- a/crates/nose-cli/tests/cli/query_base/core_contract.rs
+++ b/crates/nose-cli/tests/cli/query_base/core_contract.rs
@@ -91,6 +91,7 @@ fn assert_json_contract(dir: &Path) {
             "span_tokens",
             "is_fragment",
             "touches_shared",
+            "semantic_change",
         ] {
             assert!(
                 site.get(key).is_some(),

--- a/crates/nose-cli/tests/cli/query_base/edge_cases.rs
+++ b/crates/nose-cli/tests/cli/query_base/edge_cases.rs
@@ -60,11 +60,58 @@ fn query_base_deleted_copy_is_strict_base_divergence() {
     assert_eq!(item["gate"]["fail_default"], true);
     assert_site_files(item, "changed", &["a/f.py"]);
     assert_site_files(item, "not_updated", &["b/f.py"]);
+    assert_eq!(
+        item["changed"][0]["semantic_change"]["status"], "unavailable",
+        "a missing current unit cannot become a complete semantic witness: {json}"
+    );
+    assert!(
+        item["changed"][0]["semantic_change"]["caveats"]
+            .as_array()
+            .is_some_and(|caveats| caveats
+                .iter()
+                .any(|caveat| caveat == "missing-current-unit")),
+        "missing current unit is explicit: {json}"
+    );
 
     let gated = nose_query_base(&dir, &["--fail"]);
     assert!(
         !gated.status.success(),
         "deleting one prod copy is a strict base divergence under the current policy"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_semantic_witness_maps_a_deleted_computation() {
+    let dir = make_temp_dir("query_base_semantic_deletion");
+    let body = |name: &str, acc: &str, item: &str| {
+        format!(
+            "def {name}(items):\n    {acc} = 0\n    for {item} in items:\n        {acc} = {acc} + {item}\n    {acc} = {acc} + 1\n    return {acc}\n"
+        )
+    };
+    write_files(
+        &dir,
+        &[
+            ("a.py", &body("first", "total", "value")),
+            ("b.py", &body("second", "sum", "entry")),
+        ],
+    );
+    init_git_repo(&dir);
+    let a = dir.join("a.py");
+    let source = fs::read_to_string(&a).unwrap();
+    fs::write(&a, source.replace("    total = total + 1\n", "")).unwrap();
+
+    let json = query_base_json(&dir);
+    let item = find_item_by_lane_and_files(&json, "base-divergence", "changed", &["a.py"]);
+    let witness = &item["changed"][0]["semantic_change"];
+    assert_eq!(witness["status"], "complete", "witness: {json}");
+    assert_eq!(witness["change_kind"], "deletion", "witness: {json}");
+    assert!(
+        witness["coverage"]["mapped_shared_nodes"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "deleted semantics map to the skipped sibling: {json}"
     );
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/nose-cli/tests/cli/query_base/tier_policy.rs
+++ b/crates/nose-cli/tests/cli/query_base/tier_policy.rs
@@ -142,10 +142,7 @@ fn query_base_exact_renamed_twin_remains_strict() {
     let src = fs::read_to_string(&a).unwrap();
     fs::write(
         &a,
-        src.replace(
-            "total = total + item * item",
-            "total = total + item * item + 1",
-        ),
+        src.replace("total = total + item * item", "total = total - item * item"),
     )
     .unwrap();
 
@@ -166,11 +163,69 @@ fn query_base_exact_renamed_twin_remains_strict() {
         "exact renamed twin stays strict: {json}"
     );
     assert_eq!(finding["gate"]["fail_default"], true, "strict gate: {json}");
+    let semantic_change = &finding["changed"][0]["semantic_change"];
+    assert_eq!(semantic_change["status"], "complete", "witness: {json}");
+    assert_eq!(
+        semantic_change["change_kind"], "replacement",
+        "witness: {json}"
+    );
+    assert!(
+        semantic_change["coverage"]["mapped_shared_nodes"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "changed base semantics map to the skipped sibling: {json}"
+    );
+    assert!(
+        semantic_change["facets"]
+            .as_array()
+            .is_some_and(|facets| facets.iter().any(|facet| facet == "return")),
+        "return behavior changed: {json}"
+    );
 
     let gated = nose_query_base(&dir, &["--mode", "semantic", "--fail"]);
     assert!(
         !gated.status.success(),
         "--fail must fire for an exact renamed-twin strict divergence"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn query_base_semantic_witness_distinguishes_no_delta_and_pure_insertion() {
+    let dir = make_mode_project("query_base_semantic_change_kinds");
+    init_git_repo(&dir);
+    let a = dir.join("renamed_a.py");
+    let original = fs::read_to_string(&a).unwrap();
+
+    fs::write(&a, original.replace("return total", "return (total)")).unwrap();
+    let no_delta = query_base_json_value(&dir, &["--mode", "semantic"]);
+    let finding =
+        find_item_by_lane_and_files(&no_delta, "base-divergence", "changed", &["renamed_a.py"]);
+    assert_eq!(
+        finding["changed"][0]["semantic_change"]["change_kind"], "no-semantic-delta",
+        "source contact without a normalized semantic delta: {no_delta}"
+    );
+
+    fs::write(
+        &a,
+        original.replace(
+            "    return total",
+            "    total = total + 1\n    return total",
+        ),
+    )
+    .unwrap();
+    let insertion = query_base_json_value(&dir, &["--mode", "semantic"]);
+    let finding =
+        find_item_by_lane_and_files(&insertion, "base-divergence", "changed", &["renamed_a.py"]);
+    let witness = &finding["changed"][0]["semantic_change"];
+    assert_eq!(witness["status"], "advisory", "witness: {insertion}");
+    assert_eq!(witness["change_kind"], "insertion", "witness: {insertion}");
+    assert!(
+        witness["caveats"]
+            .as_array()
+            .is_some_and(|caveats| caveats.iter().any(|caveat| caveat == "pure-insertion")),
+        "pure insertions stay explicitly advisory: {insertion}"
     );
 
     let _ = fs::remove_dir_all(&dir);
@@ -202,6 +257,10 @@ fn first_fire_policy_finding(dir: &Path) -> serde_json::Value {
 
 fn assert_varying_spot_is_review(dir: &Path) {
     let finding = first_fire_policy_finding(dir);
+    assert_eq!(
+        finding["changed"][0]["semantic_change"]["status"], "advisory",
+        "a varying-spot edit without mapped shared semantics stays advisory: {finding}"
+    );
     assert_eq!(
         finding["fire_eligible"], false,
         "a varying-spot-only change must not be gate-eligible: {finding}"

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -132,7 +132,8 @@ Read the fields in this order — each step either decides or narrows:
 `nose query <path> base=<ref> --format json` (the `base` view) emits one `items[]`
 finding per divergence, each carrying the v2 gate fields: `tier`, `tier_reasons[]`,
 `taxonomy_hint`, and `gate.fail_default`, plus legacy `fire_eligible` compatibility
-evidence, `witness_kind`, `scope`, and per-changed-site `touches_shared`. For propagation
+evidence, `witness_kind`, `scope`, per-changed-site `touches_shared`, and the advisory
+`semantic_change` projection. For propagation
 triage over the top findings, judge each as
 should-propagate / intentional-divergence / not-a-clone using the changed member's
 diff and the un-updated sibling's body. Most fires are not propagation hazards; the

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -110,6 +110,26 @@ so suppressing on it would risk the keep-every-propagation property the shared-l
 is measured against. The shared-logic proof stays separate from graded-witness
 presentation evidence; the v2 tier decides whether that proof is default-failing.
 
+## Bounded semantic-change evidence
+
+For an already-flagged base divergence, each changed site also carries
+`semantic_change`. nose aligns that base unit with its current-tree unit, compares bounded
+value-DAG and behavior-sink projections, and maps affected base nodes into a capped set of
+skipped siblings. This distinguishes source contact with no normalized semantic delta from
+replacement, deletion, and insertion of value, return, control, or effect behavior.
+
+The analysis is candidate-local: at most 64 selected base/current files of 2 MiB each, 16
+changed sites and 16 skipped siblings per family, 512 units per file, and 2,048 value nodes
+per unit participate. It does not discover or scan the repository again. Unsupported
+fragments or declarative/container languages, parse/lower failures, missing current units,
+lossy lowering, unresolved referents, ambiguous or heuristic alignment, pure insertions,
+mixed changes, and cap exhaustion remain explicit advisory or unavailable evidence.
+
+This is deliberately not a v2 decision input. `tier()` and `gate.fail_default` continue to
+use the frozen v2 policy above; even a complete semantic-change witness cannot promote a
+finding in this implementation. The evidence exists so the development corpus can price a
+future policy before that policy is frozen and evaluated blind.
+
 ## V2 gate tiers (design contract)
 
 #670 refreshed the replay measurement and changed the next implementation target:

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -96,7 +96,8 @@ base_family_id, similarity, complexity, scope, witness_kind, fire_eligible, tier
 tier_reasons[], taxonomy_hint, gate, suppression, graded, changed[], not_updated[],
 current_only[]}` — each site carries `{file, name, start_line, end_line, lang, kind,
 span_lines, span_tokens, is_fragment, fragment_kind, reason_code, enclosing_unit,
-touches_shared, tree}`.
+touches_shared, semantic_change, tree}`. `semantic_change` is `null` for skipped/current-only
+sites and otherwise carries the bounded base-to-current evidence described below.
 `divergences` is the total before `top=N` truncation; `shown_divergences` is `items.length`;
 `limit` is the numeric row limit or `null` for `top=0`. `fire_eligible` is the legacy v1
 conservative gate verdict. In the current implementation it means the diff provably touches
@@ -109,6 +110,18 @@ instead of silent v7 additions: CI wrappers and agents need stable enums for gat
 The v7 evidence fields remain available in the base item, but `fire_eligible` stays a
 compatibility verdict rather than a raw input. The raw inputs are `scope`, `witness_kind`,
 `graded`, and per-site `touches_shared`.
+
+`changed[].semantic_change` is an evidence-only v8 extension. Its `status` is `complete`,
+`advisory`, or `unavailable`; `change_kind` is `no-semantic-delta`, `replacement`,
+`deletion`, `insertion`, `mixed`, or `unknown`. `facets[]` identifies changed `value`,
+`return`, `control`, and `effect` behavior. `coverage` records affected base/current value
+nodes, how many affected base nodes occur in a skipped sibling, and how many siblings were
+checked. `sink_deltas[]`, base/current projection status, alignment method, deterministic
+caps, and explicit `caveats[]` make partial evidence inspectable. Pure source insertions,
+mixed changes, lossy/unsupported lowering, missing or ambiguous units, heuristic alignment,
+unresolved referents, and capped mappings cannot be `complete`. This field does not alter
+`fire_eligible`, `tier`, or `gate.fail_default`; #849 emits and measures the evidence before
+a later frozen policy may consume it.
 
 The v8 `base.items[]` object adds:
 

--- a/docs/soundness-lab.md
+++ b/docs/soundness-lab.md
@@ -381,7 +381,9 @@ that completed that issue. The #862
 [`release-binding-862.v1.json`](../bench/soundness/0.20.0/release-binding-862.v1.json) separately
 binds the current crates tree, binary, replayed overlay, falsification output, Type-4 blind receipt,
 and a candidate-generated exclusion-attribution census, while proving that all frozen pair
-decisions and coverage aggregates are unchanged. The candidate census covers 13,794 units and
+decisions and coverage aggregates are unchanged. Its Type-4 input is an immutable #862 snapshot;
+the live `bench/type4/blind_attack.v1.json` continues to follow the current crates tree without
+rewriting historical release evidence. The candidate census covers 13,794 units and
 attributes every one of its 11,182 exclusions to a concrete classification and capability; generic
 or unattributed exclusions remain zero. A fresh nine-iteration query run over the seven-repository
 regression frontier uses the published v0.19.0 arm64 binary as its baseline. After subtracting a

--- a/eval/divergence_fire/RESULTS.md
+++ b/eval/divergence_fire/RESULTS.md
@@ -300,6 +300,58 @@ The remaining false-positive buckets under serialized `fire_eligible` are:
 | `test_scaffolding` | 12 | keep test/scope filtering prominent in default policy |
 | `not_a_clone` | 7 | improve family grouping quality for broad low-specificity matches |
 
+## Semantic change witness development pricing (2026-07-18, #849)
+
+#849 adds bounded base-to-current value/control/effect/return evidence to already
+flagged changed members. It does not change `tier`, `fire_eligible`, or
+`gate.fail_default`. The checked
+[`semantic_witness_dev_2026_07_18.v1.json`](semantic_witness_dev_2026_07_18.v1.json)
+prices the evidence only on the public 2026-07-06 development labels; no blind or
+temporal input was accessed.
+
+The final replay matched all 179 labeled findings with zero query errors. The frozen
+v2 strict slice remains 80 findings: 45 `should_propagate`, 17
+`no_propagation_needed`, 13 `intentional_divergence`, and 5 `not_a_clone`.
+
+| simulated predicate | selected | true positives | precision | TP retention |
+|---|---:|---:|---:|---:|
+| current v2 strict | 80 | 45 | 56.25% | 100% |
+| mapped semantic delta evidence | 22 | 12 | 54.55% | 26.67% |
+| mapped sink delta evidence | 20 | 12 | 60.00% | 26.67% |
+| require complete mapped delta | 0 | 0 | n/a | 0% |
+| demote any no-semantic-delta evidence | 76 | 44 | 57.89% | 97.78% |
+| demote no-shared-semantic-node evidence | 71 | 45 | 63.38% | 100% |
+
+The last row is promising development evidence—it removes all five `not_a_clone`
+rows and four of the 17 strict `no_propagation_needed` rows without losing a labeled
+positive—but it is frequently advisory because of lossy lowering or unresolved
+referents. #849 therefore records it without promoting it into policy. No complete
+predicate selected a real development finding, so treating absence of caveats as a
+new strict requirement would erase all strict recall rather than prove a better gate.
+
+The official-v0.19.0 runtime receipt is
+[`issue-849-official-v0.19.0-performance-2026-07-18.v1.json`](../../bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json).
+Across one frozen strict default-arm query in each of 17 development repositories,
+the final candidate adds 508.48 ms / 5.06% raw and 537.98 ms / 5.35% after the
+same-binary control. Removing `semantic_change` makes all 17 JSON outputs identical.
+The first eager implementation added 5,492.02 ms / 54.86%; lazy per-unit projection
+and caching removed that unbounded file-wide work before closeout.
+
+Reproduce the source-free aggregate artifacts after building the release binary:
+
+```sh
+python3 eval/divergence_fire/semantic_witness_eval.py selftest
+python3 eval/divergence_fire/semantic_witness_eval.py replay \
+  --jobs 4 --timeout 240 --out /tmp/issue-849-dev-replay.jsonl
+python3 eval/divergence_fire/semantic_witness_eval.py summarize \
+  --records /tmp/issue-849-dev-replay.jsonl --nose target/release/nose \
+  --out eval/divergence_fire/semantic_witness_dev_2026_07_18.v1.json
+python3 eval/divergence_fire/semantic_witness_eval.py runtime \
+  --baseline target/issue-839/official-v0.19.0/nose-cli-aarch64-apple-darwin/nose \
+  --current target/release/nose --iterations 3 --warmups 1 --timeout 240 \
+  --out /tmp/issue-849-runtime-primary.json
+```
+
 ## Fire rate (change level; 347 replayed changes per arm)
 
 | arm | fire rate | findings/fire p50 | p90 | max | divergence s p50 | p90 |

--- a/eval/divergence_fire/semantic_witness_dev_2026_07_18.v1.json
+++ b/eval/divergence_fire/semantic_witness_dev_2026_07_18.v1.json
@@ -1,0 +1,304 @@
+{
+  "baseline_v2_strict": {
+    "findings": 80,
+    "verdicts": {
+      "intentional_divergence": 13,
+      "no_propagation_needed": 17,
+      "not_a_clone": 5,
+      "should_propagate": 45
+    }
+  },
+  "blind_or_temporal_data_accessed": false,
+  "development_only": true,
+  "implementation": {
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "2f961af03e2e62f275e1b9ac4d5df162e2385c54f947475350e6c4a79bfd4eb2",
+    "nose_version": "nose 0.19.0",
+    "source_commit": "3d15ac455a167fd90e449fc3f935deadd4bdd384"
+  },
+  "inputs": {
+    "labeled_findings": 179,
+    "samples": "eval/divergence_fire/sampled_findings_2026_07_06.jsonl",
+    "samples_sha256": "05be2f55e0ef4aa810fffd741cd7c39b840a92ed2b7cc055164496a74108c288",
+    "verdicts": "eval/divergence_fire/verdicts_2026_07_06.jsonl",
+    "verdicts_sha256": "c5ab11a2c1d0cae2d52fc15b4868e43e9e7ddd8e9e25e593dc828ce1d94828fc"
+  },
+  "interpretation": "Development evidence only. These predicates do not change gate.fail_default and must not be tuned against or presented as a blind/default-on result.",
+  "issue": 849,
+  "replay": {
+    "matched_findings": 179,
+    "query_error_rows": 0,
+    "unmatched_findings": 0
+  },
+  "schema_version": 1,
+  "simulations": [
+    {
+      "false_positives": 35,
+      "name": "current-v2-strict",
+      "precision": 0.5625,
+      "selected": 80,
+      "should_propagate": 45,
+      "should_propagate_retention": 1.0,
+      "verdicts": {
+        "intentional_divergence": 13,
+        "no_propagation_needed": 17,
+        "not_a_clone": 5,
+        "should_propagate": 45
+      }
+    },
+    {
+      "false_positives": 10,
+      "name": "evidence-slice-mapped-semantic-delta",
+      "precision": 0.545455,
+      "selected": 22,
+      "should_propagate": 12,
+      "should_propagate_retention": 0.266667,
+      "verdicts": {
+        "intentional_divergence": 6,
+        "no_propagation_needed": 4,
+        "should_propagate": 12
+      }
+    },
+    {
+      "false_positives": 8,
+      "name": "evidence-slice-mapped-sink-delta",
+      "precision": 0.6,
+      "selected": 20,
+      "should_propagate": 12,
+      "should_propagate_retention": 0.266667,
+      "verdicts": {
+        "intentional_divergence": 4,
+        "no_propagation_needed": 4,
+        "should_propagate": 12
+      }
+    },
+    {
+      "false_positives": 0,
+      "name": "require-complete-mapped-semantic-delta",
+      "precision": null,
+      "selected": 0,
+      "should_propagate": 0,
+      "should_propagate_retention": 0.0,
+      "verdicts": {}
+    },
+    {
+      "false_positives": 0,
+      "name": "require-complete-mapped-sink-delta",
+      "precision": null,
+      "selected": 0,
+      "should_propagate": 0,
+      "should_propagate_retention": 0.0,
+      "verdicts": {}
+    },
+    {
+      "false_positives": 35,
+      "name": "demote-complete-no-semantic-delta",
+      "precision": 0.5625,
+      "selected": 80,
+      "should_propagate": 45,
+      "should_propagate_retention": 1.0,
+      "verdicts": {
+        "intentional_divergence": 13,
+        "no_propagation_needed": 17,
+        "not_a_clone": 5,
+        "should_propagate": 45
+      }
+    },
+    {
+      "false_positives": 32,
+      "name": "demote-on-any-no-semantic-delta-evidence",
+      "precision": 0.578947,
+      "selected": 76,
+      "should_propagate": 44,
+      "should_propagate_retention": 0.977778,
+      "verdicts": {
+        "intentional_divergence": 13,
+        "no_propagation_needed": 14,
+        "not_a_clone": 5,
+        "should_propagate": 44
+      }
+    },
+    {
+      "false_positives": 26,
+      "name": "demote-on-no-shared-semantic-node-evidence",
+      "precision": 0.633803,
+      "selected": 71,
+      "should_propagate": 45,
+      "should_propagate_retention": 1.0,
+      "verdicts": {
+        "intentional_divergence": 13,
+        "no_propagation_needed": 13,
+        "should_propagate": 45
+      }
+    }
+  ],
+  "site_evidence_by_verdict": {
+    "caveats": {
+      "fragment-unsupported": {
+        "no_propagation_needed": 1,
+        "test_scaffolding": 1
+      },
+      "heuristic-alignment": {
+        "intentional_divergence": 2,
+        "no_propagation_needed": 1,
+        "not_a_clone": 2,
+        "test_scaffolding": 2
+      },
+      "lossy-base-lowering": {
+        "intentional_divergence": 25,
+        "no_propagation_needed": 30,
+        "not_a_clone": 16,
+        "should_propagate": 26,
+        "test_scaffolding": 9
+      },
+      "lossy-current-lowering": {
+        "intentional_divergence": 25,
+        "no_propagation_needed": 30,
+        "not_a_clone": 16,
+        "should_propagate": 27,
+        "test_scaffolding": 9
+      },
+      "missing-current-unit": {
+        "test_scaffolding": 1
+      },
+      "mixed-change": {
+        "intentional_divergence": 7,
+        "no_propagation_needed": 8,
+        "not_a_clone": 3,
+        "should_propagate": 3,
+        "test_scaffolding": 2
+      },
+      "no-affected-semantic-node": {
+        "no_propagation_needed": 7,
+        "not_a_clone": 1,
+        "should_propagate": 1,
+        "test_scaffolding": 1
+      },
+      "no-shared-semantic-node": {
+        "intentional_divergence": 5,
+        "no_propagation_needed": 7,
+        "not_a_clone": 11,
+        "test_scaffolding": 5
+      },
+      "pure-insertion": {
+        "intentional_divergence": 1,
+        "no_propagation_needed": 1,
+        "should_propagate": 1,
+        "test_scaffolding": 1
+      },
+      "scoped-delta-unmapped": {
+        "no_propagation_needed": 2,
+        "not_a_clone": 1
+      },
+      "truncated": {
+        "not_a_clone": 1
+      },
+      "unresolved-referent": {
+        "intentional_divergence": 25,
+        "no_propagation_needed": 25,
+        "not_a_clone": 11,
+        "should_propagate": 20,
+        "test_scaffolding": 8
+      }
+    },
+    "change_kind": {
+      "deletion": {
+        "intentional_divergence": 2,
+        "no_propagation_needed": 2,
+        "not_a_clone": 1,
+        "should_propagate": 13,
+        "test_scaffolding": 1
+      },
+      "insertion": {
+        "intentional_divergence": 1,
+        "no_propagation_needed": 3,
+        "not_a_clone": 1,
+        "should_propagate": 1,
+        "test_scaffolding": 1
+      },
+      "mixed": {
+        "intentional_divergence": 7,
+        "no_propagation_needed": 8,
+        "not_a_clone": 3,
+        "should_propagate": 3,
+        "test_scaffolding": 2
+      },
+      "no-semantic-delta": {
+        "intentional_divergence": 1,
+        "no_propagation_needed": 7,
+        "not_a_clone": 3,
+        "should_propagate": 5
+      },
+      "replacement": {
+        "intentional_divergence": 14,
+        "no_propagation_needed": 10,
+        "not_a_clone": 9,
+        "should_propagate": 5,
+        "test_scaffolding": 5
+      },
+      "unknown": {
+        "intentional_divergence": 6,
+        "no_propagation_needed": 21,
+        "not_a_clone": 4,
+        "should_propagate": 46,
+        "test_scaffolding": 38
+      }
+    },
+    "facets": {
+      "control": {
+        "intentional_divergence": 1,
+        "no_propagation_needed": 3,
+        "not_a_clone": 4,
+        "test_scaffolding": 3
+      },
+      "effect": {
+        "intentional_divergence": 15,
+        "no_propagation_needed": 18,
+        "not_a_clone": 9,
+        "should_propagate": 7,
+        "test_scaffolding": 9
+      },
+      "return": {
+        "intentional_divergence": 16,
+        "no_propagation_needed": 14,
+        "not_a_clone": 11,
+        "should_propagate": 18
+      },
+      "value": {
+        "intentional_divergence": 24,
+        "no_propagation_needed": 23,
+        "not_a_clone": 15,
+        "should_propagate": 22,
+        "test_scaffolding": 9
+      }
+    },
+    "status": {
+      "advisory": {
+        "intentional_divergence": 25,
+        "no_propagation_needed": 30,
+        "not_a_clone": 18,
+        "should_propagate": 27,
+        "test_scaffolding": 9
+      },
+      "unavailable": {
+        "intentional_divergence": 6,
+        "no_propagation_needed": 21,
+        "not_a_clone": 3,
+        "should_propagate": 46,
+        "test_scaffolding": 38
+      }
+    }
+  },
+  "strict_no_propagation_needed": {
+    "findings": 17,
+    "predicate_hits": {
+      "complete-mapped-semantic-delta": 0,
+      "complete-mapped-sink-delta": 0,
+      "complete-no-semantic-delta": 0,
+      "mapped-semantic-delta-evidence": 4,
+      "mapped-sink-delta-evidence": 4,
+      "no-semantic-delta-evidence": 3,
+      "no-shared-semantic-node-evidence": 4
+    }
+  }
+}

--- a/eval/divergence_fire/semantic_witness_dev_2026_07_18.v1.json
+++ b/eval/divergence_fire/semantic_witness_dev_2026_07_18.v1.json
@@ -11,6 +11,8 @@
   "blind_or_temporal_data_accessed": false,
   "development_only": true,
   "implementation": {
+    "final_commit": "d639321f8668eaaa14226a4b3600292e828ec087",
+    "final_commit_transfer": "Boxed only the cached FileProjection enum variant; evidence behavior and bounded work are unchanged.",
     "nose_binary": "target/release/nose",
     "nose_binary_sha256": "2f961af03e2e62f275e1b9ac4d5df162e2385c54f947475350e6c4a79bfd4eb2",
     "nose_version": "nose 0.19.0",

--- a/eval/divergence_fire/semantic_witness_eval.py
+++ b/eval/divergence_fire/semantic_witness_eval.py
@@ -12,6 +12,7 @@ import concurrent.futures
 import hashlib
 import json
 from pathlib import Path
+import statistics
 import subprocess
 import tempfile
 import time
@@ -171,15 +172,24 @@ def cmd_replay(args):
 def witness_predicates(row):
     witnesses = [w for w in row.get("semantic_change", []) if isinstance(w, dict)]
     complete = [w for w in witnesses if w.get("status") == "complete"]
-    mapped_delta = [
-        w for w in complete
+    mapped_delta_evidence = [
+        w for w in witnesses
         if w.get("change_kind") not in {"no-semantic-delta", "mixed", "unknown"}
         and w.get("facets")
         and w.get("coverage", {}).get("mapped_shared_nodes", 0) > 0
     ]
+    complete_mapped_delta = [w for w in mapped_delta_evidence if w.get("status") == "complete"]
     return {
-        "complete-mapped-semantic-delta": bool(mapped_delta),
-        "complete-mapped-sink-delta": any(w.get("sink_deltas") for w in mapped_delta),
+        "mapped-semantic-delta-evidence": bool(mapped_delta_evidence),
+        "mapped-sink-delta-evidence": any(w.get("sink_deltas") for w in mapped_delta_evidence),
+        "no-semantic-delta-evidence": any(
+            w.get("change_kind") == "no-semantic-delta" for w in witnesses
+        ),
+        "no-shared-semantic-node-evidence": any(
+            "no-shared-semantic-node" in w.get("caveats", []) for w in witnesses
+        ),
+        "complete-mapped-semantic-delta": bool(complete_mapped_delta),
+        "complete-mapped-sink-delta": any(w.get("sink_deltas") for w in complete_mapped_delta),
         "complete-no-semantic-delta": any(
             w.get("status") == "complete" and w.get("change_kind") == "no-semantic-delta"
             for w in witnesses
@@ -294,6 +304,16 @@ def cmd_summarize(args):
         "simulations": [
             simulation("current-v2-strict", strict, lambda row: True),
             simulation(
+                "evidence-slice-mapped-semantic-delta",
+                strict,
+                lambda row: row["predicates"]["mapped-semantic-delta-evidence"],
+            ),
+            simulation(
+                "evidence-slice-mapped-sink-delta",
+                strict,
+                lambda row: row["predicates"]["mapped-sink-delta-evidence"],
+            ),
+            simulation(
                 "require-complete-mapped-semantic-delta",
                 strict,
                 lambda row: row["predicates"]["complete-mapped-semantic-delta"],
@@ -307,6 +327,16 @@ def cmd_summarize(args):
                 "demote-complete-no-semantic-delta",
                 strict,
                 lambda row: not row["predicates"]["complete-no-semantic-delta"],
+            ),
+            simulation(
+                "demote-on-any-no-semantic-delta-evidence",
+                strict,
+                lambda row: not row["predicates"]["no-semantic-delta-evidence"],
+            ),
+            simulation(
+                "demote-on-no-shared-semantic-node-evidence",
+                strict,
+                lambda row: not row["predicates"]["no-shared-semantic-node-evidence"],
             ),
         ],
         "interpretation": (
@@ -330,8 +360,159 @@ def cmd_selftest(_args):
         }]
     }
     assert witness_predicates(row)["complete-mapped-semantic-delta"]
+    assert witness_predicates(row)["mapped-semantic-delta-evidence"]
     assert not witness_predicates(row)["complete-mapped-sink-delta"]
     print("semantic_witness_eval selftest: ok")
+
+
+def strip_semantic_change(document):
+    document = json.loads(json.dumps(document))
+    for finding in document.get("items", []):
+        for key in ("changed", "not_updated", "current_only"):
+            for site in finding.get(key, []):
+                site.pop("semantic_change", None)
+    return document
+
+
+def runtime_queries(samples):
+    by_repo = {}
+    for sample in sorted(samples, key=lambda row: (row["repo"], row["sid"])):
+        if sample["arm"] == "default" and current_v2_strict(sample):
+            by_repo.setdefault(sample["repo"], sample)
+    return list(by_repo.values())
+
+
+def runtime_repo(sample, repos_root, binaries, iterations, warmups, timeout):
+    repo = sample["repo"]
+    source = repos_root / repo
+    rows = []
+    legacy_equal = True
+    with tempfile.TemporaryDirectory(prefix=f"nose-849-runtime-{repo}-") as tmp:
+        worktree = Path(tmp) / "worktree"
+        added = run([
+            "git", "-C", str(source), "worktree", "add", "--detach", "--quiet",
+            str(worktree), sample["commit"],
+        ])
+        if added.returncode != 0:
+            raise SystemExit(f"runtime worktree add failed for {repo}: {added.stderr}")
+        try:
+            command_tail = [
+                "query", ".", f"base={sample['parent']}", "top=0", "--format", "json"
+            ]
+            for _ in range(warmups):
+                for binary in binaries.values():
+                    result = run([str(binary), *command_tail], cwd=worktree, timeout=timeout)
+                    if result.returncode != 0:
+                        raise SystemExit(f"runtime warmup failed for {repo}: {result.stderr}")
+            documents = {}
+            for iteration in range(1, iterations + 1):
+                order = ("baseline", "current") if iteration % 2 else ("current", "baseline")
+                for label in order:
+                    started = time.perf_counter()
+                    result = run(
+                        [str(binaries[label]), *command_tail],
+                        cwd=worktree,
+                        timeout=timeout,
+                    )
+                    elapsed_ms = (time.perf_counter() - started) * 1000
+                    if result.returncode != 0:
+                        raise SystemExit(
+                            f"runtime query failed for {repo}/{label}: {result.stderr}"
+                        )
+                    document = json.loads(result.stdout)
+                    documents[label] = document
+                    rows.append({
+                        "repo": repo,
+                        "iteration": iteration,
+                        "label": label,
+                        "elapsed_ms": round(elapsed_ms, 6),
+                        "output_bytes": len(result.stdout.encode()),
+                    })
+                legacy_equal &= documents["baseline"] == strip_semantic_change(
+                    documents["current"]
+                )
+        finally:
+            run(["git", "-C", str(source), "worktree", "remove", "--force", str(worktree)])
+            run(["git", "-C", str(source), "worktree", "prune"])
+    return rows, legacy_equal
+
+
+def runtime_summary(rows, repos):
+    by_repo = {}
+    for repo in repos:
+        labels = {}
+        for label in ("baseline", "current"):
+            elapsed = [
+                row["elapsed_ms"] for row in rows
+                if row["repo"] == repo and row["label"] == label
+            ]
+            labels[label] = round(statistics.median(elapsed), 6)
+        baseline = labels["baseline"]
+        current = labels["current"]
+        by_repo[repo] = {
+            **labels,
+            "delta_ms": round(current - baseline, 6),
+            "delta_pct": round((current - baseline) / baseline * 100, 6),
+        }
+    baseline = sum(row["baseline"] for row in by_repo.values())
+    current = sum(row["current"] for row in by_repo.values())
+    return {
+        "aggregate": {
+            "baseline_median_sum_ms": round(baseline, 6),
+            "current_median_sum_ms": round(current, 6),
+            "delta_ms": round(current - baseline, 6),
+            "delta_pct": round((current - baseline) / baseline * 100, 6),
+        },
+        "by_repo": by_repo,
+    }
+
+
+def cmd_runtime(args):
+    samples = jsonl(args.samples)
+    queries = runtime_queries(samples)
+    binaries = {"baseline": args.baseline.resolve(), "current": args.current.resolve()}
+    rows = []
+    compatibility = {}
+    for sample in queries:
+        repo_rows, legacy_equal = runtime_repo(
+            sample, args.repos_root, binaries, args.iterations, args.warmups, args.timeout
+        )
+        rows.extend(repo_rows)
+        compatibility[sample["repo"]] = legacy_equal
+        print(f"[{sample['repo']}] runtime complete", flush=True)
+    output = {
+        "schema_version": 1,
+        "issue": 849,
+        "command": "nose query . base=<parent> top=0 --format json",
+        "development_only": True,
+        "inputs": {
+            "samples": str(args.samples.relative_to(ROOT)),
+            "samples_sha256": sha256(args.samples),
+            "harness_sha256": sha256(Path(__file__)),
+            "selection": "first current-v2-strict default-arm finding per repository",
+        },
+        "configuration": {
+            "iterations": args.iterations,
+            "warmups": args.warmups,
+            "timeout_s": args.timeout,
+            "repositories": [sample["repo"] for sample in queries],
+        },
+        "binaries": {
+            label: {
+                "path": str(binary),
+                "sha256": sha256(binary),
+                "version": run([str(binary), "--version"]).stdout.strip(),
+            }
+            for label, binary in binaries.items()
+        },
+        "legacy_output_compatibility": {
+            "all_equal_after_removing_semantic_change": all(compatibility.values()),
+            "by_repo": compatibility,
+        },
+        "runs": rows,
+        "summary": runtime_summary(rows, [sample["repo"] for sample in queries]),
+    }
+    args.out.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
 
 
 def parser():
@@ -356,6 +537,17 @@ def parser():
 
     selftest = commands.add_parser("selftest")
     selftest.set_defaults(func=cmd_selftest)
+
+    runtime = commands.add_parser("runtime")
+    runtime.add_argument("--samples", type=Path, default=DEFAULT_SAMPLES)
+    runtime.add_argument("--repos-root", type=Path, default=ROOT / "bench/repos")
+    runtime.add_argument("--baseline", type=Path, required=True)
+    runtime.add_argument("--current", type=Path, required=True)
+    runtime.add_argument("--iterations", type=int, default=3)
+    runtime.add_argument("--warmups", type=int, default=1)
+    runtime.add_argument("--timeout", type=int, default=240)
+    runtime.add_argument("--out", type=Path, required=True)
+    runtime.set_defaults(func=cmd_runtime)
     return root
 
 

--- a/eval/divergence_fire/semantic_witness_eval.py
+++ b/eval/divergence_fire/semantic_witness_eval.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Development-only replay and pricing for #849 semantic-change witnesses.
+
+This harness reads only the checked 2026-07-06 development sample and verdicts. It
+does not read the sealed blind packet or temporal reserve. Raw replay rows are scratch
+artifacts; ``summarize`` writes a source-free aggregate suitable for Git.
+"""
+
+import argparse
+from collections import Counter, defaultdict
+import concurrent.futures
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SAMPLES = ROOT / "eval/divergence_fire/sampled_findings_2026_07_06.jsonl"
+DEFAULT_VERDICTS = ROOT / "eval/divergence_fire/verdicts_2026_07_06.jsonl"
+DEFAULT_NOSE = ROOT / "target/release/nose"
+
+
+def jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(args, cwd=None, timeout=None):
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+
+
+def query_key(sample):
+    return sample["repo"], sample["commit"], sample["parent"], sample["arm"]
+
+
+def current_v2_strict(sample):
+    return (
+        sample.get("scope") == "prod"
+        and sample.get("fire_eligible") is True
+        and any(site.get("touches_shared") is True for site in sample.get("changed", []))
+    )
+
+
+def replay_repo(repo, requests, repos_root, nose, timeout):
+    source = repos_root / repo
+    rows = []
+    with tempfile.TemporaryDirectory(prefix=f"nose-849-{repo}-") as tmp:
+        worktree = Path(tmp) / "worktree"
+        head = run(["git", "-C", str(source), "rev-parse", "HEAD"])
+        if head.returncode != 0:
+            return [{"repo": repo, "ok": False, "error": "repo-head-failed"}]
+        added = run(
+            ["git", "-C", str(source), "worktree", "add", "--detach", "--quiet",
+             str(worktree), head.stdout.strip()]
+        )
+        if added.returncode != 0:
+            return [{"repo": repo, "ok": False, "error": "worktree-add-failed"}]
+        try:
+            for commit, parent, arm, samples in requests:
+                checked = run(
+                    ["git", "-C", str(worktree), "checkout", "--detach", "--quiet", commit]
+                )
+                if checked.returncode != 0:
+                    rows.append({
+                        "repo": repo, "commit": commit, "parent": parent, "arm": arm,
+                        "ok": False, "error": "checkout-failed",
+                    })
+                    continue
+                command = [
+                    str(nose), "query", ".", f"base={parent}", "top=0", "--format", "json"
+                ]
+                if arm == "near":
+                    command += ["--mode", "syntax,semantic,near"]
+                started = time.monotonic()
+                try:
+                    result = run(command, cwd=worktree, timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    rows.append({
+                        "repo": repo, "commit": commit, "parent": parent, "arm": arm,
+                        "ok": False, "error": "timeout",
+                    })
+                    continue
+                duration = round(time.monotonic() - started, 6)
+                if result.returncode != 0:
+                    rows.append({
+                        "repo": repo, "commit": commit, "parent": parent, "arm": arm,
+                        "ok": False, "error": "query-failed", "duration_s": duration,
+                    })
+                    continue
+                try:
+                    document = json.loads(result.stdout)
+                except json.JSONDecodeError:
+                    rows.append({
+                        "repo": repo, "commit": commit, "parent": parent, "arm": arm,
+                        "ok": False, "error": "invalid-json", "duration_s": duration,
+                    })
+                    continue
+                by_family = {item.get("family_id"): item for item in document.get("items", [])}
+                for sample in samples:
+                    finding = by_family.get(sample["family_id"])
+                    rows.append({
+                        "sid": sample["sid"],
+                        "repo": repo,
+                        "commit": commit,
+                        "parent": parent,
+                        "arm": arm,
+                        "family_id": sample["family_id"],
+                        "ok": True,
+                        "matched": finding is not None,
+                        "duration_s": duration,
+                        "gate_fail_default": (
+                            finding.get("gate", {}).get("fail_default") if finding else None
+                        ),
+                        "semantic_change": (
+                            [site.get("semantic_change") for site in finding.get("changed", [])]
+                            if finding else []
+                        ),
+                    })
+        finally:
+            run(["git", "-C", str(source), "worktree", "remove", "--force", str(worktree)])
+            run(["git", "-C", str(source), "worktree", "prune"])
+    return rows
+
+
+def cmd_replay(args):
+    samples = jsonl(args.samples)
+    grouped = defaultdict(list)
+    by_query = defaultdict(list)
+    for sample in samples:
+        by_query[query_key(sample)].append(sample)
+    for (repo, commit, parent, arm), rows in sorted(by_query.items()):
+        grouped[repo].append((commit, parent, arm, rows))
+
+    output = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        futures = {
+            executor.submit(
+                replay_repo, repo, requests, args.repos_root, args.nose, args.timeout
+            ): repo
+            for repo, requests in grouped.items()
+        }
+        for future in concurrent.futures.as_completed(futures):
+            repo = futures[future]
+            rows = future.result()
+            output.extend(rows)
+            print(f"[{repo}] {len(rows)} labeled findings", flush=True)
+    output.sort(key=lambda row: (row.get("sid", ""), row.get("repo", "")))
+    with args.out.open("w") as stream:
+        for row in output:
+            stream.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def witness_predicates(row):
+    witnesses = [w for w in row.get("semantic_change", []) if isinstance(w, dict)]
+    complete = [w for w in witnesses if w.get("status") == "complete"]
+    mapped_delta = [
+        w for w in complete
+        if w.get("change_kind") not in {"no-semantic-delta", "mixed", "unknown"}
+        and w.get("facets")
+        and w.get("coverage", {}).get("mapped_shared_nodes", 0) > 0
+    ]
+    return {
+        "complete-mapped-semantic-delta": bool(mapped_delta),
+        "complete-mapped-sink-delta": any(w.get("sink_deltas") for w in mapped_delta),
+        "complete-no-semantic-delta": any(
+            w.get("status") == "complete" and w.get("change_kind") == "no-semantic-delta"
+            for w in witnesses
+        ),
+    }
+
+
+def simulation(name, rows, predicate):
+    selected = [row for row in rows if predicate(row)]
+    positives = sum(row["verdict"] == "should_propagate" for row in selected)
+    baseline_positives = sum(row["verdict"] == "should_propagate" for row in rows)
+    return {
+        "name": name,
+        "selected": len(selected),
+        "should_propagate": positives,
+        "false_positives": len(selected) - positives,
+        "precision": round(positives / len(selected), 6) if selected else None,
+        "should_propagate_retention": (
+            round(positives / baseline_positives, 6) if baseline_positives else None
+        ),
+        "verdicts": dict(sorted(Counter(row["verdict"] for row in selected).items())),
+    }
+
+
+def nested_counts(rows, values):
+    result = {}
+    for value, verdicts in sorted(values.items()):
+        result[value] = dict(sorted(verdicts.items()))
+    return result
+
+
+def cmd_summarize(args):
+    samples = {row["sid"]: row for row in jsonl(args.samples)}
+    verdicts = {row["sid"]: row for row in jsonl(args.verdicts)}
+    replay = {row.get("sid"): row for row in jsonl(args.records) if row.get("sid")}
+    joined = []
+    for sid, sample in samples.items():
+        row = replay.get(sid, {})
+        joined.append({
+            **row,
+            "sid": sid,
+            "verdict": verdicts[sid]["verdict"],
+            "baseline_strict": current_v2_strict(sample),
+            "predicates": witness_predicates(row),
+        })
+
+    statuses = defaultdict(Counter)
+    change_kinds = defaultdict(Counter)
+    facets = defaultdict(Counter)
+    caveats = defaultdict(Counter)
+    for row in joined:
+        for witness in row.get("semantic_change", []):
+            if not isinstance(witness, dict):
+                continue
+            verdict = row["verdict"]
+            statuses[witness.get("status", "missing")][verdict] += 1
+            change_kinds[witness.get("change_kind", "missing")][verdict] += 1
+            for facet in witness.get("facets", []):
+                facets[facet][verdict] += 1
+            for caveat in witness.get("caveats", []):
+                caveats[caveat][verdict] += 1
+
+    strict = [row for row in joined if row["baseline_strict"]]
+    matched = [row for row in joined if row.get("matched")]
+    query_errors = [row for row in jsonl(args.records) if not row.get("ok")]
+    binary_version = run([str(args.nose), "--version"]).stdout.strip()
+    source_commit = run(["git", "rev-parse", "HEAD"], cwd=ROOT).stdout.strip()
+    artifact = {
+        "schema_version": 1,
+        "issue": 849,
+        "development_only": True,
+        "blind_or_temporal_data_accessed": False,
+        "inputs": {
+            "samples": str(args.samples.relative_to(ROOT)),
+            "samples_sha256": sha256(args.samples),
+            "verdicts": str(args.verdicts.relative_to(ROOT)),
+            "verdicts_sha256": sha256(args.verdicts),
+            "labeled_findings": len(samples),
+        },
+        "implementation": {
+            "source_commit": source_commit,
+            "nose_binary": str(args.nose),
+            "nose_binary_sha256": sha256(args.nose),
+            "nose_version": binary_version,
+        },
+        "replay": {
+            "matched_findings": len(matched),
+            "unmatched_findings": len(joined) - len(matched),
+            "query_error_rows": len(query_errors),
+        },
+        "baseline_v2_strict": {
+            "findings": len(strict),
+            "verdicts": dict(sorted(Counter(row["verdict"] for row in strict).items())),
+        },
+        "site_evidence_by_verdict": {
+            "status": nested_counts(joined, statuses),
+            "change_kind": nested_counts(joined, change_kinds),
+            "facets": nested_counts(joined, facets),
+            "caveats": nested_counts(joined, caveats),
+        },
+        "strict_no_propagation_needed": {
+            "findings": sum(row["verdict"] == "no_propagation_needed" for row in strict),
+            "predicate_hits": {
+                name: sum(
+                    row["verdict"] == "no_propagation_needed"
+                    and row["predicates"].get(name, False)
+                    for row in strict
+                )
+                for name in sorted(next(iter(strict))["predicates"] if strict else [])
+            },
+        },
+        "simulations": [
+            simulation("current-v2-strict", strict, lambda row: True),
+            simulation(
+                "require-complete-mapped-semantic-delta",
+                strict,
+                lambda row: row["predicates"]["complete-mapped-semantic-delta"],
+            ),
+            simulation(
+                "require-complete-mapped-sink-delta",
+                strict,
+                lambda row: row["predicates"]["complete-mapped-sink-delta"],
+            ),
+            simulation(
+                "demote-complete-no-semantic-delta",
+                strict,
+                lambda row: not row["predicates"]["complete-no-semantic-delta"],
+            ),
+        ],
+        "interpretation": (
+            "Development evidence only. These predicates do not change gate.fail_default and "
+            "must not be tuned against or presented as a blind/default-on result."
+        ),
+    }
+    args.out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+
+def cmd_selftest(_args):
+    sample = {
+        "scope": "prod", "fire_eligible": True,
+        "changed": [{"touches_shared": True}],
+    }
+    assert current_v2_strict(sample)
+    row = {
+        "semantic_change": [{
+            "status": "complete", "change_kind": "replacement", "facets": ["value"],
+            "coverage": {"mapped_shared_nodes": 2}, "sink_deltas": [],
+        }]
+    }
+    assert witness_predicates(row)["complete-mapped-semantic-delta"]
+    assert not witness_predicates(row)["complete-mapped-sink-delta"]
+    print("semantic_witness_eval selftest: ok")
+
+
+def parser():
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    replay = commands.add_parser("replay")
+    replay.add_argument("--samples", type=Path, default=DEFAULT_SAMPLES)
+    replay.add_argument("--repos-root", type=Path, default=ROOT / "bench/repos")
+    replay.add_argument("--nose", type=Path, default=DEFAULT_NOSE)
+    replay.add_argument("--jobs", type=int, default=4)
+    replay.add_argument("--timeout", type=int, default=240)
+    replay.add_argument("--out", type=Path, required=True)
+    replay.set_defaults(func=cmd_replay)
+
+    summarize = commands.add_parser("summarize")
+    summarize.add_argument("--samples", type=Path, default=DEFAULT_SAMPLES)
+    summarize.add_argument("--verdicts", type=Path, default=DEFAULT_VERDICTS)
+    summarize.add_argument("--records", type=Path, required=True)
+    summarize.add_argument("--nose", type=Path, default=DEFAULT_NOSE)
+    summarize.add_argument("--out", type=Path, required=True)
+    summarize.set_defaults(func=cmd_summarize)
+
+    selftest = commands.add_parser("selftest")
+    selftest.set_defaults(func=cmd_selftest)
+    return root
+
+
+if __name__ == "__main__":
+    arguments = parser().parse_args()
+    arguments.func(arguments)


### PR DESCRIPTION
Closes #849
Parent: #847

## What changed
- emit bounded base-to-current semantic change witnesses for already-flagged divergent members
- align units and report value/control/effect/return deltas, mapped shared nodes, coverage, caveats, caps, and projection status
- keep unknown, incomplete, insertion-only, lossy, missing, and unsupported evidence advisory; do not change `gate.fail_default`
- add JSON, SARIF, human output, focused fixtures, agent/user docs, and a development-only pricing harness
- lazily project only selected units and cache their value DAGs instead of scanning every unit in candidate files

## Evidence
- public development replay: 179/179 matched, 0 query errors; no blind or temporal data accessed
- frozen v2 strict baseline remains 45/80; all simulations are evidence-only
- official v0.19.0 paired runtime across 17 repositories: +5.06% raw / +5.35% control-adjusted; legacy JSON is identical in 17/17 after removing the new field
- eager prototype was +54.86%; lazy projection removed the unbounded file-wide work

## Validation
- `cargo clippy -p nose-cli --all-targets -- -D warnings`
- final source: 232 library tests, 235 CLI tests, 3 connected-witness tests
- full nose-cli suite passed before the final Box-only Clippy cleanup
- `scripts/check-docs.sh`
- harness self-test, JSON validation, and `git diff --check`
