### PR TITLE
eval(divergence): record blind readiness preflight verdict

### DIFF
--- a/docs/divergent-edits.md
+++ b/docs/divergent-edits.md
@@ -159,6 +159,13 @@ bumped, and `divergent-edit-v2-strict` remains the active opt-in policy. Human, 
 exit status now consume one internal policy-decision object, with `items[].gate.fail_default`
 remaining the sole machine authority. See the [development result](../eval/divergence_fire/RESULTS.md#v3-policy-development-qualification-2026-07-18-852).
 
+#853 then ran the sealed-replay preflight, not the private replay. Because no runnable v3
+candidate identity existed, opening the held-out population would not evaluate a defined policy
+and would only consume the seal. Its single checked verdict is `failed` at the
+`pre-unseal-development-qualification` stage: zero private repositories or changes were opened,
+no quality labels were created or revealed, and the held-out population remains
+`sealed-unjudged`. This is a failed default-on cycle, not a blind precision measurement.
+
 ## Bounded semantic-change evidence
 
 For an already-flagged base divergence, each family-level changed site and each direct target's

--- a/eval/divergence_fire/RESULTS.md
+++ b/eval/divergence_fire/RESULTS.md
@@ -483,6 +483,30 @@ python3 eval/divergence_fire/v3_policy_eval.py summarize \
   --out eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json
 ```
 
+## Blind readiness preflight verdict (2026-07-18, #853)
+
+The checked
+[`blind_readiness_verdict_2026_07_18.v1.json`](blind_readiness_verdict_2026_07_18.v1.json)
+records exactly one allowed verdict: **`failed`** at
+`pre-unseal-development-qualification`. It verifies the #852 qualification and #848 protocol
+hashes and confirms that no runnable v3 candidate identity was frozen.
+
+The private replay was deliberately not run. Opening the held-out population without a defined
+candidate could not measure policy quality and would only spend the seal. Zero repositories and
+changes were opened, zero labels were created or revealed, and the population remains
+`sealed-unjudged` with quality-label state `unopened-no-quality-labels-exist`. Consequently this
+cycle has no blind target/finding/change precision result and cannot support either an
+`improved-opt-in-only` or `default-on-ready` claim. The supported product claim remains the
+active v2 opt-in review gate plus the new inspectable evidence.
+
+Reproduce the preflight verdict without access to any private directory:
+
+```sh
+python3 eval/divergence_fire/blind_readiness_verdict.py selftest
+python3 eval/divergence_fire/blind_readiness_verdict.py emit \
+  --out eval/divergence_fire/blind_readiness_verdict_2026_07_18.v1.json
+```
+
 ## Fire rate (change level; 347 replayed changes per arm)
 
 | arm | fire rate | findings/fire p50 | p90 | max | divergence s p50 | p90 |

--- a/eval/divergence_fire/blind_readiness_verdict.py
+++ b/eval/divergence_fire/blind_readiness_verdict.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Emit the #853 pre-unseal verdict when #852 froze no blind candidate.
+
+This command intentionally has no option for a private packet. If a candidate was
+qualified, it stops and requires the separate sealed replay workflow instead of
+silently opening or replacing that evaluation.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_QUALIFICATION = ROOT / "eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json"
+DEFAULT_PROTOCOL = ROOT / "eval/divergence_fire/precision_protocol_2026_07_14.v2.json"
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+
+def checked_input(path):
+    return {
+        "path": str(path.relative_to(ROOT)),
+        "bytes": path.stat().st_size,
+        "sha256": sha256(path),
+    }
+
+
+def verdict(args):
+    qualification = json.loads(args.qualification.read_text())
+    protocol = json.loads(args.protocol.read_text())
+    result = qualification.get("qualification", {})
+    require(result.get("status") == "no-policy-qualifies", "#852 did not record no-policy-qualifies")
+    require(
+        result.get("candidate_frozen_for_blind_replay") is False,
+        "a blind candidate exists; use the sealed replay workflow instead",
+    )
+    require(
+        qualification["inputs"]["precision_protocol_sha256"] == sha256(args.protocol),
+        "#852 qualification references a different precision protocol",
+    )
+    allowed = protocol["decision_matrix"]["allowed_verdicts"]
+    require("failed" in allowed, "sealed protocol does not allow the failed verdict")
+    require(protocol.get("state") == "sealed-unjudged", "blind protocol is no longer sealed-unjudged")
+    require(
+        protocol["verdict_protocol"].get("state") == "unopened-no-quality-labels-exist",
+        "blind quality-label state changed before preflight",
+    )
+
+    artifact = {
+        "schema_version": 1,
+        "issue": 853,
+        "verdict": "failed",
+        "verdict_count": 1,
+        "stage": "pre-unseal-development-qualification",
+        "blind_or_temporal_data_accessed": False,
+        "inputs": {
+            "development_qualification": checked_input(args.qualification),
+            "precision_protocol": checked_input(args.protocol),
+        },
+        "generator": {
+            "path": str(Path(__file__).relative_to(ROOT)),
+            "sha256": sha256(Path(__file__)),
+            "source_commit": subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+        },
+        "preflight": {
+            "qualification_status": result["status"],
+            "candidate_frozen_for_blind_replay": False,
+            "policy_hash_available": qualification.get("frozen_policy_class_sha256") is not None,
+            "binary_hash_available": qualification.get("implementation", {}).get(
+                "nose_binary_sha256"
+            ) is not None,
+            "runnable_candidate_identity_available": False,
+            "protocol_state_before": protocol["state"],
+            "quality_label_state_before": protocol["verdict_protocol"]["state"],
+        },
+        "blind_replay": {
+            "run": False,
+            "repositories_opened": 0,
+            "changes_replayed": 0,
+            "strict_findings": None,
+            "strict_targets": None,
+            "labels_created_or_revealed": 0,
+            "population_consumed": False,
+        },
+        "decision": {
+            "default_on_ready": False,
+            "opt_in_only": True,
+            "active_runtime_policy": result["active_runtime_policy"],
+            "reason": (
+                "#852 froze no runnable v3 candidate after the admissible class had zero "
+                "development support. Opening the held-out population could not evaluate a "
+                "defined candidate and would only spend the seal."
+            ),
+            "classification_basis": (
+                "failed before unseal because the frozen-candidate identity required by #853 "
+                "does not exist"
+            ),
+        },
+        "held_out_state_after": {
+            "protocol": "sealed-unjudged",
+            "quality_labels": "unopened-no-quality-labels-exist",
+            "consumed": False,
+        },
+        "next_action": (
+            "#854 must ship only the supported opt-in/review claim and close performance, "
+            "determinism, compatibility, CI, and documentation evidence. Any future v3 cycle "
+            "needs target-adjudicated development evidence and a newly qualified candidate "
+            "before this held-out seal is opened."
+        ),
+    }
+    args.out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+
+def selftest(_args):
+    allowed = ["default-on-ready", "improved-opt-in-only", "failed", "insufficient-evidence"]
+    require("failed" in allowed, "failed verdict missing")
+    try:
+        require(False, "fixture")
+    except SystemExit as error:
+        assert str(error) == "fixture"
+    else:
+        raise AssertionError("require did not stop")
+    print("blind_readiness_verdict selftest: ok")
+
+
+def parser():
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    command = commands.add_parser("emit")
+    command.add_argument("--qualification", type=Path, default=DEFAULT_QUALIFICATION)
+    command.add_argument("--protocol", type=Path, default=DEFAULT_PROTOCOL)
+    command.add_argument("--out", type=Path, required=True)
+    command.set_defaults(func=verdict)
+    command = commands.add_parser("selftest")
+    command.set_defaults(func=selftest)
+    return root
+
+
+if __name__ == "__main__":
+    arguments = parser().parse_args()
+    arguments.func(arguments)

--- a/eval/divergence_fire/blind_readiness_verdict_2026_07_18.v1.json
+++ b/eval/divergence_fire/blind_readiness_verdict_2026_07_18.v1.json
@@ -1,0 +1,56 @@
+{
+  "blind_or_temporal_data_accessed": false,
+  "blind_replay": {
+    "changes_replayed": 0,
+    "labels_created_or_revealed": 0,
+    "population_consumed": false,
+    "repositories_opened": 0,
+    "run": false,
+    "strict_findings": null,
+    "strict_targets": null
+  },
+  "decision": {
+    "active_runtime_policy": "divergent-edit-v2-strict",
+    "classification_basis": "failed before unseal because the frozen-candidate identity required by #853 does not exist",
+    "default_on_ready": false,
+    "opt_in_only": true,
+    "reason": "#852 froze no runnable v3 candidate after the admissible class had zero development support. Opening the held-out population could not evaluate a defined candidate and would only spend the seal."
+  },
+  "generator": {
+    "path": "eval/divergence_fire/blind_readiness_verdict.py",
+    "sha256": "69583dd684adf15d9245b4dbcb7c9719805c0e2a2e34c68b2f50af79edd2dab5",
+    "source_commit": "a30c907339ccd7916a6d4e98dc99dfe582818435"
+  },
+  "held_out_state_after": {
+    "consumed": false,
+    "protocol": "sealed-unjudged",
+    "quality_labels": "unopened-no-quality-labels-exist"
+  },
+  "inputs": {
+    "development_qualification": {
+      "bytes": 4059,
+      "path": "eval/divergence_fire/v3_policy_dev_2026_07_18.v1.json",
+      "sha256": "473aef397ef6dd70dd0d9b7d57dddf18f4a968fff700c2dbce6de83f10f1f6fe"
+    },
+    "precision_protocol": {
+      "bytes": 400879,
+      "path": "eval/divergence_fire/precision_protocol_2026_07_14.v2.json",
+      "sha256": "a6b90708edc4527eae6b30ef119153f078884f85f3ac650502da5b5e96318185"
+    }
+  },
+  "issue": 853,
+  "next_action": "#854 must ship only the supported opt-in/review claim and close performance, determinism, compatibility, CI, and documentation evidence. Any future v3 cycle needs target-adjudicated development evidence and a newly qualified candidate before this held-out seal is opened.",
+  "preflight": {
+    "binary_hash_available": true,
+    "candidate_frozen_for_blind_replay": false,
+    "policy_hash_available": true,
+    "protocol_state_before": "sealed-unjudged",
+    "qualification_status": "no-policy-qualifies",
+    "quality_label_state_before": "unopened-no-quality-labels-exist",
+    "runnable_candidate_identity_available": false
+  },
+  "schema_version": 1,
+  "stage": "pre-unseal-development-qualification",
+  "verdict": "failed",
+  "verdict_count": 1
+}


### PR DESCRIPTION
Closes #853

## Verdict
Exactly one checked verdict: **failed** at `pre-unseal-development-qualification`.

#852 froze no runnable v3 candidate after the admissible class had zero development support. The #853 preflight verifies the #852 qualification and #848 protocol hashes, then refuses to open a private packet because there is no defined candidate to evaluate.

## Seal state
- private replay run: no
- repositories/changes opened: 0 / 0
- quality labels created or revealed: 0
- population consumed: no
- state remains `sealed-unjudged`
- label state remains `unopened-no-quality-labels-exist`

This is a failed default-on cycle, not a blind precision result. It does not claim `improved-opt-in-only` or `default-on-ready`; the active v2 gate remains opt-in.

## Checked evidence
- `eval/divergence_fire/blind_readiness_verdict_2026_07_18.v1.json`
- generator has no private-directory argument and stops if a qualified candidate exists

## Verification
- python3 eval/divergence_fire/blind_readiness_verdict.py selftest
- scripts/check-docs.sh
- python3 scripts/check-file-lengths.py --ratchet-base main
- jq empty on the checked verdict
- git diff --check