### PR TITLE
feat: compile typed semantic-pack v1 manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           python3 bench/labels/query_schema.py --self-test --nose target/release/nose
           python3 bench/labels/default_head_query_schema.py --self-test --nose target/release/nose
       - name: semantic-pack example conformance
-        run: target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+        run: target/release/nose semantic-pack check docs/examples/semantic-packs/v0 docs/examples/semantic-packs/v1 --format json
       - name: Type-4 executable focused expectations
         run: |
           NOSE_BIN=target/release/nose bench/type4/adversarial/scripts/type4-exec-check \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +313,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -304,6 +342,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "globset"
@@ -564,6 +612,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -760,6 +809,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -977,6 +1037,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ nose-markdown = { path = "crates/nose-markdown", version = "0.19.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 regex = "1"
 semver = "1"
 rustc-hash = "2"

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "7ab9303b3e29389af03e4a66556e4de5aff39fb3",
+  "product_crates_tree": "c8e864e5c180d8f66e72adb335e18aabe0d8524c",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-const CAPABILITIES_SCHEMA_VERSION: u32 = 4;
+const CAPABILITIES_SCHEMA_VERSION: u32 = 5;
 
 #[derive(serde::Serialize)]
 struct Report {
@@ -155,7 +155,7 @@ fn current_schemas() -> Schemas {
             crate::schema_versions::QUERY_JSON_SCHEMA_VERSION,
             crate::schema_versions::QUERY_BASE_JSON_SCHEMA_VERSION,
         ],
-        semantic_packs: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+        semantic_packs: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS.to_vec(),
         semantic_pack_conformance: vec![crate::semantic_pack::CONFORMANCE_SCHEMA_VERSION],
         semantic_pack_inventory: vec![crate::semantic_pack::INVENTORY_SCHEMA_VERSION],
         semantic_pack_adoption_gates: vec![crate::semantic_pack::ADOPTION_GATES_SCHEMA_VERSION],
@@ -165,7 +165,7 @@ fn current_schemas() -> Schemas {
 
 fn current_semantic_packs() -> SemanticPacks {
     SemanticPacks {
-        api_versions: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+        api_versions: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS.to_vec(),
         loading: vec![
             "compiled-builtin",
             "local-manifest-file",

--- a/crates/nose-cli/src/cli_args.rs
+++ b/crates/nose-cli/src/cli_args.rs
@@ -130,7 +130,7 @@ pub(crate) enum Cmd {
         /// Structured-ignore file for suppressed families; auto-read `nose.ignore.json` when present.
         #[arg(long, value_name = "FILE")]
         ignore_file: Option<PathBuf>,
-        /// Local semantic-pack v0 manifest file or directory to load (repeatable; explicit opt-in).
+        /// Local semantic-pack v0/v1 manifest file or directory to load (repeatable; explicit opt-in).
         #[arg(long = "semantic-pack", value_name = "FILE_OR_DIR")]
         semantic_pack: Vec<PathBuf>,
         /// Read defaults from this config file (else `nose.toml`/`.nose.toml`).
@@ -218,7 +218,7 @@ pub(crate) enum Cmd {
     },
     /// Emit the machine-readable capability contract for integrations.
     Capabilities,
-    /// Validate semantic-pack v0 manifests and declared conformance fixtures.
+    /// Validate semantic-pack v0 manifests/fixtures or compile typed v1 manifests.
     #[command(name = "semantic-pack")]
     SemanticPack {
         #[command(subcommand)]
@@ -340,7 +340,7 @@ pub(crate) enum Cmd {
 
 #[derive(Subcommand)]
 pub(crate) enum SemanticPackCmd {
-    /// Check local semantic-pack v0 manifests for structural conformance.
+    /// Check local semantic-pack v0 manifests or compile typed v1 manifests.
     Check {
         /// Semantic-pack manifest file or directory of direct `*.json` manifests.
         #[arg(required = true, value_name = "FILE_OR_DIR")]

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -34,7 +34,7 @@ pub(crate) struct QueryConfig {
     /// Minimum unit size in IL tokens.
     pub min_size: Option<usize>,
     pub ignore_file: Option<PathBuf>,
-    /// Local semantic-pack v0 manifest files or directories. These are explicit opt-ins.
+    /// Local semantic-pack v0/v1 manifest files or directories. These are explicit opt-ins.
     pub semantic_packs: Vec<PathBuf>,
 }
 

--- a/crates/nose-cli/src/query_semantic_packs.rs
+++ b/crates/nose-cli/src/query_semantic_packs.rs
@@ -19,7 +19,7 @@ pub(crate) fn with_semantic_packs(mut report: Value, semantic_packs: &[Value]) -
 }
 
 fn semantic_pack_summary_json(pack: &nose_semantics::SemanticPackSummary) -> Value {
-    json!({
+    let mut summary = json!({
         "id": &pack.id,
         "hash": pack.hash_hex(),
         "kind": pack.kind.as_str(),
@@ -41,5 +41,15 @@ fn semantic_pack_summary_json(pack: &nose_semantics::SemanticPackSummary) -> Val
             "positive_fixtures": pack.counts.positive_fixtures,
             "hard_negatives": pack.counts.hard_negatives,
         },
-    })
+    });
+    let object = summary
+        .as_object_mut()
+        .expect("semantic-pack summary is an object");
+    if let Some(api_version) = pack.api_version {
+        object.insert("api_version".to_string(), json!(api_version));
+    }
+    if let Some(semantic_digest) = &pack.semantic_digest {
+        object.insert("semantic_digest".to_string(), json!(semantic_digest));
+    }
+    summary
 }

--- a/crates/nose-cli/src/semantic_pack.rs
+++ b/crates/nose-cli/src/semantic_pack.rs
@@ -14,7 +14,7 @@ pub(crate) use compatibility::{
 };
 pub(crate) use inventory::{cmd_inventory, InventoryFormat, INVENTORY_SCHEMA_VERSION};
 
-pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 2;
+pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
 pub(crate) enum CheckFormat {
@@ -47,6 +47,8 @@ struct CheckJsonTotals {
 
 #[derive(serde::Serialize)]
 struct CheckJsonManifest {
+    api_version: Option<&'static str>,
+    semantic_digest: Option<String>,
     id: String,
     version: String,
     display_name: String,
@@ -152,6 +154,8 @@ impl CheckJsonReport {
                 .manifests
                 .iter()
                 .map(|manifest| CheckJsonManifest {
+                    api_version: manifest.pack.api_version,
+                    semantic_digest: manifest.pack.semantic_digest.clone(),
                     id: manifest.pack.id.clone(),
                     version: manifest.pack.version.clone(),
                     display_name: manifest.pack.display_name.clone(),
@@ -231,7 +235,13 @@ impl CheckJsonExecutableConformance {
 impl CheckJsonInfluencePreflight {
     fn new(report: &nose_semantics::ExternalInfluencePreflightReport) -> Self {
         Self {
-            status: if report.passed() { "ok" } else { "blocked" },
+            status: if report.rows.is_empty() {
+                "unavailable"
+            } else if report.passed() {
+                "ok"
+            } else {
+                "blocked"
+            },
             rows: report
                 .rows
                 .iter()

--- a/crates/nose-cli/src/semantic_pack/compatibility.rs
+++ b/crates/nose-cli/src/semantic_pack/compatibility.rs
@@ -75,7 +75,8 @@ impl CompatibilityReport {
             },
             current_nose_version: env!("CARGO_PKG_VERSION"),
             supported: CompatibilitySupported {
-                manifest_api_versions: vec![nose_semantics::SEMANTIC_PACK_API_VERSION],
+                manifest_api_versions: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS
+                    .to_vec(),
                 trust_lanes: vec!["builtin-default", "builtin-optional", "external-opt-in"],
                 report_sources: vec!["policy"],
                 output_formats: vec!["human", "json"],

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -12,7 +12,7 @@ fn capabilities_command_emits_machine_readable_contract() {
     let json: serde_json::Value =
         serde_json::from_str(&out).expect("capabilities must emit valid JSON");
 
-    assert_eq!(json["schema_version"], 4);
+    assert_eq!(json["schema_version"], 5);
     assert_eq!(json["tool"]["name"], "nose");
     assert_eq!(json["tool"]["version"], env!("CARGO_PKG_VERSION"));
     assert!(
@@ -63,13 +63,13 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
         vec!["capabilities", "il", "query", "semantic-pack", "stats"]
     );
     assert!(json_array_strings(&json["commands"], "deprecated").is_empty());
-    assert_eq!(json["schemas"]["capabilities"][0], 4);
+    assert_eq!(json["schemas"]["capabilities"][0], 5);
     assert_eq!(json["schemas"]["query_json"], serde_json::json!([7, 8]));
     assert_eq!(
-        json["schemas"]["semantic_packs"][0],
-        "nose.semantic-pack.v0"
+        json["schemas"]["semantic_packs"],
+        serde_json::json!(["nose.semantic-pack.v0", "nose.semantic-pack.v1"])
     );
-    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 2);
+    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 3);
     assert_eq!(json["schemas"]["semantic_pack_inventory"][0], 1);
     assert_eq!(json["schemas"]["semantic_pack_adoption_gates"][0], 1);
     assert_eq!(json["schemas"]["semantic_pack_compatibility"][0], 1);
@@ -125,8 +125,8 @@ fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
         serde_json::from_str(&out).expect("capabilities must emit valid JSON");
 
     assert_eq!(
-        json["semantic_packs"]["api_versions"][0],
-        "nose.semantic-pack.v0"
+        json["semantic_packs"]["api_versions"],
+        serde_json::json!(["nose.semantic-pack.v0", "nose.semantic-pack.v1"])
     );
     assert_eq!(
         json["semantic_packs"]["external_pack_influence"],

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -96,6 +96,11 @@ fn semantic_pack_manifest(id: &str) -> String {
     )
 }
 
+fn semantic_pack_manifest_v1() -> String {
+    include_str!("../../../../../docs/examples/semantic-packs/v1/guava-immutable-collections.json")
+        .to_string()
+}
+
 fn semantic_pack_manifest_with_value_law(id: &str) -> String {
     semantic_pack_manifest(id).replace(
         r#""value_laws": []"#,
@@ -171,6 +176,8 @@ fn assert_example_external_pack(pack: &serde_json::Value, expected_id: &str) {
     assert_eq!(pack["enabled_by_default"], false);
     assert_eq!(pack["source"], "local-manifest");
     assert_eq!(pack["influence"], "metadata-only");
+    assert_eq!(pack["api_version"], "nose.semantic-pack.v0");
+    assert!(pack.get("semantic_digest").is_none());
     assert_eq!(pack["provider"], "Example Packs");
     assert_eq!(pack["repository"], "https://example.invalid/semantic-pack");
     assert_eq!(pack["license"], "MIT");
@@ -189,3 +196,5 @@ fn assert_example_external_pack(pack: &serde_json::Value, expected_id: &str) {
 mod builtin_report;
 #[path = "config_packs/external_cases_0.rs"]
 mod external_cases_0;
+#[path = "config_packs/external_cases_v1.rs"]
+mod external_cases_v1;

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
@@ -229,7 +229,7 @@ fn semantic_pack_check_json_reports_conformance_success() {
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
-    assert_eq!(json["schema_version"], 2);
+    assert_eq!(json["schema_version"], 3);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["manifests"], 1);
     assert_eq!(json["totals"]["positive_fixtures"], 1);
@@ -240,6 +240,11 @@ fn semantic_pack_check_json_reports_conformance_success() {
     assert_eq!(json["totals"]["executable_conformance_issues"], 0);
     assert_eq!(json["totals"]["influence_rows"], 2);
     assert_eq!(json["totals"]["blocked_influence_rows"], 2);
+    assert_eq!(json["manifests"][0]["api_version"], "nose.semantic-pack.v0");
+    assert_eq!(
+        json["manifests"][0]["semantic_digest"],
+        serde_json::Value::Null
+    );
     assert_eq!(json["executable_conformance"]["status"], "unavailable");
     assert_eq!(json["influence_preflight"]["status"], "blocked");
     let influence_rows = json["influence_preflight"]["rows"].as_array().unwrap();
@@ -333,7 +338,7 @@ fn semantic_pack_check_json_reports_passed_executable_gates_without_opening_infl
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
-    assert_eq!(json["schema_version"], 2);
+    assert_eq!(json["schema_version"], 3);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["executable_conformance_rows"], 2);
     assert_eq!(json["totals"]["passed_executable_conformance_rows"], 2);

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[test]
+fn typed_v1_pack_compiles_and_reports_digest_without_changing_families() {
+    let dir = make_project("semantic_pack_v1_report");
+    let pack = dir.join("pack.json");
+    fs::write(&pack, semantic_pack_manifest_v1()).unwrap();
+
+    let without_pack = query_json(&run(&[
+        "query",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--format",
+        "json",
+    ]));
+    let with_pack = query_json(&run(&[
+        "query",
+        dir.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--semantic-pack",
+        pack.to_str().unwrap(),
+        "--format",
+        "json",
+    ]));
+
+    assert_eq!(
+        query_families(&with_pack),
+        query_families(&without_pack),
+        "compiled v1 packs must remain metadata-only before lock and evidence work"
+    );
+    let reported = semantic_pack_by_id(&with_pack, "com.example.java-guava-typed-factories");
+    assert_eq!(reported["api_version"], "nose.semantic-pack.v1");
+    assert_eq!(reported["source"], "local-manifest");
+    assert_eq!(reported["influence"], "metadata-only");
+    assert_eq!(reported["counts"]["contracts"], 2);
+    let digest = reported["semantic_digest"].as_str().unwrap();
+    assert!(digest.starts_with("sha256:"));
+    assert_eq!(digest.len(), 71);
+
+    let check = Command::new(bin())
+        .args([
+            "semantic-pack",
+            "check",
+            pack.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("v1 semantic-pack check");
+    assert!(check.status.success());
+    let check_json: serde_json::Value = serde_json::from_slice(&check.stdout).unwrap();
+    assert_eq!(check_json["schema_version"], 3);
+    assert_eq!(check_json["influence_preflight"]["status"], "unavailable");
+    assert_eq!(
+        check_json["manifests"][0]["api_version"],
+        "nose.semantic-pack.v1"
+    );
+    assert_eq!(check_json["manifests"][0]["semantic_digest"], digest);
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
@@ -11,7 +11,7 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
     assert_eq!(json["current_nose_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(
         json_array_strings(&json["supported"], "manifest_api_versions"),
-        vec!["nose.semantic-pack.v0"]
+        vec!["nose.semantic-pack.v0", "nose.semantic-pack.v1"]
     );
     assert_eq!(
         json_array_strings(&json["supported"], "report_sources"),

--- a/crates/nose-semantics/Cargo.toml
+++ b/crates/nose-semantics/Cargo.toml
@@ -11,6 +11,7 @@ rustc-hash = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [features]
 test-support = []

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -109,6 +109,7 @@ mod external;
 mod loading;
 mod manifest;
 mod result_domain_semantics;
+mod v1;
 mod validation;
 
 pub use compiled::{
@@ -133,10 +134,23 @@ pub use loading::{
     SemanticPackLoadError,
 };
 use manifest::*;
+use v1::{compile_manifest_v1, SemanticPackManifestV1};
+pub use v1::{
+    CompiledSemanticPackV1, SemanticPackV1Anchor, SemanticPackV1Arity, SemanticPackV1ArityKind,
+    SemanticPackV1Call, SemanticPackV1CallShape, SemanticPackV1Channel, SemanticPackV1Contract,
+    SemanticPackV1Coordinate, SemanticPackV1DemandProfile, SemanticPackV1EffectProfile,
+    SemanticPackV1ExceptionProfile, SemanticPackV1IdentityProfile, SemanticPackV1Import,
+    SemanticPackV1ImportRole, SemanticPackV1Language, SemanticPackV1Matcher,
+    SemanticPackV1MutationProfile, SemanticPackV1Package, SemanticPackV1PackageCoordinate,
+    SemanticPackV1PackageEcosystem, SemanticPackV1Profiles, SemanticPackV1ProtocolOperation,
+    SemanticPackV1ReceiverRole, SemanticPackV1ResultDomain, SEMANTIC_PACK_API_VERSION_V1,
+};
 
 use compiled::compiled_builtin_packs;
 use validation::validate_manifest;
 pub const SEMANTIC_PACK_API_VERSION: &str = "nose.semantic-pack.v0";
+pub const SUPPORTED_SEMANTIC_PACK_API_VERSIONS: &[&str] =
+    &[SEMANTIC_PACK_API_VERSION, SEMANTIC_PACK_API_VERSION_V1];
 
 const ALLOWED_REQUIREMENT_PREFIXES: &[&str] = &[
     "Source.",
@@ -350,6 +364,8 @@ pub struct SemanticPackSummary {
     pub license: String,
     pub supported_languages: Vec<String>,
     pub counts: SemanticPackCounts,
+    pub api_version: Option<&'static str>,
+    pub semantic_digest: Option<String>,
 }
 
 impl SemanticPackSummary {
@@ -357,7 +373,7 @@ impl SemanticPackSummary {
         format!("{:016x}", self.hash)
     }
 
-    fn from_manifest(path: PathBuf, manifest: SemanticPackManifest) -> Result<Self, String> {
+    fn from_manifest_v0(path: PathBuf, manifest: SemanticPackManifest) -> Result<Self, String> {
         validate_manifest(&manifest).map_err(|err| err.to_string())?;
         let id = manifest.pack.id;
         let supported_languages = manifest
@@ -388,7 +404,47 @@ impl SemanticPackSummary {
             license: manifest.provenance.license,
             supported_languages,
             counts,
+            api_version: Some(SEMANTIC_PACK_API_VERSION),
+            semantic_digest: None,
         })
+    }
+
+    fn from_manifest_v1(
+        path: PathBuf,
+        manifest: &SemanticPackManifestV1,
+        compiled: &CompiledSemanticPackV1,
+    ) -> Self {
+        Self {
+            id: manifest.pack.id.clone(),
+            hash: semantic_pack_hash(&manifest.pack.id),
+            kind: manifest.pack.kind,
+            version: manifest.pack.version.clone(),
+            display_name: manifest.pack.display_name.clone(),
+            trust: PackTrust::ExternalOptIn,
+            enabled_by_default: false,
+            source: SemanticPackSource::LocalManifest,
+            influence: SemanticPackInfluence::MetadataOnly,
+            manifest_path: Some(path),
+            provider: manifest.provenance.provider.name.clone(),
+            repository: manifest.provenance.repository.clone(),
+            license: manifest.provenance.license.clone(),
+            supported_languages: manifest
+                .supported_languages
+                .iter()
+                .map(|language| match language {
+                    SemanticPackV1Language::Java => "java".to_string(),
+                })
+                .collect(),
+            counts: SemanticPackCounts {
+                evidence_producers: 0,
+                contracts: manifest.declares.api_contracts.len(),
+                value_laws: 0,
+                positive_fixtures: 0,
+                hard_negatives: 0,
+            },
+            api_version: Some(SEMANTIC_PACK_API_VERSION_V1),
+            semantic_digest: Some(compiled.semantic_digest().to_string()),
+        }
     }
 }
 
@@ -402,6 +458,7 @@ pub struct SemanticPackSet {
     external_evidence_producer_rows: Vec<ExternalEvidenceProducerRow>,
     external_contract_rows: Vec<ExternalContractRow>,
     external_value_law_rows: Vec<ExternalValueLawRow>,
+    compiled_external_v1_packs: Vec<CompiledSemanticPackV1>,
 }
 
 impl SemanticPackSet {
@@ -411,6 +468,7 @@ impl SemanticPackSet {
         let mut external_evidence_producer_rows = Vec::new();
         let mut external_contract_rows = Vec::new();
         let mut external_value_law_rows = Vec::new();
+        let mut compiled_external_v1_packs = Vec::new();
         for path in manifest_paths {
             let loaded = loading::load_local_manifest_with_rows(&path)?;
             if let Some(existing) = packs
@@ -426,6 +484,9 @@ impl SemanticPackSet {
             external_evidence_producer_rows.extend(loaded.external_evidence_producer_rows);
             external_contract_rows.extend(loaded.external_contract_rows);
             external_value_law_rows.extend(loaded.external_value_law_rows);
+            if let Some(compiled) = loaded.compiled_v1 {
+                compiled_external_v1_packs.push(compiled);
+            }
             packs.push(loaded.summary);
         }
         Ok(Self {
@@ -433,6 +494,7 @@ impl SemanticPackSet {
             external_evidence_producer_rows,
             external_contract_rows,
             external_value_law_rows,
+            compiled_external_v1_packs,
         })
     }
 
@@ -442,6 +504,7 @@ impl SemanticPackSet {
             external_evidence_producer_rows: Vec::new(),
             external_contract_rows: Vec::new(),
             external_value_law_rows: Vec::new(),
+            compiled_external_v1_packs: Vec::new(),
         }
     }
 
@@ -463,6 +526,10 @@ impl SemanticPackSet {
 
     pub fn external_value_law_rows(&self) -> &[ExternalValueLawRow] {
         &self.external_value_law_rows
+    }
+
+    pub fn compiled_external_v1_packs(&self) -> &[CompiledSemanticPackV1] {
+        &self.compiled_external_v1_packs
     }
 }
 

--- a/crates/nose-semantics/src/packs/compiled.rs
+++ b/crates/nose-semantics/src/packs/compiled.rs
@@ -80,6 +80,8 @@ impl BuiltinPackDescriptor {
                 .map(|language| (*language).to_string())
                 .collect(),
             counts: self.counts(),
+            api_version: None,
+            semantic_digest: None,
         }
     }
 }

--- a/crates/nose-semantics/src/packs/loading.rs
+++ b/crates/nose-semantics/src/packs/loading.rs
@@ -10,6 +10,12 @@ pub(super) struct LoadedLocalManifest {
     pub external_evidence_producer_rows: Vec<ExternalEvidenceProducerRow>,
     pub external_contract_rows: Vec<ExternalContractRow>,
     pub external_value_law_rows: Vec<ExternalValueLawRow>,
+    pub compiled_v1: Option<CompiledSemanticPackV1>,
+}
+
+enum LocalManifest {
+    V0(Box<SemanticPackManifest>),
+    V1(Box<SemanticPackManifestV1>),
 }
 
 pub fn check_semantic_pack_conformance(
@@ -19,17 +25,36 @@ pub fn check_semantic_pack_conformance(
     let mut manifests: Vec<SemanticPackConformanceManifest> = Vec::new();
     for path in manifest_paths {
         let manifest = read_local_manifest(&path)?;
-        let conformance_command = manifest.conformance.command.clone();
-        let proof_links = manifest.conformance.proofs.clone();
-        let fixtures = collect_fixture_checks(&path, &manifest);
-        let executable = collect_executable_conformance_checks(&path, &manifest, &fixtures);
-        let pack =
-            SemanticPackSummary::from_manifest(path.clone(), manifest).map_err(|message| {
-                SemanticPackLoadError::InvalidManifest {
-                    path: path.clone(),
-                    message,
-                }
-            })?;
+        let (pack, conformance_command, proof_links, fixtures, executable) = match manifest {
+            LocalManifest::V0(manifest) => {
+                let conformance_command = manifest.conformance.command.clone();
+                let proof_links = manifest.conformance.proofs.clone();
+                let fixtures = collect_fixture_checks(&path, &manifest);
+                let executable = collect_executable_conformance_checks(&path, &manifest, &fixtures);
+                let pack = SemanticPackSummary::from_manifest_v0(path.clone(), *manifest).map_err(
+                    |message| SemanticPackLoadError::InvalidManifest {
+                        path: path.clone(),
+                        message,
+                    },
+                )?;
+                (pack, conformance_command, proof_links, fixtures, executable)
+            }
+            LocalManifest::V1(manifest) => {
+                let compiled = compile_manifest_v1(&manifest).map_err(|message| {
+                    SemanticPackLoadError::InvalidManifest {
+                        path: path.clone(),
+                        message,
+                    }
+                })?;
+                (
+                    SemanticPackSummary::from_manifest_v1(path.clone(), &manifest, &compiled),
+                    None,
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                )
+            }
+        };
         if is_compiled_builtin_pack_id(&pack.id) {
             return Err(SemanticPackLoadError::DuplicatePackId {
                 id: pack.id,
@@ -124,62 +149,131 @@ fn push_unique_manifest(
 
 pub fn load_local_manifest(path: &Path) -> Result<SemanticPackSummary, SemanticPackLoadError> {
     let manifest = read_local_manifest(path)?;
-    SemanticPackSummary::from_manifest(path.to_path_buf(), manifest).map_err(|message| {
-        SemanticPackLoadError::InvalidManifest {
-            path: path.to_path_buf(),
-            message,
+    match manifest {
+        LocalManifest::V0(manifest) => {
+            SemanticPackSummary::from_manifest_v0(path.to_path_buf(), *manifest).map_err(
+                |message| SemanticPackLoadError::InvalidManifest {
+                    path: path.to_path_buf(),
+                    message,
+                },
+            )
         }
-    })
+        LocalManifest::V1(manifest) => {
+            let compiled = compile_manifest_v1(&manifest).map_err(|message| {
+                SemanticPackLoadError::InvalidManifest {
+                    path: path.to_path_buf(),
+                    message,
+                }
+            })?;
+            Ok(SemanticPackSummary::from_manifest_v1(
+                path.to_path_buf(),
+                &manifest,
+                &compiled,
+            ))
+        }
+    }
 }
 
 pub(super) fn load_local_manifest_with_rows(
     path: &Path,
 ) -> Result<LoadedLocalManifest, SemanticPackLoadError> {
     let manifest = read_local_manifest(path)?;
-    let external_evidence_producer_rows = manifest
-        .declares
-        .evidence_producers
-        .iter()
-        .map(|producer| ExternalEvidenceProducerRow::from_manifest(path, &manifest, producer))
-        .collect();
-    let external_contract_rows = manifest
-        .declares
-        .contracts
-        .iter()
-        .map(|contract| ExternalContractRow::from_manifest(path, &manifest, contract))
-        .collect();
-    let external_value_law_rows = manifest
-        .declares
-        .value_laws
-        .iter()
-        .map(|law| ExternalValueLawRow::from_manifest(path, &manifest, law))
-        .collect();
-    let summary =
-        SemanticPackSummary::from_manifest(path.to_path_buf(), manifest).map_err(|message| {
-            SemanticPackLoadError::InvalidManifest {
-                path: path.to_path_buf(),
-                message,
-            }
-        })?;
-    Ok(LoadedLocalManifest {
-        summary,
-        external_evidence_producer_rows,
-        external_contract_rows,
-        external_value_law_rows,
-    })
+    match manifest {
+        LocalManifest::V0(manifest) => {
+            let external_evidence_producer_rows = manifest
+                .declares
+                .evidence_producers
+                .iter()
+                .map(|producer| {
+                    ExternalEvidenceProducerRow::from_manifest(path, &manifest, producer)
+                })
+                .collect();
+            let external_contract_rows = manifest
+                .declares
+                .contracts
+                .iter()
+                .map(|contract| ExternalContractRow::from_manifest(path, &manifest, contract))
+                .collect();
+            let external_value_law_rows = manifest
+                .declares
+                .value_laws
+                .iter()
+                .map(|law| ExternalValueLawRow::from_manifest(path, &manifest, law))
+                .collect();
+            let summary = SemanticPackSummary::from_manifest_v0(path.to_path_buf(), *manifest)
+                .map_err(|message| SemanticPackLoadError::InvalidManifest {
+                    path: path.to_path_buf(),
+                    message,
+                })?;
+            Ok(LoadedLocalManifest {
+                summary,
+                external_evidence_producer_rows,
+                external_contract_rows,
+                external_value_law_rows,
+                compiled_v1: None,
+            })
+        }
+        LocalManifest::V1(manifest) => {
+            let compiled_v1 = compile_manifest_v1(&manifest).map_err(|message| {
+                SemanticPackLoadError::InvalidManifest {
+                    path: path.to_path_buf(),
+                    message,
+                }
+            })?;
+            let summary =
+                SemanticPackSummary::from_manifest_v1(path.to_path_buf(), &manifest, &compiled_v1);
+            Ok(LoadedLocalManifest {
+                summary,
+                external_evidence_producer_rows: Vec::new(),
+                external_contract_rows: Vec::new(),
+                external_value_law_rows: Vec::new(),
+                compiled_v1: Some(compiled_v1),
+            })
+        }
+    }
 }
 
-fn read_local_manifest(path: &Path) -> Result<SemanticPackManifest, SemanticPackLoadError> {
+fn read_local_manifest(path: &Path) -> Result<LocalManifest, SemanticPackLoadError> {
     let text = std::fs::read_to_string(path).map_err(|source| SemanticPackLoadError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    serde_json::from_str::<SemanticPackManifest>(&text).map_err(|source| {
+    let value = serde_json::from_str::<serde_json::Value>(&text).map_err(|source| {
         SemanticPackLoadError::Json {
             path: path.to_path_buf(),
             source,
         }
-    })
+    })?;
+    let api_version = value
+        .get("api_version")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| SemanticPackLoadError::InvalidManifest {
+            path: path.to_path_buf(),
+            message: "`api_version` must be a string".to_string(),
+        })?;
+    match api_version {
+        SEMANTIC_PACK_API_VERSION => serde_json::from_value::<SemanticPackManifest>(value)
+            .map(Box::new)
+            .map(LocalManifest::V0)
+            .map_err(|source| SemanticPackLoadError::Json {
+                path: path.to_path_buf(),
+                source,
+            }),
+        SEMANTIC_PACK_API_VERSION_V1 => serde_json::from_value::<SemanticPackManifestV1>(value)
+            .map(Box::new)
+            .map(LocalManifest::V1)
+            .map_err(|source| SemanticPackLoadError::Json {
+                path: path.to_path_buf(),
+                source,
+            }),
+        other => Err(SemanticPackLoadError::InvalidManifest {
+            path: path.to_path_buf(),
+            message: format!(
+                "unsupported `api_version` `{other}`; supported versions: {}",
+                SUPPORTED_SEMANTIC_PACK_API_VERSIONS.join(", ")
+            ),
+        }),
+    }
 }
 
 fn collect_fixture_checks(

--- a/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
+++ b/crates/nose-semantics/src/packs/tests/manifest_cases_2.rs
@@ -151,7 +151,7 @@ fn compatibility_nose_must_include_current_binary_version() {
 fn unsupported_api_versions_are_rejected_before_loading() {
     for (tag, api_version) in [
         ("too_old", "nose.semantic-pack.pre-v0"),
-        ("too_new", "nose.semantic-pack.v1"),
+        ("too_new", "nose.semantic-pack.v2"),
     ] {
         let dir = unique_dir(&format!("api_version_{tag}"));
         let path = dir.join("pack.json");
@@ -164,7 +164,10 @@ fn unsupported_api_versions_are_rejected_before_loading() {
         )
         .unwrap();
         let err = load_local_manifest(&path).expect_err("unsupported API versions must fail");
-        assert!(err.to_string().contains("`api_version` must be"), "{err}");
+        assert!(
+            err.to_string().contains("unsupported `api_version`"),
+            "{err}"
+        );
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/crates/nose-semantics/src/packs/v1.rs
+++ b/crates/nose-semantics/src/packs/v1.rs
@@ -1,0 +1,304 @@
+use super::*;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const SEMANTIC_PACK_API_VERSION_V1: &str = "nose.semantic-pack.v1";
+const MAX_V1_ARITY: u8 = 32;
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SemanticPackManifestV1 {
+    #[serde(rename = "$schema")]
+    pub(super) _schema: Option<String>,
+    pub(super) api_version: String,
+    pub(super) pack: ManifestV1Pack,
+    pub(super) provenance: ManifestV1Provenance,
+    pub(super) compatibility: ManifestV1Compatibility,
+    pub(super) supported_languages: Vec<SemanticPackV1Language>,
+    pub(super) packages: Vec<SemanticPackV1Package>,
+    pub(super) declares: ManifestV1Declares,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestV1Pack {
+    pub(super) id: String,
+    pub(super) kind: SemanticPackKind,
+    pub(super) version: String,
+    pub(super) display_name: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+    pub(super) trust: ManifestV1Trust,
+    pub(super) enabled_by_default: bool,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum ManifestV1Trust {
+    ExternalOptIn,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestV1Provenance {
+    pub(super) provider: ManifestV1Provider,
+    pub(super) license: String,
+    pub(super) repository: String,
+    #[serde(default)]
+    pub(super) source_revision: Option<String>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestV1Provider {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) contact: Option<String>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestV1Compatibility {
+    pub(super) nose: String,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestV1Declares {
+    pub(super) api_contracts: Vec<SemanticPackV1Contract>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1Language {
+    Java,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1PackageEcosystem {
+    Maven,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Package {
+    pub ecosystem: SemanticPackV1PackageEcosystem,
+    pub name: String,
+    pub versions: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1Anchor {
+    CallNode,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1Matcher {
+    ImportedApi,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ImportRole {
+    Type,
+    StaticMember,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Import {
+    pub role: SemanticPackV1ImportRole,
+    pub module: String,
+    pub name: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1CallShape {
+    StaticMethod,
+    FreeFunction,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ReceiverRole {
+    ImportedType,
+    None,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ArityKind {
+    Range,
+    Set,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Arity {
+    pub kind: SemanticPackV1ArityKind,
+    #[serde(default)]
+    pub min: Option<u8>,
+    #[serde(default)]
+    pub max: Option<u8>,
+    #[serde(default)]
+    pub values: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Call {
+    pub shape: SemanticPackV1CallShape,
+    pub member: String,
+    pub arity: SemanticPackV1Arity,
+    pub receiver: SemanticPackV1ReceiverRole,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ProtocolOperation {
+    CollectionFactory,
+    MapFactory,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ResultDomain {
+    Collection,
+    Map,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1DemandProfile {
+    Eager,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1EffectProfile {
+    Pure,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ExceptionProfile {
+    NoThrow,
+    MayThrow,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1MutationProfile {
+    None,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1IdentityProfile {
+    Fresh,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Profiles {
+    pub demand: SemanticPackV1DemandProfile,
+    pub effects: SemanticPackV1EffectProfile,
+    pub exceptions: SemanticPackV1ExceptionProfile,
+    pub mutation: SemanticPackV1MutationProfile,
+    pub identity: SemanticPackV1IdentityProfile,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1Channel {
+    Near,
+    ExternalExact,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Contract {
+    pub id: String,
+    pub language: SemanticPackV1Language,
+    pub package: SemanticPackV1PackageCoordinate,
+    pub anchor: SemanticPackV1Anchor,
+    pub matcher: SemanticPackV1Matcher,
+    pub import: SemanticPackV1Import,
+    pub call: SemanticPackV1Call,
+    pub operation: SemanticPackV1ProtocolOperation,
+    pub result_domain: SemanticPackV1ResultDomain,
+    pub profiles: SemanticPackV1Profiles,
+    pub channel: SemanticPackV1Channel,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1PackageCoordinate {
+    pub ecosystem: SemanticPackV1PackageEcosystem,
+    pub name: String,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct SemanticPackV1Coordinate {
+    pub language: SemanticPackV1Language,
+    pub package: SemanticPackV1PackageCoordinate,
+    pub import: SemanticPackV1Import,
+    pub call_shape: SemanticPackV1CallShape,
+    pub member: String,
+    pub receiver: SemanticPackV1ReceiverRole,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CompiledSemanticPackV1 {
+    pack_id: String,
+    pack_version: String,
+    semantic_digest: String,
+    packages_by_coordinate: BTreeMap<SemanticPackV1PackageCoordinate, SemanticPackV1Package>,
+    contracts_by_id: BTreeMap<String, SemanticPackV1Contract>,
+    contract_ids_by_coordinate: BTreeMap<SemanticPackV1Coordinate, Vec<String>>,
+    contract_ids_by_operation: BTreeMap<SemanticPackV1ProtocolOperation, Vec<String>>,
+}
+
+impl CompiledSemanticPackV1 {
+    pub fn pack_id(&self) -> &str {
+        &self.pack_id
+    }
+
+    pub fn pack_version(&self) -> &str {
+        &self.pack_version
+    }
+
+    pub fn semantic_digest(&self) -> &str {
+        &self.semantic_digest
+    }
+
+    pub fn packages_by_coordinate(
+        &self,
+    ) -> &BTreeMap<SemanticPackV1PackageCoordinate, SemanticPackV1Package> {
+        &self.packages_by_coordinate
+    }
+
+    pub fn contracts_by_id(&self) -> &BTreeMap<String, SemanticPackV1Contract> {
+        &self.contracts_by_id
+    }
+
+    pub fn contract_ids_by_coordinate(&self) -> &BTreeMap<SemanticPackV1Coordinate, Vec<String>> {
+        &self.contract_ids_by_coordinate
+    }
+
+    pub fn contract_ids_by_operation(
+        &self,
+    ) -> &BTreeMap<SemanticPackV1ProtocolOperation, Vec<String>> {
+        &self.contract_ids_by_operation
+    }
+}
+
+mod compiler;
+pub(super) use compiler::compile_manifest_v1;
+
+#[cfg(test)]
+mod tests;

--- a/crates/nose-semantics/src/packs/v1/compiler.rs
+++ b/crates/nose-semantics/src/packs/v1/compiler.rs
@@ -1,0 +1,448 @@
+use super::*;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+pub(in crate::packs) fn compile_manifest_v1(
+    manifest: &SemanticPackManifestV1,
+) -> Result<CompiledSemanticPackV1, String> {
+    validate_manifest_v1(manifest)?;
+
+    let mut contracts = manifest.declares.api_contracts.clone();
+    for contract in &mut contracts {
+        contract.call.arity.canonicalize();
+    }
+    contracts.sort_by(|left, right| left.id.cmp(&right.id));
+    let semantic_digest = semantic_digest(manifest, &contracts)?;
+    let packages_by_coordinate = manifest
+        .packages
+        .iter()
+        .cloned()
+        .map(|package| {
+            (
+                SemanticPackV1PackageCoordinate {
+                    ecosystem: package.ecosystem,
+                    name: package.name.clone(),
+                },
+                package,
+            )
+        })
+        .collect();
+    let mut contracts_by_id = BTreeMap::new();
+    let mut contract_ids_by_coordinate = BTreeMap::<_, Vec<_>>::new();
+    let mut contract_ids_by_operation = BTreeMap::<_, Vec<_>>::new();
+    for contract in contracts {
+        let coordinate = contract.coordinate();
+        contract_ids_by_coordinate
+            .entry(coordinate)
+            .or_default()
+            .push(contract.id.clone());
+        contract_ids_by_operation
+            .entry(contract.operation)
+            .or_default()
+            .push(contract.id.clone());
+        contracts_by_id.insert(contract.id.clone(), contract);
+    }
+    Ok(CompiledSemanticPackV1 {
+        pack_id: manifest.pack.id.clone(),
+        pack_version: manifest.pack.version.clone(),
+        semantic_digest,
+        packages_by_coordinate,
+        contracts_by_id,
+        contract_ids_by_coordinate,
+        contract_ids_by_operation,
+    })
+}
+
+impl SemanticPackV1Contract {
+    fn coordinate(&self) -> SemanticPackV1Coordinate {
+        SemanticPackV1Coordinate {
+            language: self.language,
+            package: self.package.clone(),
+            import: self.import.clone(),
+            call_shape: self.call.shape,
+            member: self.call.member.clone(),
+            receiver: self.call.receiver,
+        }
+    }
+}
+
+impl SemanticPackV1Arity {
+    fn canonicalize(&mut self) {
+        self.values.sort_unstable();
+    }
+
+    fn validate(&self, contract_id: &str) -> Result<(), String> {
+        match self.kind {
+            SemanticPackV1ArityKind::Range => {
+                let (Some(min), Some(max)) = (self.min, self.max) else {
+                    return Err(format!(
+                        "contract `{contract_id}` range arity requires `min` and `max`"
+                    ));
+                };
+                if !self.values.is_empty() || min > max || max > MAX_V1_ARITY {
+                    return Err(format!(
+                        "contract `{contract_id}` range arity must satisfy min <= max <= {MAX_V1_ARITY} and omit `values`"
+                    ));
+                }
+            }
+            SemanticPackV1ArityKind::Set => {
+                if self.min.is_some() || self.max.is_some() || self.values.is_empty() {
+                    return Err(format!(
+                        "contract `{contract_id}` set arity requires non-empty `values` and omits `min`/`max`"
+                    ));
+                }
+                let unique = self.values.iter().copied().collect::<BTreeSet<_>>();
+                if unique.len() != self.values.len()
+                    || self.values.iter().any(|value| *value > MAX_V1_ARITY)
+                {
+                    return Err(format!(
+                        "contract `{contract_id}` set arity values must be unique and <= {MAX_V1_ARITY}"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn all_values_satisfy(&self, predicate: impl Fn(u8) -> bool) -> bool {
+        match self.kind {
+            SemanticPackV1ArityKind::Range => {
+                let (Some(min), Some(max)) = (self.min, self.max) else {
+                    return false;
+                };
+                (min..=max).all(predicate)
+            }
+            SemanticPackV1ArityKind::Set => self.values.iter().copied().all(predicate),
+        }
+    }
+}
+
+fn validate_manifest_v1(manifest: &SemanticPackManifestV1) -> Result<(), String> {
+    if manifest.api_version != SEMANTIC_PACK_API_VERSION_V1 {
+        return Err(format!(
+            "`api_version` must be {SEMANTIC_PACK_API_VERSION_V1}, got `{}`",
+            manifest.api_version
+        ));
+    }
+    require_stable_id("pack.id", &manifest.pack.id)?;
+    require_semver("pack.version", &manifest.pack.version)?;
+    require_non_empty("pack.display_name", &manifest.pack.display_name)?;
+    optional_non_empty("pack.description", manifest.pack.description.as_deref())?;
+    if manifest.pack.kind != SemanticPackKind::LibraryPack {
+        return Err("semantic-pack v1 currently accepts only LibraryPack manifests".to_string());
+    }
+    if manifest.pack.enabled_by_default {
+        return Err("local semantic-pack v1 manifests must be disabled by default".to_string());
+    }
+    let _trust = manifest.pack.trust;
+    require_non_empty(
+        "provenance.provider.name",
+        &manifest.provenance.provider.name,
+    )?;
+    optional_non_empty(
+        "provenance.provider.contact",
+        manifest.provenance.provider.contact.as_deref(),
+    )?;
+    require_non_empty("provenance.license", &manifest.provenance.license)?;
+    require_non_empty("provenance.repository", &manifest.provenance.repository)?;
+    optional_non_empty(
+        "provenance.source_revision",
+        manifest.provenance.source_revision.as_deref(),
+    )?;
+    validate_version_requirement("compatibility.nose", &manifest.compatibility.nose, true)?;
+    validate_targets(manifest)?;
+    validate_contracts(manifest)
+}
+
+fn validate_targets(manifest: &SemanticPackManifestV1) -> Result<(), String> {
+    if manifest.supported_languages.is_empty() {
+        return Err("`supported_languages` must contain at least one language".to_string());
+    }
+    let languages = manifest
+        .supported_languages
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if languages.len() != manifest.supported_languages.len() {
+        return Err("`supported_languages` must not contain duplicates".to_string());
+    }
+    if manifest.packages.is_empty() {
+        return Err("`packages` must contain at least one package coordinate".to_string());
+    }
+    let mut packages = BTreeSet::new();
+    for package in &manifest.packages {
+        validate_maven_coordinate("packages[].name", &package.name)?;
+        validate_version_requirement("packages[].versions", &package.versions, false)?;
+        if !packages.insert((package.ecosystem, package.name.clone())) {
+            return Err(format!(
+                "duplicate package coordinate `{:?}:{}`",
+                package.ecosystem, package.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_contracts(manifest: &SemanticPackManifestV1) -> Result<(), String> {
+    if manifest.declares.api_contracts.is_empty() {
+        return Err("`declares.api_contracts` must contain at least one contract".to_string());
+    }
+    let languages = manifest
+        .supported_languages
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let packages = manifest
+        .packages
+        .iter()
+        .map(|package| (package.ecosystem, package.name.as_str()))
+        .collect::<BTreeSet<_>>();
+    let mut ids = BTreeSet::new();
+    let mut exact_rows = BTreeSet::new();
+    for contract in &manifest.declares.api_contracts {
+        require_stable_id("declares.api_contracts[].id", &contract.id)?;
+        if !ids.insert(contract.id.as_str()) {
+            return Err(format!("duplicate v1 contract id `{}`", contract.id));
+        }
+        if !languages.contains(&contract.language) {
+            return Err(format!(
+                "contract `{}` language is not declared in `supported_languages`",
+                contract.id
+            ));
+        }
+        validate_maven_coordinate(
+            "declares.api_contracts[].package.name",
+            &contract.package.name,
+        )?;
+        if !packages.contains(&(contract.package.ecosystem, contract.package.name.as_str())) {
+            return Err(format!(
+                "contract `{}` package is not declared in `packages`",
+                contract.id
+            ));
+        }
+        validate_java_path(
+            "declares.api_contracts[].import.module",
+            &contract.import.module,
+        )?;
+        validate_java_identifier(
+            "declares.api_contracts[].import.name",
+            &contract.import.name,
+        )?;
+        validate_java_identifier(
+            "declares.api_contracts[].call.member",
+            &contract.call.member,
+        )?;
+        validate_call_shape(contract)?;
+        contract.call.arity.validate(&contract.id)?;
+        validate_operation_domain(contract)?;
+        let mut arity = contract.call.arity.clone();
+        arity.canonicalize();
+        let exact_key = (contract.coordinate(), arity);
+        if !exact_rows.insert(exact_key) {
+            return Err(format!(
+                "contract `{}` duplicates an existing package API coordinate and arity",
+                contract.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_call_shape(contract: &SemanticPackV1Contract) -> Result<(), String> {
+    let valid = matches!(
+        (
+            contract.import.role,
+            contract.call.shape,
+            contract.call.receiver
+        ),
+        (
+            SemanticPackV1ImportRole::Type,
+            SemanticPackV1CallShape::StaticMethod,
+            SemanticPackV1ReceiverRole::ImportedType
+        ) | (
+            SemanticPackV1ImportRole::StaticMember,
+            SemanticPackV1CallShape::FreeFunction,
+            SemanticPackV1ReceiverRole::None
+        )
+    );
+    if valid {
+        Ok(())
+    } else {
+        Err(format!(
+            "contract `{}` has an incompatible import role, call shape, and receiver role",
+            contract.id
+        ))
+    }
+}
+
+fn validate_operation_domain(contract: &SemanticPackV1Contract) -> Result<(), String> {
+    let valid = match (contract.operation, contract.result_domain) {
+        (
+            SemanticPackV1ProtocolOperation::CollectionFactory,
+            SemanticPackV1ResultDomain::Collection,
+        ) => true,
+        (SemanticPackV1ProtocolOperation::MapFactory, SemanticPackV1ResultDomain::Map) => contract
+            .call
+            .arity
+            .all_values_satisfy(|arity| arity % 2 == 0),
+        (SemanticPackV1ProtocolOperation::CollectionFactory, SemanticPackV1ResultDomain::Map)
+        | (SemanticPackV1ProtocolOperation::MapFactory, SemanticPackV1ResultDomain::Collection) => {
+            false
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(format!(
+            "contract `{}` operation and fixed result domain are incompatible",
+            contract.id
+        ))
+    }
+}
+
+#[derive(Serialize)]
+struct CanonicalSemanticContent<'a> {
+    api_version: &'static str,
+    pack_kind: &'static str,
+    supported_languages: Vec<SemanticPackV1Language>,
+    packages: Vec<SemanticPackV1Package>,
+    api_contracts: &'a [SemanticPackV1Contract],
+}
+
+fn semantic_digest(
+    manifest: &SemanticPackManifestV1,
+    contracts: &[SemanticPackV1Contract],
+) -> Result<String, String> {
+    let mut supported_languages = manifest.supported_languages.clone();
+    supported_languages.sort();
+    let mut packages = manifest.packages.clone();
+    packages.sort();
+    let canonical = CanonicalSemanticContent {
+        api_version: SEMANTIC_PACK_API_VERSION_V1,
+        pack_kind: manifest.pack.kind.as_str(),
+        supported_languages,
+        packages,
+        api_contracts: contracts,
+    };
+    let bytes = serde_json::to_vec(&canonical)
+        .map_err(|err| format!("serializing canonical v1 semantic content: {err}"))?;
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    Ok(format!("sha256:{hex}"))
+}
+
+fn require_non_empty(label: &str, value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        Err(format!("`{label}` must be a non-empty string"))
+    } else {
+        Ok(())
+    }
+}
+
+fn optional_non_empty(label: &str, value: Option<&str>) -> Result<(), String> {
+    if matches!(value, Some("")) {
+        Err(format!("`{label}` must be a non-empty string when present"))
+    } else {
+        Ok(())
+    }
+}
+
+fn require_stable_id(label: &str, value: &str) -> Result<(), String> {
+    require_non_empty(label, value)?;
+    let mut chars = value.chars();
+    if !chars.next().is_some_and(|c| c.is_ascii_alphanumeric())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | ':' | '-'))
+    {
+        return Err(format!("`{label}` has invalid stable id `{value}`"));
+    }
+    Ok(())
+}
+
+fn require_semver(label: &str, value: &str) -> Result<(), String> {
+    semver::Version::parse(value)
+        .map(|_| ())
+        .map_err(|err| format!("`{label}` must be a semantic version: {err}"))
+}
+
+fn validate_version_requirement(
+    label: &str,
+    value: &str,
+    require_current: bool,
+) -> Result<(), String> {
+    require_non_empty(label, value)?;
+    let normalized = value
+        .replace(',', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(",");
+    let requirement = semver::VersionReq::parse(&normalized).map_err(|err| {
+        format!("`{label}` contains unsupported version requirement `{value}`: {err}")
+    })?;
+    if require_current {
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))
+            .map_err(|err| format!("current nose version is invalid: {err}"))?;
+        if !requirement.matches(&current) {
+            return Err(format!(
+                "`{label}` range `{value}` does not include this nose binary version `{current}`"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_maven_coordinate(label: &str, value: &str) -> Result<(), String> {
+    let Some((group, artifact)) = value.split_once(':') else {
+        return Err(format!(
+            "`{label}` must be an exact Maven `group:artifact` coordinate"
+        ));
+    };
+    if artifact.contains(':') || !valid_java_path(group) || !valid_maven_artifact(artifact) {
+        return Err(format!("`{label}` has invalid Maven coordinate `{value}`"));
+    }
+    Ok(())
+}
+
+fn validate_java_path(label: &str, value: &str) -> Result<(), String> {
+    if valid_java_path(value) {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{label}` has invalid exact Java module path `{value}`"
+        ))
+    }
+}
+
+fn valid_java_path(value: &str) -> bool {
+    !value.is_empty() && value.split('.').all(valid_coordinate_segment)
+}
+
+fn validate_java_identifier(label: &str, value: &str) -> Result<(), String> {
+    if valid_coordinate_segment(value) {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{label}` has invalid exact Java identifier `{value}`"
+        ))
+    }
+}
+
+fn valid_coordinate_segment(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_' || ch == '$')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+fn valid_maven_artifact(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '$'))
+}

--- a/crates/nose-semantics/src/packs/v1/tests.rs
+++ b/crates/nose-semantics/src/packs/v1/tests.rs
@@ -1,0 +1,272 @@
+use super::*;
+
+fn manifest_json() -> String {
+    r#"{
+  "api_version":"nose.semantic-pack.v1",
+  "pack":{
+    "id":"example.guava.factories",
+    "kind":"LibraryPack",
+    "version":"1.0.0",
+    "display_name":"Guava factories",
+    "trust":"external-opt-in",
+    "enabled_by_default":false
+  },
+  "provenance":{
+    "provider":{"name":"Example"},
+    "license":"MIT",
+    "repository":"https://example.invalid/guava"
+  },
+  "compatibility":{"nose":">=0.19.0 <0.21.0"},
+  "supported_languages":["java"],
+  "packages":[{
+    "ecosystem":"maven",
+    "name":"com.google.guava:guava",
+    "versions":">=32.0.0 <34.0.0"
+  }],
+  "declares":{"api_contracts":[{
+    "id":"java.guava.immutable-list.of",
+    "language":"java",
+    "package":{"ecosystem":"maven","name":"com.google.guava:guava"},
+    "anchor":"call-node",
+    "matcher":"imported-api",
+    "import":{
+      "role":"type",
+      "module":"com.google.common.collect",
+      "name":"ImmutableList"
+    },
+    "call":{
+      "shape":"static-method",
+      "member":"of",
+      "arity":{"kind":"range","min":0,"max":12},
+      "receiver":"imported-type"
+    },
+    "operation":"collection-factory",
+    "result_domain":"collection",
+    "profiles":{
+      "demand":"eager",
+      "effects":"pure",
+      "exceptions":"may-throw",
+      "mutation":"none",
+      "identity":"fresh"
+    },
+    "channel":"near"
+  }]}
+}"#
+    .to_string()
+}
+
+fn parse_and_compile(json: &str) -> Result<CompiledSemanticPackV1, String> {
+    let manifest =
+        serde_json::from_str::<SemanticPackManifestV1>(json).map_err(|error| error.to_string())?;
+    compile_manifest_v1(&manifest)
+}
+
+#[test]
+fn compiles_read_only_deterministic_indexes() {
+    let compiled = parse_and_compile(&manifest_json()).expect("valid v1 manifest compiles");
+
+    assert_eq!(compiled.pack_id(), "example.guava.factories");
+    assert_eq!(compiled.pack_version(), "1.0.0");
+    assert_eq!(compiled.semantic_digest().len(), 71);
+    assert!(compiled.semantic_digest().starts_with("sha256:"));
+    assert_eq!(
+        compiled
+            .packages_by_coordinate()
+            .values()
+            .map(|package| package.versions.as_str())
+            .collect::<Vec<_>>(),
+        vec![">=32.0.0 <34.0.0"]
+    );
+    assert_eq!(
+        compiled.contracts_by_id().keys().collect::<Vec<_>>(),
+        vec![&"java.guava.immutable-list.of".to_string()]
+    );
+    assert_eq!(compiled.contract_ids_by_coordinate().len(), 1);
+    assert_eq!(
+        compiled
+            .contract_ids_by_operation()
+            .get(&SemanticPackV1ProtocolOperation::CollectionFactory),
+        Some(&vec!["java.guava.immutable-list.of".to_string()])
+    );
+}
+
+#[test]
+fn json_key_order_does_not_change_digest_or_indexes() {
+    let original = manifest_json();
+    let value: serde_json::Value = serde_json::from_str(&original).unwrap();
+    let reversed = render_with_reversed_object_keys(&value);
+
+    let left = parse_and_compile(&original).unwrap();
+    let right = parse_and_compile(&reversed).unwrap();
+    assert_eq!(left.semantic_digest(), right.semantic_digest());
+    assert_eq!(
+        left.packages_by_coordinate(),
+        right.packages_by_coordinate()
+    );
+    assert_eq!(left.contracts_by_id(), right.contracts_by_id());
+    assert_eq!(
+        left.contract_ids_by_coordinate(),
+        right.contract_ids_by_coordinate()
+    );
+    assert_eq!(
+        left.contract_ids_by_operation(),
+        right.contract_ids_by_operation()
+    );
+}
+
+#[test]
+fn every_supported_semantic_change_changes_the_digest() {
+    let original = manifest_json();
+    let baseline = parse_and_compile(&original).unwrap();
+    let changed = [
+        original.replace(">=32.0.0 <34.0.0", ">=33.0.0 <34.0.0"),
+        original.replace(
+            "java.guava.immutable-list.of",
+            "java.guava.immutable-list.copy-of",
+        ),
+        original.replace("com.google.guava:guava", "org.example:collections"),
+        original.replace("com.google.common.collect", "org.example.collect"),
+        original.replace("ImmutableList", "ImmutableCollection"),
+        original.replace("\"member\":\"of\"", "\"member\":\"copyOf\""),
+        original.replace("\"max\":12", "\"max\":11"),
+        original
+            .replace("\"role\":\"type\"", "\"role\":\"static-member\"")
+            .replace("\"shape\":\"static-method\"", "\"shape\":\"free-function\"")
+            .replace("\"receiver\":\"imported-type\"", "\"receiver\":\"none\""),
+        original
+            .replace(
+                "\"kind\":\"range\",\"min\":0,\"max\":12",
+                "\"kind\":\"set\",\"values\":[0,2,4,6,8,10,12]",
+            )
+            .replace(
+                "\"operation\":\"collection-factory\"",
+                "\"operation\":\"map-factory\"",
+            )
+            .replace(
+                "\"result_domain\":\"collection\"",
+                "\"result_domain\":\"map\"",
+            ),
+        original.replace(
+            "\"exceptions\":\"may-throw\"",
+            "\"exceptions\":\"no-throw\"",
+        ),
+        original.replace("\"channel\":\"near\"", "\"channel\":\"external-exact\""),
+    ];
+
+    for candidate in changed {
+        let compiled = parse_and_compile(&candidate).expect("changed manifest remains valid");
+        assert_ne!(baseline.semantic_digest(), compiled.semantic_digest());
+    }
+}
+
+#[test]
+fn unknown_vocabulary_is_rejected_during_deserialization() {
+    let original = manifest_json();
+    for invalid in [
+        original.replace("\"anchor\":\"call-node\"", "\"anchor\":\"package\""),
+        original.replace("\"matcher\":\"imported-api\"", "\"matcher\":\"regex\""),
+        original.replace(
+            "\"operation\":\"collection-factory\"",
+            "\"operation\":\"provider-rewrite\"",
+        ),
+        original.replace(
+            "\"result_domain\":\"collection\"",
+            "\"result_domain\":\"tensor\"",
+        ),
+        original.replace("\"demand\":\"eager\"", "\"demand\":\"lazy\""),
+        original.replace("\"effects\":\"pure\"", "\"effects\":\"provider-defined\""),
+        original.replace("\"identity\":\"fresh\"", "\"identity\":\"unknown\""),
+    ] {
+        assert!(parse_and_compile(&invalid).is_err());
+    }
+}
+
+#[test]
+fn provider_matcher_languages_cannot_be_encoded() {
+    let original = manifest_json();
+    for field in ["regex", "expression", "callback", "selector"] {
+        let invalid = original.replace(
+            "\"matcher\":\"imported-api\"",
+            &format!("\"matcher\":\"imported-api\",\"{field}\":\".*\""),
+        );
+        assert!(
+            parse_and_compile(&invalid).is_err(),
+            "field {field} must fail"
+        );
+    }
+}
+
+#[test]
+fn invalid_typed_combinations_fail_before_compilation() {
+    let original = manifest_json();
+    for invalid in [
+        original.replace("\"max\":12", "\"max\":33"),
+        original.replace("\"min\":0,\"max\":12", "\"min\":12,\"max\":0"),
+        original.replace(
+            "\"result_domain\":\"collection\"",
+            "\"result_domain\":\"map\"",
+        ),
+        original.replace("\"receiver\":\"imported-type\"", "\"receiver\":\"none\""),
+        original.replace("com.google.guava:guava", "not-a-maven-coordinate"),
+    ] {
+        assert!(parse_and_compile(&invalid).is_err());
+    }
+}
+
+#[test]
+fn local_set_keeps_v1_compilation_separate_from_v0_external_rows() {
+    let dir =
+        std::env::temp_dir().join(format!("nose_semantic_pack_v1_set_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("pack.json");
+    std::fs::write(&path, manifest_json()).unwrap();
+
+    let set = SemanticPackSet::new_local(&[path]).expect("v1 local pack loads");
+    let summary = set
+        .packs()
+        .iter()
+        .find(|pack| pack.id == "example.guava.factories")
+        .unwrap();
+    assert_eq!(summary.api_version, Some(SEMANTIC_PACK_API_VERSION_V1));
+    assert!(summary
+        .semantic_digest
+        .as_deref()
+        .is_some_and(|digest| digest.starts_with("sha256:")));
+    assert_eq!(summary.influence, SemanticPackInfluence::MetadataOnly);
+    assert!(set.external_evidence_producer_rows().is_empty());
+    assert!(set.external_contract_rows().is_empty());
+    assert!(set.external_value_law_rows().is_empty());
+    assert_eq!(set.compiled_external_v1_packs().len(), 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+fn render_with_reversed_object_keys(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Object(object) => {
+            let entries = object
+                .iter()
+                .rev()
+                .map(|(key, value)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(key).unwrap(),
+                        render_with_reversed_object_keys(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{entries}}}")
+        }
+        serde_json::Value::Array(array) => format!(
+            "[{}]",
+            array
+                .iter()
+                .map(render_with_reversed_object_keys)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        scalar => serde_json::to_string(scalar).unwrap(),
+    }
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -26,7 +26,7 @@ nose capabilities
 
 ```json
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "tool": {
     "name": "nose",
     "version": "<version>"
@@ -46,10 +46,10 @@ nose capabilities
     "deprecated": []
   },
   "schemas": {
-    "capabilities": [4],
+    "capabilities": [5],
     "query_json": [7, 8],
-    "semantic_packs": ["nose.semantic-pack.v0"],
-    "semantic_pack_conformance": [2],
+    "semantic_packs": ["nose.semantic-pack.v0", "nose.semantic-pack.v1"],
+    "semantic_pack_conformance": [3],
     "semantic_pack_inventory": [1],
     "semantic_pack_adoption_gates": [1],
     "semantic_pack_compatibility": [1]
@@ -90,7 +90,7 @@ nose capabilities
     }
   },
   "semantic_packs": {
-    "api_versions": ["nose.semantic-pack.v0"],
+    "api_versions": ["nose.semantic-pack.v0", "nose.semantic-pack.v1"],
     "loading": [
       "compiled-builtin",
       "local-manifest-file",
@@ -145,11 +145,11 @@ release so it can't drift.
 The JSON example above is compared against `nose capabilities` by the CLI integration test;
 only `tool.version` and the platform values are normalized for the local build.
 
-## Version 4 Fields
+## Version 5 Fields
 
 | field | type | meaning |
 |---|---|---|
-| `schema_version` | integer | Capabilities contract version. Version 4 is documented here. |
+| `schema_version` | integer | Capabilities contract version. Version 5 is documented here. |
 | `tool.name` | string | Always `nose`. |
 | `tool.version` | string | Package version of the installed binary. |
 | `platform.os` | string | Rust target OS name, such as `linux`, `macos`, or `windows`. |
@@ -159,11 +159,11 @@ only `tool.version` and the platform values are normalized for the local build.
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
 | `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query), with its versioned [query-JSON](query-json.md) contract). Hidden research commands are intentionally omitted. |
-| `commands.deprecated` | array | Commands that still work but are being retired. Version 4 reports an empty array. |
+| `commands.deprecated` | array | Commands that still work but are being retired. Version 5 reports an empty array. |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.query_json` | array | Supported `nose query --format json` schema versions ([query-json](query-json.md)). |
-| `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0`. |
-| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 2 reports structural conformance, executable fixture-expectation gate results, and row-level external influence preflight blockers. |
+| `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0` and `nose.semantic-pack.v1`. |
+| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 3 adds per-manifest API version and semantic digest reporting to the v0 structural/gate/preflight report and v1 typed compilation check. |
 | `schemas.semantic_pack_inventory` | array | Supported `nose semantic-pack inventory --format json` schema versions. Version 1 reports compiled builtin pack declarations, conformance refs, coverage status, and audit gaps. |
 | `schemas.semantic_pack_adoption_gates` | array | Supported `nose semantic-pack adoption-gates --format json` schema versions. Version 1 reports compiled builtin pack optional/default promotion gates, rollback actions, and blocker status. |
 | `schemas.semantic_pack_compatibility` | array | Supported `nose semantic-pack compatibility --format json` schema versions. Version 1 reports manifest API, installed-version, kernel-vocabulary, and external-influence compatibility policy. |
@@ -174,20 +174,20 @@ only `tool.version` and the platform values are normalized for the local build.
 | `query.config_keys` | array | Supported `[query]` keys in `nose.toml` / `.nose.toml`. |
 | `query.capabilities` | object | Stable boolean capability flags for query workflows. |
 | `semantic_packs.api_versions` | array | Supported semantic-pack manifest API versions. |
-| `semantic_packs.loading` | array | Supported loading sources. Schema version 4 reports `compiled-builtin` for compiled builtin packs, plus local manifest files/directories. |
+| `semantic_packs.loading` | array | Supported loading sources. Schema version 5 reports `compiled-builtin` for compiled builtin packs, plus local v0/v1 manifest files/directories. |
 | `semantic_packs.conformance` | array | Supported conformance input sources: local manifest files/directories. |
 | `semantic_packs.conformance_output_formats` | array | Supported `nose semantic-pack check --format` values. |
-| `semantic_packs.inventory` | array | Supported inventory sources. Version 4 reports `compiled-builtin`. |
+| `semantic_packs.inventory` | array | Supported inventory sources. Version 5 reports `compiled-builtin`. |
 | `semantic_packs.inventory_output_formats` | array | Supported `nose semantic-pack inventory --format` values. |
-| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 4 may report `compiled-builtin`; consumers should treat absence as unsupported. |
+| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 5 may report `compiled-builtin`; consumers should treat absence as unsupported. |
 | `semantic_packs.adoption_gate_output_formats` | array | Supported `nose semantic-pack adoption-gates --format` values. |
-| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 4 may report `policy`; consumers should treat absence as unsupported. |
+| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 5 may report `policy`; consumers should treat absence as unsupported. |
 | `semantic_packs.compatibility_output_formats` | array | Supported `nose semantic-pack compatibility --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
 | `semantic_packs.external_pack_influence` | string | Current influence of loaded external packs, `metadata-only`. |
 | `semantic_packs.external_influence_blockers` | array | Stable blocker labels that currently prevent external rows from influencing analysis. |
-| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 4 reports `none`; local external packs do not run recognizers, parser/lowering plugins, producer code, sandboxed code, or fixture contents. |
+| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 5 reports `none`; local external packs do not run recognizers, parser/lowering plugins, producer code, sandboxed code, or fixture contents. |
 | `il.output_formats` | array | Supported `nose il --format` values. |
 | `il.normalized` | boolean | Whether `nose il --normalized` is supported. |
 | `il.cfg_norm_toggle` | boolean | Whether `nose il --no-cfg-norm` is supported. |
@@ -201,7 +201,7 @@ capabilities schema version.
 
 ## Query Capability Flags
 
-Version 4 defines these `query.capabilities` keys:
+Version 5 defines these `query.capabilities` keys:
 
 | key | meaning |
 |---|---|
@@ -219,5 +219,5 @@ Version 4 defines these `query.capabilities` keys:
 | `query_base_sarif` | `base=<ref> --format sarif` emits divergent-edit SARIF results. Wrappers should also verify `query.output_formats` contains `sarif`. |
 | `query_base_structured_ignores` | Structured ignores are applied before the `base=<ref>` divergent-edit gate. |
 | `reinvented_view` | The `reinvented` query view is supported. |
-| `semantic_pack_loading` | local semantic-pack v0 manifest files/directories can be loaded for metadata validation. |
+| `semantic_pack_loading` | local v0 manifests can be loaded as metadata and typed v1 manifests can be compiled for metadata/digest reporting. |
 | `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,9 +83,11 @@ project paths do not depend on where `nose` was invoked. This applies to
 `--semantic-pack` remain current-working-directory relative.
 
 `semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
-an explicit local opt-in to a semantic-pack v0 manifest file or a directory of
-direct `*.json` manifests. Loaded external packs are reported as `metadata-only`;
-they do not emit evidence or enable exact contracts yet. See [semantic-pack-loading](semantic-pack-loading.md).
+an explicit local opt-in to a semantic-pack v0 or v1 manifest file, or a
+directory of direct `*.json` manifests. v0 rows remain data-only; v1 rows
+compile to typed indexes and a semantic digest. Loaded external packs are still
+`metadata-only`: they do not emit evidence or enable near/exact contracts. The
+[semantic-pack loading guide](semantic-pack-loading.md) defines the full boundary.
 
 ## Excludes
 

--- a/docs/examples/semantic-packs/v1/guava-immutable-collections.json
+++ b/docs/examples/semantic-packs/v1/guava-immutable-collections.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v1.schema.json",
+  "api_version": "nose.semantic-pack.v1",
+  "pack": {
+    "id": "com.example.java-guava-typed-factories",
+    "kind": "LibraryPack",
+    "version": "1.0.0",
+    "display_name": "Typed Guava immutable collection factories",
+    "description": "Typed v1 compiler example. It compiles to metadata and immutable indexes but does not influence analysis without later lock and evidence work.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false
+  },
+  "provenance": {
+    "provider": {
+      "name": "Example Semantic Packs",
+      "contact": "semantics@example.invalid"
+    },
+    "license": "MIT",
+    "repository": "https://example.invalid/semantic-packs/java-guava-typed-factories",
+    "source_revision": "0000000000000000000000000000000000000000"
+  },
+  "compatibility": {
+    "nose": ">=0.19.0 <0.21.0"
+  },
+  "supported_languages": [
+    "java"
+  ],
+  "packages": [
+    {
+      "ecosystem": "maven",
+      "name": "com.google.guava:guava",
+      "versions": ">=32.0.0 <34.0.0"
+    }
+  ],
+  "declares": {
+    "api_contracts": [
+      {
+        "id": "java.guava.immutable-list.of",
+        "language": "java",
+        "package": {
+          "ecosystem": "maven",
+          "name": "com.google.guava:guava"
+        },
+        "anchor": "call-node",
+        "matcher": "imported-api",
+        "import": {
+          "role": "type",
+          "module": "com.google.common.collect",
+          "name": "ImmutableList"
+        },
+        "call": {
+          "shape": "static-method",
+          "member": "of",
+          "arity": {
+            "kind": "range",
+            "min": 0,
+            "max": 12
+          },
+          "receiver": "imported-type"
+        },
+        "operation": "collection-factory",
+        "result_domain": "collection",
+        "profiles": {
+          "demand": "eager",
+          "effects": "pure",
+          "exceptions": "may-throw",
+          "mutation": "none",
+          "identity": "fresh"
+        },
+        "channel": "near"
+      },
+      {
+        "id": "java.guava.immutable-map.of",
+        "language": "java",
+        "package": {
+          "ecosystem": "maven",
+          "name": "com.google.guava:guava"
+        },
+        "anchor": "call-node",
+        "matcher": "imported-api",
+        "import": {
+          "role": "type",
+          "module": "com.google.common.collect",
+          "name": "ImmutableMap"
+        },
+        "call": {
+          "shape": "static-method",
+          "member": "of",
+          "arity": {
+            "kind": "set",
+            "values": [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+          },
+          "receiver": "imported-type"
+        },
+        "operation": "map-factory",
+        "result_domain": "map",
+        "profiles": {
+          "demand": "eager",
+          "effects": "pure",
+          "exceptions": "may-throw",
+          "mutation": "none",
+          "identity": "fresh"
+        },
+        "channel": "near"
+      }
+    ]
+  }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -100,6 +100,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-adoption](semantic-pack-adoption.md) — promotion, rollback, and adoption-gate reports for moving external or optional packs into official builtin support without forking semantic vocabulary.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic pre-analysis compiler, and semantic content digest; influence remains disabled pending locks and evidence.
 - [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for checking local pack manifests and the builtin inventory workflow for auditing shipped pack coverage.
 - [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and current metadata-only limits.
 

--- a/docs/schemas/semantic-pack-v1.schema.json
+++ b/docs/schemas/semantic-pack-v1.schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/corca-ai/nose/docs/schemas/semantic-pack-v1.schema.json",
+  "title": "nose typed semantic pack influence manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "pack",
+    "provenance",
+    "compatibility",
+    "supported_languages",
+    "packages",
+    "declares"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "api_version": {
+      "const": "nose.semantic-pack.v1"
+    },
+    "pack": {
+      "$ref": "#/$defs/pack"
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "compatibility": {
+      "$ref": "#/$defs/compatibility"
+    },
+    "supported_languages": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["java"]
+      }
+    },
+    "packages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/package"
+      }
+    },
+    "declares": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api_contracts"],
+      "properties": {
+        "api_contracts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/api_contract"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "stable_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "version",
+        "display_name",
+        "trust",
+        "enabled_by_default"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "kind": {
+          "const": "LibraryPack"
+        },
+        "version": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "display_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "description": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "trust": {
+          "const": "external-opt-in"
+        },
+        "enabled_by_default": {
+          "const": false
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "license", "repository"],
+      "properties": {
+        "provider": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/non_empty_string"
+            },
+            "contact": {
+              "$ref": "#/$defs/non_empty_string"
+            }
+          }
+        },
+        "license": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "repository": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "source_revision": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nose"],
+      "properties": {
+        "nose": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ecosystem", "name", "versions"],
+      "properties": {
+        "ecosystem": {
+          "const": "maven"
+        },
+        "name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "versions": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "package_coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ecosystem", "name"],
+      "properties": {
+        "ecosystem": {
+          "const": "maven"
+        },
+        "name": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "import_coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "module", "name"],
+      "properties": {
+        "role": {
+          "enum": ["type", "static-member"]
+        },
+        "module": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "name": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "arity": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "min", "max"],
+          "properties": {
+            "kind": {
+              "const": "range"
+            },
+            "min": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 32
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 32
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "values"],
+          "properties": {
+            "kind": {
+              "const": "set"
+            },
+            "values": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 33,
+              "uniqueItems": true,
+              "items": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 32
+              }
+            }
+          }
+        }
+      ]
+    },
+    "call_coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shape", "member", "arity", "receiver"],
+      "properties": {
+        "shape": {
+          "enum": ["static-method", "free-function"]
+        },
+        "member": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "arity": {
+          "$ref": "#/$defs/arity"
+        },
+        "receiver": {
+          "enum": ["imported-type", "none"]
+        }
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["demand", "effects", "exceptions", "mutation", "identity"],
+      "properties": {
+        "demand": {
+          "const": "eager"
+        },
+        "effects": {
+          "const": "pure"
+        },
+        "exceptions": {
+          "enum": ["no-throw", "may-throw"]
+        },
+        "mutation": {
+          "const": "none"
+        },
+        "identity": {
+          "const": "fresh"
+        }
+      }
+    },
+    "api_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "language",
+        "package",
+        "anchor",
+        "matcher",
+        "import",
+        "call",
+        "operation",
+        "result_domain",
+        "profiles",
+        "channel"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "language": {
+          "const": "java"
+        },
+        "package": {
+          "$ref": "#/$defs/package_coordinate"
+        },
+        "anchor": {
+          "const": "call-node"
+        },
+        "matcher": {
+          "const": "imported-api"
+        },
+        "import": {
+          "$ref": "#/$defs/import_coordinate"
+        },
+        "call": {
+          "$ref": "#/$defs/call_coordinate"
+        },
+        "operation": {
+          "enum": ["collection-factory", "map-factory"]
+        },
+        "result_domain": {
+          "enum": ["collection", "map"]
+        },
+        "profiles": {
+          "$ref": "#/$defs/profiles"
+        },
+        "channel": {
+          "enum": ["near", "external-exact"]
+        }
+      }
+    }
+  }
+}

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2083,6 +2083,11 @@ justifies a tranche ([design §2c](design.md)).
   conformance is implemented in
   [semantic-pack-conformance](semantic-pack-conformance.md); external packs
   remain metadata-only.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) adds the
+  first closed typed Java/Maven contract compiler, canonical semantic digest,
+  and deterministic indexes. Those indexes deliberately remain disconnected
+  from analysis until project locks/conflicts, dependency and occurrence
+  evidence, lane consumers, receipts, and a real reference pack are complete.
 - Start with data-only external packs for simple APIs once producer execution and
   executable fixture/oracle checks exist.
 - Add restricted recognizer hooks only after the manifest path is stable.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -629,8 +629,11 @@ still being migrated toward it.
   `nose.python.stdlib.type_domain` descriptor directly exposes its alias
   contract rows so producer id, contract id, conformance refs, and declaration
   counts come from one pack-owned table.
-- The external pack API is documented as a v0 manifest/schema with examples.
+- The external pack API keeps v0 permanently metadata-only and now adds a
+  closed typed `nose.semantic-pack.v1` Java/Maven package-API compiler.
   `nose-semantics` can validate local manifest files/directories as metadata,
+  compile v1 contracts into immutable ordered indexes, and report a canonical
+  SHA-256 semantic content digest. v1 still does not feed analysis consumers.
   `nose semantic-pack check` validates local manifests plus declared fixture
   assets, and `nose query --format json` reports active builtin/local packs in
   top-level `semantic_packs`. External packs are still `metadata-only`; builtin

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -427,5 +427,8 @@ previous semantic-kernel tranches.
   ecosystem slices that may become scoped packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
   the versioned external schema boundary.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
+  the first closed typed declaration compiler; its rows remain non-influential
+  until the external trust and evidence lanes are complete.
 - [semantic-pack-loading](semantic-pack-loading.md) describes manifest loading
   and the current metadata-only external behavior.

--- a/docs/semantic-pack-compatibility.md
+++ b/docs/semantic-pack-compatibility.md
@@ -1,6 +1,7 @@
 # Semantic pack compatibility
 
-Status: compatibility policy and machine-readable report for semantic-pack v0.
+Status: compatibility policy and machine-readable report for semantic-pack v0
+and typed v1.
 
 This page defines how semantic packs stay compatible as the semantic kernel
 changes. The current path is builtin-first: nose rehearses vocabulary and
@@ -11,7 +12,8 @@ analysis.
 
 Compatibility is checked across these dimensions:
 
-- manifest API version, currently `nose.semantic-pack.v0`;
+- manifest API version, currently `nose.semantic-pack.v0` or
+  `nose.semantic-pack.v1`;
 - `compatibility.nose`, which must include the installed nose binary version;
 - trust lane and default enablement;
 - stable pack ids, including builtin-reserved ids;
@@ -19,7 +21,7 @@ Compatibility is checked across these dimensions:
   vocabulary;
 - external influence and execution capability.
 
-Local manifests are strict v0 JSON documents. Unknown fields, unsupported enum
+Local manifests are strict versioned JSON documents. Unknown fields, unsupported enum
 values, unsupported API versions, unsupported nose version ranges, builtin trust
 claims, default-enabled external packs, and duplicate or reserved pack ids fail
 before analysis starts.
@@ -54,7 +56,7 @@ Important fields:
 | `schema_version` | `1` |
 | `status` | `ok` or `blocked` |
 | `current_nose_version` | Installed binary package version. |
-| `supported.manifest_api_versions[]` | Supported manifest API versions, currently `nose.semantic-pack.v0`. |
+| `supported.manifest_api_versions[]` | Supported manifest API versions, currently `nose.semantic-pack.v0` and `nose.semantic-pack.v1`. |
 | `supported.report_sources[]` | Report data sources, currently `policy`. |
 | `policy.manifest_nose_version` | `must-include-installed-version` |
 | `policy.manifest_schema_changes` | `breaking-change-requires-new-api-version` |
@@ -121,6 +123,8 @@ product output is unchanged except for additive metadata.
   behavior boundary compatibility changes must preserve.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
   the versioned schema surface.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
+  the closed typed manifest and semantic digest contract.
 - [semantic-pack-conformance](semantic-pack-conformance.md) defines validation
   checks for provider and user packs.
 - [semantic-pack-loading](semantic-pack-loading.md) describes how compatible

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -1,15 +1,20 @@
 # Semantic pack conformance
 
-Status: nose provides a local semantic-pack v0 conformance harness for manifest
-structure, declared fixture assets, and declarative fixture-expectation gates for
-exact-capable rows. The harness is a provider/user workflow, not nose approval of
-third-party semantic correctness. External packs remain `metadata-only` when
-loaded by `nose query`.
+Status: nose provides a local semantic-pack v0 conformance harness and a typed
+v1 compile check. The v0 harness covers manifest structure, declared fixture
+assets, and declarative fixture-expectation gates for exact-capable rows. These
+are provider/user workflows, not nose approval of third-party semantic
+correctness. External packs remain `metadata-only` when loaded by `nose query`.
+
+Typed v1 manifests use the same command to validate and compile their closed
+contract grammar. v1 does not inherit v0's opaque fixture/gate rows; its later
+source-analyzing receipts are separate work. Compilation alone remains
+`metadata-only`.
 
 ## Goal
 
-The conformance workflow gives pack providers a reproducible way to show that a
-pack meets the extension contract's minimum structural obligations:
+For v0, the conformance workflow gives pack providers a reproducible way to show
+that a pack meets the extension contract's minimum structural obligations:
 
 - the manifest parses as semantic-pack v0;
 - stable ids, enum values, trust/default policy, provenance, and compatibility
@@ -208,11 +213,13 @@ Important fields:
 
 ## Check JSON Report
 
-`--format json` emits schema version 2:
+`--format json` emits schema version 3. Version 3 adds `api_version` and the
+optional v1 `semantic_digest` to each manifest entry; the rest of this example
+shows the unchanged v0 fixture and influence-preflight structure:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "status": "ok",
   "totals": {
     "manifests": 1,
@@ -267,6 +274,8 @@ Important fields:
   },
   "manifests": [
     {
+      "api_version": "nose.semantic-pack.v0",
+      "semantic_digest": null,
       "id": "com.example.semantic-pack",
       "version": "0.1.0",
       "display_name": "Example semantic pack",
@@ -336,6 +345,8 @@ and `failed` when any declared gate reports issues such as `unknown-fixture`,
 
 The JSON report also includes `influence_preflight`. This is a row-level
 admission preview for local external declarations, not a grant of influence.
+Its status is `unavailable` when the loaded manifests produce no v0 preflight
+rows, including typed v1-only checks; v1 compilation is not an influence grant.
 Exact-capable rows without a passed executable gate report
 `executable-conformance-unavailable`. Rows with a passed gate clear only that
 blocker; v0 external rows still report blockers such as

--- a/docs/semantic-pack-extension-api-v1.md
+++ b/docs/semantic-pack-extension-api-v1.md
@@ -1,0 +1,123 @@
+# Typed semantic pack influence manifest v1
+
+Status: implemented typed manifest and deterministic compiler; influence is not
+enabled yet. `nose.semantic-pack.v0` remains permanently metadata-only.
+
+## Purpose
+
+v1 is the first semantic-pack format that nose can interpret without executing
+provider code. It replaces v0's opaque `surface` and `semantics` JSON with a
+small closed grammar. Loading a v1 file validates and compiles that grammar
+before analysis starts, but the compiled rows still have `metadata-only`
+influence until project locks, dependency and occurrence evidence, conflicts,
+and lane-specific conformance are implemented.
+
+The schema is [semantic-pack-v1.schema.json](schemas/semantic-pack-v1.schema.json).
+The [Guava example](examples/semantic-packs/v1/guava-immutable-collections.json)
+shows both range and explicit-set arity contracts.
+
+## Closed v1 surface
+
+The first slice deliberately covers only the Java/Maven static package APIs
+needed to exercise the 0.20 external-pack path:
+
+| Field | Accepted vocabulary |
+| --- | --- |
+| language / ecosystem | `java` / `maven` |
+| anchor / matcher | `call-node` / `imported-api` |
+| import role | `type`, `static-member` |
+| call shape | `static-method`, `free-function` |
+| receiver | `imported-type`, `none` |
+| arity | bounded `range`, or an explicit bounded `set`; values are at most 32 |
+| operation | `collection-factory`, `map-factory` |
+| fixed result domain | `collection`, `map` |
+| demand / effects | `eager` / `pure` |
+| exceptions | `no-throw`, `may-throw` |
+| mutation / identity | `none` / `fresh` |
+| requested lane | `near`, `external-exact` |
+
+The compiler checks combinations, not just individual enum labels. A type import
+must be a static method on an imported type; a static-member import must be a
+free function with no receiver. Collection and map factory operations must use
+their corresponding fixed result domain. Map-factory arities must contain only
+even positional key/value counts.
+
+Exact coordinates use validated Maven `group:artifact` names and exact Java
+module, imported-name, and member segments. There is no regex, expression,
+callback, provider matcher, selector, fingerprint, value law, generic HOF
+result, lazy/async/stream profile, or private value-graph-node field. Unknown
+fields and enum values fail while the manifest is loaded.
+
+This vocabulary is intentionally smaller than the internal kernel. Expanding it
+requires a later API version; a provider cannot introduce a new operation by
+spelling it in a string.
+
+## Compilation and indexes
+
+Each valid manifest compiles into a read-only `CompiledSemanticPackV1` before a
+query begins. It exposes deterministic ordered indexes:
+
+- contract id to typed contract;
+- exact package coordinate to its version requirement;
+- exact package/import/call coordinate to sorted contract ids;
+- kernel operation to sorted contract ids.
+
+Manifest path, directory order, JSON object-key order, hash-map iteration, and
+process state do not affect those indexes. Set arities are sorted before
+compilation. Duplicate ids, duplicate package coordinates, duplicate exact
+contract coordinates plus arity, invalid cross-field combinations, and
+out-of-range arities fail before analysis.
+
+The indexes are deliberately not read by normalize, fingerprint, exact, near,
+or detection consumers in this change. v1 summary rows therefore report
+`source: local-manifest` and `influence: metadata-only`, just like v0, while
+also reporting their API version and semantic digest.
+
+## Semantic content digest
+
+v1 reports a lowercase `sha256:<64 hex digits>` digest over canonical typed
+semantic content. The canonical projection includes:
+
+- API version and pack kind;
+- sorted supported languages and declared package coordinates/version ranges;
+- every typed contract field, sorted by contract id, with set arities sorted.
+
+It excludes display text, provider/contact, repository, license, source
+revision, local path, and the pack id/version. Those are provenance or separate
+lock coordinates; the future project lock pins API version, pack id, pack
+version, and semantic digest independently. Any change to a valid semantic
+field changes the digest, while reordering JSON object keys does not.
+
+v0 keeps its existing 64-bit id-derived report hash and has no semantic digest.
+That distinction is intentional: a v0 manifest can never become influential by
+being locked.
+
+## Reporting and current limits
+
+`nose capabilities` schema v5 lists both `nose.semantic-pack.v0` and
+`nose.semantic-pack.v1`. `nose semantic-pack compatibility` lists the same
+accepted versions. Query semantic-pack summaries conditionally add
+`api_version`; v1 also adds `semantic_digest`. Compiled builtin summaries keep
+their existing shape so no-pack product output is unchanged.
+
+`nose semantic-pack check --format json` schema v3 includes `api_version` and
+`semantic_digest` for each manifest. For v1 it validates and compiles the typed
+content, but it does not invent v0 fixture rows or report an influence grant.
+
+The following work remains outside this slice:
+
+- content-pinned project locks, trust limits, and overlap conflicts;
+- dependency/version readers and occurrence evidence;
+- near consumers and the separate external-claim exact lane;
+- source-analyzing conformance receipts and a real external reference pack.
+
+## See also
+
+- [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
+  the permanently metadata-only compatibility format.
+- [semantic-pack-loading](semantic-pack-loading.md) describes local discovery
+  and reporting.
+- [semantic-pack-architecture](semantic-pack-architecture.md) owns the kernel
+  boundary and behavior/performance gates.
+- [semantic-pack-compatibility](semantic-pack-compatibility.md) defines version
+  failure behavior.

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -1,13 +1,15 @@
 # Semantic pack loading
 
-Status: nose can validate local semantic-pack v0 manifests on `nose query`, and
-it can run a separate local conformance check for manifests and declared fixture
-assets. External packs are explicit opt-ins and are currently `metadata-only`:
+Status: nose can validate local semantic-pack v0 manifests and compile typed v1
+manifests on `nose query`, and it can run a separate local check. External packs
+are explicit opt-ins and are currently `metadata-only`:
 they do not emit evidence, open exact contracts, mint fingerprints, approve clone
 pairs, or change exact/near query results. Local `declares.evidence_producers`,
 `declares.contracts`, and `declares.value_laws` entries are registered as
 data-only rows on the active `SemanticPackSet`, but no normalize, value-graph,
-or exact consumer reads those external rows yet. `nose capabilities` reports the
+or exact consumer reads those external rows yet. v1 contracts compile into
+deterministic typed indexes and a semantic digest, but no analysis consumer
+reads those indexes yet. `nose capabilities` reports the
 same boundary with `external_pack_influence = "metadata-only"`,
 the current external influence blocker labels, and
 `external_pack_execution = "none"`.
@@ -49,6 +51,10 @@ references, exact-capable contract obligations, conformance fixture references,
 fixture expectation labels, executable fixture-expectation gates, and fixture
 file existence. It does not execute external producers, provider commands, or
 fixture contents, and it does not certify semantic correctness. See [semantic-pack-conformance](semantic-pack-conformance.md).
+
+For v1, the command validates the closed Java/Maven package-API grammar and
+builds its canonical digest and indexes. v1 does not reuse v0's opaque row or
+fixture declarations. See [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md).
 
 ## Trust policy
 
@@ -224,6 +230,8 @@ code execution, parser/lowering plugins, or manifest presence alone.
 
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
   the manifest schema that loading consumes.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
+  typed package API contracts, canonical digests, and deterministic indexes.
 - [semantic-pack-conformance](semantic-pack-conformance.md) describes validation
   before manifests are trusted for reporting.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) records version

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -249,7 +249,7 @@ mode flags are documented under [Ranking](#ranking) and [Detection modes](#detec
 | `--root <path>` / `-r <path>` | analyze another root; repeat for multi-root query runs. With `--root`, bare positional arguments are query terms. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress accepted families using a structured ignore file with reason/owner/expiry metadata |
-| `--semantic-pack <file-or-dir>` | explicitly load local semantic-pack v0 manifest metadata for provenance reporting; external packs are metadata-only today |
+| `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; external packs are metadata-only today |
 
 **Output**
 
@@ -293,7 +293,7 @@ and may change to improve readability. The stable contract is documented in
   the same `--format` contract as `query`/`il`).
   Use it to spot a language/construct that isn't lowering well; see [languages](languages.md).
 - `nose semantic-pack check <file-or-dir> [--format human|json]` — validate local
-  semantic-pack v0 manifest structure and declared fixture assets. It is a
+  semantic-pack v0 structure/fixtures or compile a typed v1 manifest. It is a
   pack-author/user workflow, not external pack certification; see [semantic-pack-conformance](semantic-pack-conformance.md).
 - `nose semantic-pack inventory [--format human|json]` — inspect compiled
   builtin pack declarations, conformance refs, exact-capable coverage status,

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -379,7 +379,10 @@ step "product query JSON schema"
 run_product_query_schema_live_check target/release/nose
 
 step "semantic-pack example conformance"
-target/release/nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+target/release/nose semantic-pack check \
+  docs/examples/semantic-packs/v0 \
+  docs/examples/semantic-packs/v1 \
+  --format json
 
 step "Type-4 executable focused expectations"
 run_type4_executable_expectations target/release/nose

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Docs quality gate. The semantic-pack example check keeps checked-in v0
-# manifests and fixture paths structurally honest. Set NOSE_BIN to run the
+# and v1 manifests and fixture paths structurally honest. Set NOSE_BIN to run the
 # product CLI conformance check from this script; CI and `check-ci-local --full`
 # run that check after a fresh release build. awiki checks the docs/ wiki is a
 # single connected graph with no orphan pages or disconnected islands.
@@ -14,7 +14,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-semantic_pack_examples=(docs/examples/semantic-packs/v0)
+semantic_pack_examples=(docs/examples/semantic-packs/v0 docs/examples/semantic-packs/v1)
 
 if command -v python3 >/dev/null 2>&1; then
     python3 scripts/check-semantic-pack-examples.py

--- a/scripts/check-semantic-pack-examples.py
+++ b/scripts/check-semantic-pack-examples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate checked-in semantic-pack v0 schema examples.
+"""Validate checked-in semantic-pack v0/v1 schema examples.
 
 This is intentionally a lightweight structural check, not a full JSON Schema
 implementation. It keeps the checked-in design examples honest in the docs job;
@@ -15,8 +15,12 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "docs" / "schemas" / "semantic-pack-v0.schema.json"
+SCHEMA_V1 = ROOT / "docs" / "schemas" / "semantic-pack-v1.schema.json"
 EXAMPLES = sorted(
     (ROOT / "docs" / "examples" / "semantic-packs" / "v0").glob("*.json")
+)
+EXAMPLES_V1 = sorted(
+    (ROOT / "docs" / "examples" / "semantic-packs" / "v1").glob("*.json")
 )
 
 API_VERSION = "nose.semantic-pack.v0"
@@ -285,6 +289,73 @@ def validate_pack(path: Path, doc: dict[str, Any]) -> None:
         validate_contract(path, law, known_refs, conformance_ids, require_surface=False)
 
 
+def validate_v1_pack(path: Path, doc: dict[str, Any]) -> None:
+    if doc.get("api_version") != "nose.semantic-pack.v1":
+        fail(path, "`api_version` must be nose.semantic-pack.v1")
+    pack = require_object(path, doc, "pack")
+    require_string(path, pack, "id")
+    require_string(path, pack, "version")
+    require_string(path, pack, "display_name")
+    require_enum(path, pack.get("kind"), {"LibraryPack"}, "pack.kind")
+    require_enum(path, pack.get("trust"), {"external-opt-in"}, "pack.trust")
+    if require_bool(path, pack, "enabled_by_default"):
+        fail(path, "semantic-pack v1 examples must be disabled by default")
+
+    provenance = require_object(path, doc, "provenance")
+    provider = require_object(path, provenance, "provider")
+    require_string(path, provider, "name")
+    require_string(path, provenance, "license")
+    require_string(path, provenance, "repository")
+    compatibility = require_object(path, doc, "compatibility")
+    require_string(path, compatibility, "nose")
+
+    languages = require_array(path, doc, "supported_languages", min_items=1)
+    for language in languages:
+        require_enum(path, language, {"java"}, "supported_languages[]")
+    packages = require_array(path, doc, "packages", min_items=1)
+    package_coordinates: set[tuple[str, str]] = set()
+    for package in packages:
+        if not isinstance(package, dict):
+            fail(path, "`packages[]` must be an object")
+        ecosystem = require_enum(path, package.get("ecosystem"), {"maven"}, "packages[].ecosystem")
+        name = require_string(path, package, "name")
+        require_string(path, package, "versions")
+        package_coordinates.add((ecosystem, name))
+
+    declares = require_object(path, doc, "declares")
+    contracts = require_array(path, declares, "api_contracts", min_items=1)
+    require_unique_ids(path, contracts, "declares.api_contracts")
+    for contract in contracts:
+        require_enum(path, contract.get("language"), {"java"}, "api_contract.language")
+        package = require_object(path, contract, "package")
+        coordinate = (
+            require_enum(path, package.get("ecosystem"), {"maven"}, "api_contract.package.ecosystem"),
+            require_string(path, package, "name"),
+        )
+        if coordinate not in package_coordinates:
+            fail(path, f"contract `{contract['id']}` references an undeclared package")
+        require_enum(path, contract.get("anchor"), {"call-node"}, "api_contract.anchor")
+        require_enum(path, contract.get("matcher"), {"imported-api"}, "api_contract.matcher")
+        import_coordinate = require_object(path, contract, "import")
+        require_enum(path, import_coordinate.get("role"), {"type", "static-member"}, "api_contract.import.role")
+        require_string(path, import_coordinate, "module")
+        require_string(path, import_coordinate, "name")
+        call = require_object(path, contract, "call")
+        require_enum(path, call.get("shape"), {"static-method", "free-function"}, "api_contract.call.shape")
+        require_string(path, call, "member")
+        require_object(path, call, "arity")
+        require_enum(path, call.get("receiver"), {"imported-type", "none"}, "api_contract.call.receiver")
+        require_enum(path, contract.get("operation"), {"collection-factory", "map-factory"}, "api_contract.operation")
+        require_enum(path, contract.get("result_domain"), {"collection", "map"}, "api_contract.result_domain")
+        profiles = require_object(path, contract, "profiles")
+        require_enum(path, profiles.get("demand"), {"eager"}, "api_contract.profiles.demand")
+        require_enum(path, profiles.get("effects"), {"pure"}, "api_contract.profiles.effects")
+        require_enum(path, profiles.get("exceptions"), {"no-throw", "may-throw"}, "api_contract.profiles.exceptions")
+        require_enum(path, profiles.get("mutation"), {"none"}, "api_contract.profiles.mutation")
+        require_enum(path, profiles.get("identity"), {"fresh"}, "api_contract.profiles.identity")
+        require_enum(path, contract.get("channel"), {"near", "external-exact"}, "api_contract.channel")
+
+
 def main() -> int:
     schema = read_json(SCHEMA)
     if schema.get("$id") is None or schema.get("title") is None:
@@ -293,7 +364,17 @@ def main() -> int:
         fail(ROOT / "docs" / "examples" / "semantic-packs" / "v0", "no examples found")
     for example in EXAMPLES:
         validate_pack(example, read_json(example))
-    print(f"validated {len(EXAMPLES)} semantic-pack v0 example(s)")
+    schema_v1 = read_json(SCHEMA_V1)
+    if schema_v1.get("$id") is None or schema_v1.get("title") is None:
+        fail(SCHEMA_V1, "schema must declare $id and title")
+    if not EXAMPLES_V1:
+        fail(ROOT / "docs" / "examples" / "semantic-packs" / "v1", "no examples found")
+    for example in EXAMPLES_V1:
+        validate_v1_pack(example, read_json(example))
+    print(
+        f"validated {len(EXAMPLES)} semantic-pack v0 example(s) and "
+        f"{len(EXAMPLES_V1)} semantic-pack v1 example(s)"
+    )
     return 0
 
 


### PR DESCRIPTION
Closes #864

## Summary
- add a closed, strictly validated `nose.semantic-pack.v1` grammar for Java/Maven package API factory contracts
- compile canonical typed content into immutable ordered indexes and SHA-256 semantic digests before analysis
- report v0/v1 capabilities and conformance metadata while keeping every external v0/v1 pack metadata-only
- add schema, checked example, documentation, and no-influence/determinism/fail-closed regression coverage

## Scope boundary
- no project locks or dependency readers (#865/#866)
- no near or external-claim exact consumers (#867/#868)
- no external provider code, regex/DSL callbacks, new value laws, HOF/async/stream semantics, or value-graph nodes

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `./scripts/check-docs.sh`
- `python3 scripts/check-semantic-pack-examples.py`
- `target/debug/nose semantic-pack check docs/examples/semantic-packs/v0 docs/examples/semantic-packs/v1 --format json`
- `git diff --check`