### PR TITLE
feat: open locked semantic-pack near influence

### DIFF
--- a/bench/semantic_pack/issue-867-locked-near-closeout-2026-07-19.v1.json
+++ b/bench/semantic_pack/issue-867-locked-near-closeout-2026-07-19.v1.json
@@ -1,0 +1,113 @@
+{
+  "schema": "nose.semantic-pack.issue-867-closeout/v1",
+  "issue": 867,
+  "generated_at": "2026-07-19",
+  "implementation": {
+    "parent_commit": "4329a94289e37da9f9026da8a896cd770d4ebb9c",
+    "candidate_commit": "a6024597f2a3fef35bf5491aa3afd932cb041d5a",
+    "parent_binary_sha256": "bf8ecfe8e9f95e645e94c66cbdde19e7ca3d70ce08a6eed9beb55ab141f722e0",
+    "candidate_binary_sha256": "f1e5af584eef741016bfb27f493709e5032d04fcf1c09e6be2ccbea78214fb3a"
+  },
+  "locked_near_fixture": {
+    "test": "commands::config_packs::project_lock::locked_near_row_changes_only_the_supported_near_family_with_provenance",
+    "result": "passed",
+    "admitted_occurrences": 2,
+    "influential_occurrences": 2,
+    "lock_removal_restored_result": true,
+    "repeated_output_identical": true,
+    "cached_families_identical": true,
+    "semantic_families_identical_with_and_without_lock": true,
+    "provenance_fields": [
+      "pack_id",
+      "row_id",
+      "semantic_digest",
+      "row_digest",
+      "lane",
+      "trust",
+      "operation",
+      "dependency",
+      "occurrence_file",
+      "call_start_line",
+      "call_end_line",
+      "caveats"
+    ]
+  },
+  "no_pack_invariance": {
+    "corpus": "bench/type4/query_regression/subset.json",
+    "repositories": 9,
+    "semantic_parent_candidate_equal": 9,
+    "near_parent_candidate_equal": 9,
+    "parent_semantic_raw_sha256": "a0dd6573f625f52ecc631d94fc0dbd2b801bcfa2d97a1aa03076f1a62b0029d5",
+    "candidate_semantic_raw_sha256": "933846818aa00ce4838ca0e32d3db48438fc89baaed6feedcc798fd4d7027445",
+    "parent_near_raw_sha256": "5f3b5b2b55a3c05d369813c70b3d7fd633942f1839b36e295693e35e3901bbc3",
+    "v0_and_unlocked_v1_tests": [
+      "query_json_reports_cli_semantic_pack_metadata_without_changing_families",
+      "query_json_keeps_executable_gated_pack_metadata_only",
+      "typed_v1_pack_compiles_and_reports_digest_without_changing_families",
+      "wrong_package_local_shadow_and_unlocked_metadata_stay_closed"
+    ]
+  },
+  "official_release_performance": {
+    "baseline": {
+      "version": "v0.19.0",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate": {
+      "commit": "a6024597f2a3fef35bf5491aa3afd932cb041d5a",
+      "binary_sha256": "f1e5af584eef741016bfb27f493709e5032d04fcf1c09e6be2ccbea78214fb3a"
+    },
+    "corpus": {
+      "repositories": [
+        "boltons",
+        "chi",
+        "cmark",
+        "gin",
+        "junit5",
+        "ky",
+        "liquid",
+        "serde_json",
+        "swift-metrics"
+      ],
+      "repeats": 5,
+      "cache": "disabled"
+    },
+    "semantic": {
+      "command": "nose query <repo> all top=0 --mode semantic --format json",
+      "baseline_aggregate_wall_ms": 741.28,
+      "candidate_aggregate_wall_ms": 736.86,
+      "delta_pct": -0.5963,
+      "investigation_triggers": 0,
+      "baseline_raw_sha256": "7ae7ffa13819448e59d9df9886eb31a378f46869868ae866e1b32790a82ebeed",
+      "candidate_raw_sha256": "60c84936bf8cd05e71e0e54c6cf4c3f0b59234fa8bf139747b85d0b479d1de6e",
+      "comparison_sha256": "2675f7ceb64b896a81e5fb1cfc84e7f09c9b509fd3771ab6e939ab3051f4e1de"
+    },
+    "near": {
+      "command": "nose query <repo> all top=0 --mode near --format json",
+      "baseline_aggregate_wall_ms": 930.05,
+      "candidate_aggregate_wall_ms": 928.32,
+      "delta_pct": -0.186,
+      "baseline_raw_sha256": "ba2b4175b5f5ab1d82a1c0e9b30c1b4dcaf470288a570910299f2f0151554ff1",
+      "candidate_raw_sha256": "66db1bddc70ca649a429aff5b10265376d0db4935103b218d7f96c617de1afb4",
+      "subset_sha256": "255d63ea75f6f73b369e758b6cd29c48a19a9c049e510d2dfe837d2801d21305"
+    },
+    "gate": {
+      "limit_pct": 5.0,
+      "passed": true
+    }
+  },
+  "exact_and_verify": {
+    "semantic_families_unchanged_by_lock": true,
+    "verify_command": "RAYON_NUM_THREADS=1 nose verify crates --max-violations 0",
+    "verify_exit_code": 0,
+    "fingerprint_groups": 779,
+    "false_merges": 0,
+    "canon_changed_units_preserved": true,
+    "verify_output_sha256": "7e1b2bcc690bd7303826ba4ac2bdc1add07d70987888edcb77e80cf170d9982a"
+  },
+  "validation": {
+    "cargo_test_workspace": "passed",
+    "cargo_clippy_workspace_all_targets_deny_warnings": "passed",
+    "docs": "passed",
+    "file_lengths": "passed"
+  }
+}

--- a/crates/nose-cli/src/baseline.rs
+++ b/crates/nose-cli/src/baseline.rs
@@ -485,6 +485,7 @@ mod tests {
             witness: None,
             varying_spots: Vec::new(),
             semantic_laws: Vec::new(),
+            semantic_pack_near: Vec::new(),
         }
     }
 
