### PR TITLE
feat(divergence): add deterministic variant evidence

### DIFF
--- a/bench/recall_loss/issue-851-official-v0.19.0-performance-2026-07-18.v1.json
+++ b/bench/recall_loss/issue-851-official-v0.19.0-performance-2026-07-18.v1.json
@@ -1,0 +1,83 @@
+{
+  "schema": "nose.issue-851.performance/v1",
+  "issue": 851,
+  "measured_at": "2026-07-18",
+  "development_only": true,
+  "blind_or_temporal_data_accessed": false,
+  "source": {
+    "candidate_commit": "201a2f4dfa607ed6a54681ca5d84b9c688535910",
+    "candidate_parent_commit": "df6ca124dc7b84f175d0ed9ca093c2b52b23eec4",
+    "baseline_release": "v0.19.0",
+    "baseline_source_commit": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9"
+  },
+  "binaries": {
+    "baseline": {
+      "version": "nose 0.19.0",
+      "sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate": {
+      "version": "nose 0.19.0",
+      "sha256": "9a1e7e3fc7ecb0ea31c8dbc8bb1008ff852b00d08285503e397885870da7e317"
+    }
+  },
+  "harness": {
+    "path": "eval/divergence_fire/direct_target_eval.py",
+    "sha256": "9db413f2a4da674de3ad83dbe987848b9997faa7bacc575b1b0fdd55ce94fc2d",
+    "shared_path": "eval/divergence_fire/semantic_witness_eval.py",
+    "shared_sha256": "82c672c8a4b004ce4c5a11bfddfbf66d92efb511e256431d744c07095000c2d6",
+    "selection": "first current-v2-strict default-arm finding per development repository",
+    "repositories": 17,
+    "iterations": 3,
+    "warmups": 1,
+    "command": "nose query . base=<parent> top=0 --format json"
+  },
+  "official_release_primary": {
+    "baseline_median_sum_ms": 10405.383374,
+    "candidate_median_sum_ms": 11283.217295,
+    "raw_delta_ms": 877.833921,
+    "raw_delta_pct": 8.436344,
+    "legacy_outputs_equal_after_removing_semantic_change_and_targets": true,
+    "legacy_outputs_equal_repositories": 17,
+    "raw_artifact_sha256": "856c2f558cda28b65fef0a0e8e8f206b7e1cc6204bab8b9e1deb322815ea1b14"
+  },
+  "same_binary_control": {
+    "first_median_sum_ms": 10029.397708,
+    "second_median_sum_ms": 10070.721292,
+    "delta_ms": 41.323584,
+    "delta_pct": 0.412025,
+    "raw_artifact_sha256": "b5e045a752638152685dd9c847d1e5c6caa47e7b51b64405661dd7f438c0f1f0"
+  },
+  "control_adjusted": {
+    "delta_ms": 836.510337,
+    "delta_pct": 8.039207,
+    "epic_budget_pct": 5.0,
+    "within_epic_budget": false
+  },
+  "tail_investigation": {
+    "nearest_rank_p90_repo_delta_pct": 44.468695,
+    "above_twenty_pct": [
+      {
+        "repo": "axios",
+        "delta_pct": 52.558274
+      },
+      {
+        "repo": "regex",
+        "delta_pct": 44.468695
+      }
+    ],
+    "diagnosis": "The cumulative #847 compatibility path still emits both family semantic evidence and target-local semantic/variant evidence. #851 reuses cached normalized files, base/current unit projections, and source lines, bounds graded role comparison to the existing 2,048-node and 64-target caps, and performs no repository-wide discovery. The remaining tail is the already-recorded family-plus-target compatibility debt; #852 must make the target policy authoritative, remove duplicate family work, and remeasure against the official release."
+  },
+  "optimization_receipt": {
+    "changes": [
+      "reuse WitnessBuilder base/current file and unit projection caches for target role evidence",
+      "cache current/base source lines used by decorator and platform comparisons",
+      "keep weak name, path, and version checks allocation-bounded and pair-local",
+      "reuse the existing 2,048-node projection and 64-target family caps",
+      "perform no second repository discovery or history query"
+    ]
+  },
+  "assessment": {
+    "status": "bounded-evidence-with-epic-budget-debt",
+    "reason": "The official v0.19.0 comparison is 8.44% raw and 8.04% after the same-binary control, with identical legacy JSON on all 17 repositories after removing the reviewed semantic_change and targets evidence. The complete #847 path remains above its 5% budget, so #852 must remove compatibility duplication before the epic can close."
+  }
+}

--- a/crates/nose-cli/src/divergence.rs
+++ b/crates/nose-cli/src/divergence.rs
@@ -19,6 +19,7 @@ mod output;
 mod targets;
 #[cfg(test)]
 mod tests;
+mod variant;
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -125,6 +126,10 @@ pub(crate) struct PropagationTarget {
     pub(crate) changed: Site,
     pub(crate) skipped: Site,
     pub(crate) direct_witness: DirectPairWitness,
+    /// Pair-local evidence that the two sites deliberately occupy different roles.
+    /// #851 only records this evidence; the frozen v3 policy in #852 decides whether
+    /// it is disqualifying for the strict tier.
+    pub(crate) variant_evidence: variant::VariantEvidence,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize)]

--- a/crates/nose-cli/src/divergence/change_witness.rs
+++ b/crates/nose-cli/src/divergence/change_witness.rs
@@ -5,6 +5,7 @@
 //! second repository discovery. The evidence is advisory in divergent-edit v2.
 
 mod analysis;
+mod variant_projection;
 
 use self::analysis::{
     analyze_change, caveat_for_projection, finish_witness, node_hashes, project_file, project_unit,
@@ -13,7 +14,8 @@ use self::analysis::{
 };
 use super::git::DiffEntry;
 use super::*;
-use nose_il::{FileId, Interner, Lang, NodeId, UnitKind};
+use crate::source_lines::FileLineCache;
+use nose_il::{FileId, Interner, Lang, NodeId, UnitKind, UnitOrigin};
 use nose_normalize::{FileReferents, ValueDag};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -104,6 +106,11 @@ pub(super) fn enrich_semantic_change_witnesses(
                     vec![SemanticWitnessCaveat::Truncated],
                 )
             });
+            builder.variant_evidence(
+                &target.changed,
+                &target.skipped,
+                &mut target.variant_evidence,
+            );
         }
         target_elapsed += target_started.elapsed();
     }
