### PR TITLE
feat: index locked semantic-pack evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ name = "nose-semantics"
 version = "0.19.0"
 dependencies = [
  "nose-il",
+ "quick-xml",
  "rustc-hash",
  "semver",
  "serde",
@@ -662,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 memchr = "2"
 toml = "0.8"
-quick-xml = "0.38"
+quick-xml = "0.41"
 
 # Centralized lint policy — every crate opts in with `[lints] workspace = true`,
 # so the quality bar is defined once and enforced uniformly. CI runs clippy with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 memchr = "2"
 toml = "0.8"
+quick-xml = "0.38"
 
 # Centralized lint policy — every crate opts in with `[lints] workspace = true`,
 # so the quality bar is defined once and enforced uniformly. CI runs clippy with

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "a3b307117591b7042dcab27c8945b9c91ae94df2",
+  "product_crates_tree": "3d16b42919c365a229f634af629388746d6d9da1",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -215,6 +215,7 @@ fn query_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
         ("query_base_sarif", true),
         ("query_base_structured_ignores", true),
         ("reinvented_view", true),
+        ("semantic_pack_dependency_evidence", true),
         ("semantic_pack_loading", true),
         ("semantic_pack_project_lock", true),
         ("structured_ignores", true),

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -22,6 +22,7 @@ pub(super) struct QueryDataset {
     pub(super) scope: QueryScope,
     pub(super) settings: QuerySettings,
     pub(super) semantic_packs: nose_semantics::SemanticPackSet,
+    pub(super) _semantic_pack_evidence: nose_semantics::SemanticPackEvidenceIndex,
     pub(super) reinvented: Vec<nose_detect::ReinventedHelper>,
     pub(super) opts: nose_detect::DetectOptions,
 }
@@ -33,8 +34,14 @@ pub(super) fn build_query_dataset(
     let (settings, semantic_packs) = resolve_query_settings(args)?;
     let opts = detection_options(settings.channels, settings.min_tokens, settings.min_lines);
     let detector = detection_engine(settings.channels, &opts);
-    let (mut report, scope) =
-        query_detect_report(args, refs, &settings.exclude, &opts, detector.as_ref());
+    let (mut report, scope, semantic_pack_evidence) = query_detect_report(
+        args,
+        refs,
+        &settings.exclude,
+        &opts,
+        detector.as_ref(),
+        &semantic_packs,
+    );
 
     let mut families = time_stage("rank_families", || nose_detect::rank_families(&report));
     preserve_query_accepted_coverage(&mut families);
@@ -82,6 +89,7 @@ pub(super) fn build_query_dataset(
         scope,
         settings,
         semantic_packs,
+        _semantic_pack_evidence: semantic_pack_evidence,
         reinvented,
         opts,
     })
@@ -200,7 +208,12 @@ fn query_detect_report(
     exclude: &[String],
     opts: &nose_detect::DetectOptions,
     detector: &dyn nose_detect::Detector,
-) -> (nose_detect::Report, QueryScope) {
+    semantic_packs: &nose_semantics::SemanticPackSet,
+) -> (
+    nose_detect::Report,
+    QueryScope,
+    nose_semantics::SemanticPackEvidenceIndex,
+) {
     if let Some(dir) = &args.cache_dir {
         // Lower AND cross-file-resolve the corpus every run (the smaller half of
         // the work, §BQ), then cache only the dominant normalize+extract step
@@ -209,6 +222,8 @@ fn query_detect_report(
         // (#275), which the old per-file source-content cache skipped.
         let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
         let scope = QueryScope::from_corpus(&corpus);
+        let semantic_pack_evidence =
+            nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
         let cache::CachedUnits {
             units,
             streams,
@@ -218,14 +233,14 @@ fn query_detect_report(
             units, files, &streams, opts, detector,
         )
         .0;
-        (report, scope)
+        (report, scope, semantic_pack_evidence)
     } else {
         let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
         let scope = QueryScope::from_corpus(&corpus);
-        (
-            nose_detect::detect_with_accepted_coverage(&corpus, opts, detector),
-            scope,
-        )
+        let semantic_pack_evidence =
+            nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
+        let report = nose_detect::detect_with_accepted_coverage(&corpus, opts, detector);
+        (report, scope, semantic_pack_evidence)
     }
 }
 

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -124,6 +124,10 @@ fn capabilities_command_reports_query_surface() {
     );
     assert_eq!(json["query"]["capabilities"]["semantic_pack_loading"], true);
     assert_eq!(
+        json["query"]["capabilities"]["semantic_pack_dependency_evidence"],
+        true
+    );
+    assert_eq!(
         json["query"]["capabilities"]["semantic_pack_project_lock"],
         true
     );

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
@@ -34,7 +34,7 @@ fn typed_v1_pack_compiles_and_reports_digest_without_changing_families() {
     assert_eq!(reported["api_version"], "nose.semantic-pack.v1");
     assert_eq!(reported["source"], "local-manifest");
     assert_eq!(reported["influence"], "metadata-only");
-    assert_eq!(reported["counts"]["contracts"], 2);
+    assert_eq!(reported["counts"]["contracts"], 3);
     let digest = reported["semantic_digest"].as_str().unwrap();
     assert!(digest.starts_with("sha256:"));
     assert_eq!(digest.len(), 71);

--- a/crates/nose-cli/tests/cli/commands/config_packs/project_lock.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/project_lock.rs
@@ -53,7 +53,7 @@ fn lock_and_status_commands_report_the_same_valid_local_decision() {
     );
     assert_eq!(created_json["influence"], "metadata-only");
     assert_eq!(created_json["totals"]["packs"], 1);
-    assert_eq!(created_json["totals"]["selected_rows"], 2);
+    assert_eq!(created_json["totals"]["selected_rows"], 3);
     assert_eq!(created_json["totals"]["conflicts"], 0);
     assert_eq!(created_json["dependencies"][0]["path"], "pom.xml");
 
@@ -115,7 +115,7 @@ fn locked_query_reports_authorization_but_keeps_families_unchanged() {
         pack["lock"]["allowed_channels"],
         serde_json::json!(["near"])
     );
-    assert_eq!(pack["lock"]["selected_rows"].as_array().unwrap().len(), 2);
+    assert_eq!(pack["lock"]["selected_rows"].as_array().unwrap().len(), 3);
     assert_eq!(pack["lock"]["dependencies"][0]["path"], "pom.xml");
 }
 

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -24,6 +24,8 @@ mod type_domain_aliases;
 
 #[cfg(test)]
 mod corpus_tests;
+#[cfg(test)]
+mod semantic_pack_evidence_tests;
 
 pub use coverage::{coverage, raw_node_surface, CoverageReport, RawSurface};
 pub use declaration_facts::{declaration_facts, DeclarationFacts};

--- a/crates/nose-frontend/src/semantic_pack_evidence_tests.rs
+++ b/crates/nose-frontend/src/semantic_pack_evidence_tests.rs
@@ -1,0 +1,137 @@
+use nose_il::{Corpus, FileId, Interner, Lang};
+use nose_semantics::{SemanticPackEvidenceIndex, SemanticPackSet};
+use std::path::PathBuf;
+
+const PACK_ID: &str = "com.example.java-guava-typed-factories";
+const LIST_ROW: &str = "java.guava.immutable-list.of";
+const STATIC_LIST_ROW: &str = "java.guava.immutable-list.static-of";
+const MAP_ROW: &str = "java.guava.immutable-map.of";
+
+fn workspace_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn evidence_for(source: &str, packs: &SemanticPackSet) -> SemanticPackEvidenceIndex {
+    let interner = Interner::new();
+    let il = crate::lower_source(
+        FileId(0),
+        "Fixture.java",
+        source.as_bytes(),
+        Lang::Java,
+        &interner,
+    )
+    .expect("Java fixture should lower");
+    SemanticPackEvidenceIndex::build(packs, &Corpus::new(interner, vec![il]))
+}
+
+#[test]
+fn locked_dependency_and_builtin_import_facts_produce_one_occurrence() {
+    let packs =
+        SemanticPackSet::new_locked(&workspace_path("docs/examples/semantic-pack-lock-v1.json"))
+            .expect("checked-in lock should validate");
+    let index = evidence_for(
+        "import com.google.common.collect.ImmutableList;\n\
+         class Example { Object f() { return ImmutableList.of(\"a\", \"b\"); } }",
+        &packs,
+    );
+
+    assert_eq!(index.dependencies().len(), 1);
+    assert_eq!(index.dependencies()[0].declared_version, "33.0.0-jre");
+    assert_eq!(index.dependencies()[0].matched_version, "33.0.0");
+    let row = index.row(PACK_ID, LIST_ROW).expect("selected list row");
+    assert_eq!(row.blocker, None);
+    assert_eq!(row.occurrence_count(), 1);
+    let occurrence = &index.occurrences_for_row(PACK_ID, LIST_ROW)[0];
+    assert_eq!(occurrence.arity, 2);
+    assert!(occurrence.receiver_evidence.is_some());
+    assert!(occurrence.receiver_span.is_some());
+    assert!(!occurrence.effect_evidence.is_empty());
+    assert_eq!(index.row(PACK_ID, MAP_ROW).unwrap().occurrence_count(), 0);
+}
+
+#[test]
+fn explicit_static_import_produces_a_receiver_free_occurrence() {
+    let packs =
+        SemanticPackSet::new_locked(&workspace_path("docs/examples/semantic-pack-lock-v1.json"))
+            .expect("checked-in lock should validate");
+    let index = evidence_for(
+        "import static com.google.common.collect.ImmutableList.of;\n\
+         class Example { Object f() { return of(\"a\"); } }",
+        &packs,
+    );
+
+    let occurrences = index.occurrences_for_row(PACK_ID, STATIC_LIST_ROW);
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].arity, 1);
+    assert_eq!(occurrences[0].receiver_evidence, None);
+    assert_eq!(occurrences[0].receiver_span, None);
+    assert_eq!(index.row(PACK_ID, LIST_ROW).unwrap().occurrence_count(), 0);
+}
+
+#[test]
+fn wrong_package_local_shadow_and_unlocked_metadata_stay_closed() {
+    let locked =
+        SemanticPackSet::new_locked(&workspace_path("docs/examples/semantic-pack-lock-v1.json"))
+            .expect("checked-in lock should validate");
+    let wrong_package = evidence_for(
+        "import example.collect.ImmutableList;\n\
+         class Example { Object f() { return ImmutableList.of(\"a\"); } }",
+        &locked,
+    );
+    assert_eq!(
+        wrong_package
+            .row(PACK_ID, LIST_ROW)
+            .unwrap()
+            .occurrence_count(),
+        0
+    );
+
+    let shadowed = evidence_for(
+        "import com.google.common.collect.ImmutableList;\n\
+         class ImmutableList { static Object of(Object x) { return x; } }\n\
+         class Example { Object f() { return ImmutableList.of(\"a\"); } }",
+        &locked,
+    );
+    assert_eq!(
+        shadowed.row(PACK_ID, LIST_ROW).unwrap().occurrence_count(),
+        0
+    );
+
+    let wildcard = evidence_for(
+        "import com.google.common.collect.*;\n\
+         class Example { Object f() { return ImmutableList.of(\"a\"); } }",
+        &locked,
+    );
+    assert_eq!(
+        wildcard.row(PACK_ID, LIST_ROW).unwrap().occurrence_count(),
+        0
+    );
+
+    let unsupported_arity = evidence_for(
+        "import com.google.common.collect.ImmutableList;\n\
+         class Example { Object f() { return ImmutableList.of(\
+           0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12); } }",
+        &locked,
+    );
+    assert_eq!(
+        unsupported_arity
+            .row(PACK_ID, LIST_ROW)
+            .unwrap()
+            .occurrence_count(),
+        0
+    );
+
+    let unlocked = SemanticPackSet::new_local(&[workspace_path(
+        "docs/examples/semantic-packs/v1/guava-immutable-collections.json",
+    )])
+    .expect("typed manifest should load as metadata");
+    let metadata_only = evidence_for(
+        "import com.google.common.collect.ImmutableList;\n\
+         class Example { Object f() { return ImmutableList.of(\"a\"); } }",
+        &unlocked,
+    );
+    assert!(metadata_only.rows().is_empty());
+    assert!(metadata_only.occurrences().is_empty());
+}

--- a/crates/nose-semantics/Cargo.toml
+++ b/crates/nose-semantics/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 nose-il = { workspace = true }
+quick-xml = { workspace = true }
 rustc-hash = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -106,6 +106,7 @@ use std::path::PathBuf;
 
 mod compiled;
 mod conformance;
+mod evidence_index;
 mod external;
 mod loading;
 mod lock;
@@ -124,6 +125,11 @@ pub use conformance::{
     SemanticPackExecutableConformanceCheck, SemanticPackExecutableConformanceIssue,
     SemanticPackExecutableOracle, SemanticPackFixtureCheck, SemanticPackFixtureIssue,
     SemanticPackFixtureKind,
+};
+pub use evidence_index::{
+    SemanticPackDependencyEvidence, SemanticPackDependencyEvidenceId, SemanticPackDependencySource,
+    SemanticPackEvidenceBlocker, SemanticPackEvidenceIndex, SemanticPackEvidenceRow,
+    SemanticPackOccurrenceEvidence,
 };
 pub use external::{
     ExternalContractRow, ExternalEvidenceProducerRow, ExternalInfluenceBlocker,

--- a/crates/nose-semantics/src/packs/evidence_index.rs
+++ b/crates/nose-semantics/src/packs/evidence_index.rs
@@ -1,0 +1,279 @@
+//! Kernel-owned dependency and occurrence evidence for locked typed packs.
+//!
+//! This index is deliberately separate from IL evidence. It consumes content-pinned
+//! project inputs and builtin frontend facts, but cannot mutate the corpus or make a
+//! detector admit a result by itself.
+
+use super::*;
+use nose_il::{Corpus, EvidenceId, Span};
+use rustc_hash::FxHashMap;
+use std::collections::BTreeMap;
+
+mod maven;
+mod occurrences;
+
+use maven::{MavenCatalog, MavenResolution};
+use occurrences::occurrences_for_contract;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct SemanticPackDependencyEvidenceId(pub u32);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct SemanticPackDependencySource {
+    pub declared_path: String,
+    pub content_digest: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackDependencyEvidence {
+    pub id: SemanticPackDependencyEvidenceId,
+    pub ecosystem: SemanticPackV1PackageEcosystem,
+    pub coordinate: String,
+    pub declared_version: String,
+    pub matched_version: String,
+    pub sources: Vec<SemanticPackDependencySource>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SemanticPackEvidenceBlocker {
+    MissingDependency,
+    InvalidDependencyVersion,
+    AmbiguousDependencyVersion,
+    OutOfRangeDependencyVersion,
+}
+
+impl SemanticPackEvidenceBlocker {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingDependency => "missing-dependency",
+            Self::InvalidDependencyVersion => "invalid-dependency-version",
+            Self::AmbiguousDependencyVersion => "ambiguous-dependency-version",
+            Self::OutOfRangeDependencyVersion => "out-of-range-dependency-version",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackEvidenceRow {
+    pub pack_id: String,
+    pub row_id: String,
+    pub semantic_digest: String,
+    pub channel: SemanticPackV1Channel,
+    pub dependency: Option<SemanticPackDependencyEvidenceId>,
+    pub blocker: Option<SemanticPackEvidenceBlocker>,
+    occurrence_start: usize,
+    occurrence_end: usize,
+}
+
+impl SemanticPackEvidenceRow {
+    pub fn occurrence_count(&self) -> usize {
+        self.occurrence_end - self.occurrence_start
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SemanticPackOccurrenceEvidence {
+    pub pack_id: String,
+    pub row_id: String,
+    pub channel: SemanticPackV1Channel,
+    pub call_span: Span,
+    pub arity: u16,
+    pub dependency: SemanticPackDependencyEvidenceId,
+    pub import_evidence: EvidenceId,
+    pub symbol_evidence: EvidenceId,
+    pub receiver_evidence: Option<EvidenceId>,
+    pub receiver_span: Option<Span>,
+    pub effect_evidence: Vec<EvidenceId>,
+    pub call_target_evidence: Vec<EvidenceId>,
+    pub domain_evidence: Vec<EvidenceId>,
+    pub place_evidence: Vec<EvidenceId>,
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct SemanticPackEvidenceIndex {
+    dependencies: Vec<SemanticPackDependencyEvidence>,
+    rows: Vec<SemanticPackEvidenceRow>,
+    occurrences: Vec<SemanticPackOccurrenceEvidence>,
+    row_by_id: BTreeMap<(String, String), usize>,
+    occurrences_by_span: FxHashMap<Span, Vec<usize>>,
+}
+
+impl SemanticPackEvidenceIndex {
+    pub fn build(packs: &SemanticPackSet, corpus: &Corpus) -> Self {
+        let catalog = MavenCatalog::from_authorizations(packs.external_v1_authorizations.values());
+        let mut builder = EvidenceIndexBuilder::new(catalog);
+        let mut compiled = packs.compiled_external_v1_packs.iter().collect::<Vec<_>>();
+        compiled.sort_by(|left, right| left.pack_id().cmp(right.pack_id()));
+        for pack in compiled {
+            let Some(authorization) = packs.external_v1_authorization(pack.pack_id()) else {
+                continue;
+            };
+            for (row_id, contract) in pack.contracts_by_id() {
+                if authorization.allows(row_id, contract.channel) {
+                    builder.push_row(pack, contract, corpus);
+                }
+            }
+        }
+        builder.finish()
+    }
+
+    pub fn dependencies(&self) -> &[SemanticPackDependencyEvidence] {
+        &self.dependencies
+    }
+
+    pub fn dependency(
+        &self,
+        id: SemanticPackDependencyEvidenceId,
+    ) -> Option<&SemanticPackDependencyEvidence> {
+        self.dependencies.get(id.0 as usize)
+    }
+
+    pub fn rows(&self) -> &[SemanticPackEvidenceRow] {
+        &self.rows
+    }
+
+    pub fn occurrences(&self) -> &[SemanticPackOccurrenceEvidence] {
+        &self.occurrences
+    }
+
+    pub fn row(&self, pack_id: &str, row_id: &str) -> Option<&SemanticPackEvidenceRow> {
+        let index = self
+            .row_by_id
+            .get(&(pack_id.to_string(), row_id.to_string()))?;
+        self.rows.get(*index)
+    }
+
+    pub fn occurrences_for_row(
+        &self,
+        pack_id: &str,
+        row_id: &str,
+    ) -> &[SemanticPackOccurrenceEvidence] {
+        let Some(row) = self.row(pack_id, row_id) else {
+            return &[];
+        };
+        &self.occurrences[row.occurrence_start..row.occurrence_end]
+    }
+
+    pub fn occurrences_at(
+        &self,
+        span: Span,
+    ) -> impl Iterator<Item = &SemanticPackOccurrenceEvidence> {
+        self.occurrences_by_span
+            .get(&span)
+            .into_iter()
+            .flatten()
+            .filter_map(|index| self.occurrences.get(*index))
+    }
+}
+
+struct EvidenceIndexBuilder {
+    catalog: MavenCatalog,
+    dependencies: Vec<SemanticPackDependencyEvidence>,
+    dependency_by_key: BTreeMap<maven::MavenEvidenceKey, SemanticPackDependencyEvidenceId>,
+    rows: Vec<SemanticPackEvidenceRow>,
+    occurrences: Vec<SemanticPackOccurrenceEvidence>,
+}
+
+impl EvidenceIndexBuilder {
+    fn new(catalog: MavenCatalog) -> Self {
+        Self {
+            catalog,
+            dependencies: Vec::new(),
+            dependency_by_key: BTreeMap::new(),
+            rows: Vec::new(),
+            occurrences: Vec::new(),
+        }
+    }
+
+    fn push_row(
+        &mut self,
+        pack: &CompiledSemanticPackV1,
+        contract: &SemanticPackV1Contract,
+        corpus: &Corpus,
+    ) {
+        let start = self.occurrences.len();
+        let (dependency, blocker) = self.resolve_dependency(pack, contract);
+        if let Some(dependency) = dependency {
+            self.occurrences.extend(occurrences_for_contract(
+                pack.pack_id(),
+                contract,
+                dependency,
+                corpus,
+            ));
+        }
+        self.rows.push(SemanticPackEvidenceRow {
+            pack_id: pack.pack_id().to_string(),
+            row_id: contract.id.clone(),
+            semantic_digest: pack.semantic_digest().to_string(),
+            channel: contract.channel,
+            dependency,
+            blocker,
+            occurrence_start: start,
+            occurrence_end: self.occurrences.len(),
+        });
+    }
+
+    fn resolve_dependency(
+        &mut self,
+        pack: &CompiledSemanticPackV1,
+        contract: &SemanticPackV1Contract,
+    ) -> (
+        Option<SemanticPackDependencyEvidenceId>,
+        Option<SemanticPackEvidenceBlocker>,
+    ) {
+        let Some(package) = pack.packages_by_coordinate().get(&contract.package) else {
+            return (None, Some(SemanticPackEvidenceBlocker::MissingDependency));
+        };
+        match self.catalog.resolve(&package.name, &package.versions) {
+            MavenResolution::Resolved(key) => {
+                let id = if let Some(id) = self.dependency_by_key.get(&key) {
+                    *id
+                } else {
+                    let id = SemanticPackDependencyEvidenceId(self.dependencies.len() as u32);
+                    self.dependencies.push(key.to_evidence(id));
+                    self.dependency_by_key.insert(key, id);
+                    id
+                };
+                (Some(id), None)
+            }
+            MavenResolution::Missing => {
+                (None, Some(SemanticPackEvidenceBlocker::MissingDependency))
+            }
+            MavenResolution::InvalidVersion => (
+                None,
+                Some(SemanticPackEvidenceBlocker::InvalidDependencyVersion),
+            ),
+            MavenResolution::AmbiguousVersion => (
+                None,
+                Some(SemanticPackEvidenceBlocker::AmbiguousDependencyVersion),
+            ),
+            MavenResolution::OutOfRange => (
+                None,
+                Some(SemanticPackEvidenceBlocker::OutOfRangeDependencyVersion),
+            ),
+        }
+    }
+
+    fn finish(self) -> SemanticPackEvidenceIndex {
+        let row_by_id = self
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| ((row.pack_id.clone(), row.row_id.clone()), index))
+            .collect();
+        let mut occurrences_by_span = FxHashMap::<Span, Vec<usize>>::default();
+        for (index, occurrence) in self.occurrences.iter().enumerate() {
+            occurrences_by_span
+                .entry(occurrence.call_span)
+                .or_default()
+                .push(index);
+        }
+        SemanticPackEvidenceIndex {
+            dependencies: self.dependencies,
+            rows: self.rows,
+            occurrences: self.occurrences,
+            row_by_id,
+            occurrences_by_span,
+        }
+    }
+}

--- a/crates/nose-semantics/src/packs/evidence_index/maven.rs
+++ b/crates/nose-semantics/src/packs/evidence_index/maven.rs
@@ -1,0 +1,541 @@
+use super::{SemanticPackDependencyEvidence, SemanticPackDependencyEvidenceId};
+use crate::{
+    SemanticPackDependencySource, SemanticPackV1Authorization, SemanticPackV1PackageEcosystem,
+};
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use semver::{Version, VersionReq};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+
+const MAX_POM_BYTES: usize = 2 * 1024 * 1024;
+const MAX_XML_DEPTH: usize = 64;
+const MAX_PROPERTY_EXPANSIONS: usize = 16;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(super) struct MavenEvidenceKey {
+    coordinate: String,
+    declared_version: String,
+    matched_version: String,
+    sources: Vec<SemanticPackDependencySource>,
+}
+
+impl MavenEvidenceKey {
+    pub(super) fn to_evidence(
+        &self,
+        id: SemanticPackDependencyEvidenceId,
+    ) -> SemanticPackDependencyEvidence {
+        SemanticPackDependencyEvidence {
+            id,
+            ecosystem: SemanticPackV1PackageEcosystem::Maven,
+            coordinate: self.coordinate.clone(),
+            declared_version: self.declared_version.clone(),
+            matched_version: self.matched_version.clone(),
+            sources: self.sources.clone(),
+        }
+    }
+}
+
+pub(super) enum MavenResolution {
+    Missing,
+    InvalidVersion,
+    AmbiguousVersion,
+    OutOfRange,
+    Resolved(MavenEvidenceKey),
+}
+
+#[derive(Default)]
+pub(super) struct MavenCatalog {
+    declarations: BTreeMap<String, Vec<MavenDeclaration>>,
+}
+
+impl MavenCatalog {
+    pub(super) fn from_authorizations<'a>(
+        authorizations: impl Iterator<Item = &'a SemanticPackV1Authorization>,
+    ) -> Self {
+        let mut files = BTreeMap::new();
+        for authorization in authorizations {
+            for file in authorization.dependencies() {
+                files
+                    .entry((file.declared_path(), file.content_digest()))
+                    .or_insert(file);
+            }
+        }
+        let mut catalog = Self::default();
+        for file in files.values() {
+            catalog.read_file(file);
+        }
+        catalog
+    }
+
+    pub(super) fn resolve(&self, coordinate: &str, requirement: &str) -> MavenResolution {
+        let Some(declarations) = self.declarations.get(coordinate) else {
+            return MavenResolution::Missing;
+        };
+        let mut versions = BTreeMap::<String, Vec<SemanticPackDependencySource>>::new();
+        let mut has_invalid = false;
+        for declaration in declarations {
+            let Some(version) = &declaration.version else {
+                has_invalid = true;
+                continue;
+            };
+            versions
+                .entry(version.clone())
+                .or_default()
+                .push(declaration.source.clone());
+        }
+        if has_invalid || versions.is_empty() {
+            return MavenResolution::InvalidVersion;
+        }
+        if versions.len() != 1 {
+            return MavenResolution::AmbiguousVersion;
+        }
+        let (declared_version, mut sources) = versions.into_iter().next().expect("one version");
+        let Some(matched_version) = maven_release_version(&declared_version) else {
+            return MavenResolution::InvalidVersion;
+        };
+        let normalized_requirement = requirement
+            .replace(',', " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(",");
+        let Ok(requirement) = VersionReq::parse(&normalized_requirement) else {
+            return MavenResolution::InvalidVersion;
+        };
+        if !requirement.matches(&matched_version) {
+            return MavenResolution::OutOfRange;
+        }
+        sources.sort();
+        sources.dedup();
+        MavenResolution::Resolved(MavenEvidenceKey {
+            coordinate: coordinate.to_string(),
+            declared_version,
+            matched_version: matched_version.to_string(),
+            sources,
+        })
+    }
+
+    fn read_file(&mut self, file: &crate::SemanticPackLockedFile) {
+        let Ok(bytes) = fs::read(file.resolved_path()) else {
+            return;
+        };
+        if bytes.len() > MAX_POM_BYTES || digest(&bytes) != file.content_digest() {
+            return;
+        }
+        let Ok(text) = std::str::from_utf8(&bytes) else {
+            return;
+        };
+        let Ok(pom) = parse_pom(text) else {
+            return;
+        };
+        let source = SemanticPackDependencySource {
+            declared_path: file.declared_path().to_string(),
+            content_digest: file.content_digest().to_string(),
+        };
+        for dependency in pom.direct_dependencies() {
+            self.declarations
+                .entry(dependency.coordinate)
+                .or_default()
+                .push(MavenDeclaration {
+                    version: dependency.version,
+                    source: source.clone(),
+                });
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MavenDeclaration {
+    version: Option<String>,
+    source: SemanticPackDependencySource,
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn maven_release_version(raw: &str) -> Option<Version> {
+    if let Ok(version) = Version::parse(raw) {
+        if version.pre.is_empty() {
+            return Some(version);
+        }
+    }
+    let core = raw
+        .strip_suffix("-jre")
+        .or_else(|| raw.strip_suffix("-android"))?;
+    let version = Version::parse(core).ok()?;
+    (version.pre.is_empty() && version.build.is_empty()).then_some(version)
+}
+
+#[derive(Default)]
+struct MavenPom {
+    project_fields: BTreeMap<String, Vec<String>>,
+    parent_fields: BTreeMap<String, Vec<String>>,
+    properties: BTreeMap<String, Vec<String>>,
+    managed: Vec<RawDependency>,
+    direct: Vec<RawDependency>,
+}
+
+impl MavenPom {
+    fn direct_dependencies(&self) -> Vec<ResolvedDependency> {
+        let properties = self.resolved_properties();
+        let managed = self.managed_versions(&properties);
+        self.direct
+            .iter()
+            .filter_map(|dependency| {
+                let group = resolve_field(&dependency.fields, "groupId", &properties)?;
+                let artifact = resolve_field(&dependency.fields, "artifactId", &properties)?;
+                let coordinate = format!("{group}:{artifact}");
+                let version = resolve_field(&dependency.fields, "version", &properties)
+                    .or_else(|| managed.get(&coordinate).cloned());
+                Some(ResolvedDependency {
+                    coordinate,
+                    version,
+                })
+            })
+            .collect()
+    }
+
+    fn resolved_properties(&self) -> BTreeMap<String, String> {
+        let mut values = BTreeMap::new();
+        for (key, candidates) in &self.properties {
+            if let Some(value) = unique(candidates) {
+                values.insert(key.clone(), value.to_string());
+            }
+        }
+        let group = unique_field(&self.project_fields, "groupId")
+            .or_else(|| unique_field(&self.parent_fields, "groupId"));
+        let version = unique_field(&self.project_fields, "version")
+            .or_else(|| unique_field(&self.parent_fields, "version"));
+        let artifact = unique_field(&self.project_fields, "artifactId");
+        insert_project_property(&mut values, "groupId", group);
+        insert_project_property(&mut values, "version", version);
+        insert_project_property(&mut values, "artifactId", artifact);
+        for _ in 0..MAX_PROPERTY_EXPANSIONS {
+            let previous = values.clone();
+            for value in values.values_mut() {
+                if let Some(expanded) = expand_properties(value, &previous) {
+                    *value = expanded;
+                }
+            }
+            if values == previous {
+                break;
+            }
+        }
+        values
+    }
+
+    fn managed_versions(&self, properties: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+        let mut versions = BTreeMap::<String, BTreeSet<String>>::new();
+        for dependency in &self.managed {
+            let Some(group) = resolve_field(&dependency.fields, "groupId", properties) else {
+                continue;
+            };
+            let Some(artifact) = resolve_field(&dependency.fields, "artifactId", properties) else {
+                continue;
+            };
+            let Some(version) = resolve_field(&dependency.fields, "version", properties) else {
+                continue;
+            };
+            versions
+                .entry(format!("{group}:{artifact}"))
+                .or_default()
+                .insert(version);
+        }
+        versions
+            .into_iter()
+            .filter_map(|(coordinate, values)| {
+                (values.len() == 1).then(|| (coordinate, values.into_iter().next().unwrap()))
+            })
+            .collect()
+    }
+}
+
+fn insert_project_property(
+    properties: &mut BTreeMap<String, String>,
+    field: &str,
+    value: Option<&str>,
+) {
+    let Some(value) = value else { return };
+    properties.insert(format!("project.{field}"), value.to_string());
+    properties.insert(format!("pom.{field}"), value.to_string());
+}
+
+struct ResolvedDependency {
+    coordinate: String,
+    version: Option<String>,
+}
+
+#[derive(Default)]
+struct RawDependency {
+    fields: BTreeMap<String, Vec<String>>,
+}
+
+struct XmlFrame {
+    name: String,
+    text: String,
+}
+
+struct ActiveDependency {
+    depth: usize,
+    managed: bool,
+    dependency: RawDependency,
+}
+
+fn parse_pom(xml: &str) -> Result<MavenPom, ()> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut frames = Vec::<XmlFrame>::new();
+    let mut pom = MavenPom::default();
+    let mut active = None::<ActiveDependency>;
+    loop {
+        match reader.read_event().map_err(|_| ())? {
+            Event::Start(start) => {
+                let name = std::str::from_utf8(start.local_name().as_ref())
+                    .map_err(|_| ())?
+                    .to_string();
+                frames.push(XmlFrame {
+                    name,
+                    text: String::new(),
+                });
+                if frames.len() > MAX_XML_DEPTH {
+                    return Err(());
+                }
+                let path = path(&frames);
+                if path == ["project", "dependencies", "dependency"] {
+                    active = Some(ActiveDependency {
+                        depth: frames.len(),
+                        managed: false,
+                        dependency: RawDependency::default(),
+                    });
+                } else if path
+                    == [
+                        "project",
+                        "dependencyManagement",
+                        "dependencies",
+                        "dependency",
+                    ]
+                {
+                    active = Some(ActiveDependency {
+                        depth: frames.len(),
+                        managed: true,
+                        dependency: RawDependency::default(),
+                    });
+                }
+            }
+            Event::Text(text) => {
+                let decoded = text.decode().map_err(|_| ())?;
+                if let Some(frame) = frames.last_mut() {
+                    frame.text.push_str(&decoded);
+                }
+            }
+            Event::CData(text) => {
+                let decoded = text.decode().map_err(|_| ())?;
+                if let Some(frame) = frames.last_mut() {
+                    frame.text.push_str(&decoded);
+                }
+            }
+            Event::End(_) => close_frame(&mut frames, &mut active, &mut pom)?,
+            Event::DocType(_) => return Err(()),
+            Event::Eof => break,
+            Event::Decl(_)
+            | Event::Comment(_)
+            | Event::PI(_)
+            | Event::Empty(_)
+            | Event::GeneralRef(_) => {}
+        }
+    }
+    if !frames.is_empty() || active.is_some() {
+        return Err(());
+    }
+    Ok(pom)
+}
+
+fn close_frame(
+    frames: &mut Vec<XmlFrame>,
+    active: &mut Option<ActiveDependency>,
+    pom: &mut MavenPom,
+) -> Result<(), ()> {
+    let path = frames
+        .iter()
+        .map(|frame| frame.name.clone())
+        .collect::<Vec<_>>();
+    let frame = frames.pop().ok_or(())?;
+    let value = frame.text.trim();
+    if let Some(dependency) = active.as_mut() {
+        if frames.len() + 1 == dependency.depth + 1 && !value.is_empty() {
+            dependency
+                .dependency
+                .fields
+                .entry(frame.name.clone())
+                .or_default()
+                .push(value.to_string());
+        }
+        if frames.len() + 1 == dependency.depth {
+            let dependency = active.take().expect("active dependency");
+            if dependency.managed {
+                pom.managed.push(dependency.dependency);
+            } else {
+                pom.direct.push(dependency.dependency);
+            }
+        }
+        return Ok(());
+    }
+    if path.len() == 2 && path[0] == "project" && !value.is_empty() {
+        pom.project_fields
+            .entry(frame.name)
+            .or_default()
+            .push(value.to_string());
+    } else if path.len() == 3 && path[..2] == ["project", "parent"] && !value.is_empty() {
+        pom.parent_fields
+            .entry(frame.name)
+            .or_default()
+            .push(value.to_string());
+    } else if path.len() == 3 && path[..2] == ["project", "properties"] && !value.is_empty() {
+        pom.properties
+            .entry(frame.name)
+            .or_default()
+            .push(value.to_string());
+    }
+    Ok(())
+}
+
+fn path(frames: &[XmlFrame]) -> Vec<&str> {
+    frames.iter().map(|frame| frame.name.as_str()).collect()
+}
+
+fn resolve_field(
+    fields: &BTreeMap<String, Vec<String>>,
+    name: &str,
+    properties: &BTreeMap<String, String>,
+) -> Option<String> {
+    let raw = unique(fields.get(name)?)?;
+    let resolved = expand_properties(raw, properties)?;
+    (!resolved.is_empty()).then_some(resolved)
+}
+
+fn unique_field<'a>(fields: &'a BTreeMap<String, Vec<String>>, name: &str) -> Option<&'a str> {
+    unique(fields.get(name)?)
+}
+
+fn unique(values: &[String]) -> Option<&str> {
+    let first = values.first()?;
+    values.iter().all(|value| value == first).then_some(first)
+}
+
+fn expand_properties(raw: &str, properties: &BTreeMap<String, String>) -> Option<String> {
+    let mut output = String::with_capacity(raw.len());
+    let mut rest = raw;
+    while let Some(start) = rest.find("${") {
+        output.push_str(&rest[..start]);
+        let tail = &rest[start + 2..];
+        let end = tail.find('}')?;
+        let name = &tail[..end];
+        output.push_str(properties.get(name)?);
+        rest = &tail[end + 1..];
+        if output.len() > 4096 {
+            return None;
+        }
+    }
+    output.push_str(rest);
+    Some(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_direct_and_managed_property_versions_but_not_profiles() {
+        let pom = parse_pom(
+            r#"<project>
+              <properties><guava.version>33.0.0-jre</guava.version></properties>
+              <dependencyManagement><dependencies><dependency>
+                <groupId>com.google.guava</groupId><artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+              </dependency></dependencies></dependencyManagement>
+              <dependencies><dependency>
+                <groupId>com.google.guava</groupId><artifactId>guava</artifactId>
+              </dependency></dependencies>
+              <profiles><profile><dependencies><dependency>
+                <groupId>hidden</groupId><artifactId>profile-only</artifactId><version>1.0.0</version>
+              </dependency></dependencies></profile></profiles>
+            </project>"#,
+        )
+        .unwrap();
+        let dependencies = pom.direct_dependencies();
+        assert_eq!(dependencies.len(), 1);
+        assert_eq!(dependencies[0].coordinate, "com.google.guava:guava");
+        assert_eq!(dependencies[0].version.as_deref(), Some("33.0.0-jre"));
+    }
+
+    #[test]
+    fn only_release_distribution_suffixes_project_to_semver() {
+        assert_eq!(
+            maven_release_version("33.0.0-jre").unwrap(),
+            Version::new(33, 0, 0)
+        );
+        assert!(maven_release_version("33.0.0-rc1").is_none());
+        assert!(maven_release_version("LATEST").is_none());
+    }
+
+    #[test]
+    fn doctypes_and_unresolved_properties_fail_closed() {
+        assert!(parse_pom("<!DOCTYPE project><project/>").is_err());
+        assert!(expand_properties("${env.GUAVA_VERSION}", &BTreeMap::new()).is_none());
+    }
+
+    #[test]
+    fn missing_out_of_range_invalid_and_ambiguous_dependencies_are_distinct() {
+        let source = SemanticPackDependencySource {
+            declared_path: "pom.xml".to_string(),
+            content_digest: "sha256:test".to_string(),
+        };
+        let mut catalog = MavenCatalog::default();
+        catalog.declarations.insert(
+            "present:library".to_string(),
+            vec![MavenDeclaration {
+                version: Some("2.0.0".to_string()),
+                source: source.clone(),
+            }],
+        );
+        catalog.declarations.insert(
+            "invalid:library".to_string(),
+            vec![MavenDeclaration {
+                version: Some("LATEST".to_string()),
+                source: source.clone(),
+            }],
+        );
+        catalog.declarations.insert(
+            "ambiguous:library".to_string(),
+            vec![
+                MavenDeclaration {
+                    version: Some("1.0.0".to_string()),
+                    source: source.clone(),
+                },
+                MavenDeclaration {
+                    version: Some("2.0.0".to_string()),
+                    source,
+                },
+            ],
+        );
+
+        assert!(matches!(
+            catalog.resolve("missing:library", ">=1.0.0"),
+            MavenResolution::Missing
+        ));
+        assert!(matches!(
+            catalog.resolve("present:library", ">=3.0.0"),
+            MavenResolution::OutOfRange
+        ));
+        assert!(matches!(
+            catalog.resolve("invalid:library", ">=1.0.0"),
+            MavenResolution::InvalidVersion
+        ));
+        assert!(matches!(
+            catalog.resolve("ambiguous:library", ">=1.0.0"),
+            MavenResolution::AmbiguousVersion
+        ));
+    }
+}

--- a/crates/nose-semantics/src/packs/evidence_index/occurrences.rs
+++ b/crates/nose-semantics/src/packs/evidence_index/occurrences.rs
@@ -1,0 +1,259 @@
+use super::{SemanticPackDependencyEvidenceId, SemanticPackOccurrenceEvidence};
+use crate::{
+    asserted_language_core_record, imported_binding_symbol,
+    imported_occurrence_symbol_dependencies_valid, SemanticPackV1ArityKind,
+    SemanticPackV1CallShape, SemanticPackV1Contract, SemanticPackV1ImportRole,
+    SemanticPackV1Language,
+};
+use nose_il::{
+    stable_symbol_hash, Corpus, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
+    EvidenceRecord, EvidenceStatus, Il, ImportEvidenceKind, Interner, Lang, NodeId, NodeKind,
+    Payload, SymbolEvidenceKind,
+};
+
+pub(super) fn occurrences_for_contract(
+    pack_id: &str,
+    contract: &SemanticPackV1Contract,
+    dependency: SemanticPackDependencyEvidenceId,
+    corpus: &Corpus,
+) -> Vec<SemanticPackOccurrenceEvidence> {
+    let mut occurrences = Vec::new();
+    for il in &corpus.files {
+        if !language_matches(contract.language, il.meta.lang) {
+            continue;
+        }
+        for index in 0..il.nodes.len() {
+            let call = NodeId(index as u32);
+            if let Some(occurrence) =
+                occurrence_at_call(pack_id, contract, dependency, il, &corpus.interner, call)
+            {
+                occurrences.push(occurrence);
+            }
+        }
+    }
+    occurrences
+}
+
+fn occurrence_at_call(
+    pack_id: &str,
+    contract: &SemanticPackV1Contract,
+    dependency: SemanticPackDependencyEvidenceId,
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+) -> Option<SemanticPackOccurrenceEvidence> {
+    if il.kind(call) != NodeKind::Call {
+        return None;
+    }
+    let (&callee, args) = il.children(call).split_first()?;
+    if args.len() > u16::MAX as usize || !arity_matches(contract, args.len() as u16) {
+        return None;
+    }
+    let imported = match (contract.import.role, contract.call.shape) {
+        (SemanticPackV1ImportRole::Type, SemanticPackV1CallShape::StaticMethod) => {
+            imported_type_callee(il, interner, callee, contract)?
+        }
+        (SemanticPackV1ImportRole::StaticMember, SemanticPackV1CallShape::FreeFunction) => {
+            imported_static_member_callee(il, interner, callee, contract)?
+        }
+        _ => return None,
+    };
+    let call_span = il.node(call).span;
+    Some(SemanticPackOccurrenceEvidence {
+        pack_id: pack_id.to_string(),
+        row_id: contract.id.clone(),
+        channel: contract.channel,
+        call_span,
+        arity: args.len() as u16,
+        dependency,
+        import_evidence: imported.import,
+        symbol_evidence: imported.symbol,
+        receiver_evidence: imported.receiver,
+        receiver_span: imported.receiver_span,
+        effect_evidence: builtin_evidence_ids_at_call(il, call, EvidenceClass::Effect),
+        call_target_evidence: builtin_evidence_ids_at_call(il, call, EvidenceClass::CallTarget),
+        domain_evidence: builtin_evidence_ids_at_call(il, call, EvidenceClass::Domain),
+        place_evidence: builtin_evidence_ids_at_call(il, call, EvidenceClass::Place),
+    })
+}
+
+struct ImportedProof {
+    import: EvidenceId,
+    symbol: EvidenceId,
+    receiver: Option<EvidenceId>,
+    receiver_span: Option<nose_il::Span>,
+}
+
+fn imported_type_callee(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    contract: &SemanticPackV1Contract,
+) -> Option<ImportedProof> {
+    if il.kind(callee) != NodeKind::Field
+        || !matches!(il.node(callee).payload, Payload::Name(member) if interner.resolve(member) == contract.call.member)
+    {
+        return None;
+    }
+    let receiver = il.children(callee).first().copied()?;
+    let proof = imported_binding_proof(
+        il,
+        interner,
+        receiver,
+        &contract.import.module,
+        &contract.import.name,
+    )?;
+    Some(ImportedProof {
+        import: proof.import,
+        symbol: proof.symbol,
+        receiver: Some(proof.symbol),
+        receiver_span: Some(il.node(receiver).span),
+    })
+}
+
+fn imported_static_member_callee(
+    il: &Il,
+    interner: &Interner,
+    callee: NodeId,
+    contract: &SemanticPackV1Contract,
+) -> Option<ImportedProof> {
+    if il.kind(callee) != NodeKind::Var || contract.call.member != contract.import.name {
+        return None;
+    }
+    let proof = imported_binding_proof(
+        il,
+        interner,
+        callee,
+        &contract.import.module,
+        &contract.import.name,
+    )?;
+    Some(ImportedProof {
+        import: proof.import,
+        symbol: proof.symbol,
+        receiver: None,
+        receiver_span: None,
+    })
+}
+
+fn imported_binding_proof(
+    il: &Il,
+    interner: &Interner,
+    occurrence: NodeId,
+    module: &str,
+    exported: &str,
+) -> Option<ImportedProof> {
+    if !imported_binding_symbol(il, interner, occurrence, module, exported) {
+        return None;
+    }
+    let expected = SymbolEvidenceKind::ImportedBinding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    };
+    let occurrence_record = unique_record(
+        il.evidence_anchored_at(il.node(occurrence).span)
+            .filter(|record| {
+                record.anchor == EvidenceAnchor::node(il.node(occurrence).span, NodeKind::Var)
+                    && record.kind == EvidenceKind::Symbol(expected)
+            }),
+    );
+    if let Some(record) = occurrence_record {
+        if !asserted_language_core_record(il, record)
+            || !imported_occurrence_symbol_dependencies_valid(il, interner, record, expected)
+        {
+            return None;
+        }
+    }
+    let local_hash = local_name_hash(il, interner, occurrence)?;
+    let binding = unique_record(il.evidence.iter().filter(|record| {
+        matches!(
+            record.anchor,
+            EvidenceAnchor::Binding {
+                local_hash: actual,
+                ..
+            } if actual == local_hash
+        ) && record.kind == EvidenceKind::Symbol(expected)
+    }))?;
+    if !asserted_language_core_record(il, binding) {
+        return None;
+    }
+    let EvidenceAnchor::Binding { span, .. } = binding.anchor else {
+        return None;
+    };
+    let import_kind = EvidenceKind::Import(ImportEvidenceKind::Binding {
+        module_hash: stable_symbol_hash(module),
+        exported_hash: stable_symbol_hash(exported),
+    });
+    let import = unique_record(il.evidence_anchored_at(span).filter(|record| {
+        record.anchor == EvidenceAnchor::binding(span, local_hash) && record.kind == import_kind
+    }))?;
+    if !asserted_language_core_record(il, import) {
+        return None;
+    }
+    Some(ImportedProof {
+        import: import.id,
+        symbol: occurrence_record.unwrap_or(binding).id,
+        receiver: None,
+        receiver_span: None,
+    })
+}
+
+fn unique_record<'a>(
+    records: impl Iterator<Item = &'a EvidenceRecord>,
+) -> Option<&'a EvidenceRecord> {
+    let mut records = records;
+    let first = records.next()?;
+    records.next().is_none().then_some(first)
+}
+
+fn local_name_hash(il: &Il, interner: &Interner, node: NodeId) -> Option<u64> {
+    let Payload::Name(name) = il.node(node).payload else {
+        return None;
+    };
+    Some(stable_symbol_hash(interner.resolve(name)))
+}
+
+fn arity_matches(contract: &SemanticPackV1Contract, arity: u16) -> bool {
+    let Ok(arity) = u8::try_from(arity) else {
+        return false;
+    };
+    match contract.call.arity.kind {
+        SemanticPackV1ArityKind::Range => {
+            contract.call.arity.min.is_some_and(|min| arity >= min)
+                && contract.call.arity.max.is_some_and(|max| arity <= max)
+        }
+        SemanticPackV1ArityKind::Set => contract.call.arity.values.binary_search(&arity).is_ok(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EvidenceClass {
+    Effect,
+    CallTarget,
+    Domain,
+    Place,
+}
+
+fn builtin_evidence_ids_at_call(il: &Il, call: NodeId, class: EvidenceClass) -> Vec<EvidenceId> {
+    let span = il.node(call).span;
+    il.evidence_anchored_at(span)
+        .filter(|record| {
+            record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                && record.status == EvidenceStatus::Asserted
+                && record.provenance.emitter == EvidenceEmitter::Builtin
+                && il.evidence_dependencies_asserted(record)
+                && match class {
+                    EvidenceClass::Effect => matches!(record.kind, EvidenceKind::Effect(_)),
+                    EvidenceClass::CallTarget => {
+                        matches!(record.kind, EvidenceKind::CallTarget(_))
+                    }
+                    EvidenceClass::Domain => matches!(record.kind, EvidenceKind::Domain(_)),
+                    EvidenceClass::Place => matches!(record.kind, EvidenceKind::Place(_)),
+                }
+        })
+        .map(|record| record.id)
+        .collect()
+}
+
+fn language_matches(language: SemanticPackV1Language, lang: Lang) -> bool {
+    matches!((language, lang), (SemanticPackV1Language::Java, Lang::Java))
+}

--- a/crates/nose-semantics/src/packs/lock/tests.rs
+++ b/crates/nose-semantics/src/packs/lock/tests.rs
@@ -55,7 +55,7 @@ fn creates_and_validates_a_content_pinned_relative_lock() {
 
     assert!(lock_path.is_file());
     assert_eq!(created.authorizations().len(), 1);
-    assert_eq!(created.authorizations()[0].selected_rows().len(), 2);
+    assert_eq!(created.authorizations()[0].selected_rows().len(), 3);
     assert!(created.summary().decision_digest().starts_with("sha256:"));
     let json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&lock_path).unwrap()).unwrap();

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -88,6 +88,7 @@ nose capabilities
       "query_base_sarif": true,
       "query_base_structured_ignores": true,
       "reinvented_view": true,
+      "semantic_pack_dependency_evidence": true,
       "semantic_pack_loading": true,
       "semantic_pack_project_lock": true,
       "structured_ignores": true
@@ -212,6 +213,12 @@ consumers. New fields may be added to existing objects without changing
 `schema_version`; changing a documented field's type or meaning requires a new
 capabilities schema version.
 
+The global `dependency-backed-evidence-unavailable` influence blocker describes
+the existing opaque/data-only external-row preflight. A locked typed v1 query
+can build the separate dependency/occurrence index advertised by
+`semantic_pack_dependency_evidence`, but no lane consumes that index yet and it
+does not remove the global `metadata-only` policy.
+
 ## Query Capability Flags
 
 Version 6 defines these `query.capabilities` keys:
@@ -232,6 +239,7 @@ Version 6 defines these `query.capabilities` keys:
 | `query_base_sarif` | `base=<ref> --format sarif` emits divergent-edit SARIF results. Wrappers should also verify `query.output_formats` contains `sarif`. |
 | `query_base_structured_ignores` | Structured ignores are applied before the `base=<ref>` divergent-edit gate. |
 | `reinvented_view` | The `reinvented` query view is supported. |
+| `semantic_pack_dependency_evidence` | A content-pinned v1 lock can build a local-only immutable Maven dependency/import/symbol/receiver/effect occurrence index; the index does not imply analysis influence. |
 | `semantic_pack_loading` | local v0 manifests can be loaded as metadata and typed v1 manifests can be compiled for metadata/digest reporting. |
 | `semantic_pack_project_lock` | local v1 project locks can be created, validated, and supplied to query before analysis. |
 | `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/examples/semantic-pack-lock-v1.json
+++ b/docs/examples/semantic-pack-lock-v1.json
@@ -14,12 +14,13 @@
       "pack_id": "com.example.java-guava-typed-factories",
       "pack_version": "1.0.0",
       "nose_compatibility": ">=0.19.0 <0.21.0",
-      "semantic_digest": "sha256:817b10234f105bb6a629782b6c914997fb2758085d48f671013576bae1c9bfc9",
+      "semantic_digest": "sha256:e09ebd7c851c49647237e6bf2ff81e7e6a49d6b5cae66d1e5a4a8dcd30c2c454",
       "allowed_channels": [
         "near"
       ],
       "selected_rows": [
         "java.guava.immutable-list.of",
+        "java.guava.immutable-list.static-of",
         "java.guava.immutable-map.of"
       ]
     }

--- a/docs/examples/semantic-packs/v1/guava-immutable-collections.json
+++ b/docs/examples/semantic-packs/v1/guava-immutable-collections.json
@@ -6,7 +6,7 @@
     "kind": "LibraryPack",
     "version": "1.0.0",
     "display_name": "Typed Guava immutable collection factories",
-    "description": "Typed v1 compiler example. It compiles to metadata and immutable indexes but does not influence analysis without later lock and evidence work.",
+    "description": "Typed v1 example. A project lock can build immutable occurrence evidence, but no lane consumes it yet and the pack remains metadata-only.",
     "trust": "external-opt-in",
     "enabled_by_default": false
   },
@@ -57,6 +57,41 @@
             "max": 12
           },
           "receiver": "imported-type"
+        },
+        "operation": "collection-factory",
+        "result_domain": "collection",
+        "profiles": {
+          "demand": "eager",
+          "effects": "pure",
+          "exceptions": "may-throw",
+          "mutation": "none",
+          "identity": "fresh"
+        },
+        "channel": "near"
+      },
+      {
+        "id": "java.guava.immutable-list.static-of",
+        "language": "java",
+        "package": {
+          "ecosystem": "maven",
+          "name": "com.google.guava:guava"
+        },
+        "anchor": "call-node",
+        "matcher": "imported-api",
+        "import": {
+          "role": "static-member",
+          "module": "com.google.common.collect.ImmutableList",
+          "name": "of"
+        },
+        "call": {
+          "shape": "free-function",
+          "member": "of",
+          "arity": {
+            "kind": "range",
+            "min": 0,
+            "max": 12
+          },
+          "receiver": "none"
         },
         "operation": "collection-factory",
         "result_domain": "collection",

--- a/docs/home.md
+++ b/docs/home.md
@@ -100,8 +100,8 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-adoption](semantic-pack-adoption.md) — promotion, rollback, and adoption-gate reports for moving external or optional packs into official builtin support without forking semantic vocabulary.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
-- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic pre-analysis compiler, and semantic content digest; influence remains disabled pending evidence and lane consumers.
-- [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, and deterministic conflict rejection.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence index, and semantic content digest; influence remains disabled pending lane consumers.
+- [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, deterministic conflict rejection, and evidence input boundary.
 - [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for checking local pack manifests and the builtin inventory workflow for auditing shipped pack coverage.
 - [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and current metadata-only limits.
 

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2089,9 +2089,13 @@ justifies a tranche ([design §2c](design.md)).
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) adds the first
   content-pinned project authorization and deterministic semantic-coordinate
   conflict boundary. It pins selected rows/channels and checked-in dependency
-  inputs without opening influence. The typed indexes deliberately remain
-  disconnected from analysis until dependency and occurrence evidence, lane
-  consumers, receipts, and a real reference pack are complete.
+  inputs without opening influence.
+- Locked v1 queries now build an immutable dependency/occurrence index with a
+  bounded Maven POM reader and builtin Java import/symbol/receiver/effect
+  matchers. Missing, invalid, ambiguous, out-of-range, wrong-package, wildcard,
+  shadowed, and rebound cases fail closed. The evidence index is threaded
+  through query analysis but deliberately remains disconnected from detection
+  until lane consumers, receipts, and a real reference pack are complete.
 - Start with data-only external packs for simple APIs once producer execution and
   executable fixture/oracle checks exist.
 - Add restricted recognizer hooks only after the manifest path is stable.

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -637,7 +637,11 @@ still being migrated toward it.
   `nose.semantic-pack-lock.v1` layer now pins manifest identity/content,
   selected rows/channels, dependency inputs, and optional receipts; rejects
   path escapes and overlapping cross-pack coordinates; and exposes local
-  create/status commands. v1 still does not feed analysis consumers.
+  create/status commands. Locked queries now use a bounded Maven POM reader and
+  builtin Java evidence matcher to build an immutable dependency/import/symbol/
+  receiver/effect occurrence index. The index is threaded through query
+  analysis but still does not feed normalize, exact, near, or detection
+  consumers.
   `nose semantic-pack check` validates local manifests plus declared fixture
   assets, and `nose query --format json` reports active builtin/local packs in
   top-level `semantic_packs`. External packs are still `metadata-only`; builtin

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -423,6 +423,10 @@ previous semantic-kernel tranches.
    `nose.semantic-pack-lock.v1` project lock: it content-pins typed v1 rows,
    channels, dependency inputs, and optional receipts, rejects path escapes and
    overlapping coordinates, and still opens no analysis influence by itself.
+   The next completed boundary is a query-local immutable evidence index: a
+   bounded kernel Maven reader connects pinned dependency versions to builtin
+   Java import/symbol/receiver/effect facts, but no lane consumes those facts
+   yet.
 8. **Phase 7, adoption gates:** define `external-opt-in -> builtin-optional` and
    `builtin-optional -> builtin-default` promotion criteria, rollback behavior,
    corpus regression, docs, and performance budgets.
@@ -440,8 +444,9 @@ previous semantic-kernel tranches.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
   the versioned external schema boundary.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
-  the first closed typed declaration compiler; its rows remain non-influential
-  until the external trust and evidence lanes are complete.
+  the first closed typed declaration compiler and locked occurrence-evidence
+  index; its rows remain non-influential until the external trust lanes are
+  complete.
 - [semantic-pack-loading](semantic-pack-loading.md) describes manifest loading
   and the current metadata-only external behavior.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) defines the

--- a/docs/semantic-pack-extension-api-v1.md
+++ b/docs/semantic-pack-extension-api-v1.md
@@ -1,7 +1,8 @@
 # Typed semantic pack influence manifest v1
 
-Status: implemented typed manifest, deterministic compiler, and content-pinned
-project authorization. Influence is not enabled yet.
+Status: implemented typed manifest, deterministic compiler, content-pinned
+project authorization, and kernel-owned dependency/occurrence evidence index.
+Influence is not enabled yet.
 `nose.semantic-pack.v0` remains permanently metadata-only.
 
 ## Purpose
@@ -9,10 +10,12 @@ project authorization. Influence is not enabled yet.
 v1 is the first semantic-pack format that nose can interpret without executing
 provider code. It replaces v0's opaque `surface` and `semantics` JSON with a
 small closed grammar. Loading a v1 file validates and compiles that grammar
-before analysis starts. A validated project lock can now pin and authorize rows,
-channels, dependency files, and an optional receipt, but the compiled rows still
-have `metadata-only` influence until dependency/occurrence evidence and
-lane-specific consumers are implemented.
+before analysis starts. A validated project lock pins and authorizes rows,
+channels, dependency files, and an optional receipt. During a locked query nose
+can now read the pinned Maven inputs and bind selected rows to builtin Java
+import/symbol/receiver/effect facts. The resulting index is intentionally not
+consumed by detection yet, so compiled rows still have `metadata-only`
+influence until lane-specific consumers are implemented.
 
 The schema is [semantic-pack-v1.schema.json](schemas/semantic-pack-v1.schema.json).
 The [Guava example](examples/semantic-packs/v1/guava-immutable-collections.json)
@@ -70,10 +73,51 @@ compilation. Duplicate ids, duplicate package coordinates, duplicate exact
 contract coordinates plus arity, invalid cross-field combinations, and
 out-of-range arities fail before analysis.
 
-The indexes are deliberately not read by normalize, fingerprint, exact, near,
-or detection consumers in this change. v1 summary rows therefore report
+The compiled contract indexes are read only by the dependency/occurrence index
+builder. That evidence index is deliberately not read by normalize,
+fingerprint, exact, near, or detection consumers in this change. v1 summary rows therefore report
 `source: local-manifest` and `influence: metadata-only`, just like v0, while
 also reporting their API version and semantic digest.
+
+## Locked dependency and occurrence evidence
+
+Evidence construction runs once per query after builtin lowering. It is
+available only when a validated `nose.semantic-pack-lock.v1` authorizes the row
+and its requested lane; loading the same manifest without a lock produces no
+row or occurrence evidence.
+
+The first dependency reader accepts checked-in Maven POM XML only. It reads
+top-level direct dependencies, top-level `dependencyManagement` versions, and
+bounded `${property}` references from the project, parent coordinate, and
+top-level `properties`. Profiles, plugins, external entities, unresolved
+environment/system properties, Maven version ranges, snapshots, release
+aliases, malformed XML, and files over the resource cap do not produce facts.
+The Guava distribution suffixes `-jre` and `-android` are matched by their
+three-component release version; other prerelease qualifiers stay closed. The
+reader rechecks each locked content digest and never invokes Maven, a registry,
+a build tool, an installer, provider code, or the network.
+
+For an in-range unique dependency, the Java matcher supports two exact source
+forms:
+
+- an explicit type import followed by a qualified static call such as
+  `ImmutableList.of(...)`;
+- an explicit static-member import followed by a free call such as `of(...)`.
+
+Every admitted occurrence records the dependency fact id, binding import id,
+symbol proof id, receiver span/proof when the contract has an imported-type
+receiver, and any builtin effect, call-target, domain, and place ids already
+anchored to the call. These are references to existing kernel/frontend facts,
+not provider-emitted IL. Exact package/module/member, arity, binding visibility,
+and dependency liveness are checked. Wildcards, wrong-package or same-name local
+APIs, shadowed/rebound bindings, conflicting or ambiguous versions, missing or
+out-of-range dependencies, unsupported receiver dispatch, and evidence-broken
+records produce no occurrence.
+
+The index exposes deterministic row and dependency summaries plus lookup by row
+or exact call span. Its collections are immutable after construction, it uses no
+global registry, and its ids are query-local. Merely building it does not emit
+IL evidence, change a family, or authorize either lane.
 
 ## Semantic content digest
 
@@ -96,7 +140,7 @@ being locked.
 
 ## Reporting and current limits
 
-`nose capabilities` schema v5 lists both `nose.semantic-pack.v0` and
+`nose capabilities` schema v6 lists both `nose.semantic-pack.v0` and
 `nose.semantic-pack.v1`. `nose semantic-pack compatibility` lists the same
 accepted versions. Query semantic-pack summaries conditionally add
 `api_version`; v1 also adds `semantic_digest`. Compiled builtin summaries keep
@@ -114,7 +158,6 @@ cross-pack coordinates independent of load order.
 
 The following work remains outside this slice:
 
-- dependency/version readers and occurrence evidence;
 - near consumers and the separate external-claim exact lane;
 - source-analyzing conformance receipts and a real external reference pack.
 

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -215,10 +215,13 @@ Trust is separate from channel eligibility.
 `nose query --format json` validates configured and CLI-provided semantic-pack
 paths before analysis and reports the active builtin/local pack set in the
 top-level `semantic_packs` array. Local external packs remain metadata-only
-while builtin compiled packs report `evidence-and-contracts` influence. External
-producer, contract, and value-law rows are available to the loaded pack set for
-future conflict checks and adoption gates, but they are not serialized into
-clone-family law provenance and do not affect analysis. Builtin pack order in
+while builtin compiled packs report `evidence-and-contracts` influence. A
+validated v1 project lock additionally builds a query-local, immutable Maven
+dependency and Java occurrence-evidence index from content-pinned inputs and
+builtin frontend facts. External producer, contract, and value-law rows are
+available to the loaded pack set for future conflict checks and adoption gates,
+but neither those rows nor the evidence index are serialized into clone-family
+law provenance or consumed by detection yet. Builtin pack order in
 this array follows the compiled registry's stable reporting order; roadmap and
 snapshot prose may group packs by migration narrative instead.
 
@@ -229,12 +232,14 @@ producer, contract, and value-law declarations as data-only rows, can report
 row-id conflicts with builtin or other external rows, and can run a data-only
 influence preflight report. It also validates fixed call result-domain
 declarations in `semantics.result_domain` against the known domain vocabulary
-and requires required `LibraryApi.Contract` evidence for those rows. Today that
-preflight blocks all external rows until dependency-backed occurrence evidence
-and lane consumers exist. A project lock now supplies explicit content/row/lane
-authorization and rejects semantic-coordinate conflicts before analysis, but it
-does not itself produce occurrence evidence or influence. Exact-capable rows also
-remain blocked until they have passed declarative executable conformance.
+and requires required `LibraryApi.Contract` evidence for those rows. The v0
+preflight still blocks opaque external rows. For locked typed v1 rows, a
+kernel-owned Maven reader and Java matcher now produce dependency-backed
+occurrence facts, while lane consumers remain unavailable. A project lock
+supplies explicit content/row/lane authorization and rejects
+semantic-coordinate conflicts before analysis; its evidence index alone cannot
+influence a result. Exact-capable rows also remain blocked until they have passed
+declarative executable conformance.
 `nose semantic-pack check --format json` exposes that row-level preflight to
 providers and integrations, but query, normalize, value-graph, exact, and
 detection consumers do not read it. It does not yet:

--- a/docs/semantic-pack-project-lock.md
+++ b/docs/semantic-pack-project-lock.md
@@ -1,9 +1,10 @@
 # Semantic-pack project locks
 
-Status: project lock v1, local creation/status commands, and pre-analysis
-validation are implemented. A valid lock authorizes selected v1 rows and lanes,
-but external rows remain `metadata-only` until the evidence and lane consumers
-land. v0 can never become influential through a lock.
+Status: project lock v1, local creation/status commands, pre-analysis
+validation, and a locked Maven evidence reader are implemented. A valid lock
+authorizes selected v1 rows and lanes and bounds which local dependency inputs
+the evidence index may read, but external rows remain `metadata-only` until lane
+consumers land. v0 can never become influential through a lock.
 
 ## Why a separate lock exists
 
@@ -83,11 +84,18 @@ before source analysis. Without a configured lock, ordinary v0/v1 manifest
 loading remains available for metadata/check workflows and cannot influence
 analysis.
 
+Query analysis builds a query-local dependency/occurrence evidence index from
+the validated lock and builtin frontend facts. It rereads no path outside the
+pin set and rechecks content digests before using dependency facts. Missing,
+ambiguous, invalid, or out-of-range versions keep selected rows closed rather
+than consulting Maven or a registry.
+
 Query JSON keeps `influence: "metadata-only"` for locked v1 packs in this phase
 and adds a `lock` object containing `status: "valid"`, lock API and decision
 digest, authorized channels, selected rows, dependency pins, and optional
-receipt. Removing the lock or narrowing a regenerated selection removes that
-authorization without changing the manifest.
+receipt. Occurrence counts are not reported until a lane consumer can explain
+their effect. Removing the lock or narrowing a regenerated selection removes
+that authorization and its evidence index without changing the manifest.
 
 ## Determinism and conflicts
 


### PR DESCRIPTION
Closes #866

## Summary
- parse content-pinned Maven POM dependencies locally with bounded, fail-closed version/property handling
- build an immutable per-query v1 pack evidence index from builtin Java import, symbol, receiver, effect, call-target, domain, and place facts
- support explicit type-qualified static calls and explicit static-member imports while closing wrong-package, wildcard, shadow, rebind, ambiguity, invalid-version, and out-of-range cases
- thread the index through query analysis without changing near/exact detection or external `metadata-only` influence
- extend the checked-in Guava v1 example/lock with a static-import row and document the trust/runtime boundary

## Validation
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-file-lengths.py`
- `scripts/check-docs.sh`
- `python3 scripts/check-semantic-pack-examples.py`
- release blind attacker: 54 exact groups, 0 false merges, 0 canon violations