@@ -507,6 +508,7 @@ mod tests {
             in_test_module: false,
             looks_generated: false,
             shared_subdag: None,
+            semantic_pack_near: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -193,7 +193,7 @@ fn current_semantic_packs() -> SemanticPacks {
         compatibility_output_formats: vec!["human", "json"],
         trust: vec!["builtin-default", "builtin-optional", "external-opt-in"],
         external_packs_enabled_by_default: false,
-        external_pack_influence: "metadata-only",
+        external_pack_influence: "metadata-or-locked-near-only",
         external_influence_blockers: crate::semantic_pack::external_influence_blocker_labels(),
         external_pack_execution: "none",
     }
@@ -216,6 +216,7 @@ fn query_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
         ("query_base_structured_ignores", true),
         ("reinvented_view", true),
         ("semantic_pack_dependency_evidence", true),
+        ("semantic_pack_locked_near_influence", true),
         ("semantic_pack_loading", true),
         ("semantic_pack_project_lock", true),
         ("structured_ignores", true),

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -239,6 +239,7 @@ fn divergence_family(locs: Vec<Loc>) -> RefactorFamily {
         witness: None,
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
+        semantic_pack_near: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/divergence/variant.rs
+++ b/crates/nose-cli/src/divergence/variant.rs
@@ -456,6 +456,7 @@ mod tests {
             in_test_module: false,
             looks_generated: false,
             shared_subdag: None,
+            semantic_pack_near: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/src/ignores/match_tests.rs
+++ b/crates/nose-cli/src/ignores/match_tests.rs
@@ -51,6 +51,7 @@ fn family_with_locations(locations: &[(String, &str)]) -> RefactorFamily {
         witness: None,
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
+        semantic_pack_near: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/main_tests/surface_hints.rs
+++ b/crates/nose-cli/src/main_tests/surface_hints.rs
@@ -162,6 +162,7 @@ pub(super) fn fam_kind(
         witness: None,
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
+        semantic_pack_near: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/query_commands.rs
+++ b/crates/nose-cli/src/query_commands.rs
@@ -35,7 +35,7 @@ fn run_query_base(args: &QueryArgs, base_ref: &str, q: &Query, path_arg: &str) -
         );
     }
     let semantic_packs_json = if matches!(args.format, ReportFormat::Json) {
-        semantic_packs_json(&resolve_query_semantic_packs(args)?)
+        semantic_packs_json(&resolve_query_semantic_packs(args)?, None)
     } else {
         Vec::new()
     };
@@ -213,7 +213,10 @@ fn semantic_packs_for_output(
     dataset: &QueryDataset,
 ) -> Vec<serde_json::Value> {
     if matches!(format, ReportFormat::Json) {
-        semantic_packs_json(&dataset.semantic_packs)
+        semantic_packs_json(
+            &dataset.semantic_packs,
+            Some(&dataset.semantic_pack_near_report),
+        )
     } else {
         Vec::new()
     }

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -12,6 +12,7 @@ use crate::source_lines::{
 };
 use crate::timing::{time_lower, time_stage};
 use crate::{cache, config, ignores};
+use std::collections::BTreeSet;
 
 /// The ranked family dataset behind `nose query`: detect, rank,
 /// filter (min-members / min-value / scope), relativize paths, weight shared lines, and
@@ -22,7 +23,7 @@ pub(super) struct QueryDataset {
     pub(super) scope: QueryScope,
     pub(super) settings: QuerySettings,
     pub(super) semantic_packs: nose_semantics::SemanticPackSet,
-    pub(super) _semantic_pack_evidence: nose_semantics::SemanticPackEvidenceIndex,
+    pub(super) semantic_pack_near_report: nose_semantics::SemanticPackNearReport,
     pub(super) reinvented: Vec<nose_detect::ReinventedHelper>,
     pub(super) opts: nose_detect::DetectOptions,
 }
@@ -34,7 +35,7 @@ pub(super) fn build_query_dataset(
     let (settings, semantic_packs) = resolve_query_settings(args)?;
     let opts = detection_options(settings.channels, settings.min_tokens, settings.min_lines);
     let detector = detection_engine(settings.channels, &opts);
-    let (mut report, scope, semantic_pack_evidence) = query_detect_report(
+    let (mut report, scope, semantic_pack_near) = query_detect_report(
         args,
         refs,
         &settings.exclude,
@@ -44,6 +45,7 @@ pub(super) fn build_query_dataset(
     );
 
     let mut families = time_stage("rank_families", || nose_detect::rank_families(&report));
+    annotate_semantic_pack_near(&mut families, &semantic_pack_near);
     preserve_query_accepted_coverage(&mut families);
     time_stage("query_filter", || {
         if settings.channels.abstraction_only() {
@@ -59,6 +61,12 @@ pub(super) fn build_query_dataset(
         for f in &mut families {
             for l in &mut f.locations {
                 relativize_loc(l, &cwd);
+                for provenance in &mut l.semantic_pack_near {
+                    provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
+                }
+            }
+            for provenance in &mut f.semantic_pack_near {
+                provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
             }
             for obligation in &mut f.accepted_coverage {
                 for l in &mut obligation.sites {
@@ -84,12 +92,17 @@ pub(super) fn build_query_dataset(
                 .then_with(|| family_anchor(a).cmp(&family_anchor(b)))
         })
     });
+    let semantic_pack_near_report = semantic_pack_near.report_with_influential(
+        families
+            .iter()
+            .flat_map(|family| family.semantic_pack_near.iter()),
+    );
     Ok(QueryDataset {
         families,
         scope,
         settings,
         semantic_packs,
-        _semantic_pack_evidence: semantic_pack_evidence,
+        semantic_pack_near_report,
         reinvented,
         opts,
     })
@@ -212,35 +225,83 @@ fn query_detect_report(
 ) -> (
     nose_detect::Report,
     QueryScope,
-    nose_semantics::SemanticPackEvidenceIndex,
+    nose_semantics::SemanticPackNearRegistry,
 ) {
-    if let Some(dir) = &args.cache_dir {
-        // Lower AND cross-file-resolve the corpus every run (the smaller half of
-        // the work, §BQ), then cache only the dominant normalize+extract step
-        // keyed on the post-resolve IL. This makes the cached query identical to
-        // the non-cached path including imported-immutable-literal convergence
-        // (#275), which the old per-file source-content cache skipped.
-        let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
-        let scope = QueryScope::from_corpus(&corpus);
-        let semantic_pack_evidence =
-            nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
+    // Lower AND cross-file-resolve every run. The cache skips only the dominant
+    // normalize/extract step and therefore stays identical to the uncached path.
+    let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
+    let scope = QueryScope::from_corpus(&corpus);
+    let semantic_pack_evidence =
+        nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
+    let semantic_pack_near = nose_semantics::SemanticPackNearRegistry::build(
+        semantic_packs,
+        &semantic_pack_evidence,
+        &corpus,
+    );
+    let (mut units, streams, files) = if let Some(dir) = &args.cache_dir {
         let cache::CachedUnits {
             units,
             streams,
             files,
         } = cache::build_units_cached(&corpus, opts, dir);
-        let report = nose_detect::detect_from_units_with_accepted_coverage(
-            units, files, &streams, opts, detector,
-        )
-        .0;
-        (report, scope, semantic_pack_evidence)
+        (units, streams, files)
     } else {
-        let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
-        let scope = QueryScope::from_corpus(&corpus);
-        let semantic_pack_evidence =
-            nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
-        let report = nose_detect::detect_with_accepted_coverage(&corpus, opts, detector);
-        (report, scope, semantic_pack_evidence)
+        let features = time_stage("normalize+extract", || {
+            nose_detect::corpus_features(&corpus, opts)
+        });
+        (features.units, features.streams, features.files)
+    };
+    if opts.shape_candidates && semantic_pack_near.is_active() {
+        for unit in &mut units {
+            unit.semantic_pack_near_protocols =
+                semantic_pack_near.protocols_for_unit(&unit.path, unit.start_line, unit.end_line);
+        }
+    }
+    let report = nose_detect::detect_from_units_with_accepted_coverage(
+        units, files, &streams, opts, detector,
+    )
+    .0;
+    (report, scope, semantic_pack_near)
+}
+
+fn annotate_semantic_pack_near(
+    families: &mut [nose_detect::RefactorFamily],
+    registry: &nose_semantics::SemanticPackNearRegistry,
+) {
+    if !registry.is_active() {
+        return;
+    }
+    for family in families.iter_mut().filter(|family| {
+        family.witness.as_ref().map(|witness| witness.kind) == Some("structural-similarity")
+    }) {
+        let protocols = family
+            .locations
+            .iter()
+            .map(|location| {
+                registry.protocols_for_unit(&location.file, location.start_line, location.end_line)
+            })
+            .collect::<Vec<_>>();
+        let mut aggregate = BTreeSet::new();
+        for (index, location) in family.locations.iter_mut().enumerate() {
+            let mut member = BTreeSet::new();
+            for protocol in &protocols[index] {
+                let Some(provenance) = &protocol.provenance else {
+                    continue;
+                };
+                let supported = protocols.iter().enumerate().any(|(other_index, others)| {
+                    other_index != index
+                        && others
+                            .iter()
+                            .any(|other| other.operation == protocol.operation)
+                });
+                if supported {
+                    member.insert(provenance.clone());
+                    aggregate.insert(provenance.clone());
+                }
+            }
+            location.semantic_pack_near = member.into_iter().collect();
+        }
+        family.semantic_pack_near = aggregate.into_iter().collect();
     }
 }
 

--- a/crates/nose-cli/src/query_model.rs
+++ b/crates/nose-cli/src/query_model.rs
@@ -260,6 +260,32 @@ fn query_family_metrics_json(f: &nose_detect::RefactorFamily) -> serde_json::Val
     })
 }
 
+fn query_location_json(
+    location: &nose_detect::Loc,
+    existing_helper: Option<&nose_detect::Loc>,
+) -> serde_json::Value {
+    let mut object = serde_json::json!({
+        "id": baseline::member_id(location),
+        "file": location.file, "start": location.start_line, "end": location.end_line,
+        "name": location.name, "lang": location.lang.as_str(),
+    });
+    if existing_helper.is_some_and(|helper| std::ptr::eq(helper, location)) {
+        object["role"] = serde_json::Value::from("existing-helper");
+    }
+    if let Some((start, end)) = location.shared_subdag {
+        object["shared_subdag"] = serde_json::json!([start, end]);
+    }
+    if !location.origin.is_unknown() {
+        object["origin"] =
+            serde_json::to_value(location.origin).expect("UnitOrigin JSON serialization");
+    }
+    if !location.semantic_pack_near.is_empty() {
+        object["semantic_pack_near"] = serde_json::to_value(&location.semantic_pack_near)
+            .expect("semantic-pack near provenance is JSON serializable");
+    }
+    object
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn query_family_json_with_counts(
     f: &nose_detect::RefactorFamily,
@@ -277,28 +303,7 @@ pub(super) fn query_family_json_with_counts(
     let locations: Vec<_> = f
         .locations
         .iter()
-        .map(|l| {
-            let mut o = serde_json::json!({
-                "id": baseline::member_id(l),
-                "file": l.file, "start": l.start_line, "end": l.end_line,
-                "name": l.name, "lang": l.lang.as_str(),
-            });
-            // Mark the member that is itself the existing helper, so the agent does not read
-            // it as one more copy to fold (#374 item 5).
-            if helper.is_some_and(|h| std::ptr::eq(h, l)) {
-                o["role"] = serde_json::Value::from("existing-helper");
-            }
-            // For a shared-sub-dag (partial) clone, where the proven shared computation lives
-            // at this site — so the caller can see what is provably equal, not just the unit.
-            if let Some((s, e)) = l.shared_subdag {
-                o["shared_subdag"] = serde_json::json!([s, e]);
-            }
-            if !l.origin.is_unknown() {
-                o["origin"] =
-                    serde_json::to_value(l.origin).expect("UnitOrigin JSON serialization");
-            }
-            o
-        })
+        .map(|location| query_location_json(location, helper))
         .collect();
     let mut obj = serde_json::json!({
         "id": id.clone(),
@@ -326,6 +331,10 @@ pub(super) fn query_family_json_with_counts(
     // proven span per location instead). Evidence, not a verdict.
     if let Some(n) = f.witness.as_ref().and_then(|w| w.value_nodes) {
         obj["value_nodes"] = serde_json::Value::from(n);
+    }
+    if !f.semantic_pack_near.is_empty() {
+        obj["semantic_pack_near"] = serde_json::to_value(&f.semantic_pack_near)
+            .expect("semantic-pack near provenance is JSON serializable");
     }
     // Temporal status against a `since=` snapshot (new/changed/unchanged), when one was given.
     if let Some(cmp) = since {

--- a/crates/nose-cli/src/query_semantic_packs.rs
+++ b/crates/nose-cli/src/query_semantic_packs.rs
@@ -1,10 +1,13 @@
 use serde_json::{json, Value};
 
-pub(crate) fn semantic_packs_json(semantic_packs: &nose_semantics::SemanticPackSet) -> Vec<Value> {
+pub(crate) fn semantic_packs_json(
+    semantic_packs: &nose_semantics::SemanticPackSet,
+    near_report: Option<&nose_semantics::SemanticPackNearReport>,
+) -> Vec<Value> {
     semantic_packs
         .packs()
         .iter()
-        .map(|pack| semantic_pack_summary_json(pack, semantic_packs))
+        .map(|pack| semantic_pack_summary_json(pack, semantic_packs, near_report))
         .collect()
 }
 
@@ -21,6 +24,7 @@ pub(crate) fn with_semantic_packs(mut report: Value, semantic_packs: &[Value]) -
 fn semantic_pack_summary_json(
     pack: &nose_semantics::SemanticPackSummary,
     semantic_packs: &nose_semantics::SemanticPackSet,
+    near_report: Option<&nose_semantics::SemanticPackNearReport>,
 ) -> Value {
     let mut summary = json!({
         "id": &pack.id,
@@ -78,6 +82,26 @@ fn semantic_pack_summary_json(
                     "path": receipt.declared_path(),
                     "content_digest": receipt.content_digest(),
                 })),
+            }),
+        );
+    }
+    if let Some(counts) = near_report.and_then(|report| report.pack(&pack.id)) {
+        object.insert(
+            "near_influence".to_string(),
+            json!({
+                "lane": "near",
+                "trust": "external-opt-in",
+                "selected_rows": counts.selected_rows,
+                "admitted_rows": counts.admitted_rows,
+                "rejected_rows": counts.rejected_rows,
+                "admitted_occurrences": counts.admitted_occurrences,
+                "influential_occurrences": counts.influential_occurrences,
+                "caveats": [
+                    "near-only",
+                    "not-an-equivalence-proof",
+                    "provider-claim-user-authorized",
+                    "exact-output-unchanged"
+                ],
             }),
         );
     }

--- a/crates/nose-cli/src/semantic_pack/adoption_gates.rs
+++ b/crates/nose-cli/src/semantic_pack/adoption_gates.rs
@@ -97,7 +97,7 @@ impl AdoptionGateReport {
                 scope: "compiled-builtin",
                 default_lane: "builtin-default",
                 optional_lane: "builtin-optional",
-                external_influence: "metadata-only",
+                external_influence: "unlocked-metadata-or-locked-near-only",
                 product_behavior_gate: "required-for-builtin-default-promotion",
                 performance_gate: "required-for-builtin-default-promotion",
             },

--- a/crates/nose-cli/src/semantic_pack/compatibility.rs
+++ b/crates/nose-cli/src/semantic_pack/compatibility.rs
@@ -61,6 +61,7 @@ struct CompatibilityChecks {
     builtin_inventory_status: &'static str,
     builtin_packs: usize,
     external_metadata_only: bool,
+    external_locked_near_only: bool,
     external_influence_blockers: Vec<&'static str>,
 }
 
@@ -89,7 +90,7 @@ impl CompatibilityReport {
                 manifest_schema_changes: "breaking-change-requires-new-api-version",
                 kernel_vocabulary_changes: "document-and-rehearse-with-builtin-packs-first",
                 capabilities_changes: "additive-or-schema-versioned",
-                external_pack_influence: "metadata-only",
+                external_pack_influence: "metadata-or-locked-near-only",
                 external_pack_authorization: "content-pinned-project-lock-required",
                 external_pack_execution: "none",
                 external_packs_enabled_by_default: false,
@@ -110,7 +111,7 @@ impl CompatibilityReport {
                     "unsupported-capability-fail-closed",
                     "unknown-fields-and-enums-rejected",
                     "external-execution-none",
-                    "metadata-only-external-rows-do-not-influence-analysis",
+                    "unlocked-or-v0-external-rows-do-not-influence-analysis",
                 ],
                 migration: vec![
                     "builtin-pack-migration-before-external-influence",
@@ -124,7 +125,8 @@ impl CompatibilityReport {
             checks: CompatibilityChecks {
                 builtin_inventory_status: inventory.status,
                 builtin_packs: inventory.totals.builtin_packs,
-                external_metadata_only: true,
+                external_metadata_only: false,
+                external_locked_near_only: true,
                 external_influence_blockers: blockers,
             },
         }

--- a/crates/nose-cli/src/semantic_pack/project_lock.rs
+++ b/crates/nose-cli/src/semantic_pack/project_lock.rs
@@ -107,7 +107,15 @@ impl LockStatusReport {
             lock_api_version: lock.summary().api_version(),
             lock_path: lock.summary().lock_path().display().to_string(),
             decision_digest: lock.summary().decision_digest().to_string(),
-            influence: "metadata-only",
+            influence: if lock.authorizations().iter().any(|authorization| {
+                authorization
+                    .allowed_channels()
+                    .contains(&nose_semantics::SemanticPackV1Channel::Near)
+            }) {
+                "near-only"
+            } else {
+                "metadata-only"
+            },
             totals: LockStatusTotals {
                 packs: packs.len(),
                 selected_rows: packs.iter().map(|pack| pack.selected_rows.len()).sum(),

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -128,6 +128,10 @@ fn capabilities_command_reports_query_surface() {
         true
     );
     assert_eq!(
+        json["query"]["capabilities"]["semantic_pack_locked_near_influence"],
+        true
+    );
+    assert_eq!(
         json["query"]["capabilities"]["semantic_pack_project_lock"],
         true
     );
@@ -147,7 +151,7 @@ fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
     assert_semantic_pack_project_lock_capabilities(&json);
     assert_eq!(
         json["semantic_packs"]["external_pack_influence"],
-        "metadata-only"
+        "metadata-or-locked-near-only"
     );
     assert_eq!(
         json_array_strings(&json["semantic_packs"], "external_influence_blockers"),

--- a/crates/nose-cli/tests/cli/commands/config_packs/project_lock.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/project_lock.rs
@@ -9,7 +9,9 @@ fn prepare_locked_project(tag: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     let dependency = dir.join("pom.xml");
     fs::write(
         &dependency,
-        "<project><dependency>com.google.guava:guava:33.0.0</dependency></project>\n",
+        "<project><modelVersion>4.0.0</modelVersion><dependencies><dependency>\
+         <groupId>com.google.guava</groupId><artifactId>guava</artifactId>\
+         <version>33.0.0-jre</version></dependency></dependencies></project>\n",
     )
     .unwrap();
     let lock = dir.join("nose.semantic-pack-lock.json");
@@ -51,7 +53,7 @@ fn lock_and_status_commands_report_the_same_valid_local_decision() {
         created_json["lock_api_version"],
         "nose.semantic-pack-lock.v1"
     );
-    assert_eq!(created_json["influence"], "metadata-only");
+    assert_eq!(created_json["influence"], "near-only");
     assert_eq!(created_json["totals"]["packs"], 1);
     assert_eq!(created_json["totals"]["selected_rows"], 3);
     assert_eq!(created_json["totals"]["conflicts"], 0);
@@ -77,7 +79,7 @@ fn lock_and_status_commands_report_the_same_valid_local_decision() {
 }
 
 #[test]
-fn locked_query_reports_authorization_but_keeps_families_unchanged() {
+fn locked_query_reports_near_authorization_without_evidence_occurrences() {
     let (dir, _, _, _) = prepare_locked_project("semantic_pack_locked_query");
     assert!(create_lock(&dir, "human").status.success());
     let without = Command::new(bin())
@@ -108,7 +110,9 @@ fn locked_query_reports_authorization_but_keeps_families_unchanged() {
     let with: serde_json::Value = serde_json::from_slice(&with.stdout).unwrap();
     assert_eq!(with["families"], without["families"]);
     let pack = semantic_pack_by_id(&with, "com.example.java-guava-typed-factories");
-    assert_eq!(pack["influence"], "metadata-only");
+    assert_eq!(pack["influence"], "near-only");
+    assert_eq!(pack["near_influence"]["admitted_occurrences"], 0);
+    assert_eq!(pack["near_influence"]["influential_occurrences"], 0);
     assert_eq!(pack["lock"]["status"], "valid");
     assert_eq!(pack["lock"]["api_version"], "nose.semantic-pack-lock.v1");
     assert_eq!(
@@ -117,6 +121,115 @@ fn locked_query_reports_authorization_but_keeps_families_unchanged() {
     );
     assert_eq!(pack["lock"]["selected_rows"].as_array().unwrap().len(), 3);
     assert_eq!(pack["lock"]["dependencies"][0]["path"], "pom.xml");
+}
+
+#[test]
+fn locked_near_row_changes_only_the_supported_near_family_with_provenance() {
+    let (dir, _, _, _) = prepare_locked_project("semantic_pack_near_influence");
+    for child in ["a", "b", "c", "tests"] {
+        let _ = fs::remove_dir_all(dir.join(child));
+    }
+    write_files(
+        &dir,
+        &[
+            (
+                "External.java",
+                "import com.google.common.collect.ImmutableList;\n\
+                 class External {\n\
+                   Object collect(Object first, Object second) {\n\
+                     Object values = ImmutableList.of(first, second);\n\
+                     int size = first.hashCode() + second.hashCode();\n\
+                     if (size > 0) { return values; }\n\
+                     return ImmutableList.of(second, first);\n\
+                   }\n\
+                 }\n",
+            ),
+            (
+                "Builtin.java",
+                "import java.util.List;\n\
+                 class Builtin {\n\
+                   Object gather(Object first, Object second) {\n\
+                     Object values = List.of(first, second);\n\
+                     int size = first.hashCode() + second.hashCode();\n\
+                     if (size > 0) { return values; }\n\
+                     return List.of(first);\n\
+                   }\n\
+                 }\n",
+            ),
+        ],
+    );
+    assert!(create_lock(&dir, "human").status.success());
+    let query = |locked: bool, mode: &str, cache: bool| {
+        let mut command = Command::new(bin());
+        command.args([
+            "query",
+            ".",
+            "all",
+            "top=0",
+            "--mode",
+            mode,
+            "--min-lines",
+            "3",
+            "--min-size",
+            "12",
+            "--format",
+            "json",
+        ]);
+        if locked {
+            command.args(["--semantic-pack-lock", "nose.semantic-pack-lock.json"]);
+        }
+        if cache {
+            command.args(["--cache-dir", ".nose-cache"]);
+        }
+        let output = command.current_dir(&dir).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap()
+    };
+
+    let without = query(false, "near", false);
+    let with = query(true, "near", false);
+    let influenced = with["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|family| family.get("semantic_pack_near").is_some())
+        .unwrap_or_else(|| panic!("locked query should expose influenced family: {with}"));
+    assert!(
+        without["families"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|family| family["id"] != influenced["id"]),
+        "removing the lock must remove the protocol-supported family"
+    );
+    let provenance = &influenced["semantic_pack_near"][0];
+    assert_eq!(provenance["lane"], "near");
+    assert_eq!(provenance["trust"], "external-opt-in");
+    assert_eq!(provenance["dependency"]["matched_version"], "33.0.0");
+    assert!(provenance["row_digest"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+    assert!(influenced["locations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|location| location.get("semantic_pack_near").is_some()));
+    let pack = semantic_pack_by_id(&with, "com.example.java-guava-typed-factories");
+    assert_eq!(pack["near_influence"]["admitted_occurrences"], 2);
+    assert_eq!(pack["near_influence"]["influential_occurrences"], 2);
+
+    let repeated = query(true, "near", false);
+    assert_eq!(with, repeated, "locked near output must be deterministic");
+    let cached = query(true, "near", true);
+    assert_eq!(with["families"], cached["families"]);
+    let semantic_without = query(false, "semantic", false);
+    let semantic_with = query(true, "semantic", false);
+    assert_eq!(semantic_without["families"], semantic_with["families"]);
 }
 
 #[test]

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
@@ -19,7 +19,10 @@ fn assert_adoption_gate_totals(json: &serde_json::Value) {
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["policy"]["scope"], "compiled-builtin");
-    assert_eq!(json["policy"]["external_influence"], "metadata-only");
+    assert_eq!(
+        json["policy"]["external_influence"],
+        "unlocked-metadata-or-locked-near-only"
+    );
     assert_eq!(json["totals"]["builtin_packs"], 49);
     assert_eq!(json["totals"]["builtin_default_packs"], 49);
     assert_eq!(json["totals"]["builtin_optional_packs"], 0);

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
@@ -25,7 +25,10 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
         json["policy"]["manifest_nose_version"],
         "must-include-installed-version"
     );
-    assert_eq!(json["policy"]["external_pack_influence"], "metadata-only");
+    assert_eq!(
+        json["policy"]["external_pack_influence"],
+        "metadata-or-locked-near-only"
+    );
     assert_eq!(
         json["policy"]["external_pack_authorization"],
         "content-pinned-project-lock-required"
@@ -37,10 +40,11 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
     assert!(json_array_strings(&json["requirements"], "kernel")
         .contains(&"unsupported-capability-fail-closed"));
     assert!(json_array_strings(&json["requirements"], "kernel")
-        .contains(&"metadata-only-external-rows-do-not-influence-analysis"));
+        .contains(&"unlocked-or-v0-external-rows-do-not-influence-analysis"));
     assert_eq!(json["checks"]["builtin_inventory_status"], "ok");
     assert_eq!(json["checks"]["builtin_packs"], 49);
-    assert_eq!(json["checks"]["external_metadata_only"], true);
+    assert_eq!(json["checks"]["external_metadata_only"], false);
+    assert_eq!(json["checks"]["external_locked_near_only"], true);
     assert_eq!(
         json_array_strings(&json["checks"], "external_influence_blockers"),
         vec![

--- a/crates/nose-detect/src/detectors.rs
+++ b/crates/nose-detect/src/detectors.rs
@@ -138,6 +138,35 @@ impl Detector for StructuralDetector {
     }
 
     fn score(&self, a: &UnitFeat, b: &UnitFeat) -> f64 {
+        let protocol_match = self.candidate_mode && external_near_protocol_match(a, b);
+        let score = self.base_score(a, b, protocol_match);
+        if protocol_match && score >= 0.60 {
+            // A reviewed protocol row is supporting near evidence, never an exact proof.
+            // Move an already-substantial existing candidate only one quarter of the
+            // remaining distance toward 1.0 and keep it visibly below exact confidence.
+            (score + (1.0 - score) * 0.25).min(0.95)
+        } else {
+            score
+        }
+    }
+}
+
+fn external_near_protocol_match(a: &UnitFeat, b: &UnitFeat) -> bool {
+    a.semantic_pack_near_protocols.iter().any(|left| {
+        left.provenance.is_some()
+            && b.semantic_pack_near_protocols
+                .iter()
+                .any(|right| right.operation == left.operation)
+    }) || b.semantic_pack_near_protocols.iter().any(|right| {
+        right.provenance.is_some()
+            && a.semantic_pack_near_protocols
+                .iter()
+                .any(|left| left.operation == right.operation)
+    })
+}
+
+impl StructuralDetector {
+    fn base_score(&self, a: &UnitFeat, b: &UnitFeat, protocol_match: bool) -> f64 {
         // Oracle-certified fast path (§AJ): an identical value-graph fingerprint means
         // behaviorally-equal — `nose verify` proved fingerprint-equality ⟹ behavior
         // -equality across the corpus (0 false merges). So accept an exact match
@@ -190,7 +219,7 @@ impl Detector for StructuralDetector {
         // Score-preserving early-exit: RANSAC (≤1) and the gates only lower the
         // score, so if the upper bound `wv·vj+ws·sj+wr` can't reach threshold the
         // pair is rejected anyway — skip the alignment DP.
-        if wv * vj + ws * sj + wr < self.accept_threshold {
+        if !protocol_match && wv * vj + ws * sj + wr < self.accept_threshold {
             return wv * vj + ws * sj + wr;
         }
         let l = align::ransac_ratio(&a.linear, &b.linear);
@@ -324,7 +353,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{units_of_file, DetectOptions};
     use nose_il::{FileId, FileMeta, IlBuilder, Lang, NodeKind, Payload, Span};
+    use nose_semantics::{
+        SemanticPackNearDependency, SemanticPackNearProtocol, SemanticPackNearProvenance,
+        SemanticPackV1Channel, SemanticPackV1ProtocolOperation,
+    };
 
     #[test]
     fn exact_safety_keeps_same_line_functions_separate_by_byte_span() {
@@ -355,5 +389,75 @@ mod tests {
         assert_eq!(safety.len(), 2);
         assert!(safety[&(0, 8)]);
         assert!(!safety[&(9, 18)]);
+    }
+
+    #[test]
+    fn locked_protocol_evidence_only_lifts_substantial_near_scores() {
+        let interner = Interner::new();
+        let il = nose_frontend::lower_source(
+            FileId(0),
+            "T.java",
+            b"class T { Object a(Object x) { return x; } Object b(Object x) { return x; } }",
+            Lang::Java,
+            &interner,
+        )
+        .expect("Java fixture lowers");
+        let options = DetectOptions {
+            min_lines: 1,
+            min_tokens: 1,
+            shape_features: true,
+            ..DetectOptions::default()
+        };
+        let mut units = units_of_file(&il, &interner, &options);
+        let mut right = units.pop().expect("second method");
+        let mut left = units.pop().expect("first method");
+        left.value = vec![1, 2];
+        right.value = vec![1, 3];
+        left.shapes = vec![1, 2, 3, 4, 5];
+        right.shapes = vec![1, 2, 3, 4, 6];
+        left.linear = vec![1, 2, 3, 4];
+        right.linear = left.linear.clone();
+        let detector = StructuralDetector::candidates(0.5)
+            .without_exact_behavior()
+            .with_threshold(0.70);
+        let base = detector.score(&left, &right);
+        assert!((0.60..0.70).contains(&base), "calibrated base={base}");
+
+        left.semantic_pack_near_protocols = vec![external_collection_protocol()];
+        right.semantic_pack_near_protocols = vec![SemanticPackNearProtocol {
+            operation: SemanticPackV1ProtocolOperation::CollectionFactory,
+            provenance: None,
+        }];
+        let supported = detector.score(&left, &right);
+        assert!((0.70..1.0).contains(&supported), "score={supported}");
+
+        right.semantic_pack_near_protocols[0].operation =
+            SemanticPackV1ProtocolOperation::MapFactory;
+        assert_eq!(detector.score(&left, &right), base);
+    }
+
+    fn external_collection_protocol() -> SemanticPackNearProtocol {
+        SemanticPackNearProtocol {
+            operation: SemanticPackV1ProtocolOperation::CollectionFactory,
+            provenance: Some(SemanticPackNearProvenance {
+                pack_id: "example.pack".into(),
+                row_id: "example.row".into(),
+                semantic_digest: "sha256:pack".into(),
+                row_digest: "sha256:row".into(),
+                lane: SemanticPackV1Channel::Near,
+                trust: "external-opt-in".into(),
+                operation: SemanticPackV1ProtocolOperation::CollectionFactory,
+                dependency: SemanticPackNearDependency {
+                    coordinate: "example:pack".into(),
+                    declared_version: "1.0.0".into(),
+                    matched_version: "1.0.0".into(),
+                    sources: Vec::new(),
+                },
+                occurrence_file: "T.java".into(),
+                call_start_line: 1,
+                call_end_line: 1,
+                caveats: Vec::new(),
+            }),
+        }
     }
 }

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -49,9 +49,9 @@ pub use model::{
 };
 pub use options::DetectOptions;
 pub use orchestration::{
-    detect, detect_from_units, detect_from_units_with_accepted_coverage,
+    corpus_features, detect, detect_from_units, detect_from_units_with_accepted_coverage,
     detect_with_accepted_coverage, detect_with_direct_accepted_coverage, detect_with_dump,
-    file_stream, units_of_file,
+    file_stream, units_of_file, CorpusFeatures,
 };
 pub use reinvented::{reinvented_helpers, ReinventedHelper};
 pub use report::{

--- a/crates/nose-detect/src/model.rs
+++ b/crates/nose-detect/src/model.rs
@@ -74,6 +74,9 @@ pub struct Loc {
     /// partial clone point at *where* the shared computation lives in each copy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared_subdag: Option<(u32, u32)>,
+    /// External near-lane evidence that contributed to this member's structural family.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_pack_near: Vec<nose_semantics::SemanticPackNearProvenance>,
 }
 
 /// Inclusive source-line range used to construct a [`Loc`].
@@ -154,6 +157,7 @@ impl Loc {
             in_test_module: false,
             looks_generated: false,
             shared_subdag: None,
+            semantic_pack_near: Vec::new(),
         }
     }
 }

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -100,6 +100,59 @@ pub fn units_of_file(il: &Il, interner: &Interner, opts: &DetectOptions) -> Vec<
     extract_units_of_file(il, interner, opts, &norm_opts, &seeds)
 }
 
+/// Corpus features ready for detection. The caller may attach query-local evidence to
+/// `units` before handing the immutable feature set to [`detect_from_units`].
+pub struct CorpusFeatures {
+    pub units: Vec<UnitFeat>,
+    pub streams: Vec<Stream>,
+    pub files: usize,
+}
+
+pub fn corpus_features(corpus: &Corpus, opts: &DetectOptions) -> CorpusFeatures {
+    let norm_opts = NormalizeOptions {
+        cfg_norm: opts.cfg_norm,
+        dce: opts.dce,
+        ..Default::default()
+    };
+    let seeds = minhash::seeds(opts.minhash_k);
+    let per_file: Vec<(Vec<UnitFeat>, Option<Stream>)> = corpus
+        .files
+        .par_iter()
+        .map(|il| {
+            let units = if opts.structural {
+                extract_units_of_file(il, &corpus.interner, opts, &norm_opts, &seeds)
+            } else {
+                Vec::new()
+            };
+            // Build contiguous copy-paste streams from raw IL. Alpha-renaming is
+            // function-scoped, so normalized identifiers would vary by enclosing unit;
+            // renamed Type-2/3/4 matches remain the structural channel's job.
+            let stream = opts
+                .contiguous
+                .then(|| contiguous::stream(il, &corpus.interner));
+            (units, stream)
+        })
+        .collect();
+    let unit_count = per_file.iter().map(|(units, _)| units.len()).sum();
+    let stream_count = per_file
+        .iter()
+        .filter(|(_, stream)| stream.is_some())
+        .count();
+    let mut units = Vec::with_capacity(unit_count);
+    let mut streams = Vec::with_capacity(stream_count);
+    for (file_units, stream) in per_file {
+        units.extend(file_units);
+        if let Some(stream) = stream {
+            streams.push(stream);
+        }
+    }
+    CorpusFeatures {
+        units,
+        streams,
+        files: corpus.files.len(),
+    }
+}
+
 /// Keep the normalization/extraction body out of the Rayon closure. This path
 /// is large and hot; sharing one non-inlined implementation with the cached
 /// per-file entry point avoids code-layout-sensitive copies while preserving
@@ -152,52 +205,11 @@ fn detect_with_dump_inner(
     // Normalize each file and extract its units in one fused parallel pass — a file's
     // normalized IL stays hot in cache through extraction and is freed immediately,
     // rather than materializing the whole normalized corpus first.
-    let norm_opts = NormalizeOptions {
-        cfg_norm: opts.cfg_norm,
-        dce: opts.dce,
-        ..Default::default()
-    };
-    let seeds = minhash::seeds(opts.minhash_k);
-    // Normalize each file once; extract its units and (when enabled) its contiguous
-    // token stream from the same hot normalized IL.
-    let per_file: Vec<(Vec<UnitFeat>, Option<Stream>)> = corpus
-        .files
-        .par_iter()
-        .map(|il| {
-            let units = if opts.structural {
-                extract_units_of_file(il, &corpus.interner, opts, &norm_opts, &seeds)
-            } else {
-                Vec::new()
-            };
-            // Build the contiguous stream from the *raw* IL, not the normalized one:
-            // alpha-renaming is function-scoped, so a copy-pasted block's variable
-            // cids depend on its enclosing function and identical blocks diverge.
-            // Raw tokens (names content-hashed by `node_tag`) are stable across files
-            // — matching jscpd's name-based copy-paste. Renamed Type-2/3/4 is the
-            // structural channel's job.
-            let stream = opts
-                .contiguous
-                .then(|| contiguous::stream(il, &corpus.interner));
-            (units, stream)
-        })
-        .collect();
-    // `UnitFeat` is large enough that repeatedly growing the aggregate vector
-    // copies a meaningful amount of memory on repositories with many files.
-    // The parallel pass already owns every per-file length, so reserve the
-    // exact aggregate capacities before moving the results into place.
-    let unit_count = per_file.iter().map(|(units, _)| units.len()).sum();
-    let stream_count = per_file
-        .iter()
-        .filter(|(_, stream)| stream.is_some())
-        .count();
-    let mut units: Vec<UnitFeat> = Vec::with_capacity(unit_count);
-    let mut streams: Vec<Stream> = Vec::with_capacity(stream_count);
-    for (u, s) in per_file {
-        units.extend(u);
-        if let Some(s) = s {
-            streams.push(s);
-        }
-    }
+    let CorpusFeatures {
+        units,
+        streams,
+        files,
+    } = corpus_features(corpus, opts);
     clk.lap("normalize+extract");
 
     // `detect_from_units` runs its own `StageTimer` for the detection sub-phases
@@ -205,7 +217,7 @@ fn detect_with_dump_inner(
     // mislabel the whole call (group scoring dwarfs contiguous) as "contiguous".
     detect_from_units_inner(
         units,
-        corpus.files.len(),
+        files,
         &streams,
         opts,
         detector,

--- a/crates/nose-detect/src/report/model.rs
+++ b/crates/nose-detect/src/report/model.rs
@@ -102,6 +102,9 @@ pub struct RefactorFamily {
     /// Pack-facing semantic laws that influenced this family-level value fingerprint.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub semantic_laws: Vec<ValueLawProvenance>,
+    /// Deduplicated external near-lane evidence that contributed to this family.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_pack_near: Vec<nose_semantics::SemanticPackNearProvenance>,
     /// WHY the members merged — the agent-facing equivalence witness (#222): an
     /// exact value-graph proof, a shared heavy sub-DAG, a token-identical
     /// copy-paste run, or structural similarity with its value/shape components.

--- a/crates/nose-detect/src/report/ranking.rs
+++ b/crates/nose-detect/src/report/ranking.rs
@@ -132,6 +132,7 @@ fn family_of_with_edges(group: &Group, group_edges: &[AcceptedEdge]) -> Refactor
             .iter()
             .filter_map(|&law| value_law_provenance(law))
             .collect(),
+        semantic_pack_near: Vec::new(),
     }
 }
 

--- a/crates/nose-detect/src/report/tests/support.rs
+++ b/crates/nose-detect/src/report/tests/support.rs
@@ -118,6 +118,7 @@ pub(super) fn fam(
         witness: None,
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
+        semantic_pack_near: Vec::new(),
     }
 }
 

--- a/crates/nose-detect/src/units.rs
+++ b/crates/nose-detect/src/units.rs
@@ -558,6 +558,7 @@ fn extract_unit(
         called_helper_returns: Vec::new(),
         anchors,
         semantic_laws,
+        semantic_pack_near_protocols: Vec::new(),
         exact_safe,
         fragment_kind,
         proof_facts,

--- a/crates/nose-detect/src/units/model.rs
+++ b/crates/nose-detect/src/units/model.rs
@@ -89,6 +89,10 @@ pub struct UnitFeat {
     /// Pack-facing value laws that actually rewrote or bridged this unit's value graph.
     #[serde(default)]
     pub semantic_laws: Vec<ValueLaw>,
+    /// Query-local, dependency-backed protocol evidence for the external near lane.
+    /// Empty in cached units and every no-pack or exact-only run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_pack_near_protocols: Vec<nose_semantics::SemanticPackNearProtocol>,
     /// Whether the value fingerprint is safe to use as a strict semantic proof.
     ///
     /// `semantic` mode must not report units whose fingerprint passed through lossy

--- a/crates/nose-frontend/src/semantic_pack_evidence_tests.rs
+++ b/crates/nose-frontend/src/semantic_pack_evidence_tests.rs
@@ -26,6 +26,19 @@ fn evidence_for(source: &str, packs: &SemanticPackSet) -> SemanticPackEvidenceIn
     SemanticPackEvidenceIndex::build(packs, &Corpus::new(interner, vec![il]))
 }
 
+fn corpus_for(source: &str) -> Corpus {
+    let interner = Interner::new();
+    let il = crate::lower_source(
+        FileId(0),
+        "Fixture.java",
+        source.as_bytes(),
+        Lang::Java,
+        &interner,
+    )
+    .expect("Java fixture should lower");
+    Corpus::new(interner, vec![il])
+}
+
 #[test]
 fn locked_dependency_and_builtin_import_facts_produce_one_occurrence() {
     let packs =
@@ -134,4 +147,40 @@ fn wrong_package_local_shadow_and_unlocked_metadata_stay_closed() {
     );
     assert!(metadata_only.rows().is_empty());
     assert!(metadata_only.occurrences().is_empty());
+}
+
+#[test]
+fn locked_near_registry_joins_external_and_builtin_protocol_evidence() {
+    let packs =
+        SemanticPackSet::new_locked(&workspace_path("docs/examples/semantic-pack-lock-v1.json"))
+            .expect("checked-in lock should validate");
+    let corpus = corpus_for(
+        "import com.google.common.collect.ImmutableList;\n\
+         class Example { Object f() { return ImmutableList.of(\"a\", \"b\"); } }",
+    );
+    let evidence = SemanticPackEvidenceIndex::build(&packs, &corpus);
+    let row = evidence.row(PACK_ID, LIST_ROW).expect("selected list row");
+    assert_eq!(row.row_digest.len(), 71);
+    assert!(row.row_digest.starts_with("sha256:"));
+
+    let registry = nose_semantics::SemanticPackNearRegistry::build(&packs, &evidence, &corpus);
+    assert!(registry.is_active());
+    let protocols = registry.protocols_for_unit("Fixture.java", 1, 2);
+    assert!(protocols
+        .iter()
+        .any(|protocol| protocol.provenance.is_some()));
+    assert!(protocols
+        .iter()
+        .any(|protocol| protocol.provenance.is_none()));
+    let report = registry.report_with_influential(
+        protocols
+            .iter()
+            .filter_map(|protocol| protocol.provenance.as_ref()),
+    );
+    let counts = report.pack(PACK_ID).expect("near pack counts");
+    assert_eq!(counts.selected_rows, 3);
+    assert_eq!(counts.admitted_rows, 3);
+    assert_eq!(counts.rejected_rows, 0);
+    assert_eq!(counts.admitted_occurrences, 1);
+    assert_eq!(counts.influential_occurrences, 1);
 }

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -31,6 +31,7 @@ pub(in crate::library_api) use receiver_dependencies::{
 pub(crate) use receiver_dependencies::{
     language_core_builtin_at_call, library_api_dependency_id_for_normalized_hof,
 };
+pub(crate) use registry::admitted_library_api_near_operation_for_call_record;
 pub use registry::admitted_library_api_result_domain_for_call_record;
 pub(in crate::library_api) use registry::{
     library_api_callee_contract_for_hash, library_api_contract_id_from_hash,

--- a/crates/nose-semantics/src/library_api/registry.rs
+++ b/crates/nose-semantics/src/library_api/registry.rs
@@ -70,6 +70,47 @@ pub(super) fn library_api_contract_id_from_hash(hash: u64) -> Option<LibraryApiC
         .find(|id| library_api_contract_id_hash(*id) == hash)
 }
 
+pub(crate) fn admitted_library_api_near_operation_for_call_record(
+    il: &Il,
+    interner: &Interner,
+    call: NodeId,
+    record: &EvidenceRecord,
+) -> Option<SemanticPackV1ProtocolOperation> {
+    let EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract { contract_hash, .. }) =
+        record.kind
+    else {
+        return None;
+    };
+    if record.status != EvidenceStatus::Asserted
+        || record.provenance.emitter != EvidenceEmitter::Builtin
+        || !il.evidence_dependencies_asserted(record)
+        || !library_api_record_admitted_for_current_shape(il, interner, call, record)
+    {
+        return None;
+    }
+    match library_api_contract_id_from_hash(contract_hash)? {
+        LibraryApiContractId::PythonBuiltinCollectionFactory
+        | LibraryApiContractId::PythonImportedCollectionFactory
+        | LibraryApiContractId::SwiftCollectionFactory(_)
+        | LibraryApiContractId::RustStdCollectionFactory
+        | LibraryApiContractId::RustVecMacroFactory
+        | LibraryApiContractId::RustVecNewFactory
+        | LibraryApiContractId::JavaCollectionFactory(_)
+        | LibraryApiContractId::JavaCollectionConstructor(_)
+        | LibraryApiContractId::RubySetFactory
+        | LibraryApiContractId::JsLikeSetConstructor => {
+            Some(SemanticPackV1ProtocolOperation::CollectionFactory)
+        }
+        LibraryApiContractId::SwiftMapFactory(_)
+        | LibraryApiContractId::RustStdMapFactory
+        | LibraryApiContractId::JavaMapFactory(_)
+        | LibraryApiContractId::JsLikeMapConstructor => {
+            Some(SemanticPackV1ProtocolOperation::MapFactory)
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn library_api_record_admitted_for_current_shape(
     il: &Il,
     interner: &Interner,

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -111,6 +111,7 @@ mod external;
 mod loading;
 mod lock;
 mod manifest;
+mod near_registry;
 mod result_domain_semantics;
 mod v1;
 mod validation;
@@ -147,6 +148,10 @@ pub use lock::{
     ValidatedSemanticPackProjectLock, SEMANTIC_PACK_LOCK_API_VERSION_V1,
 };
 use manifest::*;
+pub use near_registry::{
+    SemanticPackNearDependency, SemanticPackNearPackCounts, SemanticPackNearProtocol,
+    SemanticPackNearProvenance, SemanticPackNearRegistry, SemanticPackNearReport,
+};
 use v1::{compile_manifest_v1, SemanticPackManifestV1};
 pub use v1::{
     CompiledSemanticPackV1, SemanticPackV1Anchor, SemanticPackV1Arity, SemanticPackV1ArityKind,
@@ -202,6 +207,7 @@ impl SemanticPackSource {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SemanticPackInfluence {
     EvidenceAndContracts,
+    NearOnly,
     MetadataOnly,
 }
 
@@ -209,6 +215,7 @@ impl SemanticPackInfluence {
     pub const fn as_str(self) -> &'static str {
         match self {
             SemanticPackInfluence::EvidenceAndContracts => "evidence-and-contracts",
+            SemanticPackInfluence::NearOnly => "near-only",
             SemanticPackInfluence::MetadataOnly => "metadata-only",
         }
     }

--- a/crates/nose-semantics/src/packs/evidence_index.rs
+++ b/crates/nose-semantics/src/packs/evidence_index.rs
@@ -18,7 +18,7 @@ use occurrences::occurrences_for_contract;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct SemanticPackDependencyEvidenceId(pub u32);
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
 pub struct SemanticPackDependencySource {
     pub declared_path: String,
     pub content_digest: String,
@@ -58,6 +58,7 @@ pub struct SemanticPackEvidenceRow {
     pub pack_id: String,
     pub row_id: String,
     pub semantic_digest: String,
+    pub row_digest: String,
     pub channel: SemanticPackV1Channel,
     pub dependency: Option<SemanticPackDependencyEvidenceId>,
     pub blocker: Option<SemanticPackEvidenceBlocker>,
@@ -205,6 +206,10 @@ impl EvidenceIndexBuilder {
             pack_id: pack.pack_id().to_string(),
             row_id: contract.id.clone(),
             semantic_digest: pack.semantic_digest().to_string(),
+            row_digest: pack
+                .row_digest(&contract.id)
+                .expect("compiled v1 contract has a row digest")
+                .to_string(),
             channel: contract.channel,
             dependency,
             blocker,

--- a/crates/nose-semantics/src/packs/lock.rs
+++ b/crates/nose-semantics/src/packs/lock.rs
@@ -147,6 +147,17 @@ impl ValidatedSemanticPackProjectLock {
     }
 
     pub fn into_semantic_packs(mut self) -> SemanticPackSet {
+        for pack in &mut self.semantic_packs.packs {
+            if self.authorizations.iter().any(|authorization| {
+                authorization.pack_id == pack.id
+                    && authorization
+                        .allowed_channels
+                        .binary_search(&SemanticPackV1Channel::Near)
+                        .is_ok()
+            }) {
+                pack.influence = super::SemanticPackInfluence::NearOnly;
+            }
+        }
         self.semantic_packs.external_v1_authorizations = self
             .authorizations
             .iter()

--- a/crates/nose-semantics/src/packs/near_registry.rs
+++ b/crates/nose-semantics/src/packs/near_registry.rs
@@ -1,0 +1,253 @@
+//! Query-local protocol evidence for the locked external near lane.
+
+use super::*;
+use nose_il::{EvidenceAnchor, EvidenceKind, LibraryApiEvidenceKind, NodeId, NodeKind};
+use std::collections::{BTreeMap, BTreeSet};
+
+const NEAR_CAVEATS: &[&str] = &[
+    "near-only",
+    "not-an-equivalence-proof",
+    "provider-claim-user-authorized",
+    "exact-output-unchanged",
+];
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SemanticPackNearDependency {
+    pub coordinate: String,
+    pub declared_version: String,
+    pub matched_version: String,
+    pub sources: Vec<SemanticPackDependencySource>,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SemanticPackNearProvenance {
+    pub pack_id: String,
+    pub row_id: String,
+    pub semantic_digest: String,
+    pub row_digest: String,
+    pub lane: SemanticPackV1Channel,
+    pub trust: String,
+    pub operation: SemanticPackV1ProtocolOperation,
+    pub dependency: SemanticPackNearDependency,
+    pub occurrence_file: String,
+    pub call_start_line: u32,
+    pub call_end_line: u32,
+    pub caveats: Vec<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SemanticPackNearProtocol {
+    pub operation: SemanticPackV1ProtocolOperation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<SemanticPackNearProvenance>,
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct SemanticPackNearPackCounts {
+    pub selected_rows: usize,
+    pub admitted_rows: usize,
+    pub rejected_rows: usize,
+    pub admitted_occurrences: usize,
+    pub influential_occurrences: usize,
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct SemanticPackNearReport {
+    packs: BTreeMap<String, SemanticPackNearPackCounts>,
+}
+
+impl SemanticPackNearReport {
+    pub fn pack(&self, pack_id: &str) -> Option<&SemanticPackNearPackCounts> {
+        self.packs.get(pack_id)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct ProtocolOccurrence {
+    start_line: u32,
+    end_line: u32,
+    protocol: SemanticPackNearProtocol,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct SemanticPackNearRegistry {
+    by_file: BTreeMap<String, Vec<ProtocolOccurrence>>,
+    report: SemanticPackNearReport,
+}
+
+impl SemanticPackNearRegistry {
+    pub fn build(
+        packs: &SemanticPackSet,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &nose_il::Corpus,
+    ) -> Self {
+        let mut registry = Self::default();
+        registry.index_external(packs, evidence, corpus);
+        if registry.has_external_occurrences() {
+            registry.index_builtin(corpus);
+        }
+        for occurrences in registry.by_file.values_mut() {
+            occurrences.sort();
+            occurrences.dedup();
+        }
+        registry
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.has_external_occurrences()
+    }
+
+    pub fn protocols_for_unit(
+        &self,
+        path: &str,
+        start_line: u32,
+        end_line: u32,
+    ) -> Vec<SemanticPackNearProtocol> {
+        let Some(occurrences) = self.by_file.get(path) else {
+            return Vec::new();
+        };
+        let mut protocols = occurrences
+            .iter()
+            .filter(|occurrence| {
+                start_line <= occurrence.start_line && occurrence.end_line <= end_line
+            })
+            .map(|occurrence| occurrence.protocol.clone())
+            .collect::<Vec<_>>();
+        protocols.sort();
+        protocols.dedup();
+        protocols
+    }
+
+    pub fn report_with_influential<'a>(
+        &self,
+        influential: impl IntoIterator<Item = &'a SemanticPackNearProvenance>,
+    ) -> SemanticPackNearReport {
+        let mut report = self.report.clone();
+        let unique = influential.into_iter().collect::<BTreeSet<_>>();
+        for provenance in unique {
+            if let Some(counts) = report.packs.get_mut(&provenance.pack_id) {
+                counts.influential_occurrences += 1;
+            }
+        }
+        report
+    }
+
+    fn has_external_occurrences(&self) -> bool {
+        self.by_file
+            .values()
+            .flatten()
+            .any(|occurrence| occurrence.protocol.provenance.is_some())
+    }
+
+    fn index_external(
+        &mut self,
+        packs: &SemanticPackSet,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &nose_il::Corpus,
+    ) {
+        for row in evidence
+            .rows()
+            .iter()
+            .filter(|row| row.channel == SemanticPackV1Channel::Near)
+        {
+            let counts = self.report.packs.entry(row.pack_id.clone()).or_default();
+            counts.selected_rows += 1;
+            if row.blocker.is_some() {
+                counts.rejected_rows += 1;
+                continue;
+            }
+            counts.admitted_rows += 1;
+            let Some(pack) = packs
+                .compiled_external_v1_packs()
+                .iter()
+                .find(|pack| pack.pack_id() == row.pack_id)
+            else {
+                continue;
+            };
+            let Some(contract) = pack.contracts_by_id().get(&row.row_id) else {
+                continue;
+            };
+            for occurrence in evidence.occurrences_for_row(&row.pack_id, &row.row_id) {
+                let Some(dependency) = evidence.dependency(occurrence.dependency) else {
+                    continue;
+                };
+                let Some(file) = corpus.files.get(occurrence.call_span.file.0 as usize) else {
+                    continue;
+                };
+                counts.admitted_occurrences += 1;
+                self.by_file
+                    .entry(file.meta.path.clone())
+                    .or_default()
+                    .push(ProtocolOccurrence {
+                        start_line: occurrence.call_span.start_line,
+                        end_line: occurrence.call_span.end_line,
+                        protocol: SemanticPackNearProtocol {
+                            operation: contract.operation,
+                            provenance: Some(SemanticPackNearProvenance {
+                                pack_id: row.pack_id.clone(),
+                                row_id: row.row_id.clone(),
+                                semantic_digest: row.semantic_digest.clone(),
+                                row_digest: row.row_digest.clone(),
+                                lane: SemanticPackV1Channel::Near,
+                                trust: PackTrust::ExternalOptIn.as_manifest_str().to_string(),
+                                operation: contract.operation,
+                                dependency: SemanticPackNearDependency {
+                                    coordinate: dependency.coordinate.clone(),
+                                    declared_version: dependency.declared_version.clone(),
+                                    matched_version: dependency.matched_version.clone(),
+                                    sources: dependency.sources.clone(),
+                                },
+                                occurrence_file: file.meta.path.clone(),
+                                call_start_line: occurrence.call_span.start_line,
+                                call_end_line: occurrence.call_span.end_line,
+                                caveats: NEAR_CAVEATS
+                                    .iter()
+                                    .map(|caveat| (*caveat).to_string())
+                                    .collect(),
+                            }),
+                        },
+                    });
+            }
+        }
+    }
+
+    fn index_builtin(&mut self, corpus: &nose_il::Corpus) {
+        for il in &corpus.files {
+            for index in 0..il.nodes.len() {
+                let call = NodeId(index as u32);
+                if il.kind(call) != NodeKind::Call {
+                    continue;
+                }
+                let span = il.node(call).span;
+                for record in il.evidence_anchored_at(span).filter(|record| {
+                    record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+                        && matches!(
+                            record.kind,
+                            EvidenceKind::LibraryApi(LibraryApiEvidenceKind::Contract { .. })
+                        )
+                }) {
+                    let Some(operation) =
+                        crate::library_api::admitted_library_api_near_operation_for_call_record(
+                            il,
+                            &corpus.interner,
+                            call,
+                            record,
+                        )
+                    else {
+                        continue;
+                    };
+                    self.by_file.entry(il.meta.path.clone()).or_default().push(
+                        ProtocolOccurrence {
+                            start_line: span.start_line,
+                            end_line: span.end_line,
+                            protocol: SemanticPackNearProtocol {
+                                operation,
+                                provenance: None,
+                            },
+                        },
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/nose-semantics/src/packs/v1.rs
+++ b/crates/nose-semantics/src/packs/v1.rs
@@ -267,6 +267,7 @@ pub struct CompiledSemanticPackV1 {
     pack_version: String,
     nose_compatibility: String,
     semantic_digest: String,
+    row_digests_by_id: BTreeMap<String, String>,
     packages_by_coordinate: BTreeMap<SemanticPackV1PackageCoordinate, SemanticPackV1Package>,
     contracts_by_id: BTreeMap<String, SemanticPackV1Contract>,
     contract_ids_by_coordinate: BTreeMap<SemanticPackV1Coordinate, Vec<String>>,
@@ -298,6 +299,10 @@ impl CompiledSemanticPackV1 {
 
     pub fn contracts_by_id(&self) -> &BTreeMap<String, SemanticPackV1Contract> {
         &self.contracts_by_id
+    }
+
+    pub fn row_digest(&self, row_id: &str) -> Option<&str> {
+        self.row_digests_by_id.get(row_id).map(String::as_str)
     }
 
     pub fn contract_ids_by_coordinate(&self) -> &BTreeMap<SemanticPackV1Coordinate, Vec<String>> {

--- a/crates/nose-semantics/src/packs/v1/compiler.rs
+++ b/crates/nose-semantics/src/packs/v1/compiler.rs
@@ -15,6 +15,10 @@ pub(in crate::packs) fn compile_manifest_v1(
     }
     contracts.sort_by(|left, right| left.id.cmp(&right.id));
     let semantic_digest = semantic_digest(manifest, &contracts)?;
+    let row_digests_by_id = contracts
+        .iter()
+        .map(|contract| Ok((contract.id.clone(), digest_json(contract)?)))
+        .collect::<Result<BTreeMap<_, _>, String>>()?;
     let packages_by_coordinate = manifest
         .packages
         .iter()
@@ -49,6 +53,7 @@ pub(in crate::packs) fn compile_manifest_v1(
         pack_version: manifest.pack.version.clone(),
         nose_compatibility: manifest.compatibility.nose.clone(),
         semantic_digest,
+        row_digests_by_id,
         packages_by_coordinate,
         contracts_by_id,
         contract_ids_by_coordinate,
@@ -327,7 +332,11 @@ fn semantic_digest(
         packages,
         api_contracts: contracts,
     };
-    let bytes = serde_json::to_vec(&canonical)
+    digest_json(&canonical)
+}
+
+fn digest_json(value: &impl Serialize) -> Result<String, String> {
+    let bytes = serde_json::to_vec(value)
         .map_err(|err| format!("serializing canonical v1 semantic content: {err}"))?;
     let digest = Sha256::digest(bytes);
     let mut hex = String::with_capacity(64);

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -89,6 +89,7 @@ nose capabilities
       "query_base_structured_ignores": true,
       "reinvented_view": true,
       "semantic_pack_dependency_evidence": true,
+      "semantic_pack_locked_near_influence": true,
       "semantic_pack_loading": true,
       "semantic_pack_project_lock": true,
       "structured_ignores": true
@@ -122,7 +123,7 @@ nose capabilities
       "external-opt-in"
     ],
     "external_packs_enabled_by_default": false,
-    "external_pack_influence": "metadata-only",
+    "external_pack_influence": "metadata-or-locked-near-only",
     "external_influence_blockers": [
       "data-only-registration",
       "dependency-backed-evidence-unavailable",
@@ -199,7 +200,7 @@ only `tool.version` and the platform values are normalized for the local build.
 | `semantic_packs.compatibility_output_formats` | array | Supported `nose semantic-pack compatibility --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
-| `semantic_packs.external_pack_influence` | string | Current influence of loaded external packs, `metadata-only`. |
+| `semantic_packs.external_pack_influence` | string | Current external boundary: unlocked/v0 metadata, or dependency-backed locked v1 near-only influence. |
 | `semantic_packs.external_influence_blockers` | array | Stable blocker labels that currently prevent external rows from influencing analysis. |
 | `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 6 reports `none`; local external packs do not run recognizers, parser/lowering plugins, producer code, sandboxed code, or fixture contents. |
 | `il.output_formats` | array | Supported `nose il --format` values. |
@@ -213,11 +214,11 @@ consumers. New fields may be added to existing objects without changing
 `schema_version`; changing a documented field's type or meaning requires a new
 capabilities schema version.
 
-The global `dependency-backed-evidence-unavailable` influence blocker describes
-the existing opaque/data-only external-row preflight. A locked typed v1 query
-can build the separate dependency/occurrence index advertised by
-`semantic_pack_dependency_evidence`, but no lane consumes that index yet and it
-does not remove the global `metadata-only` policy.
+The blocker list describes rows outside the admitted locked-near slice,
+especially opaque v0/unlocked rows and external exact. A locked typed v1 query
+can build the dependency/occurrence index advertised by
+`semantic_pack_dependency_evidence`; `semantic_pack_locked_near_influence`
+means its admitted near rows may support existing near candidates.
 
 ## Query Capability Flags
 
@@ -239,7 +240,8 @@ Version 6 defines these `query.capabilities` keys:
 | `query_base_sarif` | `base=<ref> --format sarif` emits divergent-edit SARIF results. Wrappers should also verify `query.output_formats` contains `sarif`. |
 | `query_base_structured_ignores` | Structured ignores are applied before the `base=<ref>` divergent-edit gate. |
 | `reinvented_view` | The `reinvented` query view is supported. |
-| `semantic_pack_dependency_evidence` | A content-pinned v1 lock can build a local-only immutable Maven dependency/import/symbol/receiver/effect occurrence index; the index does not imply analysis influence. |
+| `semantic_pack_dependency_evidence` | A content-pinned v1 lock can build a local-only immutable Maven dependency/import/symbol/receiver/effect occurrence index; lane authorization and a consumer are still required for influence. |
+| `semantic_pack_locked_near_influence` | Near-authorized dependency-backed v1 occurrences may support existing near candidates with family/member provenance; exact output remains unchanged. |
 | `semantic_pack_loading` | local v0 manifests can be loaded as metadata and typed v1 manifests can be compiled for metadata/digest reporting. |
 | `semantic_pack_project_lock` | local v1 project locks can be created, validated, and supplied to query before analysis. |
 | `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,8 +89,10 @@ current-working-directory relative.
 `semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
 an explicit local opt-in to a semantic-pack v0 or v1 manifest file, or a
 directory of direct `*.json` manifests. v0 rows remain data-only; v1 rows
-compile to typed indexes and a semantic digest. Loaded external packs are still
-`metadata-only`: they do not emit evidence or enable near/exact contracts. The
+compile to typed indexes and a semantic digest. Unlocked external packs are
+`metadata-only`: they do not emit evidence or enable near/exact contracts. A
+valid `semantic-pack-lock` may authorize eligible v1 rows to support existing
+near candidates; external exact remains closed. The
 [semantic-pack loading guide](semantic-pack-loading.md) defines the full boundary.
 
 `semantic-pack-lock` selects one content-pinned

--- a/docs/home.md
+++ b/docs/home.md
@@ -100,10 +100,10 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-adoption](semantic-pack-adoption.md) — promotion, rollback, and adoption-gate reports for moving external or optional packs into official builtin support without forking semantic vocabulary.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
-- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence index, and semantic content digest; influence remains disabled pending lane consumers.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence, semantic/row digests, and the bounded locked near-only consumer.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, deterministic conflict rejection, and evidence input boundary.
 - [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for checking local pack manifests and the builtin inventory workflow for auditing shipped pack coverage.
-- [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and current metadata-only limits.
+- [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and metadata-or-locked-near-only limits.
 
 #### Planning and pricing
 

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -23,7 +23,7 @@ Every response is an object with:
 | `tool` | `"nose"` |
 | `view` | which surface produced it: `dashboard` \| `list` \| `group` \| `family` \| `reinvented` \| `base` |
 | `path` | the analyzed path expression, as given; multi-root commands render the repeated `--root`/`-r` flags |
-| `semantic_packs` | active builtin packs plus local metadata-only packs loaded through unlocked paths or a validated project lock |
+| `semantic_packs` | active builtin packs plus local external packs loaded through unlocked paths or a validated project lock |
 
 plus the view-specific body below. Like the human surface, a result is a pure function of
 (repo state, command); an unknown field or enum value is a hard error.
@@ -49,16 +49,18 @@ Each entry has:
 | `trust` | string | `builtin-default`, `builtin-optional`, or `external-opt-in`. Local manifests must still use `external-opt-in`; builtin trust is reserved for packs shipped and gated with nose. |
 | `enabled_by_default` | boolean | Whether the pack is default-enabled. Local manifests are rejected unless this is `false`; compiled builtin packs report `true`. |
 | `source` | string | `compiled-builtin` for compiled builtin packs, or `local-manifest` for local manifest opt-ins. |
-| `influence` | string | `evidence-and-contracts` for compiled builtin semantics, `metadata-only` for loaded local external packs today. |
+| `influence` | string | `evidence-and-contracts` for compiled builtin semantics, `metadata-only` for unlocked/v0 external packs, or `near-only` for a v1 pack with valid near authorization. |
 | `path` | string or null | Canonical local manifest path for loaded manifests; `null` for compiled builtin packs. |
 | `provider`, `repository`, `license` | string | Pack provenance fields. |
 | `supported_languages` | array | Language ids declared by the pack. |
 | `counts` | object | Counts of declared `evidence_producers`, `contracts`, `value_laws`, `positive_fixtures`, and `hard_negatives`. |
-| `lock` | object, locked v1 only | Valid project-lock API/decision digest, allowed channels, selected rows, dependency pins, and optional receipt. Its presence authorizes future consumers but `influence` remains `metadata-only` in this phase. |
+| `lock` | object, locked v1 only | Valid project-lock API/decision digest, allowed channels, selected rows, dependency pins, and optional receipt. |
+| `near_influence` | object, near-authorized v1 only | `{lane,trust,selected_rows,admitted_rows,rejected_rows,admitted_occurrences,influential_occurrences,caveats[]}`. Counts distinguish authorization/evidence from occurrences that contributed to retained near families. |
 
-Local external packs are reported for provenance and validation only. They must
-not change families, ranking, witnesses, surfaces, or exact/near results while
-their `influence` is `metadata-only`.
+Local external packs must not change families, ranking, witnesses, surfaces, or
+exact/near results while their `influence` is `metadata-only`. `near-only` rows
+may support an existing near candidate but cannot create candidates or change
+fingerprints, exact results, or `nose verify`.
 
 For a locked v1 pack, `lock.status` is `valid`; invalid locks fail before a query
 report exists. `lock.decision_digest` is independent of workspace location and
@@ -249,7 +251,8 @@ Composition rules for v8:
 | `folds` | count of overlapping slice families folded under this one |
 | `subsumes` | (present when this family has folded slices, in any view) the `id=` handles of the slice families this one subsumes — open any to inspect |
 | `subsumed_by` | (present when this family is a slice, in any view) the `id=` handle of the fuller overlapping family this one is a slice of |
-| `locations[]` | every copy: `{id, file, start, end, name, lang}` where `id` is the member id used by baseline diagnostics; when the frontend knows source-origin facts the location also carries `origin` (domains/body/region facets such as `type-contract`, `style`, `markup`, `declaration-only`, or `vue-sfc`); the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
+| `semantic_pack_near` | affected near families only: deduplicated provenance rows with pack/row semantic digests, lane/trust/operation, dependency coordinate and pinned source digests, occurrence span, and caveats |
+| `locations[]` | every copy: `{id, file, start, end, name, lang}` where `id` is the member id used by baseline diagnostics; when the frontend knows source-origin facts the location also carries `origin` (domains/body/region facets such as `type-contract`, `style`, `markup`, `declaration-only`, or `vue-sfc`); a near-influenced member carries `semantic_pack_near`; the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
 | `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, each varying spot a `⟨param N: class⟩` placeholder (`class` = `literal`/`name`/`call`/`expr`/`block` — a coarse value-class hint for the helper signature) |
 
 `metrics` carries the raw `RefactorFamily` features before query's view-specific display fields

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2081,21 +2081,21 @@ justifies a tranche ([design §2c](design.md)).
   metadata loading is implemented for manifest files/directories and documented
   in [semantic-pack-loading](semantic-pack-loading.md); local structural
   conformance is implemented in
-  [semantic-pack-conformance](semantic-pack-conformance.md); external packs
-  remain metadata-only.
+  [semantic-pack-conformance](semantic-pack-conformance.md); v0 and unlocked
+  packs remain metadata-only.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) adds the
   first closed typed Java/Maven contract compiler, canonical semantic digest,
   and deterministic indexes.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) adds the first
   content-pinned project authorization and deterministic semantic-coordinate
   conflict boundary. It pins selected rows/channels and checked-in dependency
-  inputs without opening influence.
+  inputs before any influence is considered.
 - Locked v1 queries now build an immutable dependency/occurrence index with a
   bounded Maven POM reader and builtin Java import/symbol/receiver/effect
   matchers. Missing, invalid, ambiguous, out-of-range, wrong-package, wildcard,
-  shadowed, and rebound cases fail closed. The evidence index is threaded
-  through query analysis but deliberately remains disconnected from detection
-  until lane consumers, receipts, and a real reference pack are complete.
+  shadowed, and rebound cases fail closed. The first bounded consumer maps
+  admitted `collection-factory`/`map-factory` occurrences onto existing near
+  candidates only; it cannot create candidates or affect exact/verify output.
 - Start with data-only external packs for simple APIs once producer execution and
   executable fixture/oracle checks exist.
 - Add restricted recognizer hooks only after the manifest path is stable.
@@ -2107,9 +2107,9 @@ justifies a tranche ([design §2c](design.md)).
 - User configuration and `--semantic-pack` can load local manifests explicitly;
   `semantic-pack-lock`/`--semantic-pack-lock` select a mutually exclusive,
   content-pinned v1 set.
-- Query JSON reports active pack provenance and whether each pack influenced
-  evidence/contracts or metadata only. Per-finding contract/law provenance and
-  external pack influence on `near`/exact results remain open.
+- Query JSON reports active pack provenance and whether each pack is builtin,
+  metadata-only, or locked near-only. Affected near families/members report row
+  and dependency provenance; external-claim exact remains open.
 
 The external schema must make proof obligations first-class. For example, a pack
 claiming `pkg.Foo.map` maps to the `Map` protocol must say how `pkg.Foo` is

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -639,12 +639,13 @@ still being migrated toward it.
   path escapes and overlapping cross-pack coordinates; and exposes local
   create/status commands. Locked queries now use a bounded Maven POM reader and
   builtin Java evidence matcher to build an immutable dependency/import/symbol/
-  receiver/effect occurrence index. The index is threaded through query
-  analysis but still does not feed normalize, exact, near, or detection
-  consumers.
+  receiver/effect occurrence index. The first bounded consumer maps admitted
+  collection/map factory occurrences onto existing near candidates; normalize,
+  fingerprints, exact, and verify remain disconnected.
   `nose semantic-pack check` validates local manifests plus declared fixture
   assets, and `nose query --format json` reports active builtin/local packs in
-  top-level `semantic_packs`. External packs are still `metadata-only`; builtin
+  top-level `semantic_packs`. Unlocked/v0 packs stay `metadata-only`, while a
+  valid near lock reports `near-only`; builtin
   producers remain compiled Rust and are expected to map onto the same
   vocabulary. The first compiled pilots are the `nose.lang.*` builtin language
   descriptor/source-fact producer set, with `nose.lang.c` also carrying C
@@ -1654,13 +1655,13 @@ language.
   obligations.
 - External producer execution does not exist. New languages and libraries that
   affect analysis must still be added inside the main crates.
-- Query JSON now exposes the active builtin/local pack set at top level, but
-  family/member-level pack provenance is still limited. Selected findings can
-  expose internal law provenance; local external packs remain metadata-only.
+- Query JSON exposes the active builtin/local pack set at top level. Selected
+  findings can expose internal law provenance, and locked near-influenced
+  families/members expose external row/dependency provenance.
 - Builtin and external responsibility boundaries are documented and represented
-  in the internal facade as provenance/trust policy. Loaded external manifests
-  remain metadata-only until a producer runtime and executable fixture/oracle
-  workflow exist.
+  in the internal facade as provenance/trust policy. Unlocked/v0 manifests stay
+  metadata-only; external exact remains closed until the executable
+  fixture/oracle workflow exists.
 
 ## Current fail-closed choices
 

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -316,9 +316,9 @@ spelling as aliases, but local manifests that claim builtin trust remain
 invalid. Changing public strings requires a schema/capabilities update.
 
 External packs may declare their intended eligibility, but users choose whether
-to trust that declaration. Today, explicitly loaded external packs are reported
-as `metadata-only`; exact matching is enabled only by compiled builtin
-evidence/contracts.
+to trust that declaration. Explicitly loaded unlocked packs are reported as
+`metadata-only`. A content-pinned v1 project lock may authorize the narrow
+near-only protocol consumer; external exact matching remains closed.
 
 ## Pack conformance
 

--- a/docs/semantic-pack-adoption.md
+++ b/docs/semantic-pack-adoption.md
@@ -11,7 +11,7 @@ responsibility. It must not create a second implementation path.
 
 | lane | owner | default | meaning |
 |---|---|---|---|
-| `external-opt-in` | provider/user | off | Local manifests are explicit opt-ins and metadata-only until influence gates exist. |
+| `external-opt-in` | provider/user | off | Local manifests are explicit opt-ins. Unlocked manifests are metadata-only; a valid v1 project lock may authorize the narrow near-only consumer. |
 | `builtin-optional` | nose | off | Shipped with nose, but not default-enabled until product risk is accepted. |
 | `builtin-default` | nose | on | Shipped with nose and enabled by default. |
 
@@ -199,7 +199,7 @@ Important fields:
 | `policy.scope` | `compiled-builtin` |
 | `policy.default_lane` | `builtin-default` |
 | `policy.optional_lane` | `builtin-optional` |
-| `policy.external_influence` | `metadata-only` |
+| `policy.external_influence` | `unlocked-metadata-or-locked-near-only` |
 | `policy.product_behavior_gate` | `required-for-builtin-default-promotion` |
 | `policy.performance_gate` | `required-for-builtin-default-promotion` |
 | `packs[].adoption_status` | `default-gated`, `optional-gated`, `blocked`, or `tracked` |

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -198,11 +198,12 @@ Behavior-change defaults:
 - Metadata-only external packs must not change families, ranking, witnesses,
   surfaces, or exact/near results.
 
-Locked external packs remain metadata-only until an issue explicitly opens a
-consumer lane. Lock validation finishes before lowering and may add only
-top-level pack/authorization metadata. Missing, stale, escaped, or conflicting
-configured locks fail before analysis rather than falling back to unlocked
-metadata or precedence.
+The first explicitly opened consumer is locked near-only protocol support.
+It may raise only an existing near candidate with dependency/occurrence evidence
+and must leave fingerprints, exact groups, and oracle behavior untouched. Lock
+validation still finishes before lowering; missing, stale, escaped, or
+conflicting configured locks fail before analysis rather than falling back to
+unlocked metadata or precedence.
 
 ## Performance Gate
 
@@ -210,8 +211,10 @@ The migration should be performance-neutral or performance-positive. A pack
 boundary must not put manifest parsing, string-heavy lookup, dynamic dispatch,
 global locks, or repeated registry scans on per-node or per-unit hot paths.
 Builtin descriptors should be static data or once-built indexes. External
-manifest loading should happen before analysis, and metadata-only packs must not
-add work inside normalize, detect, value-graph, fragment, or oracle loops.
+manifest loading and near-registry construction should happen before detection.
+Metadata-only packs must not add work inside normalize, detect, value-graph,
+fragment, or oracle loops; locked near rows may add only indexed unit annotation
+and existing-candidate scoring work.
 
 Use the product query-regression path when a corpus is available:
 
@@ -444,11 +447,10 @@ previous semantic-kernel tranches.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) defines
   the versioned external schema boundary.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
-  the first closed typed declaration compiler and locked occurrence-evidence
-  index; its rows remain non-influential until the external trust lanes are
-  complete.
+  the first closed typed declaration compiler, locked occurrence-evidence
+  index, and bounded near-only consumer.
 - [semantic-pack-loading](semantic-pack-loading.md) describes manifest loading
-  and the current metadata-only external behavior.
+  and the metadata-or-locked-near-only external behavior.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) defines the
   content-addressed user authorization between manifest claims and future
   evidence/influence consumers.

--- a/docs/semantic-pack-compatibility.md
+++ b/docs/semantic-pack-compatibility.md
@@ -70,7 +70,7 @@ Important fields:
 | `policy.manifest_schema_changes` | `breaking-change-requires-new-api-version` |
 | `policy.kernel_vocabulary_changes` | `document-and-rehearse-with-builtin-packs-first` |
 | `policy.capabilities_changes` | `additive-or-schema-versioned` |
-| `policy.external_pack_influence` | `metadata-only` |
+| `policy.external_pack_influence` | `metadata-or-locked-near-only` |
 | `policy.external_pack_authorization` | `content-pinned-project-lock-required` |
 | `policy.external_pack_execution` | `none` |
 | `policy.external_packs_enabled_by_default` | `false` |
@@ -80,7 +80,8 @@ Important fields:
 | `failure_modes[].code` | Stable failure label. |
 | `failure_modes[].action` | `reject-before-analysis` or `block-external-influence`. |
 | `checks.builtin_inventory_status` | Current builtin inventory status. |
-| `checks.external_metadata_only` | Whether local external rows remain metadata-only. |
+| `checks.external_metadata_only` | `false` now that a locked near consumer exists. |
+| `checks.external_locked_near_only` | Whether locked v1 near influence is available while exact remains closed. |
 | `checks.external_influence_blockers[]` | Stable blocker labels preventing external influence. |
 
 ## Version Policy
@@ -119,7 +120,8 @@ precedence. See [semantic-pack-project-lock](semantic-pack-project-lock.md).
 Kernel vocabulary changes must keep builtin packs ahead of external influence:
 
 - add or migrate builtin descriptors, tests, conformance refs, and docs first;
-- keep external manifests metadata-only while the new vocabulary is being proven;
+- keep unlocked manifests metadata-only and keep locked near rows non-influential
+  while new vocabulary is being proven;
 - add compatibility notes for renamed fields, aliases, or enum values;
 - use additive capabilities fields for additive reporting;
 - require a new manifest API version for breaking manifest changes.

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -4,12 +4,14 @@ Status: nose provides a local semantic-pack v0 conformance harness and a typed
 v1 compile check. The v0 harness covers manifest structure, declared fixture
 assets, and declarative fixture-expectation gates for exact-capable rows. These
 are provider/user workflows, not nose approval of third-party semantic
-correctness. External packs remain `metadata-only` when loaded by `nose query`.
+correctness. v0 and unlocked v1 external packs remain `metadata-only` when
+loaded by `nose query`. A separately validated v1 project lock may authorize
+the narrow near-only consumer; conformance checking alone never does.
 
 Typed v1 manifests use the same command to validate and compile their closed
 contract grammar. v1 does not inherit v0's opaque fixture/gate rows; its later
-source-analyzing receipts are separate work. Compilation alone remains
-`metadata-only`.
+source-analyzing receipts are separate work. Compilation or conformance alone
+remains `metadata-only`.
 
 ## Goal
 

--- a/docs/semantic-pack-ecosystem-candidates.md
+++ b/docs/semantic-pack-ecosystem-candidates.md
@@ -28,9 +28,10 @@ Create an implementation issue only when the candidate can name:
 - product output and runtime measurement plan;
 - adoption-gate and rollback evidence.
 
-External ecosystem packs remain explicit opt-ins and metadata-only until the
-compatibility, dependency-backed evidence, trust, conformance, and conflict gates
-all exist.
+External ecosystem packs remain explicit opt-ins. Unlocked packs are
+metadata-only; locked v1 rows may enter only the narrow near-only consumer after
+compatibility, dependency-backed evidence, trust, and conflict gates pass.
+External exact remains closed until its separate conformance-receipt gate exists.
 
 ## Candidate Matrix
 

--- a/docs/semantic-pack-extension-api-v1.md
+++ b/docs/semantic-pack-extension-api-v1.md
@@ -142,6 +142,11 @@ caveats. The top-level pack entry reports selected/admitted/rejected rows plus
 admitted and influential occurrence counts. Rows with dependency blockers stay
 visible in these counts but cannot annotate a unit.
 
+The [#867 closeout receipt](../bench/semantic_pack/issue-867-locked-near-closeout-2026-07-19.v1.json)
+binds the implementation and release-binary identities, focused lock/rollback
+fixture, 9-repository no-pack parity, official-v0.19.0 semantic and near runtime
+measurements, and the zero-false-merge verify result.
+
 ## Semantic content digest
 
 v1 reports a lowercase `sha256:<64 hex digits>` digest over canonical typed

--- a/docs/semantic-pack-extension-api-v1.md
+++ b/docs/semantic-pack-extension-api-v1.md
@@ -1,8 +1,8 @@
 # Typed semantic pack influence manifest v1
 
 Status: implemented typed manifest, deterministic compiler, content-pinned
-project authorization, and kernel-owned dependency/occurrence evidence index.
-Influence is not enabled yet.
+project authorization, kernel-owned dependency/occurrence evidence, and the
+first locked near-only consumer.
 `nose.semantic-pack.v0` remains permanently metadata-only.
 
 ## Purpose
@@ -13,9 +13,9 @@ small closed grammar. Loading a v1 file validates and compiles that grammar
 before analysis starts. A validated project lock pins and authorizes rows,
 channels, dependency files, and an optional receipt. During a locked query nose
 can now read the pinned Maven inputs and bind selected rows to builtin Java
-import/symbol/receiver/effect facts. The resulting index is intentionally not
-consumed by detection yet, so compiled rows still have `metadata-only`
-influence until lane-specific consumers are implemented.
+import/symbol/receiver/effect facts. For near-authorized rows, the resulting
+immutable index may support an existing near candidate; unlocked v1 and every
+v0 manifest remain `metadata-only`.
 
 The schema is [semantic-pack-v1.schema.json](schemas/semantic-pack-v1.schema.json).
 The [Guava example](examples/semantic-packs/v1/guava-immutable-collections.json)
@@ -66,6 +66,7 @@ query begins. It exposes deterministic ordered indexes:
 - exact package coordinate to its version requirement;
 - exact package/import/call coordinate to sorted contract ids;
 - kernel operation to sorted contract ids.
+- contract id to a canonical SHA-256 row digest.
 
 Manifest path, directory order, JSON object-key order, hash-map iteration, and
 process state do not affect those indexes. Set arities are sorted before
@@ -73,11 +74,10 @@ compilation. Duplicate ids, duplicate package coordinates, duplicate exact
 contract coordinates plus arity, invalid cross-field combinations, and
 out-of-range arities fail before analysis.
 
-The compiled contract indexes are read only by the dependency/occurrence index
-builder. That evidence index is deliberately not read by normalize,
-fingerprint, exact, near, or detection consumers in this change. v1 summary rows therefore report
-`source: local-manifest` and `influence: metadata-only`, just like v0, while
-also reporting their API version and semantic digest.
+The compiled indexes feed the dependency/occurrence index and the locked near
+registry. Unlocked v1 summaries remain `metadata-only`; a valid lock that allows
+`near` reports `near-only`. Neither path changes normalization, fingerprints,
+exact value graphs, exact membership, witnesses, or oracle behavior.
 
 ## Locked dependency and occurrence evidence
 
@@ -107,7 +107,6 @@ forms:
 Every admitted occurrence records the dependency fact id, binding import id,
 symbol proof id, receiver span/proof when the contract has an imported-type
 receiver, and any builtin effect, call-target, domain, and place ids already
-anchored to the call. These are references to existing kernel/frontend facts,
 not provider-emitted IL. Exact package/module/member, arity, binding visibility,
 and dependency liveness are checked. Wildcards, wrong-package or same-name local
 APIs, shadowed/rebound bindings, conflicting or ambiguous versions, missing or
@@ -117,7 +116,31 @@ records produce no occurrence.
 The index exposes deterministic row and dependency summaries plus lookup by row
 or exact call span. Its collections are immutable after construction, it uses no
 global registry, and its ids are query-local. Merely building it does not emit
-IL evidence, change a family, or authorize either lane.
+IL evidence or change a family; the near consumer additionally requires a valid
+near authorization, an admitted occurrence, and a matching builtin protocol
+operation in an existing near candidate.
+
+## Locked near consumer
+
+The first consumer maps the closed `collection-factory` and `map-factory`
+operations onto admitted builtin factory evidence. It annotates extracted units
+once per query, after cache lookup, and can only raise the score of a candidate
+already proposed by the ordinary value/shape/anchor indexes. It does not create
+candidate pairs. The base score must be at least `0.60`; supporting protocol
+evidence moves it one quarter of the remaining distance toward `1.0`, capped at
+`0.95`. This opens a narrow default-threshold boundary without turning a
+provider claim into equality proof.
+
+Only the near detector reads these annotations. Semantic-only runs, exact
+fingerprints, exact groups, `nose verify`, connected witnesses, copy-paste runs,
+and `base=<ref>` remain unchanged. Removing the lock removes the annotations;
+cached and uncached runs attach the same query-local evidence.
+
+Affected family and member JSON includes pack and row digests, lane, trust,
+operation, dependency coordinate/version/source pins, occurrence span, and
+caveats. The top-level pack entry reports selected/admitted/rejected rows plus
+admitted and influential occurrence counts. Rows with dependency blockers stay
+visible in these counts but cannot annotate a unit.
 
 ## Semantic content digest
 
@@ -158,7 +181,7 @@ cross-pack coordinates independent of load order.
 
 The following work remains outside this slice:
 
-- near consumers and the separate external-claim exact lane;
+- the separate external-claim exact lane;
 - source-analyzing conformance receipts and a real external reference pack.
 
 ## See also

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -3,15 +3,16 @@
 Status: nose can validate local semantic-pack v0 manifests, compile typed v1
 manifests, and validate content-pinned v1 project locks before `nose query`.
 It also provides separate local check/lock/status commands. External packs are
-explicit opt-ins and are currently `metadata-only`:
-they do not emit evidence, open exact contracts, mint fingerprints, approve clone
-pairs, or change exact/near query results. Local `declares.evidence_producers`,
+explicit opt-ins. Unlocked v0/v1 packs are `metadata-only`; a content-pinned v1
+lock may authorize the narrow near-only consumer. External packs do not emit IL
+evidence, open exact contracts, mint fingerprints, or approve exact clone
+pairs. Local `declares.evidence_producers`,
 `declares.contracts`, and `declares.value_laws` entries are registered as
 data-only rows on the active `SemanticPackSet`, but no normalize, value-graph,
 or exact consumer reads those external rows yet. v1 contracts compile into
-deterministic typed indexes and a semantic digest, but no analysis consumer
-reads those indexes yet. `nose capabilities` reports the
-same boundary with `external_pack_influence = "metadata-only"`,
+deterministic typed indexes and a semantic digest; the near consumer reads only
+locked dependency-backed occurrences. `nose capabilities` reports the
+same boundary with `external_pack_influence = "metadata-or-locked-near-only"`,
 the current external influence blocker labels, and
 `external_pack_execution = "none"`.
 
@@ -214,14 +215,16 @@ Trust is separate from channel eligibility.
 
 `nose query --format json` validates configured and CLI-provided semantic-pack
 paths before analysis and reports the active builtin/local pack set in the
-top-level `semantic_packs` array. Local external packs remain metadata-only
-while builtin compiled packs report `evidence-and-contracts` influence. A
+top-level `semantic_packs` array. Unlocked local external packs remain
+metadata-only while builtin compiled packs report `evidence-and-contracts`
+influence. A
 validated v1 project lock additionally builds a query-local, immutable Maven
 dependency and Java occurrence-evidence index from content-pinned inputs and
 builtin frontend facts. External producer, contract, and value-law rows are
 available to the loaded pack set for future conflict checks and adoption gates,
-but neither those rows nor the evidence index are serialized into clone-family
-law provenance or consumed by detection yet. Builtin pack order in
+Those rows cannot enter exact/value-law consumers. Near-authorized admitted
+occurrences may support existing near candidates and are serialized as separate
+family/member near provenance. Builtin pack order in
 this array follows the compiled registry's stable reporting order; roadmap and
 snapshot prose may group packs by migration narrative instead.
 
@@ -234,15 +237,16 @@ influence preflight report. It also validates fixed call result-domain
 declarations in `semantics.result_domain` against the known domain vocabulary
 and requires required `LibraryApi.Contract` evidence for those rows. The v0
 preflight still blocks opaque external rows. For locked typed v1 rows, a
-kernel-owned Maven reader and Java matcher now produce dependency-backed
-occurrence facts, while lane consumers remain unavailable. A project lock
+kernel-owned Maven reader and Java matcher produce dependency-backed occurrence
+facts. The near lane consumes only admitted `collection-factory` and
+`map-factory` occurrences matched to builtin protocol evidence. A project lock
 supplies explicit content/row/lane authorization and rejects
-semantic-coordinate conflicts before analysis; its evidence index alone cannot
+semantic-coordinate conflicts before analysis; the evidence index alone cannot
 influence a result. Exact-capable rows also remain blocked until they have passed
 declarative executable conformance.
 `nose semantic-pack check --format json` exposes that row-level preflight to
-providers and integrations, but query, normalize, value-graph, exact, and
-detection consumers do not read it. It does not yet:
+providers and integrations, but normalize, value-graph, and exact consumers do
+not read it. It does not yet:
 
 - execute external evidence producers;
 - register external contract rows with exact consumers;

--- a/docs/semantic-pack-project-lock.md
+++ b/docs/semantic-pack-project-lock.md
@@ -1,10 +1,9 @@
 # Semantic-pack project locks
 
 Status: project lock v1, local creation/status commands, pre-analysis
-validation, and a locked Maven evidence reader are implemented. A valid lock
-authorizes selected v1 rows and lanes and bounds which local dependency inputs
-the evidence index may read, but external rows remain `metadata-only` until lane
-consumers land. v0 can never become influential through a lock.
+validation, a locked Maven evidence reader, and the first near-only consumer are
+implemented. A valid near lock may support existing near candidates; v0 can
+never become influential through a lock.
 
 ## Why a separate lock exists
 
@@ -90,12 +89,14 @@ pin set and rechecks content digests before using dependency facts. Missing,
 ambiguous, invalid, or out-of-range versions keep selected rows closed rather
 than consulting Maven or a registry.
 
-Query JSON keeps `influence: "metadata-only"` for locked v1 packs in this phase
-and adds a `lock` object containing `status: "valid"`, lock API and decision
-digest, authorized channels, selected rows, dependency pins, and optional
-receipt. Occurrence counts are not reported until a lane consumer can explain
-their effect. Removing the lock or narrowing a regenerated selection removes
-that authorization and its evidence index without changing the manifest.
+Query JSON reports `influence: "near-only"` when a lock authorizes near rows and
+adds a `lock` object containing `status: "valid"`, lock API and decision digest,
+authorized channels, selected rows, dependency pins, and optional receipt. Its
+`near_influence` object reports admitted/rejected rows and admitted/influential
+occurrences. Removing the lock or narrowing a regenerated selection removes the
+authorization, evidence, and supported near results without changing the
+manifest. Exact-only authorization remains metadata-only until its separate
+consumer lands.
 
 ## Determinism and conflicts
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,8 +250,8 @@ mode flags are documented under [Ranking](#ranking) and [Detection modes](#detec
 | `--root <path>` / `-r <path>` | analyze another root; repeat for multi-root query runs. With `--root`, bare positional arguments are query terms. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress accepted families using a structured ignore file with reason/owner/expiry metadata |
-| `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; external packs are metadata-only today |
-| `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; mutually exclusive with unlocked semantic-pack paths |
+| `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; unlocked external packs are metadata-only |
+| `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; eligible rows may support existing near candidates, and unlocked pack paths cannot be mixed in |
 
 **Output**
 


### PR DESCRIPTION
Closes #867

## Summary
- add an immutable query-local registry for dependency-backed locked v1 near rows
- support only existing near candidates through collection/map factory protocol evidence
- expose pack/row/dependency provenance and admitted/rejected/influential counts
- keep unlocked/v0 packs metadata-only and exact, verify, candidate generation, and fingerprints unchanged

## Validation
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- scripts/check-docs.sh
- scripts/check-file-lengths.py
- focused lock removal, repeat, cache, semantic invariance integration test
- no-pack semantic and near parity: 9/9 repositories against parent
- official v0.19.0 performance: semantic -0.60%, near -0.19%, zero triggers
- nose verify crates --max-violations 0: 0 false merges

Closeout: bench/semantic_pack/issue-867-locked-near-closeout-2026-07-19.v1.json