### PR TITLE
refactor(divergence): freeze v3 qualification outcome

### DIFF
--- a/crates/nose-cli/src/divergence.rs
+++ b/crates/nose-cli/src/divergence.rs
@@ -32,6 +32,7 @@ pub(crate) use detect::{detect_divergences, divergences_fire};
 pub(crate) use output::divergence_items_json;
 
 pub(crate) const DIVERGENT_EDIT_V2_POLICY: &str = "divergent-edit-v2-strict";
+const ACTIVE_DIVERGENT_EDIT_POLICY: &str = DIVERGENT_EDIT_V2_POLICY;
 #[cfg(test)]
 pub(crate) const DIVERGENCE_LANE_VALUES: &[&str] = &["base-divergence", "new-copy"];
 #[cfg(test)]
@@ -127,8 +128,8 @@ pub(crate) struct PropagationTarget {
     pub(crate) skipped: Site,
     pub(crate) direct_witness: DirectPairWitness,
     /// Pair-local evidence that the two sites deliberately occupy different roles.
-    /// #851 only records this evidence; the frozen v3 policy in #852 decides whether
-    /// it is disqualifying for the strict tier.
+    /// #851 records this evidence. #852 found no non-degenerate v3 policy that
+    /// qualified to consume it, so the active v2 tier remains unchanged.
     pub(crate) variant_evidence: variant::VariantEvidence,
 }
 