@@ -151,6 +158,7 @@ struct FileProjection {
 struct UnitSkeleton {
     root: NodeId,
     kind: UnitKind,
+    origin: UnitOrigin,
     name: Option<String>,
     start_line: u32,
     end_line: u32,
@@ -159,6 +167,7 @@ struct UnitSkeleton {
 #[derive(Clone)]
 struct UnitProjection {
     kind: UnitKind,
+    origin: UnitOrigin,
     name: Option<String>,
     start_line: u32,
     end_line: u32,
@@ -196,6 +205,7 @@ struct WitnessBuilder<'a> {
     projections: HashMap<(Tree, String, NodeId), UnitProjection>,
     prepared: HashMap<String, PreparedChange>,
     sibling_nodes: HashMap<String, Vec<u64>>,
+    source_lines: FileLineCache,
 }
 
 struct UnavailableChange {
@@ -237,6 +247,7 @@ impl<'a> WitnessBuilder<'a> {
             projections: HashMap::new(),
             prepared: HashMap::new(),
             sibling_nodes: HashMap::new(),
+            source_lines: FileLineCache::default(),
         }
     }
 

--- a/crates/nose-cli/src/divergence/change_witness/analysis.rs
+++ b/crates/nose-cli/src/divergence/change_witness/analysis.rs
@@ -258,6 +258,7 @@ pub(super) fn project_file(
         units.push(UnitSkeleton {
             root: unit.root,
             kind: unit.kind,
+            origin: unit.origin,
             name,
             start_line: span.start_line,
             end_line: span.end_line,
@@ -292,6 +293,7 @@ pub(super) fn project_unit(file: &FileProjection, unit: &UnitSkeleton) -> UnitPr
         .any(|referent| referent.referent.is_none());
     UnitProjection {
         kind: unit.kind,
+        origin: unit.origin,
         name: unit.name.clone(),
         start_line: unit.start_line,
         end_line: unit.end_line,

--- a/crates/nose-cli/src/divergence/change_witness/variant_projection.rs
+++ b/crates/nose-cli/src/divergence/change_witness/variant_projection.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::divergence::variant::{
-    enrich_projected, enrich_source, VariantCaveatCode, VariantEvidence,
+    enrich_projected, enrich_source, VariantCaveatCode, VariantEvidence, VariantSourceContext,
 };
 
 impl WitnessBuilder<'_> {
@@ -36,15 +36,18 @@ impl WitnessBuilder<'_> {
                 .unit
                 .as_ref()
                 .map(|unit| (unit.start_line, unit.end_line));
+            let mut context = VariantSourceContext {
+                current_root: self.current_root,
+                base_root: self.base_root,
+                lines: &mut self.source_lines,
+            };
             enrich_source(
                 evidence,
                 changed,
                 current_path,
                 current_span,
                 skipped,
-                self.current_root,
-                self.base_root,
-                &mut self.source_lines,
+                &mut context,
             );
         }
         let mut details = Vec::new();

--- a/crates/nose-cli/src/divergence/change_witness/variant_projection.rs
+++ b/crates/nose-cli/src/divergence/change_witness/variant_projection.rs
@@ -1,0 +1,105 @@
+use super::*;
+use crate::divergence::variant::{
+    enrich_projected, enrich_source, VariantCaveatCode, VariantEvidence,
+};
+
+impl WitnessBuilder<'_> {
+    pub(super) fn variant_evidence(
+        &mut self,
+        changed: &Site,
+        skipped: &Site,
+        evidence: &mut VariantEvidence,
+    ) {
+        if changed.is_fragment || skipped.is_fragment {
+            evidence.caveat(
+                VariantCaveatCode::ProjectionUnavailable,
+                ["fragment-unsupported".to_string()],
+            );
+            return;
+        }
+        let changed_base = self.project_base(changed);
+        let skipped_projection = self.project_base(skipped);
+        let current_path = self.current_path(&changed.file);
+        let current_projection = match (changed_base.unit.as_ref(), current_path.as_deref()) {
+            (Some(base_unit), Some(current_path)) => {
+                let ranges = self
+                    .current_changed
+                    .get(current_path)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                self.project_current(base_unit, current_path, ranges)
+            }
+            _ => ProjectionAttempt::failed(SemanticProjectionStatus::NotAttempted),
+        };
+        if let Some(current_path) = current_path.as_deref() {
+            let current_span = current_projection
+                .unit
+                .as_ref()
+                .map(|unit| (unit.start_line, unit.end_line));
+            enrich_source(
+                evidence,
+                changed,
+                current_path,
+                current_span,
+                skipped,
+                self.current_root,
+                self.base_root,
+                &mut self.source_lines,
+            );
+        }
+        let mut details = Vec::new();
+        if current_projection.status != SemanticProjectionStatus::Ok {
+            details.push(format!(
+                "current:{}",
+                projection_status_label(current_projection.status)
+            ));
+        }
+        if skipped_projection.status != SemanticProjectionStatus::Ok {
+            details.push(format!(
+                "skipped:{}",
+                projection_status_label(skipped_projection.status)
+            ));
+        }
+        match (current_projection.unit, skipped_projection.unit) {
+            (Some(changed_unit), Some(skipped_unit)) => {
+                let truncated = changed_unit.truncated || skipped_unit.truncated;
+                let witness = nose_detect::graded_witness(
+                    &changed_unit.dag,
+                    &skipped_unit.dag,
+                    !changed_unit.exact_safe,
+                    !skipped_unit.exact_safe,
+                );
+                enrich_projected(
+                    evidence,
+                    witness.as_ref(),
+                    changed_unit.origin,
+                    skipped_unit.origin,
+                    &details,
+                    truncated,
+                );
+            }
+            (changed_unit, skipped_unit) => enrich_projected(
+                evidence,
+                None,
+                changed_unit.map_or(UnitOrigin::unknown(), |unit| unit.origin),
+                skipped_unit.map_or(UnitOrigin::unknown(), |unit| unit.origin),
+                &details,
+                false,
+            ),
+        }
+    }
+}
+
+fn projection_status_label(status: SemanticProjectionStatus) -> &'static str {
+    match status {
+        SemanticProjectionStatus::Ok => "ok",
+        SemanticProjectionStatus::Missing => "missing",
+        SemanticProjectionStatus::Unsupported => "unsupported",
+        SemanticProjectionStatus::ReadFailed => "read-failed",
+        SemanticProjectionStatus::LowerFailed => "lower-failed",
+        SemanticProjectionStatus::UnitMissing => "unit-missing",
+        SemanticProjectionStatus::AmbiguousUnit => "ambiguous-unit",
+        SemanticProjectionStatus::CapExceeded => "cap-exceeded",
+        SemanticProjectionStatus::NotAttempted => "not-attempted",
+    }
+}

--- a/crates/nose-cli/src/divergence/output.rs
+++ b/crates/nose-cli/src/divergence/output.rs
@@ -32,6 +32,7 @@ fn target_json(target: &PropagationTarget) -> serde_json::Value {
         "changed": site_json(&target.changed, "base"),
         "skipped": site_json(&target.skipped, "base"),
         "direct_witness": target.direct_witness,
+        "variant_evidence": target.variant_evidence,
     })
 }
 

--- a/crates/nose-cli/src/divergence/targets.rs
+++ b/crates/nose-cli/src/divergence/targets.rs
@@ -1,4 +1,5 @@
 use super::detect::{site_touched_loc, to_site, to_site_touch, touches_shared_lines};
+use super::variant::initial_evidence;
 use super::{DirectPairWitness, PropagationTarget, Site};
 use crate::source_lines::FileLineCache;
 use nose_detect::{FragmentKind, Loc, RefactorFamily};
@@ -78,6 +79,7 @@ fn append_direct_targets(
         );
         let changed_site = to_site_touch(changed_loc, touch);
         let skipped_site = to_site(skipped_loc);
+        let variant_evidence = initial_evidence(changed_loc, skipped_loc);
         targets.push(PropagationTarget {
             target_id: propagation_target_id(&changed_site, &skipped_site),
             changed: changed_site,
@@ -86,6 +88,7 @@ fn append_direct_targets(
                 kind: edge.witness_kind,
                 similarity: edge.score,
             },
+            variant_evidence,
         });
     }
 }

--- a/crates/nose-cli/src/divergence/variant.rs
+++ b/crates/nose-cli/src/divergence/variant.rs
@@ -100,6 +100,12 @@ pub(crate) struct VariantEvidence {
     pub(crate) caveats: Vec<VariantCaveat>,
 }
 