@@ -167,22 +168,33 @@ impl DivergenceLane {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum DivergenceTier {
     Strict,
     Review,
     ReportOnly,
 }
 
-impl DivergenceTier {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Strict => "strict",
-            Self::Review => "review",
-            Self::ReportOnly => "report-only",
-        }
-    }
+/// The one active policy decision consumed by human, JSON, SARIF, and exit-status
+/// surfaces. Keeping the gate fields together prevents a renderer from silently
+/// re-deriving a different hard-block decision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+pub(crate) struct DivergenceGateDecision {
+    pub(crate) eligible: bool,
+    pub(crate) fail_default: bool,
+    pub(crate) policy: &'static str,
+}
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DivergencePolicyDecision {
+    pub(crate) tier: DivergenceTier,
+    pub(crate) tier_reasons: Vec<&'static str>,
+    pub(crate) taxonomy_hint: &'static str,
+    pub(crate) gate: DivergenceGateDecision,
+}
+
+impl DivergenceTier {
     pub(crate) fn sarif_rule_id(self) -> &'static str {
         match self {
             Self::Strict => "nose.divergent.strict",
@@ -213,22 +225,15 @@ impl DivergenceTier {
 }
 
 impl Divergence {
-    pub(crate) fn tier(&self) -> DivergenceTier {
-        if self.lane == DivergenceLane::NewCopy || self.scope != "prod" {
+    pub(crate) fn policy_decision(&self) -> DivergencePolicyDecision {
+        let tier = if self.lane == DivergenceLane::NewCopy || self.scope != "prod" {
             DivergenceTier::ReportOnly
         } else if self.fire_eligible {
             DivergenceTier::Strict
         } else {
             DivergenceTier::Review
-        }
-    }
-
-    pub(crate) fn gate_fail_default(&self) -> bool {
-        self.tier() == DivergenceTier::Strict
-    }
-
-    pub(crate) fn taxonomy_hint(&self) -> &'static str {
-        if self.lane == DivergenceLane::NewCopy {
+        };
+        let taxonomy_hint = if self.lane == DivergenceLane::NewCopy {
             "unclear"
         } else if self.scope != "prod" {
             "test_scaffolding"
@@ -238,10 +243,7 @@ impl Divergence {
             "no_propagation_needed"
         } else {
             "unclear"
-        }
-    }
-
-    pub(crate) fn tier_reasons(&self) -> Vec<&'static str> {
+        };
         let mut reasons = Vec::with_capacity(3);
         if self.lane == DivergenceLane::NewCopy {
             reasons.push("new_copy_no_base_member");
@@ -260,7 +262,35 @@ impl Divergence {
             reasons.push("test_scope");
             reasons.push("test_scaffolding");
         }
-        reasons
+        DivergencePolicyDecision {
+            tier,
+            tier_reasons: reasons,
+            taxonomy_hint,
+            gate: DivergenceGateDecision {
+                eligible: tier.gate_eligible(),
+                fail_default: tier == DivergenceTier::Strict,
+                policy: ACTIVE_DIVERGENT_EDIT_POLICY,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tier(&self) -> DivergenceTier {
+        self.policy_decision().tier
+    }
+
+    pub(crate) fn gate_fail_default(&self) -> bool {
+        self.policy_decision().gate.fail_default
+    }
+
+    #[cfg(test)]
+    pub(crate) fn taxonomy_hint(&self) -> &'static str {
+        self.policy_decision().taxonomy_hint
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tier_reasons(&self) -> Vec<&'static str> {
+        self.policy_decision().tier_reasons
     }
 }
 

--- a/crates/nose-cli/src/divergence/output.rs
+++ b/crates/nose-cli/src/divergence/output.rs
@@ -74,7 +74,7 @@ pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::V
     flagged
         .iter()
         .map(|d| {
-            let tier = d.tier();
+            let decision = d.policy_decision();
             let mut item = json!({
                 "family_id": d.family_id,
                 "lane": d.lane.as_str(),
@@ -84,14 +84,10 @@ pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::V
                 "scope": d.scope,
                 "witness_kind": d.witness_kind,
                 "fire_eligible": d.fire_eligible,
-                "tier": tier.as_str(),
-                "tier_reasons": d.tier_reasons(),
-                "taxonomy_hint": d.taxonomy_hint(),
-                "gate": {
-                    "eligible": tier.gate_eligible(),
-                    "fail_default": d.gate_fail_default(),
-                    "policy": DIVERGENT_EDIT_V2_POLICY,
-                },
+                "tier": decision.tier,
+                "tier_reasons": decision.tier_reasons,
+                "taxonomy_hint": decision.taxonomy_hint,
+                "gate": decision.gate,
                 "suppression": null,
                 "graded": d.graded,
                 "targets": d.targets.iter().map(target_json).collect::<Vec<_>>(),
@@ -158,7 +154,8 @@ fn tier_label(tier: DivergenceTier) -> &'static str {
 
 fn divergence_sarif_result(d: &Divergence) -> serde_json::Value {
     use serde_json::json;
-    let tier = d.tier();
+    let decision = d.policy_decision();
+    let tier = decision.tier;
     let changed = d
         .changed
         .iter()
@@ -226,15 +223,11 @@ fn divergence_sarif_result(d: &Divergence) -> serde_json::Value {
             "family_id": d.family_id,
             "base_family_id": d.lane.base_family_id(&d.family_id),
             "lane": d.lane.as_str(),
-            "tier": tier.as_str(),
-            "tier_reasons": d.tier_reasons(),
-            "taxonomy_hint": d.taxonomy_hint(),
-            "gate": {
-                "eligible": tier.gate_eligible(),
-                "fail_default": d.gate_fail_default(),
-                "policy": DIVERGENT_EDIT_V2_POLICY,
-            },
-            "policy": DIVERGENT_EDIT_V2_POLICY,
+            "tier": decision.tier,
+            "tier_reasons": decision.tier_reasons,
+            "taxonomy_hint": decision.taxonomy_hint,
+            "gate": decision.gate,
+            "policy": decision.gate.policy,
             "fire_eligible": d.fire_eligible,
             "targets": d.targets.iter().map(target_json).collect::<Vec<_>>(),
             "semantic_change": d.changed.iter()

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -468,3 +468,20 @@ fn v8_json_and_sarif_share_policy_fields() {
         );
     }
 }
+
+#[test]
+fn active_policy_decision_is_the_single_gate_authority() {
+    for divergence in [
+        tier_divergence("prod", true, Some(true)),
+        tier_divergence("prod", false, Some(false)),
+        tier_divergence("mixed", true, Some(true)),
+    ] {
+        let decision = divergence.policy_decision();
+        assert_eq!(divergence.tier(), decision.tier);
+        assert_eq!(divergence.tier_reasons(), decision.tier_reasons);
+        assert_eq!(divergence.taxonomy_hint(), decision.taxonomy_hint);
+        assert_eq!(divergence.gate_fail_default(), decision.gate.fail_default);
+        assert_eq!(decision.gate.eligible, decision.tier.gate_eligible());
+        assert_eq!(decision.gate.policy, DIVERGENT_EDIT_V2_POLICY);
+    }
+}

--- a/crates/nose-cli/src/divergence/variant.rs
+++ b/crates/nose-cli/src/divergence/variant.rs
@@ -1,9 +1,9 @@
 //! Deterministic, pair-local evidence for intentional clone variants.
 //!
 //! This module does not decide the active divergent-edit tier. It records strong
-//! disqualifiers, weak review hints, and uncertainty separately so #852 can price a
-//! frozen policy without turning names, paths, or repository-specific prose into gate
-//! authority.
+//! disqualifiers, weak review hints, and uncertainty separately. #852 priced the
+//! admissible policy class and found no non-degenerate v3 candidate; names, paths,
+//! and repository-specific prose therefore remain outside gate authority.
 
 mod source;
 

--- a/crates/nose-cli/src/query_views.rs
+++ b/crates/nose-cli/src/query_views.rs
@@ -127,7 +127,8 @@ pub(super) fn render_query_base(
         format!("{}:{}-{}{name}", s.file, s.start_line, s.end_line)
     };
     for d in flagged.iter().take(limit) {
-        let propagation = match (d.tier(), d.lane, d.taxonomy_hint()) {
+        let decision = d.policy_decision();
+        let propagation = match (decision.tier, d.lane, decision.taxonomy_hint) {
             (divergence::DivergenceTier::Strict, _, _) => "strict (likely missed propagation)",
             (divergence::DivergenceTier::Review, _, "no_propagation_needed") => {
                 "review (shared logic not touched)"

--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -112,8 +112,9 @@ Each target has a stable `target_id`, base-tree `changed` and `skipped` sites, a
 change are recomputed for that exact pair. The ID is derived from repo-relative base coordinates
 and unit metadata, so changing the temporary worktree path or moving/renaming the current-tree
 file does not change the base target. JSON and SARIF expose the same ID; SARIF also attaches it
-to the skipped primary location and changed related location. The v2 family gate remains the
-authority until the measured v3 policy in #852 consumes target evidence.
+to the skipped primary location and changed related location. The #852 development
+qualification found no non-degenerate v3 candidate, so the v2 family gate remains the active
+authority and target evidence remains inspectable review context.
 
 Each target also carries `variant_evidence`. Its closed `status` is `none`, `advisory`, or
 `disqualifying`; the last value means that at least one strong, pair-local signal was observed.
@@ -125,8 +126,8 @@ provably disjoint platform constraints. Every signal names its exact changed/ski
 Name, path, and version-label differences are emitted only with `strength="weak"`; they cannot
 become hard-block authority alone. Projection/source loss, unresolved referents, truncation, and
 overlapping or incomparable platform constraints remain explicit advisory `caveats[]`. #851
-records these facts but deliberately leaves the v2 tier and `gate.fail_default` unchanged; #852
-is the first issue allowed to consume them in a frozen policy.
+records these facts but deliberately leaves the v2 tier and `gate.fail_default` unchanged. #852
+priced the admissible target-local policy class and did not qualify a v3 consumer.
 
 The graded witness is **evidence for the consumer, not a fire gate**: a clean
 `equal_modulo_holes` family is a strong missed-propagation candidate, while a
@@ -137,6 +138,26 @@ difference does not stop a shared-*body* fix from being a genuine missed propaga
 so suppressing on it would risk the keep-every-propagation property the shared-logic policy
 is measured against. The shared-logic proof stays separate from graded-witness
 presentation evidence; the v2 tier decides whether that proof is default-failing.
+
+## V3 development qualification outcome
+
+#852 froze a monotone precision-first policy class: a hard-block target must have a direct
+changed→skipped edge, pair-local shared contact, a caveat-free `complete` semantic witness for a
+mapped replacement or deletion, and no strong variant or uncertainty caveat. Closed variant
+signals may only demote; missing evidence cannot promote.
+
+On the 80-finding public development slice, 168 direct targets were emitted but zero had a
+`complete` semantic witness. Because every admissible policy requires that witness, every
+policy in the class has zero support before any variant-code choice is made. A diagnostic that
+relaxed the fail-closed caveat requirements selected 13 findings at only 0.538 finding
+precision. Development labels also adjudicate findings rather than the newly introduced direct
+targets, so they cannot establish target precision.
+
+The checked result is therefore `no-policy-qualifies`: no v3 binary or threshold was frozen for
+blind replay, the sealed blind labels remain unopened, schema v8 and capability flags were not
+bumped, and `divergent-edit-v2-strict` remains the active opt-in policy. Human, JSON, SARIF, and
+exit status now consume one internal policy-decision object, with `items[].gate.fail_default`
+remaining the sole machine authority. See the [development result](../eval/divergence_fire/RESULTS.md#v3-policy-development-qualification-2026-07-18-852).
 
 ## Bounded semantic-change evidence
 
@@ -157,8 +178,9 @@ mixed changes, and cap exhaustion remain explicit advisory or unavailable eviden
 
 This is deliberately not a v2 decision input. `tier()` and `gate.fail_default` continue to
 use the frozen v2 policy above; even a complete semantic-change witness cannot promote a
-finding in this implementation. The evidence exists so the development corpus can price a
-future policy before that policy is frozen and evaluated blind.
+finding in this implementation. The evidence remains review context; a future policy cycle
+would need a fresh target-adjudicated development set before it could be frozen and evaluated
+blind.
 
 ## V2 gate tiers (design contract)
 
@@ -206,7 +228,7 @@ The tier decision is deterministic. Apply these rules in order:
    only `scope="prod"` can be `strict`.
 3. An unsuppressed finding with `fire_eligible=true` and
    `taxonomy_hint="missed_propagation"` in `scope="prod"` routes to `strict`. This v2
-   compatibility decision remains family-level; #852 freezes the target-local v3 policy.
+   compatibility decision remains family-level; #852 did not qualify a target-local v3 policy.
 4. Every other unsuppressed base-tree divergent-edit candidate routes to `review`.
 
 Newly added copy evidence is a separate report-only lane, not a base-tree

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -101,9 +101,10 @@ sites and otherwise carries the bounded base-to-current evidence described below
 `divergences` is the total before `top=N` truncation; `shown_divergences` is `items.length`;
 `limit` is the numeric row limit or `null` for `top=0`. `fire_eligible` is the legacy v1
 conservative gate verdict. In the current implementation it means the diff provably touches
-shared logic in the family and the family is not all-test scaffolding. Direct target evidence
-does not alter this compatibility verdict until #852 freezes v3. `strict` counts the v2 default-failing
-items, but it is only a summary count; CI decisions should read each emitted item's
+shared logic in the family and the family is not all-test scaffolding. The #852 development
+qualification found no non-degenerate v3 candidate, so direct target evidence does not alter
+this compatibility verdict. `strict` counts the v2 default-failing items, but it is only a
+summary count; CI decisions should read each emitted item's
 `gate.fail_default`, ideally from a `top=0` run.
 
 The v8 base-view additions for divergent-edit v2 are intentionally schema-breaking
@@ -122,7 +123,8 @@ caps, and explicit `caveats[]` make partial evidence inspectable. Pure source in
 mixed changes, lossy/unsupported lowering, missing or ambiguous units, heuristic alignment,
 unresolved referents, and capped mappings cannot be `complete`. This field does not alter
 `fire_eligible`, `tier`, or `gate.fail_default`; #849 emits and measures the evidence before
-a later frozen policy may consume it.
+policy qualification. #852 found no admissible non-degenerate v3 consumer, so it remains
+review evidence under schema v8.
 
 `targets[]` is an evidence-only v8 extension for target-level policy development. A target is
 `{target_id, changed, skipped, direct_witness, variant_evidence}`. `target_id` is the 16-hex-digit FNV identity of
@@ -145,7 +147,7 @@ and `version-label-mismatch` are always `strength="weak"`. Caveat codes are
 `lossy-projection`, `unresolved-referent`, `truncated`, and
 `conflicting-platform-guard`. Missing or contradictory evidence is advisory, and weak signals
 cannot disqualify a target. This field does not change the v2 `tier` or `gate.fail_default`;
-#852 may consume it only through the frozen v3 policy.
+#852 did not qualify or activate a v3 policy that consumes it.
 The evidence compares the current changed result to the skipped base-tree endpoint; the stable
 `target_id` and `direct_witness` remain anchored to the accepted base-tree edge.
 
@@ -154,8 +156,8 @@ keeps one result per family: `properties.targets` mirrors JSON's `targets`, and 
 target-backed primary/related location carries the same `target_id` in its `properties`. A base
 finding with no retained direct target remains review context and falls back to family
 locations; consumers must not reconstruct targets from those fallback locations. This
-extension does not make target evidence a v2 gate input by itself; #852 freezes the policy that
-may consume it.
+extension does not make target evidence a v2 gate input by itself. #852 left the v2 contract
+active after the admissible v3 class had zero development support.
 
 The v8 `base.items[]` object adds:
 

--- a/eval/divergence_fire/RESULTS.md
+++ b/eval/divergence_fire/RESULTS.md
@@ -326,8 +326,8 @@ The last row is promising development evidence—it removes all five `not_a_clon
 rows and four of the 17 strict `no_propagation_needed` rows without losing a labeled
 positive—but it is frequently advisory because of lossy lowering or unresolved
 referents. #849 therefore records it without promoting it into policy. No complete
-predicate selected a real development finding, so treating absence of caveats as a
-new strict requirement would erase all strict recall rather than prove a better gate.
+predicate selected a real development finding; #852 later confirmed that requiring
+the protocol's caveat-free evidence leaves the admissible policy class with zero support.
 
 The official-v0.19.0 runtime receipt is
 [`issue-849-official-v0.19.0-performance-2026-07-18.v1.json`](../../bench/recall_loss/issue-849-official-v0.19.0-performance-2026-07-18.v1.json).
@@ -363,8 +363,8 @@ All 179 labeled findings replayed without an error. The frozen v2 strict slice s
 contains 80 findings, now exposing 168 direct targets and retaining 26
 transitive-only locations as review context rather than action endpoints. Requiring a
 direct target demotes none of the five `not_a_clone` rows, so #850 improves target
-identity and evidence locality but does not claim a precision gain. Policy tuning
-remains reserved for #852.
+identity and evidence locality but does not claim a precision gain. #852 later found
+no target-local policy with non-degenerate development support.
 
 The official-v0.19.0 runtime receipt is
 [`issue-850-official-v0.19.0-performance-2026-07-18.v1.json`](../../bench/recall_loss/issue-850-official-v0.19.0-performance-2026-07-18.v1.json).
@@ -377,9 +377,9 @@ The 64.13% nearest-rank repository p90 triggered the required investigation.
 Profiling found and removed repeated group-by-pair distribution and cloned location
 ownership; prepared semantic changes and sibling hashes are now cached and target
 count is capped. The remaining total exceeds #847's 5% budget because the
-compatibility path retains both #849 family evidence and #850 target evidence. #852
-must collapse that duplication during the v3 target-policy transition and remeasure
-against the same official binary before the epic can close.
+compatibility path retains both #849 family evidence and #850 target evidence. #852 did
+not qualify a v3 target-policy transition, so #854 must remove the cumulative cost or
+record that the epic's runtime gate fails in the closeout verdict.
 
 Reproduce the development artifacts after building the release binary:
 
@@ -410,8 +410,8 @@ excluding every target carrying any strong variant signal would fully demote 27
 findings: 12 false positives and 15 `should_propagate` positives. It identifies six of
 the 13 `intentional_divergence` false positives but is not a standalone precision
 policy: selected precision moves only 56.25% → 56.60%, while TP retention falls to
-66.67%. #852 must therefore combine these facts with semantic/direct-target
-requirements instead of treating every strong variant code as a sufficient policy.
+66.67%. #852 combined these facts with semantic/direct-target requirements and found
+that the protocol-admissible class has zero non-degenerate development support.
 
 | strong signal | fully demoted FP | fully demoted TP |
 |---|---:|---:|
@@ -434,8 +434,8 @@ and 836.51 ms / 8.04% after the same-binary control. Removing `semantic_change` 
 `targets` keeps every legacy output equal. The nearest-rank repository p90 is 44.47%
 (axios 52.56%, regex 44.47%); target role analysis is bounded and reuses file, unit,
 projection, and source caches, but the cumulative family-plus-target compatibility
-path remains above #847's 5% budget. #852 must remove that duplicate path and
-remeasure against the official release.
+path remains above #847's 5% budget. Because #852 did not qualify a v3 policy, #854
+must remove the cumulative cost or record the failed runtime gate in the closeout verdict.
 
 Reproduce the development aggregate after building the release binary:
 
@@ -446,6 +446,41 @@ python3 eval/divergence_fire/semantic_witness_eval.py replay \
 python3 eval/divergence_fire/variant_evidence_eval.py summarize \
   --records /tmp/issue-851-dev-replay.jsonl --nose target/release/nose \
   --out eval/divergence_fire/variant_evidence_dev_2026_07_18.v1.json
+```
+
+## V3 policy development qualification (2026-07-18, #852)
+
+#852 combines #849 semantic witnesses, #850 direct targets, and #851 variant evidence under
+the sealed #848 objective without opening blind or temporal data. The checked
+[`v3_policy_dev_2026_07_18.v1.json`](v3_policy_dev_2026_07_18.v1.json) freezes the admissible
+policy class, its hash, the protocol and public-development input hashes, the source commit,
+and the release binary hash.
+
+The admissible class is monotone and fail-closed. A strict target requires a detector-accepted
+direct edge, pair-local shared contact, a caveat-free complete semantic witness for a mapped
+replacement or deletion, and no strong variant or uncertainty caveat. Variant codes may only
+demote. Of 168 direct targets on the 80-finding v2 strict slice, zero have a complete semantic
+witness. Therefore every policy in the admissible class has zero strict findings and targets,
+regardless of which closed variant demotions are selected.
+
+The only relaxed diagnostic—allowing known incomplete/lossy evidence and variant caveats—selects
+13 findings and 22 targets, with seven positive findings and six false positives (finding
+precision 0.538). It is not an admissible policy. The development verdicts are finding-level,
+not direct-target adjudications, so target precision is also unavailable rather than inferred.
+
+The frozen qualification status is **`no-policy-qualifies`**. No v3 candidate, binary, or
+threshold is released to blind replay; the blind and temporal labels remain sealed. Schema v8,
+capability flags, and the active `divergent-edit-v2-strict` output stay unchanged. Human, JSON,
+SARIF, and exit status now consume one internal policy-decision object, preventing any renderer
+from re-deriving a different `gate.fail_default` value.
+
+Reproduce the source-free aggregate after building the recorded release source commit:
+
+```sh
+python3 eval/divergence_fire/v3_policy_eval.py selftest
+python3 eval/divergence_fire/v3_policy_eval.py summarize \
+  --records /tmp/issue-852-dev-replay.jsonl --nose target/release/nose \
+  --out eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json
 ```
 
 ## Fire rate (change level; 347 replayed changes per arm)

--- a/eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json
+++ b/eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json
@@ -1,0 +1,100 @@
+{
+  "blind_or_temporal_data_accessed": false,
+  "development_only": true,
+  "evidence_ceiling": {
+    "complete_semantic_witness_targets": 0,
+    "direct_targets": 168,
+    "proof": "Every admissible target requires a complete semantic witness. The development replay has none, so every monotone policy in the frozen class has zero support.",
+    "protocol_admissible_targets": 0
+  },
+  "frozen_policy_class": {
+    "allowed_tuning": "closed strong variant codes may only demote",
+    "finding_fails_when": "at least one target has disposition strict",
+    "gate_authority": "items[].gate.fail_default",
+    "policy_class": "divergent-edit-v3-monotone-precision-first",
+    "target_requires_all": [
+      "direct_target",
+      "shared_contact",
+      "complete_semantic_witness",
+      "qualified_change_kind",
+      "qualified_alignment",
+      "mapped_shared_node",
+      "semantic_facets",
+      "semantic_projections_ok",
+      "no_semantic_caveat",
+      "no_strong_variant",
+      "no_variant_caveat"
+    ],
+    "unknown_or_caveated": "review",
+    "weak_variant_signals": "advisory-only"
+  },
+  "frozen_policy_class_sha256": "3b02b1151b0dcdce11d4384910573ca4aa900fb0c1edfbed4f7e8e1c3e7ce3a5",
+  "implementation": {
+    "harness": "eval/divergence_fire/v3_policy_eval.py",
+    "harness_sha256": "b2d759ab6682a678ca76029d1faf85ca731ad7715fa0897206fa70e59f8a86f0",
+    "nose_binary": "target/release/nose",
+    "nose_binary_sha256": "039c4b4619915226a1f51d69092182649396afa2bd62e606b624723c4ee3eede",
+    "nose_version": "nose 0.19.0",
+    "source_commit": "6739c449a7f222fb90a438580dd1fa43970b15fe"
+  },
+  "inputs": {
+    "labeled_findings": 179,
+    "precision_protocol": "eval/divergence_fire/precision_protocol_2026_07_14.v2.json",
+    "precision_protocol_sha256": "a6b90708edc4527eae6b30ef119153f078884f85f3ac650502da5b5e96318185",
+    "replay_records": "/tmp/nose-851-variant-replay-final.jsonl",
+    "replay_records_sha256": "4ce9f795b41b0e22d1f770935c0113a8ed9b340e99d169f8bd76e8405edf1dd1",
+    "samples": "eval/divergence_fire/sampled_findings_2026_07_06.jsonl",
+    "samples_sha256": "05be2f55e0ef4aa810fffd741cd7c39b840a92ed2b7cc055164496a74108c288",
+    "v2_strict_findings": 80,
+    "verdicts": "eval/divergence_fire/verdicts_2026_07_06.jsonl",
+    "verdicts_sha256": "c5ab11a2c1d0cae2d52fc15b4868e43e9e7ddd8e9e25e593dc828ce1d94828fc"
+  },
+  "issue": 852,
+  "qualification": {
+    "active_runtime_policy": "divergent-edit-v2-strict",
+    "candidate_frozen_for_blind_replay": false,
+    "reason": "The protocol-admissible class has zero development support; target precision also cannot be estimated from finding-level development labels. Activating or versioning a v3 hard-block contract would overstate the evidence.",
+    "schema_or_capability_bump": false,
+    "status": "no-policy-qualifies"
+  },
+  "qualification_thresholds": {
+    "non_degenerate_strict_findings_min": 1,
+    "non_degenerate_strict_targets_min": 1,
+    "strict_finding_precision_min": 0.95,
+    "strict_target_precision_min": 0.95
+  },
+  "replay": {
+    "matched_findings": 179,
+    "query_error_rows": 0,
+    "unmatched_findings": 0
+  },
+  "schema_version": 1,
+  "simulations": [
+    {
+      "false_positive_findings": 0,
+      "finding_precision": null,
+      "name": "protocol-admissible-v3",
+      "should_propagate_findings": 0,
+      "strict_findings": 0,
+      "strict_targets": 0,
+      "target_precision": null,
+      "target_precision_reason": "development labels adjudicate findings, not direct targets",
+      "verdicts": {}
+    },
+    {
+      "false_positive_findings": 6,
+      "finding_precision": 0.538462,
+      "name": "diagnostic-only-allow-incomplete-semantic-and-variant-caveats",
+      "should_propagate_findings": 7,
+      "strict_findings": 13,
+      "strict_targets": 22,
+      "target_precision": null,
+      "target_precision_reason": "development labels adjudicate findings, not direct targets",
+      "verdicts": {
+        "intentional_divergence": 3,
+        "no_propagation_needed": 3,
+        "should_propagate": 7
+      }
+    }
+  ]
+}

--- a/eval/divergence_fire/v3_policy_eval.py
+++ b/eval/divergence_fire/v3_policy_eval.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Development-only qualification for the #852 divergent-edit v3 policy.
+
+The admissible policy class is monotone: every hard-block target must satisfy all
+protocol-required positive evidence, and closed variant signals may only demote it.
+The harness reads the public development sample and verdicts plus a scratch replay;
+it never opens the sealed blind packet or temporal reserve.
+"""
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+import semantic_witness_eval as replay
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SAMPLES = ROOT / "eval/divergence_fire/sampled_findings_2026_07_06.jsonl"
+DEFAULT_VERDICTS = ROOT / "eval/divergence_fire/verdicts_2026_07_06.jsonl"
+DEFAULT_PROTOCOL = ROOT / "eval/divergence_fire/precision_protocol_2026_07_14.v2.json"
+DEFAULT_NOSE = ROOT / "target/release/nose"
+QUALIFIED_CHANGE_KINDS = ("replacement", "deletion")
+QUALIFIED_ALIGNMENTS = ("exact-span", "stable-name", "changed-range")
+TARGET_PREDICATE_NAMES = (
+    "direct_target",
+    "shared_contact",
+    "complete_semantic_witness",
+    "qualified_change_kind",
+    "qualified_alignment",
+    "mapped_shared_node",
+    "semantic_facets",
+    "semantic_projections_ok",
+    "no_semantic_caveat",
+    "no_strong_variant",
+    "no_variant_caveat",
+)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_sha256(value):
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def target_predicates(target):
+    semantic = target.get("changed", {}).get("semantic_change") or {}
+    variant = target.get("variant_evidence") or {}
+    coverage = semantic.get("coverage") or {}
+    direct = target.get("direct_witness") or {}
+    return {
+        "direct_target": bool(target.get("target_id") and direct.get("kind")),
+        "shared_contact": target.get("changed", {}).get("touches_shared") is True,
+        "complete_semantic_witness": semantic.get("status") == "complete",
+        "qualified_change_kind": semantic.get("change_kind") in QUALIFIED_CHANGE_KINDS,
+        "qualified_alignment": semantic.get("alignment") in QUALIFIED_ALIGNMENTS,
+        "mapped_shared_node": coverage.get("mapped_shared_nodes", 0) > 0,
+        "semantic_facets": bool(semantic.get("facets")),
+        "semantic_projections_ok": (
+            semantic.get("base_projection") == "ok"
+            and semantic.get("current_projection") == "ok"
+        ),
+        "no_semantic_caveat": not semantic.get("caveats"),
+        "no_strong_variant": variant.get("status") != "disqualifying",
+        "no_variant_caveat": not variant.get("caveats"),
+    }
+
+
+def strict_target(target):
+    return all(target_predicates(target).values())
+
+
+def relaxed_diagnostic_target(target):
+    """Non-policy diagnostic: prices mapped evidence while allowing known caveats."""
+    predicates = target_predicates(target)
+    return all(
+        predicates[name]
+        for name in (
+            "direct_target",
+            "shared_contact",
+            "qualified_change_kind",
+            "qualified_alignment",
+            "mapped_shared_node",
+            "semantic_facets",
+            "semantic_projections_ok",
+            "no_strong_variant",
+        )
+    )
+
+
+def finding_summary(name, rows, target_selector):
+    selected = []
+    target_count = 0
+    for row in rows:
+        targets = [target for target in row["targets"] if target_selector(target)]
+        if targets:
+            selected.append(row)
+            target_count += len(targets)
+    positives = sum(row["verdict"] == "should_propagate" for row in selected)
+    return {
+        "name": name,
+        "strict_findings": len(selected),
+        "strict_targets": target_count,
+        "should_propagate_findings": positives,
+        "false_positive_findings": len(selected) - positives,
+        "finding_precision": round(positives / len(selected), 6) if selected else None,
+        "verdicts": dict(sorted(Counter(row["verdict"] for row in selected).items())),
+        "target_precision": None,
+        "target_precision_reason": "development labels adjudicate findings, not direct targets",
+    }
+
+
+def summarize(args):
+    samples = {row["sid"]: row for row in replay.jsonl(args.samples)}
+    verdicts = {row["sid"]: row for row in replay.jsonl(args.verdicts)}
+    record_rows = replay.jsonl(args.records)
+    records = {row.get("sid"): row for row in record_rows if row.get("sid")}
+    rows = []
+    for sid, sample in samples.items():
+        if not replay.current_v2_strict(sample):
+            continue
+        record = records.get(sid, {})
+        rows.append({
+            "sid": sid,
+            "verdict": verdicts[sid]["verdict"],
+            "targets": [
+                target for target in record.get("targets", []) if isinstance(target, dict)
+            ],
+        })
+
+    policy_spec = {
+        "policy_class": "divergent-edit-v3-monotone-precision-first",
+        "finding_fails_when": "at least one target has disposition strict",
+        "target_requires_all": list(TARGET_PREDICATE_NAMES),
+        "allowed_tuning": "closed strong variant codes may only demote",
+        "unknown_or_caveated": "review",
+        "weak_variant_signals": "advisory-only",
+        "gate_authority": "items[].gate.fail_default",
+    }
+    qualified = finding_summary("protocol-admissible-v3", rows, strict_target)
+    relaxed = finding_summary(
+        "diagnostic-only-allow-incomplete-semantic-and-variant-caveats",
+        rows,
+        relaxed_diagnostic_target,
+    )
+    strict_targets = [
+        target for row in rows for target in row["targets"] if strict_target(target)
+    ]
+    complete_targets = [
+        target
+        for row in rows
+        for target in row["targets"]
+        if target_predicates(target)["complete_semantic_witness"]
+    ]
+    protocol = json.loads(args.protocol.read_text())
+    artifact = {
+        "schema_version": 1,
+        "issue": 852,
+        "development_only": True,
+        "blind_or_temporal_data_accessed": False,
+        "inputs": {
+            "samples": str(args.samples.relative_to(ROOT)),
+            "samples_sha256": sha256(args.samples),
+            "verdicts": str(args.verdicts.relative_to(ROOT)),
+            "verdicts_sha256": sha256(args.verdicts),
+            "precision_protocol": str(args.protocol.relative_to(ROOT)),
+            "precision_protocol_sha256": sha256(args.protocol),
+            "labeled_findings": len(samples),
+            "v2_strict_findings": len(rows),
+            "replay_records": str(args.records),
+            "replay_records_sha256": sha256(args.records),
+        },
+        "implementation": {
+            "source_commit": subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+            "nose_binary": str(args.nose),
+            "nose_binary_sha256": sha256(args.nose),
+            "nose_version": subprocess.run(
+                [str(args.nose), "--version"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+            "harness": str(Path(__file__).relative_to(ROOT)),
+            "harness_sha256": sha256(Path(__file__)),
+        },
+        "frozen_policy_class": policy_spec,
+        "frozen_policy_class_sha256": canonical_sha256(policy_spec),
+        "replay": {
+            "matched_findings": sum(
+                records.get(sid, {}).get("matched") is True for sid in samples
+            ),
+            "unmatched_findings": sum(
+                records.get(sid, {}).get("matched") is not True for sid in samples
+            ),
+            "query_error_rows": sum(row.get("ok") is not True for row in record_rows),
+        },
+        "qualification_thresholds": {
+            "strict_finding_precision_min": 0.95,
+            "strict_target_precision_min": protocol["decision_matrix"]["blind_policy_gate"][
+                "strict_target_precision_min"
+            ],
+            "non_degenerate_strict_findings_min": 1,
+            "non_degenerate_strict_targets_min": 1,
+        },
+        "evidence_ceiling": {
+            "direct_targets": sum(len(row["targets"]) for row in rows),
+            "complete_semantic_witness_targets": len(complete_targets),
+            "protocol_admissible_targets": len(strict_targets),
+            "proof": (
+                "Every admissible target requires a complete semantic witness. The development "
+                "replay has none, so every monotone policy in the frozen class has zero support."
+            ),
+        },
+        "simulations": [qualified, relaxed],
+        "qualification": {
+            "status": "no-policy-qualifies",
+            "candidate_frozen_for_blind_replay": False,
+            "active_runtime_policy": "divergent-edit-v2-strict",
+            "schema_or_capability_bump": False,
+            "reason": (
+                "The protocol-admissible class has zero development support; target precision "
+                "also cannot be estimated from finding-level development labels. Activating or "
+                "versioning a v3 hard-block contract would overstate the evidence."
+            ),
+        },
+    }
+    args.out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+
+def selftest(_args):
+    complete = {
+        "target_id": "abc",
+        "direct_witness": {"kind": "exact-value-graph"},
+        "changed": {
+            "touches_shared": True,
+            "semantic_change": {
+                "status": "complete",
+                "change_kind": "replacement",
+                "alignment": "stable-name",
+                "base_projection": "ok",
+                "current_projection": "ok",
+                "coverage": {"mapped_shared_nodes": 1},
+                "facets": ["value"],
+                "caveats": [],
+            },
+        },
+        "variant_evidence": {"status": "none", "caveats": []},
+    }
+    assert strict_target(complete)
+    caveated = json.loads(json.dumps(complete))
+    caveated["changed"]["semantic_change"]["caveats"] = ["lossy-base-lowering"]
+    assert not strict_target(caveated)
+    assert relaxed_diagnostic_target(caveated)
+    variant = json.loads(json.dumps(complete))
+    variant["variant_evidence"]["status"] = "disqualifying"
+    assert not strict_target(variant)
+    print("v3_policy_eval selftest: ok")
+
+
+def parser():
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    command = commands.add_parser("summarize")
+    command.add_argument("--samples", type=Path, default=DEFAULT_SAMPLES)
+    command.add_argument("--verdicts", type=Path, default=DEFAULT_VERDICTS)
+    command.add_argument("--protocol", type=Path, default=DEFAULT_PROTOCOL)
+    command.add_argument("--records", type=Path, required=True)
+    command.add_argument("--nose", type=Path, default=DEFAULT_NOSE)
+    command.add_argument("--out", type=Path, required=True)
+    command.set_defaults(func=summarize)
+    command = commands.add_parser("selftest")
+    command.set_defaults(func=selftest)
+    return root
+
+
+if __name__ == "__main__":
+    arguments = parser().parse_args()
+    arguments.func(arguments)


### PR DESCRIPTION
Closes #852

## Outcome
The admissible precision-first v3 class does not qualify on development evidence, so this PR deliberately does not activate or advertise a v3 hard-block contract.

- 179/179 public development findings replayed, 0 query errors
- 80 v2-strict findings expose 168 direct targets
- 0 targets have the protocol-required caveat-free complete semantic witness
- every monotone admissible policy therefore has 0 strict findings/targets
- a relaxed, non-admissible diagnostic reaches only 7/13 positive findings (0.538 precision)
- development labels are finding-level, so direct-target precision is unavailable and is not inferred
- blind and temporal labels remain sealed

The active policy stays `divergent-edit-v2-strict`, schema v8 and capabilities stay unchanged, and no v3 binary/threshold is released to #853.

## Contract hardening
Human, JSON, SARIF, and exit status now consume one internal policy-decision object. `items[].gate.fail_default` remains the only machine authority.

## Checked evidence
- `eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json`
- frozen source commit, binary hash, policy-class hash, protocol/input hashes, and thresholds

## Verification
- cargo clippy -p nose-cli --all-targets -- -D warnings
- cargo test -p nose-cli --lib divergence::tests
- cargo test -p nose-cli --test cli query_base::core_contract::query_base_flags_divergent_edits
- scripts/check-docs.sh
- python3 eval/divergence_fire/v3_policy_eval.py selftest
- python3 scripts/check-file-lengths.py --ratchet-base main
- cargo fmt --all -- --check
- git diff --check