+pub(super) struct VariantSourceContext<'a> {
+    pub(super) current_root: &'a Path,
+    pub(super) base_root: &'a Path,
+    pub(super) lines: &'a mut FileLineCache,
+}
+
 impl VariantEvidence {
     fn empty() -> Self {
         Self {
@@ -191,9 +197,7 @@ pub(super) fn enrich_source(
     current_path: &str,
     current_span: Option<(u32, u32)>,
     skipped: &super::Site,
-    current_root: &Path,
-    base_root: &Path,
-    lines: &mut FileLineCache,
+    context: &mut VariantSourceContext<'_>,
 ) {
     source_signals(
         evidence,
@@ -201,9 +205,7 @@ pub(super) fn enrich_source(
         current_path,
         current_span,
         skipped,
-        current_root,
-        base_root,
-        lines,
+        context,
     );
 }
 

--- a/crates/nose-cli/src/divergence/variant.rs
+++ b/crates/nose-cli/src/divergence/variant.rs
@@ -1,0 +1,562 @@
+//! Deterministic, pair-local evidence for intentional clone variants.
+//!
+//! This module does not decide the active divergent-edit tier. It records strong
+//! disqualifiers, weak review hints, and uncertainty separately so #852 can price a
+//! frozen policy without turning names, paths, or repository-specific prose into gate
+//! authority.
+
+mod source;
+
+use self::source::source_signals;
+use crate::source_lines::FileLineCache;
+use nose_detect::{GradedWitness, Loc};
+use nose_il::{UnitEvidenceFlag, UnitOrigin};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+const DETAIL_CAP: usize = 8;
+const DETAIL_CHARS: usize = 160;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum VariantEvidenceStatus {
+    None,
+    Advisory,
+    Disqualifying,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum VariantEvidenceStrength {
+    Weak,
+    Strong,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum VariantSignalCode {
+    ReferentMismatch,
+    DecoratorMismatch,
+    AsyncRoleMismatch,
+    EffectRoleMismatch,
+    ProtocolRoleMismatch,
+    DisjointPlatformGuard,
+    NameMismatch,
+    PathMismatch,
+    VersionLabelMismatch,
+}
+
+impl VariantSignalCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReferentMismatch => "referent-mismatch",
+            Self::DecoratorMismatch => "decorator-mismatch",
+            Self::AsyncRoleMismatch => "async-role-mismatch",
+            Self::EffectRoleMismatch => "effect-role-mismatch",
+            Self::ProtocolRoleMismatch => "protocol-role-mismatch",
+            Self::DisjointPlatformGuard => "disjoint-platform-guard",
+            Self::NameMismatch => "name-mismatch",
+            Self::PathMismatch => "path-mismatch",
+            Self::VersionLabelMismatch => "version-label-mismatch",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum VariantCaveatCode {
+    SourceUnavailable,
+    ProjectionUnavailable,
+    AlignmentUnavailable,
+    LossyProjection,
+    UnresolvedReferent,
+    Truncated,
+    ConflictingPlatformGuard,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+pub(crate) struct VariantSignal {
+    pub(crate) code: VariantSignalCode,
+    pub(crate) strength: VariantEvidenceStrength,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) changed: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) skipped: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+pub(crate) struct VariantCaveat {
+    pub(crate) code: VariantCaveatCode,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) details: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct VariantEvidence {
+    pub(crate) status: VariantEvidenceStatus,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) signals: Vec<VariantSignal>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) caveats: Vec<VariantCaveat>,
+}
+
+impl VariantEvidence {
+    fn empty() -> Self {
+        Self {
+            status: VariantEvidenceStatus::None,
+            signals: Vec::new(),
+            caveats: Vec::new(),
+        }
+    }
+
+    fn signal(
+        &mut self,
+        code: VariantSignalCode,
+        strength: VariantEvidenceStrength,
+        changed: impl IntoIterator<Item = String>,
+        skipped: impl IntoIterator<Item = String>,
+    ) {
+        self.signals.push(VariantSignal {
+            code,
+            strength,
+            changed: bounded(changed),
+            skipped: bounded(skipped),
+        });
+        self.finish();
+    }
+
+    pub(super) fn caveat(
+        &mut self,
+        code: VariantCaveatCode,
+        details: impl IntoIterator<Item = String>,
+    ) {
+        self.caveats.push(VariantCaveat {
+            code,
+            details: bounded(details),
+        });
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        self.signals.sort();
+        self.signals.dedup();
+        self.caveats.sort();
+        self.caveats.dedup();
+        self.status = if self
+            .signals
+            .iter()
+            .any(|signal| signal.strength == VariantEvidenceStrength::Strong)
+        {
+            VariantEvidenceStatus::Disqualifying
+        } else if self.signals.is_empty() && self.caveats.is_empty() {
+            VariantEvidenceStatus::None
+        } else {
+            VariantEvidenceStatus::Advisory
+        };
+    }
+
+    pub(crate) fn concise_label(&self) -> Option<String> {
+        if self.status == VariantEvidenceStatus::None {
+            return None;
+        }
+        let prefix = match self.status {
+            VariantEvidenceStatus::Disqualifying => "strong variant",
+            VariantEvidenceStatus::Advisory => "variant advisory",
+            VariantEvidenceStatus::None => return None,
+        };
+        let codes = self
+            .signals
+            .iter()
+            .map(|signal| signal.code.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if codes.is_empty() {
+            Some(format!("{prefix} (evidence unavailable)"))
+        } else {
+            Some(format!("{prefix} ({codes})"))
+        }
+    }
+}
+
+pub(super) fn initial_evidence(changed: &Loc, skipped: &Loc) -> VariantEvidence {
+    let mut evidence = VariantEvidence::empty();
+    weak_identity_signals(&mut evidence, changed, skipped);
+    origin_signals(&mut evidence, changed.origin, skipped.origin);
+    evidence
+}
+
+pub(super) fn enrich_source(
+    evidence: &mut VariantEvidence,
+    changed: &super::Site,
+    current_path: &str,
+    current_span: Option<(u32, u32)>,
+    skipped: &super::Site,
+    current_root: &Path,
+    base_root: &Path,
+    lines: &mut FileLineCache,
+) {
+    source_signals(
+        evidence,
+        changed,
+        current_path,
+        current_span,
+        skipped,
+        current_root,
+        base_root,
+        lines,
+    );
+}
+
+pub(super) fn enrich_projected(
+    evidence: &mut VariantEvidence,
+    witness: Option<&GradedWitness>,
+    changed_origin: UnitOrigin,
+    skipped_origin: UnitOrigin,
+    projection_details: &[String],
+    truncated: bool,
+) {
+    origin_signals(evidence, changed_origin, skipped_origin);
+    let Some(witness) = witness else {
+        let code = if projection_details.is_empty() {
+            VariantCaveatCode::AlignmentUnavailable
+        } else {
+            VariantCaveatCode::ProjectionUnavailable
+        };
+        evidence.caveat(code, projection_details.iter().cloned());
+        if truncated {
+            evidence.caveat(VariantCaveatCode::Truncated, std::iter::empty());
+        }
+        return;
+    };
+    if !witness.referent_mismatches.is_empty() {
+        let names = witness.referent_mismatches.iter().cloned();
+        evidence.signal(
+            VariantSignalCode::ReferentMismatch,
+            VariantEvidenceStrength::Strong,
+            names.clone(),
+            names,
+        );
+    }
+    if witness.patterns.contains(&"async-mirror") {
+        evidence.signal(
+            VariantSignalCode::AsyncRoleMismatch,
+            VariantEvidenceStrength::Strong,
+            ["one-sided-await-observed".to_string()],
+            ["one-sided-await-observed".to_string()],
+        );
+    }
+    if witness.patterns.contains(&"effects-reordered") {
+        evidence.signal(
+            VariantSignalCode::EffectRoleMismatch,
+            VariantEvidenceStrength::Strong,
+            ["effect-order-a".to_string()],
+            ["effect-order-b".to_string()],
+        );
+    }
+    if !witness.caveat_names.is_empty() {
+        evidence.caveat(
+            VariantCaveatCode::UnresolvedReferent,
+            witness.caveat_names.iter().cloned(),
+        );
+    }
+    if witness.modeled_caveat {
+        evidence.caveat(VariantCaveatCode::LossyProjection, std::iter::empty());
+    }
+    if truncated {
+        evidence.caveat(VariantCaveatCode::Truncated, std::iter::empty());
+    }
+}
+
+fn origin_signals(evidence: &mut VariantEvidence, changed: UnitOrigin, skipped: UnitOrigin) {
+    // A missing/legacy origin is not proof of the negative role. The projection
+    // caveat remains advisory instead of treating unknown as sync/non-throws.
+    if changed.is_unknown() || skipped.is_unknown() {
+        return;
+    }
+    let async_roles = roles(changed, skipped, UnitEvidenceFlag::Async, "async", "sync");
+    if let Some((changed_role, skipped_role)) = async_roles {
+        evidence.signal(
+            VariantSignalCode::AsyncRoleMismatch,
+            VariantEvidenceStrength::Strong,
+            [changed_role],
+            [skipped_role],
+        );
+    }
+    let throw_roles = roles(
+        changed,
+        skipped,
+        UnitEvidenceFlag::Throws,
+        "throws",
+        "non-throws",
+    );
+    if let Some((changed_role, skipped_role)) = throw_roles {
+        evidence.signal(
+            VariantSignalCode::EffectRoleMismatch,
+            VariantEvidenceStrength::Strong,
+            [changed_role],
+            [skipped_role],
+        );
+    }
+    if let (Some(changed_role), Some(skipped_role)) =
+        (protocol_role(changed), protocol_role(skipped))
+    {
+        if changed_role != skipped_role {
+            evidence.signal(
+                VariantSignalCode::ProtocolRoleMismatch,
+                VariantEvidenceStrength::Strong,
+                [changed_role.to_string()],
+                [skipped_role.to_string()],
+            );
+        }
+    }
+}
+
+fn roles(
+    changed: UnitOrigin,
+    skipped: UnitOrigin,
+    flag: UnitEvidenceFlag,
+    positive: &str,
+    negative: &str,
+) -> Option<(String, String)> {
+    match (changed.has_evidence(flag), skipped.has_evidence(flag)) {
+        (true, false) => Some((positive.to_string(), negative.to_string())),
+        (false, true) => Some((negative.to_string(), positive.to_string())),
+        _ => None,
+    }
+}
+
+fn protocol_role(origin: UnitOrigin) -> Option<&'static str> {
+    [
+        (
+            UnitEvidenceFlag::ProtocolRequirement,
+            "protocol-requirement",
+        ),
+        (UnitEvidenceFlag::ProtocolExtension, "protocol-extension"),
+        (
+            UnitEvidenceFlag::ConcreteTypeExtension,
+            "concrete-type-extension",
+        ),
+        (
+            UnitEvidenceFlag::InterfaceDefaultMethod,
+            "interface-default-method",
+        ),
+        (
+            UnitEvidenceFlag::InterfaceStaticMethod,
+            "interface-static-method",
+        ),
+        (
+            UnitEvidenceFlag::InterfacePrivateMethod,
+            "interface-private-method",
+        ),
+    ]
+    .into_iter()
+    .find_map(|(flag, role)| origin.has_evidence(flag).then_some(role))
+}
+
+fn weak_identity_signals(evidence: &mut VariantEvidence, changed: &Loc, skipped: &Loc) {
+    let changed_name = effective_name(changed);
+    let skipped_name = effective_name(skipped);
+    if let (Some(changed_name), Some(skipped_name)) = (changed_name, skipped_name) {
+        if changed_name != skipped_name {
+            evidence.signal(
+                VariantSignalCode::NameMismatch,
+                VariantEvidenceStrength::Weak,
+                [changed_name.to_string()],
+                [skipped_name.to_string()],
+            );
+        }
+    }
+    if changed.file != skipped.file {
+        evidence.signal(
+            VariantSignalCode::PathMismatch,
+            VariantEvidenceStrength::Weak,
+            [changed.file.clone()],
+            [skipped.file.clone()],
+        );
+    }
+    let changed_versions = version_labels(changed);
+    let skipped_versions = version_labels(skipped);
+    if changed_versions != skipped_versions
+        && (!changed_versions.is_empty() || !skipped_versions.is_empty())
+    {
+        evidence.signal(
+            VariantSignalCode::VersionLabelMismatch,
+            VariantEvidenceStrength::Weak,
+            changed_versions,
+            skipped_versions,
+        );
+    }
+}
+
+fn effective_name(loc: &Loc) -> Option<&str> {
+    loc.name
+        .as_deref()
+        .or_else(|| loc.enclosing_unit.as_ref()?.name.as_deref())
+}
+
+fn version_labels(loc: &Loc) -> Vec<String> {
+    let mut labels = BTreeSet::new();
+    let text = format!("{} {}", loc.file, effective_name(loc).unwrap_or_default());
+    for token in text.split(|character: char| !character.is_ascii_alphanumeric()) {
+        let lower = token.to_ascii_lowercase();
+        let numeric_version = lower
+            .strip_prefix('v')
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()));
+        if numeric_version || matches!(lower.as_str(), "legacy" | "modern") {
+            labels.insert(lower);
+        }
+    }
+    labels.into_iter().collect()
+}
+
+fn bounded(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut values = values
+        .into_iter()
+        .map(|value| cap_detail(&value))
+        .collect::<Vec<_>>();
+    values.sort();
+    values.dedup();
+    values.truncate(DETAIL_CAP);
+    values
+}
+
+fn cap_detail(value: &str) -> String {
+    if value.chars().count() <= DETAIL_CHARS {
+        return value.to_string();
+    }
+    let end = value
+        .char_indices()
+        .nth(DETAIL_CHARS)
+        .map_or(value.len(), |(index, _)| index);
+    format!("{}…", &value[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc(file: &str, name: &str) -> Loc {
+        Loc {
+            file: file.to_string(),
+            start_line: 1,
+            end_line: 2,
+            lang: "go".to_string(),
+            kind: nose_il::UnitKind::Function,
+            origin: UnitOrigin::unknown(),
+            name: Some(name.to_string()),
+            sem: 1,
+            span_lines: 2,
+            span_tokens: 2,
+            is_fragment: false,
+            fragment_kind: None,
+            reason_code: None,
+            enclosing_unit: None,
+            in_test_module: false,
+            looks_generated: false,
+            shared_subdag: None,
+        }
+    }
+
+    #[test]
+    fn version_labels_are_exact_weak_hints() {
+        let changed = loc("completion_v2.go", "renderV2");
+        let skipped = loc("completion.go", "render");
+        let mut evidence = VariantEvidence::empty();
+        weak_identity_signals(&mut evidence, &changed, &skipped);
+        assert_eq!(evidence.status, VariantEvidenceStatus::Advisory);
+        assert!(evidence.signals.iter().any(|signal| {
+            signal.code == VariantSignalCode::VersionLabelMismatch
+                && signal.strength == VariantEvidenceStrength::Weak
+        }));
+    }
+
+    #[test]
+    fn weak_name_only_is_never_disqualifying() {
+        let changed = loc("same.go", "changes");
+        let skipped = loc("same.go", "resets");
+        let mut evidence = VariantEvidence::empty();
+        weak_identity_signals(&mut evidence, &changed, &skipped);
+        assert_eq!(evidence.status, VariantEvidenceStatus::Advisory);
+        assert_eq!(evidence.signals.len(), 1);
+        assert_eq!(evidence.signals[0].code, VariantSignalCode::NameMismatch);
+        assert_eq!(evidence.signals[0].strength, VariantEvidenceStrength::Weak);
+    }
+
+    #[test]
+    fn referent_async_and_protocol_evidence_name_strong_roles() {
+        let witness = GradedWitness {
+            holes: 0,
+            spots: Vec::new(),
+            patterns: vec!["referent-mismatch"],
+            referent_mismatches: vec!["handler".to_string()],
+            caveat_names: Vec::new(),
+            equal_modulo_holes: false,
+            modeled_caveat: false,
+        };
+        let changed = UnitOrigin::unknown()
+            .with_evidence(UnitEvidenceFlag::Async)
+            .with_evidence(UnitEvidenceFlag::ProtocolRequirement);
+        let skipped = UnitOrigin::unknown().with_evidence(UnitEvidenceFlag::ProtocolExtension);
+        let mut evidence = VariantEvidence::empty();
+        enrich_projected(&mut evidence, Some(&witness), changed, skipped, &[], false);
+        assert_eq!(evidence.status, VariantEvidenceStatus::Disqualifying);
+        for code in [
+            VariantSignalCode::ReferentMismatch,
+            VariantSignalCode::AsyncRoleMismatch,
+            VariantSignalCode::ProtocolRoleMismatch,
+        ] {
+            assert!(evidence.signals.iter().any(|signal| signal.code == code));
+        }
+    }
+
+    #[test]
+    fn variant_contract_codes_are_closed_and_kebab_cased() {
+        let signals = [
+            VariantSignalCode::ReferentMismatch,
+            VariantSignalCode::DecoratorMismatch,
+            VariantSignalCode::AsyncRoleMismatch,
+            VariantSignalCode::EffectRoleMismatch,
+            VariantSignalCode::ProtocolRoleMismatch,
+            VariantSignalCode::DisjointPlatformGuard,
+            VariantSignalCode::NameMismatch,
+            VariantSignalCode::PathMismatch,
+            VariantSignalCode::VersionLabelMismatch,
+        ];
+        assert_eq!(
+            signals.map(VariantSignalCode::as_str),
+            [
+                "referent-mismatch",
+                "decorator-mismatch",
+                "async-role-mismatch",
+                "effect-role-mismatch",
+                "protocol-role-mismatch",
+                "disjoint-platform-guard",
+                "name-mismatch",
+                "path-mismatch",
+                "version-label-mismatch",
+            ]
+        );
+        let caveats = serde_json::to_value([
+            VariantCaveatCode::SourceUnavailable,
+            VariantCaveatCode::ProjectionUnavailable,
+            VariantCaveatCode::AlignmentUnavailable,
+            VariantCaveatCode::LossyProjection,
+            VariantCaveatCode::UnresolvedReferent,
+            VariantCaveatCode::Truncated,
+            VariantCaveatCode::ConflictingPlatformGuard,
+        ])
+        .unwrap();
+        assert_eq!(
+            caveats,
+            serde_json::json!([
+                "source-unavailable",
+                "projection-unavailable",
+                "alignment-unavailable",
+                "lossy-projection",
+                "unresolved-referent",
+                "truncated",
+                "conflicting-platform-guard"
+            ])
+        );
+    }
+}

--- a/crates/nose-cli/src/divergence/variant/source.rs
+++ b/crates/nose-cli/src/divergence/variant/source.rs
@@ -1,0 +1,289 @@
+use super::*;
+use crate::divergence::Site;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(super) fn source_signals(
+    evidence: &mut VariantEvidence,
+    changed: &Site,
+    current_path: &str,
+    current_span: Option<(u32, u32)>,
+    skipped: &Site,
+    current_root: &Path,
+    base_root: &Path,
+    lines: &mut FileLineCache,
+) {
+    let (current_start, current_end) = current_span.unwrap_or_else(|| {
+        let (start, end) = effective_span(changed);
+        (start, end.saturating_add(32))
+    });
+    let changed_lines = site_lines(
+        current_path,
+        current_start,
+        current_end,
+        current_root,
+        lines,
+    );
+    let (skipped_start, skipped_end) = effective_span(skipped);
+    let skipped_lines = site_lines(&skipped.file, skipped_start, skipped_end, base_root, lines);
+    let (Some(changed_lines), Some(skipped_lines)) = (changed_lines, skipped_lines) else {
+        evidence.caveat(VariantCaveatCode::SourceUnavailable, std::iter::empty());
+        return;
+    };
+    let changed_decorators = decorator_lines(
+        &changed.lang,
+        &changed_lines,
+        changed.enclosing_unit.is_some() || changed.kind != nose_il::UnitKind::Block,
+    );
+    let skipped_decorators = decorator_lines(
+        &skipped.lang,
+        &skipped_lines,
+        skipped.enclosing_unit.is_some() || skipped.kind != nose_il::UnitKind::Block,
+    );
+    if changed_decorators != skipped_decorators
+        && (!changed_decorators.is_empty() || !skipped_decorators.is_empty())
+    {
+        evidence.signal(
+            VariantSignalCode::DecoratorMismatch,
+            VariantEvidenceStrength::Strong,
+            changed_decorators,
+            skipped_decorators,
+        );
+    }
+    compare_platform_guards(evidence, &changed_lines, &skipped_lines);
+}
+
+fn effective_span(site: &Site) -> (u32, u32) {
+    site.enclosing_unit
+        .as_ref()
+        .map(|unit| (unit.start_line, unit.end_line))
+        .unwrap_or((site.start_line, site.end_line))
+}
+
+fn site_lines(
+    file: &str,
+    start: u32,
+    end: u32,
+    root: &Path,
+    lines: &mut FileLineCache,
+) -> Option<Vec<String>> {
+    let path = root.join(file).to_string_lossy().into_owned();
+    lines.slice(&path, start, end)
+}
+
+fn decorator_lines(lang: &str, lines: &[String], prefix_only: bool) -> Vec<String> {
+    let prefix = match lang {
+        "python" | "java" | "javascript" | "typescript" => "@",
+        "rust" => "#[",
+        _ => return Vec::new(),
+    };
+    let mut decorators = Vec::new();
+    for line in lines
+        .iter()
+        .take(if prefix_only { 32 } else { lines.len() })
+    {
+        let line = line.trim();
+        if line.is_empty()
+            || line.starts_with("//")
+            || line.starts_with("/*")
+            || line.starts_with('*')
+        {
+            continue;
+        }
+        if line.starts_with(prefix) {
+            if !line.starts_with("#[cfg") {
+                decorators.push(cap_detail(line));
+            }
+            continue;
+        }
+        if prefix_only {
+            break;
+        }
+    }
+    decorators.sort();
+    decorators.dedup();
+    decorators.truncate(DETAIL_CAP);
+    decorators
+}
+
+#[derive(Default)]
+struct PlatformGuards {
+    by_dimension: BTreeMap<&'static str, BTreeSet<String>>,
+    source: Vec<String>,
+}
+
+fn compare_platform_guards(
+    evidence: &mut VariantEvidence,
+    changed_lines: &[String],
+    skipped_lines: &[String],
+) {
+    let changed = platform_guards(changed_lines);
+    let skipped = platform_guards(skipped_lines);
+    let mut comparable = false;
+    let mut disjoint = false;
+    let mut conflict = false;
+    for (dimension, changed_values) in &changed.by_dimension {
+        let Some(skipped_values) = skipped.by_dimension.get(dimension) else {
+            continue;
+        };
+        comparable = true;
+        let overlap = changed_values.intersection(skipped_values).next().is_some();
+        disjoint |= !overlap;
+        conflict |= overlap && changed_values != skipped_values;
+    }
+    if comparable && disjoint {
+        evidence.signal(
+            VariantSignalCode::DisjointPlatformGuard,
+            VariantEvidenceStrength::Strong,
+            changed.source,
+            skipped.source,
+        );
+    } else if conflict || (!comparable && !changed.source.is_empty() && !skipped.source.is_empty())
+    {
+        evidence.caveat(
+            VariantCaveatCode::ConflictingPlatformGuard,
+            changed.source.into_iter().chain(skipped.source),
+        );
+    }
+}
+
+fn platform_guards(lines: &[String]) -> PlatformGuards {
+    let mut guards = PlatformGuards::default();
+    for line in lines {
+        let trimmed = line.trim();
+        if !(trimmed.starts_with("#[cfg")
+            || trimmed.starts_with("#if")
+            || trimmed.starts_with("#ifdef"))
+        {
+            continue;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        let before = guards
+            .by_dimension
+            .values()
+            .map(BTreeSet::len)
+            .sum::<usize>();
+        for (dimension, key) in [
+            ("target-os", "target_os"),
+            ("target-arch", "target_arch"),
+            ("target-env", "target_env"),
+            ("pointer-width", "target_pointer_width"),
+        ] {
+            for value in quoted_values_after(&lower, key) {
+                guards
+                    .by_dimension
+                    .entry(dimension)
+                    .or_default()
+                    .insert(value);
+            }
+        }
+        for (dimension, function) in [("target-os", "os("), ("target-arch", "arch(")] {
+            for value in call_values(&lower, function) {
+                guards
+                    .by_dimension
+                    .entry(dimension)
+                    .or_default()
+                    .insert(value);
+            }
+        }
+        for (needle, value) in [
+            ("_win32", "windows"),
+            ("__linux__", "linux"),
+            ("__apple__", "apple"),
+            ("__android__", "android"),
+            ("__freebsd__", "freebsd"),
+        ] {
+            if lower.contains(needle) && !lower.starts_with("#ifndef") {
+                guards
+                    .by_dimension
+                    .entry("target-os")
+                    .or_default()
+                    .insert(value.to_string());
+            }
+        }
+        let after = guards
+            .by_dimension
+            .values()
+            .map(BTreeSet::len)
+            .sum::<usize>();
+        if after > before {
+            guards.source.push(cap_detail(trimmed));
+        }
+    }
+    guards.source.sort();
+    guards.source.dedup();
+    guards.source.truncate(DETAIL_CAP);
+    guards
+}
+
+fn quoted_values_after(text: &str, key: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut rest = text;
+    while let Some(index) = rest.find(key) {
+        rest = &rest[index + key.len()..];
+        let Some(open) = rest.find('"') else { break };
+        let tail = &rest[open + 1..];
+        let Some(close) = tail.find('"') else { break };
+        values.push(tail[..close].to_string());
+        rest = &tail[close + 1..];
+    }
+    values
+}
+
+fn call_values(text: &str, function: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut rest = text;
+    while let Some(index) = rest.find(function) {
+        let tail = &rest[index + function.len()..];
+        let Some(close) = tail.find(')') else { break };
+        let value = tail[..close].trim();
+        if !value.is_empty() && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            values.push(value.to_string());
+        }
+        rest = &tail[close + 1..];
+    }
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutually_exclusive_platform_values_are_strong_but_overlap_is_advisory() {
+        let linux = vec!["#[cfg(target_os = \"linux\")]".to_string()];
+        let windows = vec!["#[cfg(target_os = \"windows\")]".to_string()];
+        let mut evidence = VariantEvidence::empty();
+        compare_platform_guards(&mut evidence, &linux, &windows);
+        assert_eq!(evidence.status, VariantEvidenceStatus::Disqualifying);
+        assert_eq!(
+            evidence.signals[0].code,
+            VariantSignalCode::DisjointPlatformGuard
+        );
+
+        let linux_or_macos =
+            vec!["#[cfg(any(target_os = \"linux\", target_os = \"macos\"))]".to_string()];
+        let mut contradictory = VariantEvidence::empty();
+        compare_platform_guards(&mut contradictory, &linux_or_macos, &linux);
+        assert_eq!(contradictory.status, VariantEvidenceStatus::Advisory);
+        assert!(contradictory.signals.is_empty());
+        assert_eq!(
+            contradictory.caveats[0].code,
+            VariantCaveatCode::ConflictingPlatformGuard
+        );
+    }
+
+    #[test]
+    fn decorators_are_definition_prefix_only_and_cfg_is_priced_as_a_guard() {
+        let lines = vec![
+            "@cache".to_string(),
+            "def work():".to_string(),
+            "    @nested".to_string(),
+        ];
+        assert_eq!(decorator_lines("python", &lines, true), vec!["@cache"]);
+        assert_eq!(
+            decorator_lines("python", &lines, false),
+            vec!["@cache", "@nested"]
+        );
+        assert!(decorator_lines("rust", &["#[cfg(unix)]".to_string()], true).is_empty());
+    }
+}

--- a/crates/nose-cli/src/divergence/variant/source.rs
+++ b/crates/nose-cli/src/divergence/variant/source.rs
@@ -8,9 +8,7 @@ pub(super) fn source_signals(
     current_path: &str,
     current_span: Option<(u32, u32)>,
     skipped: &Site,
-    current_root: &Path,
-    base_root: &Path,
-    lines: &mut FileLineCache,
+    context: &mut VariantSourceContext<'_>,
 ) {
     let (current_start, current_end) = current_span.unwrap_or_else(|| {
         let (start, end) = effective_span(changed);
@@ -20,11 +18,17 @@ pub(super) fn source_signals(
         current_path,
         current_start,
         current_end,
-        current_root,
-        lines,
+        context.current_root,
+        context.lines,
     );
     let (skipped_start, skipped_end) = effective_span(skipped);
-    let skipped_lines = site_lines(&skipped.file, skipped_start, skipped_end, base_root, lines);
+    let skipped_lines = site_lines(
+        &skipped.file,
+        skipped_start,
+        skipped_end,
+        context.base_root,
+        context.lines,
+    );
     let (Some(changed_lines), Some(skipped_lines)) = (changed_lines, skipped_lines) else {
         evidence.caveat(VariantCaveatCode::SourceUnavailable, std::iter::empty());
         return;

--- a/crates/nose-cli/src/query_views.rs
+++ b/crates/nose-cli/src/query_views.rs
@@ -162,6 +162,9 @@ pub(super) fn render_query_base(
                         target.direct_witness.kind,
                         target.direct_witness.similarity,
                     );
+                    if let Some(label) = target.variant_evidence.concise_label() {
+                        println!("      variant:    {label}");
+                    }
                 }
             }
             divergence::DivergenceLane::NewCopy => {

--- a/crates/nose-cli/tests/cli/query_base.rs
+++ b/crates/nose-cli/tests/cli/query_base.rs
@@ -14,6 +14,8 @@ mod semantic_packs;
 mod suppression_edges;
 #[path = "query_base/tier_policy.rs"]
 mod tier_policy;
+#[path = "query_base/variant_evidence.rs"]
+mod variant_evidence;
 
 fn git_in(dir: &Path, args: &[&str]) {
     let out = Command::new("git")

--- a/crates/nose-cli/tests/cli/query_base/core_contract.rs
+++ b/crates/nose-cli/tests/cli/query_base/core_contract.rs
@@ -93,6 +93,13 @@ fn assert_json_target_contract(item: &serde_json::Value, json: &serde_json::Valu
             && target["direct_witness"]["similarity"].is_number(),
         "target carries pair-local detector evidence: {json}"
     );
+    assert!(
+        matches!(
+            target["variant_evidence"]["status"].as_str(),
+            Some("none" | "advisory" | "disqualifying")
+        ),
+        "target carries closed pair-local variant evidence: {json}"
+    );
 }
 
 fn assert_json_site_contract(item: &serde_json::Value, json: &serde_json::Value) {
@@ -201,6 +208,10 @@ fn assert_sarif_target_contract(
     assert_eq!(
         result["properties"]["targets"][0]["target_id"], target_id,
         "JSON and SARIF name the same exact direct target: {sarif}"
+    );
+    assert!(
+        result["properties"]["targets"][0]["variant_evidence"]["status"].is_string(),
+        "SARIF carries the same target-local variant evidence: {sarif}"
     );
     assert_eq!(
         result["locations"][0]["properties"]["target_id"], target_id,

--- a/crates/nose-cli/tests/cli/query_base/variant_evidence.rs
+++ b/crates/nose-cli/tests/cli/query_base/variant_evidence.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+fn target_with_files<'a>(
+    json: &'a serde_json::Value,
+    changed: &str,
+    skipped: &str,
+) -> &'a serde_json::Value {
+    query_base_items(json)
+        .iter()
+        .flat_map(|item| item["targets"].as_array().into_iter().flatten())
+        .find(|target| target["changed"]["file"] == changed && target["skipped"]["file"] == skipped)
+        .unwrap_or_else(|| panic!("expected target {changed} -> {skipped}: {json}"))
+}
+
+fn signal_codes(target: &serde_json::Value) -> Vec<&str> {
+    target["variant_evidence"]["signals"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|signal| signal["code"].as_str())
+        .collect()
+}
+
+#[test]
+fn query_base_names_definition_decorator_mismatch_without_changing_v2_gate() {
+    let project = GitProject::new("query_base_variant_decorator");
+    let body = |decorator: &str, name: &str| {
+        format!(
+            "@route(\"{decorator}\")\ndef {name}(values):\n    total = 0\n    for value in values:\n        if value > 0:\n            total = total + value * 2\n    return total\n"
+        )
+    };
+    project.write("a.py", &body("alpha", "first"));
+    project.write("b.py", &body("beta", "second"));
+    project.init();
+    project.write(
+        "a.py",
+        &body("alpha", "first").replace("    return total", "    return total + 1"),
+    );
+
+    let json = query_base_json_value(project.path(), &[]);
+    let target = target_with_files(&json, "a.py", "b.py");
+    assert_eq!(target["variant_evidence"]["status"], "disqualifying");
+    assert!(signal_codes(target).contains(&"decorator-mismatch"));
+    let item = query_base_items(&json)
+        .iter()
+        .find(|item| {
+            item["targets"]
+                .as_array()
+                .is_some_and(|targets| targets.contains(target))
+        })
+        .expect("owning divergence");
+    assert_eq!(
+        item["gate"]["fail_default"], true,
+        "#851 records evidence but leaves the v2 policy unchanged: {json}"
+    );
+}
+
+#[test]
+fn query_base_names_pair_local_referent_mismatch() {
+    let project = GitProject::new("query_base_variant_referent");
+    let body = |delta: i32, name: &str| {
+        format!(
+            "def handler(value):\n    return value + {delta}\n\ndef {name}(values):\n    total = 0\n    for value in values:\n        if value > 0:\n            total = total + handler(value)\n    return total\n"
+        )
+    };
+    project.write("a.py", &body(1, "first"));
+    project.write("b.py", &body(2, "second"));
+    project.init();
+    project.write(
+        "a.py",
+        &body(1, "first").replace("    return total", "    return total + 1"),
+    );
+
+    let json = query_base_json_value(project.path(), &[]);
+    let target = target_with_files(&json, "a.py", "b.py");
+    assert_eq!(target["variant_evidence"]["status"], "disqualifying");
+    let referent = target["variant_evidence"]["signals"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|signal| signal["code"] == "referent-mismatch")
+        .unwrap_or_else(|| panic!("referent mismatch should be inspectable: {json}"));
+    assert_eq!(referent["strength"], "strong");
+    assert!(
+        referent["changed"]
+            .as_array()
+            .is_some_and(|names| names.iter().any(|name| name == "handler")),
+        "the mismatched referent is named: {json}"
+    );
+}

--- a/docs/agent-recipe.md
+++ b/docs/agent-recipe.md
@@ -137,7 +137,10 @@ evidence, `witness_kind`, `scope`, per-changed-site `touches_shared`, and the ad
 pairs; use its stable `target_id`, pair-local `direct_witness`, and target-local
 `changed.touches_shared` / `changed.semantic_change` rather than treating every
 transitively grouped family member as an action. Keep `changed[]` / `not_updated[]` as
-broader review context. For propagation triage over the top findings, judge each target as
+broader review context. Read `variant_evidence` at the same target boundary: strong signals
+name exact referent, decorator, async/effect, protocol, or disjoint-platform evidence; name,
+path, and version differences are weak hints only. Under v2 this evidence does not override
+`gate.fail_default`. For propagation triage over the top findings, judge each target as
 should-propagate / intentional-divergence / not-a-clone using the changed member's
 diff and the un-updated sibling's body. Most fires are not propagation hazards; the
 current checked strict baseline has precision 0.562 ([experiments](experiments.md)

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -241,6 +241,9 @@ JSON and SARIF keep one finding/result per family and carry the same `targets[]`
 SARIF target-backed primary and related locations repeat `target_id` in location properties,
 so an annotation identifies the exact skipped sibling and changed source without promoting a
 bridge member reached only through transitive family closure.
+Each target also mirrors the same closed `variant_evidence`: strong pair evidence is separated
+from weak name/path/version hints and explicit caveats. It is development evidence in v2, not
+another CI authority; wrappers must still decide only from `gate.fail_default`.
 
 Structured ignores apply before the gate: a suppressed divergent-edit family must not
 produce a `strict` failure, and report-only lanes such as newly added clone evidence

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -115,6 +115,17 @@ file does not change the base target. JSON and SARIF expose the same ID; SARIF a
 to the skipped primary location and changed related location. The v2 family gate remains the
 authority until the measured v3 policy in #852 consumes target evidence.
 
+Each target also carries `variant_evidence`. Its closed `status` is `none`, `advisory`, or
+`disqualifying`; the last value means that at least one strong, pair-local signal was observed.
+Strong signals are limited to resolved referent mismatch, definition decorator/attribute
+mismatch, async or observable-effect role mismatch, incompatible explicit protocol roles, and
+provably disjoint platform constraints. Every signal names its exact changed/skipped evidence.
+Name, path, and version-label differences are emitted only with `strength="weak"`; they cannot
+become hard-block authority alone. Projection/source loss, unresolved referents, truncation, and
+overlapping or incomparable platform constraints remain explicit advisory `caveats[]`. #851
+records these facts but deliberately leaves the v2 tier and `gate.fail_default` unchanged; #852
+is the first issue allowed to consume them in a frozen policy.
+
 The graded witness is **evidence for the consumer, not a fire gate**: a clean
 `equal_modulo_holes` family is a strong missed-propagation candidate, while a
 `referent-mismatch` / `decorator-differs` family is evidence that the copies may have

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -117,6 +117,8 @@ authority until the measured v3 policy in #852 consumes target evidence.
 
 Each target also carries `variant_evidence`. Its closed `status` is `none`, `advisory`, or
 `disqualifying`; the last value means that at least one strong, pair-local signal was observed.
+Role and definition-modifier evidence compares the current changed result with the base-tree
+skipped endpoint, while identity remains anchored to the direct base edge.
 Strong signals are limited to resolved referent mismatch, definition decorator/attribute
 mismatch, async or observable-effect role mismatch, incompatible explicit protocol roles, and
 provably disjoint platform constraints. Every signal names its exact changed/skipped evidence.

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -146,6 +146,8 @@ and `version-label-mismatch` are always `strength="weak"`. Caveat codes are
 `conflicting-platform-guard`. Missing or contradictory evidence is advisory, and weak signals
 cannot disqualify a target. This field does not change the v2 `tier` or `gate.fail_default`;
 #852 may consume it only through the frozen v3 policy.
+The evidence compares the current changed result to the skipped base-tree endpoint; the stable
+`target_id` and `direct_witness` remain anchored to the accepted base-tree edge.
 
 JSON keeps one `items[]` finding per family, with zero or more direct targets. SARIF likewise
 keeps one result per family: `properties.targets` mirrors JSON's `targets`, and every

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -125,7 +125,7 @@ unresolved referents, and capped mappings cannot be `complete`. This field does 
 a later frozen policy may consume it.
 
 `targets[]` is an evidence-only v8 extension for target-level policy development. A target is
-`{target_id, changed, skipped, direct_witness}`. `target_id` is the 16-hex-digit FNV identity of
+`{target_id, changed, skipped, direct_witness, variant_evidence}`. `target_id` is the 16-hex-digit FNV identity of
 the directed pair's repo-relative base coordinates and unit metadata; temporary base-worktree
 paths and enclosing-family membership are not inputs. `direct_witness` is the pair-local
 `{kind, similarity}` recorded when the detector accepted that edge, before transitive family
@@ -134,6 +134,18 @@ closure. `changed.touches_shared` is computed against only that target's `skippe
 top-level `changed[]` / `not_updated[]` arrays remain the complete family review context, so a
 bridge member reachable only through another clone stays visible there but is not silently
 turned into a propagation target.
+
+`variant_evidence` is pair-local and uses closed enums. `status` is `none`, `advisory`, or
+`disqualifying`; `signals[]` entries contain `{code, strength, changed[], skipped[]}` and
+`caveats[]` contain `{code, details[]}`. Strong signal codes are `referent-mismatch`,
+`decorator-mismatch`, `async-role-mismatch`, `effect-role-mismatch`,
+`protocol-role-mismatch`, and `disjoint-platform-guard`. `name-mismatch`, `path-mismatch`,
+and `version-label-mismatch` are always `strength="weak"`. Caveat codes are
+`source-unavailable`, `projection-unavailable`, `alignment-unavailable`,
+`lossy-projection`, `unresolved-referent`, `truncated`, and
+`conflicting-platform-guard`. Missing or contradictory evidence is advisory, and weak signals
+cannot disqualify a target. This field does not change the v2 `tier` or `gate.fail_default`;
+#852 may consume it only through the frozen v3 policy.
 
 JSON keeps one `items[]` finding per family, with zero or more direct targets. SARIF likewise
 keeps one result per family: `properties.targets` mirrors JSON's `targets`, and every
@@ -154,7 +166,7 @@ The v8 `base.items[]` object adds:
 | `taxonomy_hint` | string or null | Closed evidence/routing bucket for UI copy: `missed_propagation`, `no_propagation_needed`, `intentional_variant`, `test_scaffolding`, `grouping_artifact`, or `unclear`. This guides inspection; it is not a harm or correctness verdict. |
 | `gate` | object | `{eligible, fail_default, policy}` where `eligible` is informational (`true` for `strict` and `review`, false for `report-only` and `suppressed`), `fail_default` is the authoritative default CI decision and is true only for unsuppressed `strict`, and `policy` names the policy version such as `divergent-edit-v2-strict`. |
 | `suppression` | object or null | Structured-ignore match metadata when a future suppressed/debug view asks for it: `{kind, reason, owner, expires_at}`. `kind` is the closed enum `structured-ignore` for v8. Active human/SARIF output omits suppressed findings by default. |
-| `targets[]` | array | Direct detector-accepted changed→skipped propagation edges. Each target has stable `target_id`, pair-local `direct_witness`, and base-tree `changed` / `skipped` sites carrying pair-specific shared-line and semantic-change mapping. Empty for `new-copy` and when no direct edge survives. |
+| `targets[]` | array | Direct detector-accepted changed→skipped propagation edges. Each target has stable `target_id`, pair-local `direct_witness`, base-tree `changed` / `skipped` sites carrying pair-specific shared-line and semantic-change mapping, and closed `variant_evidence`. Empty for `new-copy` and when no direct edge survives. |
 
 Composition rules for v8:
 

--- a/eval/divergence_fire/RESULTS.md
+++ b/eval/divergence_fire/RESULTS.md
@@ -396,6 +396,58 @@ python3 eval/divergence_fire/direct_target_eval.py runtime \
   --out /tmp/issue-850-runtime-primary.json
 ```
 
+## Target variant evidence development pricing (2026-07-18, #851)
+
+#851 adds closed, pair-local strong signals for resolved referent, definition modifier,
+async/effect role, protocol role, and disjoint platform differences. Name, path, and
+version-label differences remain weak hints and cannot disqualify a target. The checked
+[`variant_evidence_dev_2026_07_18.v1.json`](variant_evidence_dev_2026_07_18.v1.json)
+uses only the public development labels; no blind or temporal input was accessed, and
+the v2 `gate.fail_default` output is unchanged.
+
+All 179 findings replayed with zero query errors. On the 80-finding v2 strict slice,
+excluding every target carrying any strong variant signal would fully demote 27
+findings: 12 false positives and 15 `should_propagate` positives. It identifies six of
+the 13 `intentional_divergence` false positives but is not a standalone precision
+policy: selected precision moves only 56.25% → 56.60%, while TP retention falls to
+66.67%. #852 must therefore combine these facts with semantic/direct-target
+requirements instead of treating every strong variant code as a sufficient policy.
+
+| strong signal | fully demoted FP | fully demoted TP |
+|---|---:|---:|
+| referent mismatch | 6 | 8 |
+| decorator/attribute mismatch | 6 | 5 |
+| async role mismatch | 1 | 0 |
+| effect role mismatch | 1 | 0 |
+| disjoint platform guard | 1 | 0 |
+| protocol role mismatch | 0 | 0 |
+
+Signal effects overlap, so rows do not sum to the 27-finding combined effect. There
+were 91 weak-only targets and zero weak-only disqualifications. Missing projections,
+lossy lowering, unresolved referents, truncation, and conflicting platform constraints
+remain named advisory caveats rather than guessed negatives.
+
+The official-v0.19.0 runtime receipt is
+[`issue-851-official-v0.19.0-performance-2026-07-18.v1.json`](../../bench/recall_loss/issue-851-official-v0.19.0-performance-2026-07-18.v1.json).
+Across the same 17-repository selection, the candidate adds 877.83 ms / 8.44% raw
+and 836.51 ms / 8.04% after the same-binary control. Removing `semantic_change` and
+`targets` keeps every legacy output equal. The nearest-rank repository p90 is 44.47%
+(axios 52.56%, regex 44.47%); target role analysis is bounded and reuses file, unit,
+projection, and source caches, but the cumulative family-plus-target compatibility
+path remains above #847's 5% budget. #852 must remove that duplicate path and
+remeasure against the official release.
+
+Reproduce the development aggregate after building the release binary:
+
+```sh
+python3 eval/divergence_fire/variant_evidence_eval.py selftest
+python3 eval/divergence_fire/semantic_witness_eval.py replay \
+  --jobs 4 --timeout 240 --out /tmp/issue-851-dev-replay.jsonl
+python3 eval/divergence_fire/variant_evidence_eval.py summarize \
+  --records /tmp/issue-851-dev-replay.jsonl --nose target/release/nose \
+  --out eval/divergence_fire/variant_evidence_dev_2026_07_18.v1.json
+```
+
 ## Fire rate (change level; 347 replayed changes per arm)
 
 | arm | fire rate | findings/fire p50 | p90 | max | divergence s p50 | p90 |

--- a/eval/divergence_fire/variant_evidence_dev_2026_07_18.v1.json
+++ b/eval/divergence_fire/variant_evidence_dev_2026_07_18.v1.json
@@ -1,0 +1,237 @@
+{
+  "all_strong_signal_effect": {
+    "false_positives_removed": 12,
+    "fully_demoted_by_verdict": {
+      "intentional_divergence": 6,
+      "no_propagation_needed": 4,
+      "not_a_clone": 2,
+      "should_propagate": 15
+    },
+    "fully_demoted_findings": 27,
+    "true_positives_demoted": 15
+  },
+  "baseline_v2_strict": {
+    "direct_shared_targets": 151,
+    "findings": 80,
+    "verdicts": {
+      "intentional_divergence": 13,
+      "no_propagation_needed": 17,
+      "not_a_clone": 5,
+      "should_propagate": 45
+    }
+  },
+  "blind_or_temporal_data_accessed": false,
+  "development_only": true,
+  "implementation": {
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "9a1e7e3fc7ecb0ea31c8dbc8bb1008ff852b00d08285503e397885870da7e317",
+    "nose_version": "nose 0.19.0",
+    "replay_harness": "eval/divergence_fire/semantic_witness_eval.py",
+    "replay_harness_sha256": "82c672c8a4b004ce4c5a11bfddfbf66d92efb511e256431d744c07095000c2d6",
+    "source_commit": "201a2f4dfa607ed6a54681ca5d84b9c688535910",
+    "summary_harness": "eval/divergence_fire/variant_evidence_eval.py",
+    "summary_harness_sha256": "67285c839411bf454da68851342eb9d92ff633b3b58afc4ffe6bc8afcc539abf"
+  },
+  "inputs": {
+    "labeled_findings": 179,
+    "replay_records": "/tmp/nose-851-variant-replay-final.jsonl",
+    "samples": "eval/divergence_fire/sampled_findings_2026_07_06.jsonl",
+    "samples_sha256": "05be2f55e0ef4aa810fffd741cd7c39b840a92ed2b7cc055164496a74108c288",
+    "verdicts": "eval/divergence_fire/verdicts_2026_07_06.jsonl",
+    "verdicts_sha256": "c5ab11a2c1d0cae2d52fc15b4868e43e9e7ddd8e9e25e593dc828ce1d94828fc"
+  },
+  "intentional_divergence_focus": {
+    "baseline_false_positives": 13,
+    "fully_demoted": 6,
+    "retained": 7
+  },
+  "interpretation": "Development evidence only. #851 records deterministic target-local variant evidence and leaves v2 gate.fail_default unchanged; #852 may consume only the closed strong codes in a separately frozen policy.",
+  "issue": 851,
+  "per_strong_signal_effect": {
+    "async-role-mismatch": {
+      "exposed_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "false_positives_removed": 1,
+      "findings_exposed": 1,
+      "findings_fully_demoted": 1,
+      "fully_demoted_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "true_positives_demoted": 0
+    },
+    "decorator-mismatch": {
+      "exposed_by_verdict": {
+        "intentional_divergence": 3,
+        "no_propagation_needed": 2,
+        "not_a_clone": 1,
+        "should_propagate": 7
+      },
+      "false_positives_removed": 6,
+      "findings_exposed": 13,
+      "findings_fully_demoted": 11,
+      "fully_demoted_by_verdict": {
+        "intentional_divergence": 3,
+        "no_propagation_needed": 2,
+        "not_a_clone": 1,
+        "should_propagate": 5
+      },
+      "true_positives_demoted": 5
+    },
+    "disjoint-platform-guard": {
+      "exposed_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "false_positives_removed": 1,
+      "findings_exposed": 1,
+      "findings_fully_demoted": 1,
+      "fully_demoted_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "true_positives_demoted": 0
+    },
+    "effect-role-mismatch": {
+      "exposed_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "false_positives_removed": 1,
+      "findings_exposed": 1,
+      "findings_fully_demoted": 1,
+      "fully_demoted_by_verdict": {
+        "intentional_divergence": 1
+      },
+      "true_positives_demoted": 0
+    },
+    "protocol-role-mismatch": {
+      "exposed_by_verdict": {},
+      "false_positives_removed": 0,
+      "findings_exposed": 0,
+      "findings_fully_demoted": 0,
+      "fully_demoted_by_verdict": {},
+      "true_positives_demoted": 0
+    },
+    "referent-mismatch": {
+      "exposed_by_verdict": {
+        "intentional_divergence": 2,
+        "no_propagation_needed": 2,
+        "not_a_clone": 2,
+        "should_propagate": 14
+      },
+      "false_positives_removed": 6,
+      "findings_exposed": 20,
+      "findings_fully_demoted": 14,
+      "fully_demoted_by_verdict": {
+        "intentional_divergence": 2,
+        "no_propagation_needed": 2,
+        "not_a_clone": 2,
+        "should_propagate": 8
+      },
+      "true_positives_demoted": 8
+    }
+  },
+  "replay": {
+    "matched_findings": 179,
+    "query_error_rows": 0,
+    "unmatched_findings": 0
+  },
+  "schema_version": 1,
+  "simulations": [
+    {
+      "false_positives": 35,
+      "name": "current-v2-strict",
+      "precision": 0.5625,
+      "selected": 80,
+      "should_propagate": 45,
+      "should_propagate_retention": 1.0,
+      "verdicts": {
+        "intentional_divergence": 13,
+        "no_propagation_needed": 17,
+        "not_a_clone": 5,
+        "should_propagate": 45
+      }
+    },
+    {
+      "false_positives": 23,
+      "name": "exclude-all-strong-variant-targets",
+      "precision": 0.566038,
+      "selected": 53,
+      "should_propagate": 30,
+      "should_propagate_retention": 0.666667,
+      "verdicts": {
+        "intentional_divergence": 7,
+        "no_propagation_needed": 13,
+        "not_a_clone": 3,
+        "should_propagate": 30
+      }
+    }
+  ],
+  "target_caveats_by_verdict": {
+    "lossy-projection": {
+      "intentional_divergence": 15,
+      "no_propagation_needed": 29,
+      "not_a_clone": 5,
+      "should_propagate": 54
+    },
+    "projection-unavailable": {
+      "intentional_divergence": 3,
+      "no_propagation_needed": 7,
+      "should_propagate": 38
+    },
+    "truncated": {
+      "not_a_clone": 1
+    },
+    "unresolved-referent": {
+      "intentional_divergence": 10,
+      "no_propagation_needed": 7,
+      "not_a_clone": 4,
+      "should_propagate": 46
+    }
+  },
+  "target_signals_by_verdict": {
+    "async-role-mismatch": {
+      "intentional_divergence": 1
+    },
+    "decorator-mismatch": {
+      "intentional_divergence": 3,
+      "no_propagation_needed": 2,
+      "not_a_clone": 1,
+      "should_propagate": 7
+    },
+    "disjoint-platform-guard": {
+      "intentional_divergence": 1
+    },
+    "effect-role-mismatch": {
+      "intentional_divergence": 1
+    },
+    "name-mismatch": {
+      "intentional_divergence": 6,
+      "no_propagation_needed": 21,
+      "not_a_clone": 5,
+      "should_propagate": 42
+    },
+    "path-mismatch": {
+      "intentional_divergence": 11,
+      "no_propagation_needed": 31,
+      "not_a_clone": 2,
+      "should_propagate": 92
+    },
+    "referent-mismatch": {
+      "intentional_divergence": 2,
+      "no_propagation_needed": 6,
+      "not_a_clone": 2,
+      "should_propagate": 35
+    },
+    "version-label-mismatch": {
+      "not_a_clone": 1
+    }
+  },
+  "weak_signal_safety": {
+    "closed_weak_codes": [
+      "name-mismatch",
+      "path-mismatch",
+      "version-label-mismatch"
+    ],
+    "unexpected_disqualifying_weak_only_targets": 0,
+    "weak_only_targets": 91
+  }
+}

--- a/eval/divergence_fire/variant_evidence_eval.py
+++ b/eval/divergence_fire/variant_evidence_eval.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Development-only pricing for #851 target-local variant evidence.
+
+This harness consumes only the checked 2026-07-06 development sample/verdicts and
+scratch replay rows. It never reads the sealed blind packet or temporal reserve.
+"""
+
+import argparse
+from collections import Counter, defaultdict
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+import semantic_witness_eval as replay
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SAMPLES = ROOT / "eval/divergence_fire/sampled_findings_2026_07_06.jsonl"
+DEFAULT_VERDICTS = ROOT / "eval/divergence_fire/verdicts_2026_07_06.jsonl"
+DEFAULT_NOSE = ROOT / "target/release/nose"
+STRONG_CODES = (
+    "referent-mismatch",
+    "decorator-mismatch",
+    "async-role-mismatch",
+    "effect-role-mismatch",
+    "protocol-role-mismatch",
+    "disjoint-platform-guard",
+)
+WEAK_CODES = ("name-mismatch", "path-mismatch", "version-label-mismatch")
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def target_evidence(row):
+    targets = [
+        target for target in row.get("targets", [])
+        if isinstance(target, dict) and target.get("changed", {}).get("touches_shared") is True
+    ]
+    output = []
+    for target in targets:
+        evidence = target.get("variant_evidence", {})
+        signals = [signal for signal in evidence.get("signals", []) if isinstance(signal, dict)]
+        output.append({
+            "status": evidence.get("status", "missing"),
+            "strong_codes": sorted({
+                signal.get("code") for signal in signals
+                if signal.get("strength") == "strong"
+            } - {None}),
+            "weak_codes": sorted({
+                signal.get("code") for signal in signals
+                if signal.get("strength") == "weak"
+            } - {None}),
+            "caveats": sorted({
+                caveat.get("code") for caveat in evidence.get("caveats", [])
+                if isinstance(caveat, dict) and caveat.get("code")
+            }),
+        })
+    return output
+
+
+def counts(rows):
+    return dict(sorted(Counter(row["verdict"] for row in rows).items()))
+
+
+def policy_summary(name, baseline, retained):
+    positives = sum(row["verdict"] == "should_propagate" for row in retained)
+    baseline_positives = sum(row["verdict"] == "should_propagate" for row in baseline)
+    return {
+        "name": name,
+        "selected": len(retained),
+        "should_propagate": positives,
+        "false_positives": len(retained) - positives,
+        "precision": round(positives / len(retained), 6) if retained else None,
+        "should_propagate_retention": (
+            round(positives / baseline_positives, 6) if baseline_positives else None
+        ),
+        "verdicts": counts(retained),
+    }
+
+
+def signal_effect(rows, code):
+    exposed = [row for row in rows if any(code in target["strong_codes"] for target in row["evidence"])]
+    fully_demoted = [
+        row for row in rows
+        if row["evidence"] and all(code in target["strong_codes"] for target in row["evidence"])
+    ]
+    return {
+        "findings_exposed": len(exposed),
+        "exposed_by_verdict": counts(exposed),
+        "findings_fully_demoted": len(fully_demoted),
+        "false_positives_removed": sum(
+            row["verdict"] != "should_propagate" for row in fully_demoted
+        ),
+        "true_positives_demoted": sum(
+            row["verdict"] == "should_propagate" for row in fully_demoted
+        ),
+        "fully_demoted_by_verdict": counts(fully_demoted),
+    }
+
+
+def summarize(args):
+    samples = {row["sid"]: row for row in replay.jsonl(args.samples)}
+    verdicts = {row["sid"]: row for row in replay.jsonl(args.verdicts)}
+    records = {row.get("sid"): row for row in replay.jsonl(args.records) if row.get("sid")}
+    joined = []
+    for sid, sample in samples.items():
+        record = records.get(sid, {})
+        joined.append({
+            "sid": sid,
+            "verdict": verdicts[sid]["verdict"],
+            "baseline_strict": replay.current_v2_strict(sample),
+            "matched": record.get("matched") is True,
+            "evidence": target_evidence(record),
+        })
+
+    strict = [row for row in joined if row["baseline_strict"]]
+    demoted = [
+        row for row in strict
+        if row["evidence"] and all(target["status"] == "disqualifying" for target in row["evidence"])
+    ]
+    retained = [row for row in strict if row not in demoted]
+    target_signals = defaultdict(Counter)
+    target_caveats = defaultdict(Counter)
+    for row in strict:
+        for target in row["evidence"]:
+            for code in target["strong_codes"] + target["weak_codes"]:
+                target_signals[code][row["verdict"]] += 1
+            for code in target["caveats"]:
+                target_caveats[code][row["verdict"]] += 1
+
+    weak_only = [
+        target
+        for row in strict
+        for target in row["evidence"]
+        if target["weak_codes"] and not target["strong_codes"]
+    ]
+    intentional = [row for row in strict if row["verdict"] == "intentional_divergence"]
+    intentional_demoted = [row for row in demoted if row["verdict"] == "intentional_divergence"]
+    binary_version = subprocess.run(
+        [str(args.nose), "--version"], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    artifact = {
+        "schema_version": 1,
+        "issue": 851,
+        "development_only": True,
+        "blind_or_temporal_data_accessed": False,
+        "inputs": {
+            "samples": str(args.samples.relative_to(ROOT)),
+            "samples_sha256": sha256(args.samples),
+            "verdicts": str(args.verdicts.relative_to(ROOT)),
+            "verdicts_sha256": sha256(args.verdicts),
+            "labeled_findings": len(samples),
+            "replay_records": str(args.records),
+        },
+        "implementation": {
+            "source_commit": subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, text=True, check=True
+            ).stdout.strip(),
+            "nose_binary": str(args.nose),
+            "nose_binary_sha256": sha256(args.nose),
+            "nose_version": binary_version,
+            "summary_harness": str(Path(__file__).relative_to(ROOT)),
+            "summary_harness_sha256": sha256(Path(__file__)),
+            "replay_harness": "eval/divergence_fire/semantic_witness_eval.py",
+            "replay_harness_sha256": sha256(ROOT / "eval/divergence_fire/semantic_witness_eval.py"),
+        },
+        "replay": {
+            "matched_findings": sum(row["matched"] for row in joined),
+            "unmatched_findings": sum(not row["matched"] for row in joined),
+            "query_error_rows": sum(not row.get("ok", False) for row in replay.jsonl(args.records)),
+        },
+        "baseline_v2_strict": {
+            "findings": len(strict),
+            "verdicts": counts(strict),
+            "direct_shared_targets": sum(len(row["evidence"]) for row in strict),
+        },
+        "all_strong_signal_effect": {
+            "fully_demoted_findings": len(demoted),
+            "fully_demoted_by_verdict": counts(demoted),
+            "false_positives_removed": sum(row["verdict"] != "should_propagate" for row in demoted),
+            "true_positives_demoted": sum(row["verdict"] == "should_propagate" for row in demoted),
+        },
+        "intentional_divergence_focus": {
+            "baseline_false_positives": len(intentional),
+            "fully_demoted": len(intentional_demoted),
+            "retained": len(intentional) - len(intentional_demoted),
+        },
+        "per_strong_signal_effect": {
+            code: signal_effect(strict, code) for code in STRONG_CODES
+        },
+        "target_signals_by_verdict": {
+            code: dict(sorted(counter.items())) for code, counter in sorted(target_signals.items())
+        },
+        "target_caveats_by_verdict": {
+            code: dict(sorted(counter.items())) for code, counter in sorted(target_caveats.items())
+        },
+        "weak_signal_safety": {
+            "weak_only_targets": len(weak_only),
+            "unexpected_disqualifying_weak_only_targets": sum(
+                target["status"] == "disqualifying" for target in weak_only
+            ),
+            "closed_weak_codes": list(WEAK_CODES),
+        },
+        "simulations": [
+            policy_summary("current-v2-strict", strict, strict),
+            policy_summary("exclude-all-strong-variant-targets", strict, retained),
+        ],
+        "interpretation": (
+            "Development evidence only. #851 records deterministic target-local variant evidence "
+            "and leaves v2 gate.fail_default unchanged; #852 may consume only the closed strong "
+            "codes in a separately frozen policy."
+        ),
+    }
+    args.out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+
+def selftest(_args):
+    row = {
+        "targets": [{
+            "changed": {"touches_shared": True},
+            "variant_evidence": {
+                "status": "disqualifying",
+                "signals": [
+                    {"code": "referent-mismatch", "strength": "strong"},
+                    {"code": "path-mismatch", "strength": "weak"},
+                ],
+                "caveats": [{"code": "unresolved-referent"}],
+            },
+        }]
+    }
+    evidence = target_evidence(row)
+    assert evidence[0]["strong_codes"] == ["referent-mismatch"]
+    assert evidence[0]["weak_codes"] == ["path-mismatch"]
+    assert evidence[0]["caveats"] == ["unresolved-referent"]
+    print("variant_evidence_eval selftest: ok")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    summary = sub.add_parser("summarize")
+    summary.add_argument("--samples", type=Path, default=DEFAULT_SAMPLES)
+    summary.add_argument("--verdicts", type=Path, default=DEFAULT_VERDICTS)
+    summary.add_argument("--records", type=Path, required=True)
+    summary.add_argument("--nose", type=Path, default=DEFAULT_NOSE)
+    summary.add_argument("--out", type=Path, required=True)
+    summary.set_defaults(func=summarize)
+    test = sub.add_parser("selftest")
+    test.set_defaults(func=selftest)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #851

## What changed
- attach deterministic pair-local variant evidence to every direct propagation target
- keep strong disqualifiers, weak hints, and fail-closed caveats as closed machine-readable codes
- compare the current changed result with the skipped base endpoint while keeping target identity base-edge anchored
- expose one evidence object through human, JSON, and SARIF output without changing the v2 gate
- add fixtures, an evaluation harness, checked development pricing, docs, and an official-v0.19.0 performance receipt

## Development result
- replay: 179/179 labeled findings, 0 query errors
- all strong signals would demote 12 false positives and 15 true positives; standalone precision is 0.566, so this evidence is not sufficient as a v3 policy by itself
- weak-only evidence never disqualifies
- control-adjusted aggregate runtime: +8.04% vs official v0.19.0, above the epic's 5% budget; #852 must account for or remove this cumulative debt before freezing a candidate

## Verification
- cargo test --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- scripts/check-docs.sh
- python3 eval/divergence_fire/variant_evidence_eval.py selftest
- python3 scripts/check-file-lengths.py --ratchet-base main
- cargo fmt --all -- --check
- git diff --check
