### PR TITLE
feat: gate external exact semantic-pack claims

### DIFF
--- a/bench/semantic_pack/issue-868-external-exact-closeout-2026-07-19.v1.json
+++ b/bench/semantic_pack/issue-868-external-exact-closeout-2026-07-19.v1.json
@@ -1,0 +1,131 @@
+{
+  "schema": "nose.semantic-pack.issue-868-closeout/v1",
+  "issue": 868,
+  "generated_at": "2026-07-19",
+  "implementation": {
+    "parent_commit": "83de37bf696f4d287b23339ab47bbb141811fa00",
+    "candidate_commit": "1b4056c5b3345ac3f8eeba9cdc67ac0ed8b199e0",
+    "parent_binary_sha256": "f1e5af584eef741016bfb27f493709e5032d04fcf1c09e6be2ccbea78214fb3a",
+    "candidate_binary_sha256": "68f903b639a61e8fa9b1a318b1f1a0ad2e4cb77acddad7f0404c138b7a605edb",
+    "kernel_capability": "nose.kernel.external-collection-factory-exact.v1",
+    "receipt_api": "nose.semantic-pack-conformance-receipt.v1"
+  },
+  "kernel_source_conformance": {
+    "result": "passed",
+    "focused_tests": 6,
+    "execution_model": "nose parses and analyzes fixture source; fixture programs, provider commands, Maven resolution, and network access are never executed",
+    "positive_requires_new_cross_boundary_family": true,
+    "closed_expectations": [
+      "external-exact-match",
+      "no-external-exact-match"
+    ],
+    "fail_closed_boundaries": [
+      "missing-or-stale-receipt",
+      "manifest-or-row-digest-drift",
+      "fixture-or-dependency-digest-drift",
+      "malformed-source",
+      "symlinked-fixture-component",
+      "fixture-file-or-byte-cap",
+      "dependency-byte-cap",
+      "dependency-version-or-import-mismatch",
+      "shadow-or-rebind",
+      "receiver-arity-effect-demand-mutation-identity-mismatch",
+      "coordinate-conflict"
+    ]
+  },
+  "external_exact_lane": {
+    "operation": "collection-factory",
+    "assurance": "external-claim-exact",
+    "builtin_certification": false,
+    "requires_project_lock_channel": "external-exact",
+    "requires_matching_receipt": true,
+    "base_query_rejected": true,
+    "provenance_fields": [
+      "pack_id",
+      "row_id",
+      "semantic_digest",
+      "row_digest",
+      "lane",
+      "assurance",
+      "trust",
+      "dependency",
+      "receipt_digest",
+      "occurrence_file",
+      "call_start_line",
+      "call_end_line",
+      "caveats"
+    ]
+  },
+  "no_pack_invariance": {
+    "corpus": "bench/type4/query_regression/subset.json",
+    "repositories": 9,
+    "semantic_parent_candidate_equal": 9,
+    "near_parent_candidate_equal": 9,
+    "semantic_measurement_sha256": "cea28d5e64b31dc6b49557b142d21e0213c6389a2eae6c2fd51a1db2aad0d7bd",
+    "near_measurement_sha256": "caf7b0a17f7ce674d3825c7d2ec93ce40c17cc33bac4f5e53ce2ce4c4e55b3b5"
+  },
+  "official_release_performance": {
+    "baseline": {
+      "version": "v0.19.0",
+      "source_commit": "54f8a67436e39e24c777a85e14224273116add6b",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate": {
+      "commit": "1b4056c5b3345ac3f8eeba9cdc67ac0ed8b199e0",
+      "binary_sha256": "68f903b639a61e8fa9b1a318b1f1a0ad2e4cb77acddad7f0404c138b7a605edb"
+    },
+    "corpus": {
+      "repositories": 9,
+      "repeats": 5,
+      "warmups": 1,
+      "threads": 1
+    },
+    "semantic": {
+      "baseline_aggregate_wall_ms": 2653.1492,
+      "candidate_aggregate_wall_ms": 2644.9261,
+      "delta_ms": -8.2232,
+      "delta_pct": -0.3099,
+      "measurement_sha256": "01cdb7ac73c4e9e38fe8dbfb362cfedb1663287362692e64dbf66eb9d3eea292"
+    },
+    "near": {
+      "baseline_aggregate_wall_ms": 3334.3854,
+      "candidate_aggregate_wall_ms": 3327.5082,
+      "delta_ms": -6.8772,
+      "delta_pct": -0.2063,
+      "measurement_sha256": "966b29d13f40f0793c90775a885edda99368ac64d7a5b4c1ad75b03c1f356918"
+    },
+    "swift_near_outlier_control": {
+      "reason": "the five-repeat run crossed the 10% investigation threshold by 9.00 ms on a small repository",
+      "repeats": 15,
+      "warmups": 2,
+      "baseline_wall_ms": 73.7447,
+      "candidate_wall_ms": 74.0172,
+      "delta_ms": 0.2725,
+      "delta_pct": 0.3695,
+      "measurement_sha256": "4ed9f7417b4a84383ff1bbb47b62bf7c111beeb7c64edbca0e61dd970eda6875",
+      "resolved_as_noise": true
+    },
+    "gate": {
+      "limit_pct": 5.0,
+      "floor_ms": 5.0,
+      "passed": true
+    }
+  },
+  "exact_and_verify": {
+    "verify_command": "RAYON_NUM_THREADS=1 nose verify crates --max-violations 0",
+    "verify_exit_code": 0,
+    "fingerprint_groups": 790,
+    "false_merges": 0,
+    "canon_changed_units_preserved": true,
+    "verify_output_sha256": "dd938e5d0459aa07f421e728ce4943b7994010e94c1ae72cb99213091328bf4c"
+  },
+  "validation": {
+    "focused_external_exact_tests": "6 passed",
+    "cargo_test_workspace": "passed",
+    "cargo_clippy_workspace_all_targets_deny_warnings": "passed",
+    "cargo_fmt_check": "passed",
+    "docs": "passed",
+    "file_lengths": "passed",
+    "git_diff_check": "passed"
+  }
+}

--- a/crates/nose-cli/src/baseline.rs
+++ b/crates/nose-cli/src/baseline.rs
@@ -486,6 +486,7 @@ mod tests {
             varying_spots: Vec::new(),
             semantic_laws: Vec::new(),
             semantic_pack_near: Vec::new(),
+            semantic_pack_external_exact: Vec::new(),
         }
     }
 
@@ -509,6 +510,7 @@ mod tests {
             looks_generated: false,
             shared_subdag: None,
             semantic_pack_near: Vec::new(),
+            semantic_pack_external_exact: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-const CAPABILITIES_SCHEMA_VERSION: u32 = 6;
+const CAPABILITIES_SCHEMA_VERSION: u32 = 7;
 
 #[derive(serde::Serialize)]
 struct Report {
@@ -48,6 +48,7 @@ struct Schemas {
     query_json: Vec<u32>,
     semantic_packs: Vec<&'static str>,
     semantic_pack_locks: Vec<&'static str>,
+    semantic_pack_receipts: Vec<&'static str>,
     semantic_pack_lock_status: Vec<u32>,
     semantic_pack_conformance: Vec<u32>,
     semantic_pack_inventory: Vec<u32>,
@@ -83,6 +84,7 @@ struct SemanticPacks {
     trust: Vec<&'static str>,
     external_packs_enabled_by_default: bool,
     external_pack_influence: &'static str,
+    external_exact_operations: Vec<&'static str>,
     external_influence_blockers: Vec<&'static str>,
     external_pack_execution: &'static str,
 }
@@ -163,6 +165,7 @@ fn current_schemas() -> Schemas {
         ],
         semantic_packs: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS.to_vec(),
         semantic_pack_locks: vec![nose_semantics::SEMANTIC_PACK_LOCK_API_VERSION_V1],
+        semantic_pack_receipts: vec![nose_semantics::SEMANTIC_PACK_RECEIPT_API_VERSION_V1],
         semantic_pack_lock_status: vec![crate::semantic_pack::LOCK_STATUS_SCHEMA_VERSION],
         semantic_pack_conformance: vec![crate::semantic_pack::CONFORMANCE_SCHEMA_VERSION],
         semantic_pack_inventory: vec![crate::semantic_pack::INVENTORY_SCHEMA_VERSION],
@@ -183,7 +186,13 @@ fn current_semantic_packs() -> SemanticPacks {
         ],
         project_lock: vec!["create", "status"],
         project_lock_output_formats: vec!["human", "json"],
-        conformance: vec!["local-manifest-file", "local-manifest-directory"],
+        conformance: vec![
+            "local-manifest-file",
+            "local-manifest-directory",
+            "v0-fixture-metadata",
+            "v1-kernel-source-analysis",
+            "receipt-output",
+        ],
         conformance_output_formats: vec!["human", "json"],
         inventory: vec!["compiled-builtin"],
         inventory_output_formats: vec!["human", "json"],
@@ -193,7 +202,8 @@ fn current_semantic_packs() -> SemanticPacks {
         compatibility_output_formats: vec!["human", "json"],
         trust: vec!["builtin-default", "builtin-optional", "external-opt-in"],
         external_packs_enabled_by_default: false,
-        external_pack_influence: "metadata-or-locked-near-only",
+        external_pack_influence: "metadata-or-locked-near-or-receipt-backed-external-claim-exact",
+        external_exact_operations: vec!["collection-factory"],
         external_influence_blockers: crate::semantic_pack::external_influence_blocker_labels(),
         external_pack_execution: "none",
     }
@@ -217,6 +227,8 @@ fn query_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
         ("reinvented_view", true),
         ("semantic_pack_dependency_evidence", true),
         ("semantic_pack_locked_near_influence", true),
+        ("semantic_pack_external_claim_exact", true),
+        ("semantic_pack_kernel_conformance_receipt", true),
         ("semantic_pack_loading", true),
         ("semantic_pack_project_lock", true),
         ("structured_ignores", true),

--- a/crates/nose-cli/src/cli_args.rs
+++ b/crates/nose-cli/src/cli_args.rs
@@ -348,6 +348,9 @@ pub(crate) enum SemanticPackCmd {
         /// Semantic-pack manifest file or directory of direct `*.json` manifests.
         #[arg(required = true, value_name = "FILE_OR_DIR")]
         paths: Vec<PathBuf>,
+        /// Write the passed kernel conformance receipt for one v1 pack.
+        #[arg(long, value_name = "FILE")]
+        receipt_out: Option<PathBuf>,
         /// Output format.
         #[arg(long, default_value = "human")]
         format: semantic_pack::CheckFormat,

--- a/crates/nose-cli/src/command_dispatch.rs
+++ b/crates/nose-cli/src/command_dispatch.rs
@@ -29,7 +29,11 @@ pub(crate) fn run() -> Result<()> {
         } => cmd_il(path, format, normalized, no_cfg_norm),
         Cmd::Capabilities => capabilities::print(),
         Cmd::SemanticPack { cmd } => match cmd {
-            SemanticPackCmd::Check { paths, format } => semantic_pack::cmd_check(paths, format),
+            SemanticPackCmd::Check {
+                paths,
+                receipt_out,
+                format,
+            } => semantic_pack::cmd_check(paths, receipt_out, format),
             SemanticPackCmd::Lock {
                 manifests,
                 output,

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -240,6 +240,7 @@ fn divergence_family(locs: Vec<Loc>) -> RefactorFamily {
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
         semantic_pack_near: Vec::new(),
+        semantic_pack_external_exact: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/divergence/variant.rs
+++ b/crates/nose-cli/src/divergence/variant.rs
@@ -457,6 +457,7 @@ mod tests {
             looks_generated: false,
             shared_subdag: None,
             semantic_pack_near: Vec::new(),
+            semantic_pack_external_exact: Vec::new(),
         }
     }
 

--- a/crates/nose-cli/src/ignores/match_tests.rs
+++ b/crates/nose-cli/src/ignores/match_tests.rs
@@ -52,6 +52,7 @@ fn family_with_locations(locations: &[(String, &str)]) -> RefactorFamily {
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
         semantic_pack_near: Vec::new(),
+        semantic_pack_external_exact: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/main_tests/surface_hints.rs
+++ b/crates/nose-cli/src/main_tests/surface_hints.rs
@@ -163,6 +163,7 @@ pub(super) fn fam_kind(
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
         semantic_pack_near: Vec::new(),
+        semantic_pack_external_exact: Vec::new(),
     }
 }
 

--- a/crates/nose-cli/src/query_commands.rs
+++ b/crates/nose-cli/src/query_commands.rs
@@ -35,7 +35,7 @@ fn run_query_base(args: &QueryArgs, base_ref: &str, q: &Query, path_arg: &str) -
         );
     }
     let semantic_packs_json = if matches!(args.format, ReportFormat::Json) {
-        semantic_packs_json(&resolve_query_semantic_packs(args)?, None)
+        semantic_packs_json(&resolve_query_semantic_packs(args)?, None, None)
     } else {
         Vec::new()
     };
@@ -216,6 +216,7 @@ fn semantic_packs_for_output(
         semantic_packs_json(
             &dataset.semantic_packs,
             Some(&dataset.semantic_pack_near_report),
+            Some(&dataset.semantic_pack_external_exact_report),
         )
     } else {
         Vec::new()

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -24,6 +24,7 @@ pub(super) struct QueryDataset {
     pub(super) settings: QuerySettings,
     pub(super) semantic_packs: nose_semantics::SemanticPackSet,
     pub(super) semantic_pack_near_report: nose_semantics::SemanticPackNearReport,
+    pub(super) semantic_pack_external_exact_report: nose_semantics::SemanticPackExternalExactReport,
     pub(super) reinvented: Vec<nose_detect::ReinventedHelper>,
     pub(super) opts: nose_detect::DetectOptions,
 }
@@ -35,7 +36,7 @@ pub(super) fn build_query_dataset(
     let (settings, semantic_packs) = resolve_query_settings(args)?;
     let opts = detection_options(settings.channels, settings.min_tokens, settings.min_lines);
     let detector = detection_engine(settings.channels, &opts);
-    let (mut report, scope, semantic_pack_near) = query_detect_report(
+    let (mut report, scope, semantic_pack_near, semantic_pack_external_exact) = query_detect_report(
         args,
         refs,
         &settings.exclude,
@@ -46,6 +47,7 @@ pub(super) fn build_query_dataset(
 
     let mut families = time_stage("rank_families", || nose_detect::rank_families(&report));
     annotate_semantic_pack_near(&mut families, &semantic_pack_near);
+    annotate_semantic_pack_external_exact(&mut families, &semantic_pack_external_exact);
     preserve_query_accepted_coverage(&mut families);
     time_stage("query_filter", || {
         if settings.channels.abstraction_only() {
@@ -64,8 +66,14 @@ pub(super) fn build_query_dataset(
                 for provenance in &mut l.semantic_pack_near {
                     provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
                 }
+                for provenance in &mut l.semantic_pack_external_exact {
+                    provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
+                }
             }
             for provenance in &mut f.semantic_pack_near {
+                provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
+            }
+            for provenance in &mut f.semantic_pack_external_exact {
                 provenance.occurrence_file = relativize(&provenance.occurrence_file, &cwd);
             }
             for obligation in &mut f.accepted_coverage {
@@ -97,12 +105,18 @@ pub(super) fn build_query_dataset(
             .iter()
             .flat_map(|family| family.semantic_pack_near.iter()),
     );
+    let semantic_pack_external_exact_report = semantic_pack_external_exact.report_with_influential(
+        families
+            .iter()
+            .flat_map(|family| family.semantic_pack_external_exact.iter()),
+    );
     Ok(QueryDataset {
         families,
         scope,
         settings,
         semantic_packs,
         semantic_pack_near_report,
+        semantic_pack_external_exact_report,
         reinvented,
         opts,
     })
@@ -226,10 +240,11 @@ fn query_detect_report(
     nose_detect::Report,
     QueryScope,
     nose_semantics::SemanticPackNearRegistry,
+    nose_semantics::SemanticPackExternalExactRegistry,
 ) {
     // Lower AND cross-file-resolve every run. The cache skips only the dominant
     // normalize/extract step and therefore stays identical to the uncached path.
-    let corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
+    let mut corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
     let scope = QueryScope::from_corpus(&corpus);
     let semantic_pack_evidence =
         nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
@@ -238,6 +253,12 @@ fn query_detect_report(
         &semantic_pack_evidence,
         &corpus,
     );
+    let semantic_pack_external_exact = nose_semantics::SemanticPackExternalExactRegistry::build(
+        semantic_packs,
+        &semantic_pack_evidence,
+        &corpus,
+    );
+    semantic_pack_external_exact.apply(&mut corpus);
     let (mut units, streams, files) = if let Some(dir) = &args.cache_dir {
         let cache::CachedUnits {
             units,
@@ -261,7 +282,12 @@ fn query_detect_report(
         units, files, &streams, opts, detector,
     )
     .0;
-    (report, scope, semantic_pack_near)
+    (
+        report,
+        scope,
+        semantic_pack_near,
+        semantic_pack_external_exact,
+    )
 }
 
 fn annotate_semantic_pack_near(
@@ -302,6 +328,27 @@ fn annotate_semantic_pack_near(
             location.semantic_pack_near = member.into_iter().collect();
         }
         family.semantic_pack_near = aggregate.into_iter().collect();
+    }
+}
+
+fn annotate_semantic_pack_external_exact(
+    families: &mut [nose_detect::RefactorFamily],
+    registry: &nose_semantics::SemanticPackExternalExactRegistry,
+) {
+    if !registry.is_active() {
+        return;
+    }
+    for family in families.iter_mut().filter(|family| {
+        family.witness.as_ref().map(|witness| witness.kind) == Some("exact-value-graph")
+    }) {
+        let mut aggregate = BTreeSet::new();
+        for location in &mut family.locations {
+            let claims =
+                registry.claims_for_unit(&location.file, location.start_line, location.end_line);
+            aggregate.extend(claims.iter().cloned());
+            location.semantic_pack_external_exact = claims;
+        }
+        family.semantic_pack_external_exact = aggregate.into_iter().collect();
     }
 }
 

--- a/crates/nose-cli/src/query_model.rs
+++ b/crates/nose-cli/src/query_model.rs
@@ -283,6 +283,11 @@ fn query_location_json(
         object["semantic_pack_near"] = serde_json::to_value(&location.semantic_pack_near)
             .expect("semantic-pack near provenance is JSON serializable");
     }
+    if !location.semantic_pack_external_exact.is_empty() {
+        object["semantic_pack_external_exact"] =
+            serde_json::to_value(&location.semantic_pack_external_exact)
+                .expect("semantic-pack external exact provenance is JSON serializable");
+    }
     object
 }
 
@@ -335,6 +340,10 @@ pub(super) fn query_family_json_with_counts(
     if !f.semantic_pack_near.is_empty() {
         obj["semantic_pack_near"] = serde_json::to_value(&f.semantic_pack_near)
             .expect("semantic-pack near provenance is JSON serializable");
+    }
+    if !f.semantic_pack_external_exact.is_empty() {
+        obj["semantic_pack_external_exact"] = serde_json::to_value(&f.semantic_pack_external_exact)
+            .expect("semantic-pack external exact provenance is JSON serializable");
     }
     // Temporal status against a `since=` snapshot (new/changed/unchanged), when one was given.
     if let Some(cmp) = since {

--- a/crates/nose-cli/src/query_semantic_packs.rs
+++ b/crates/nose-cli/src/query_semantic_packs.rs
@@ -3,11 +3,12 @@ use serde_json::{json, Value};
 pub(crate) fn semantic_packs_json(
     semantic_packs: &nose_semantics::SemanticPackSet,
     near_report: Option<&nose_semantics::SemanticPackNearReport>,
+    exact_report: Option<&nose_semantics::SemanticPackExternalExactReport>,
 ) -> Vec<Value> {
     semantic_packs
         .packs()
         .iter()
-        .map(|pack| semantic_pack_summary_json(pack, semantic_packs, near_report))
+        .map(|pack| semantic_pack_summary_json(pack, semantic_packs, near_report, exact_report))
         .collect()
 }
 
@@ -25,6 +26,7 @@ fn semantic_pack_summary_json(
     pack: &nose_semantics::SemanticPackSummary,
     semantic_packs: &nose_semantics::SemanticPackSet,
     near_report: Option<&nose_semantics::SemanticPackNearReport>,
+    exact_report: Option<&nose_semantics::SemanticPackExternalExactReport>,
 ) -> Value {
     let mut summary = json!({
         "id": &pack.id,
@@ -101,6 +103,26 @@ fn semantic_pack_summary_json(
                     "not-an-equivalence-proof",
                     "provider-claim-user-authorized",
                     "exact-output-unchanged"
+                ],
+            }),
+        );
+    }
+    if let Some(counts) = exact_report.and_then(|report| report.pack(&pack.id)) {
+        object.insert(
+            "external_exact_influence".to_string(),
+            json!({
+                "lane": "external-claim-exact",
+                "trust": "external-opt-in",
+                "assurance": "kernel-conformance-receipt",
+                "selected_rows": counts.selected_rows,
+                "admitted_rows": counts.admitted_rows,
+                "rejected_rows": counts.rejected_rows,
+                "admitted_occurrences": counts.admitted_occurrences,
+                "influential_occurrences": counts.influential_occurrences,
+                "caveats": [
+                    "external-claim-not-builtin-certification",
+                    "provider-claim-user-authorized",
+                    "local-content-pinned"
                 ],
             }),
         );

--- a/crates/nose-cli/src/semantic_pack.rs
+++ b/crates/nose-cli/src/semantic_pack.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 mod adoption_gates;
 mod compatibility;
 mod inventory;
+mod kernel_conformance;
 mod project_lock;
 
 pub(crate) use adoption_gates::{
@@ -18,7 +19,7 @@ pub(crate) use project_lock::{
     cmd_lock, cmd_status, LockChannel, LockCommand, LockStatusFormat, LOCK_STATUS_SCHEMA_VERSION,
 };
 
-pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 3;
+pub(crate) const CONFORMANCE_SCHEMA_VERSION: u32 = 4;
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
 pub(crate) enum CheckFormat {
@@ -32,6 +33,7 @@ struct CheckJsonReport {
     status: &'static str,
     totals: CheckJsonTotals,
     executable_conformance: CheckJsonExecutableConformance,
+    kernel_conformance: serde_json::Value,
     influence_preflight: CheckJsonInfluencePreflight,
     manifests: Vec<CheckJsonManifest>,
 }
@@ -47,6 +49,8 @@ struct CheckJsonTotals {
     executable_conformance_issues: usize,
     influence_rows: usize,
     blocked_influence_rows: usize,
+    kernel_conformance_fixtures: usize,
+    passed_kernel_conformance_fixtures: usize,
 }
 
 #[derive(serde::Serialize)]
@@ -137,10 +141,15 @@ impl CheckJsonReport {
     fn new(
         report: &nose_semantics::SemanticPackConformanceReport,
         influence_preflight: &nose_semantics::ExternalInfluencePreflightReport,
+        kernel: &kernel_conformance::KernelConformanceReport,
     ) -> Self {
         Self {
             schema_version: CONFORMANCE_SCHEMA_VERSION,
-            status: if report.passed() { "ok" } else { "failed" },
+            status: if report.passed() && kernel.passed() {
+                "ok"
+            } else {
+                "failed"
+            },
             totals: CheckJsonTotals {
                 manifests: report.manifest_count(),
                 positive_fixtures: report.positive_fixture_count(),
@@ -151,8 +160,12 @@ impl CheckJsonReport {
                 executable_conformance_issues: report.executable_conformance_issue_count(),
                 influence_rows: influence_preflight.rows.len(),
                 blocked_influence_rows: influence_preflight.blocked_count(),
+                kernel_conformance_fixtures: kernel.fixture_count(),
+                passed_kernel_conformance_fixtures: kernel.passed_fixture_count(),
             },
             executable_conformance: CheckJsonExecutableConformance::new(report),
+            kernel_conformance: serde_json::to_value(kernel)
+                .expect("kernel conformance is JSON serializable"),
             influence_preflight: CheckJsonInfluencePreflight::new(influence_preflight),
             manifests: report
                 .manifests
@@ -269,33 +282,59 @@ impl CheckJsonInfluencePreflight {
     }
 }
 
-pub(crate) fn cmd_check(paths: Vec<PathBuf>, format: CheckFormat) -> Result<()> {
+pub(crate) fn cmd_check(
+    paths: Vec<PathBuf>,
+    receipt_out: Option<PathBuf>,
+    format: CheckFormat,
+) -> Result<()> {
     let report = nose_semantics::check_semantic_pack_conformance(&paths)?;
+    let kernel = kernel_conformance::run(&paths)?;
     match format {
-        CheckFormat::Human => print_human(&report),
+        CheckFormat::Human => print_human(&report, &kernel),
         CheckFormat::Json => {
             let influence_preflight = nose_semantics::SemanticPackSet::new_local(&paths)?
                 .external_influence_preflight_with_conformance(&report);
             println!(
                 "{}",
-                serde_json::to_string_pretty(&CheckJsonReport::new(&report, &influence_preflight))?
+                serde_json::to_string_pretty(&CheckJsonReport::new(
+                    &report,
+                    &influence_preflight,
+                    &kernel,
+                ))?
             );
         }
     }
-    if !report.passed() {
+    if !report.passed() || !kernel.passed() {
         anyhow::bail!(
-            "semantic pack conformance failed: {} fixture issue(s), {} executable gate issue(s)",
+            "semantic pack conformance failed: {} fixture issue(s), {} executable gate issue(s), {} kernel fixture failure(s)",
             report.fixture_issue_count(),
-            report.executable_conformance_issue_count()
+            report.executable_conformance_issue_count(),
+            kernel.fixture_count().saturating_sub(kernel.passed_fixture_count()),
         );
+    }
+    if let Some(path) = receipt_out {
+        let [receipt] = kernel.receipts.as_slice() else {
+            anyhow::bail!("--receipt-out requires exactly one v1 pack with source conformance");
+        };
+        let mut json = serde_json::to_string_pretty(receipt)?;
+        json.push('\n');
+        std::fs::write(&path, json)
+            .map_err(|error| anyhow::anyhow!("writing receipt {}: {error}", path.display()))?;
     }
     Ok(())
 }
 
-fn print_human(report: &nose_semantics::SemanticPackConformanceReport) {
+fn print_human(
+    report: &nose_semantics::SemanticPackConformanceReport,
+    kernel: &kernel_conformance::KernelConformanceReport,
+) {
     println!(
         "semantic pack conformance: {}",
-        if report.passed() { "ok" } else { "failed" }
+        if report.passed() && kernel.passed() {
+            "ok"
+        } else {
+            "failed"
+        }
     );
     println!(
         "manifests: {}; fixtures: {} positive, {} hard-negative; fixture issues: {}",
@@ -317,6 +356,12 @@ fn print_human(report: &nose_semantics::SemanticPackConformanceReport) {
         report.passed_executable_conformance_count(),
         report.executable_conformance_count(),
         report.executable_conformance_issue_count()
+    );
+    println!(
+        "kernel source conformance: {}; {} passed / {} fixture(s)",
+        kernel.status,
+        kernel.passed_fixture_count(),
+        kernel.fixture_count(),
     );
     for manifest in &report.manifests {
         println!(

--- a/crates/nose-cli/src/semantic_pack/adoption_gates.rs
+++ b/crates/nose-cli/src/semantic_pack/adoption_gates.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use super::inventory::{InventoryJsonPack, InventoryJsonReport};
 
-pub(crate) const ADOPTION_GATES_SCHEMA_VERSION: u32 = 1;
+pub(crate) const ADOPTION_GATES_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
 pub(crate) enum AdoptionGateFormat {
@@ -97,7 +97,8 @@ impl AdoptionGateReport {
                 scope: "compiled-builtin",
                 default_lane: "builtin-default",
                 optional_lane: "builtin-optional",
-                external_influence: "unlocked-metadata-or-locked-near-only",
+                external_influence:
+                    "unlocked-metadata-or-locked-near-or-receipt-backed-external-claim-exact",
                 product_behavior_gate: "required-for-builtin-default-promotion",
                 performance_gate: "required-for-builtin-default-promotion",
             },

--- a/crates/nose-cli/src/semantic_pack/compatibility.rs
+++ b/crates/nose-cli/src/semantic_pack/compatibility.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use super::inventory::InventoryJsonReport;
 
-pub(crate) const COMPATIBILITY_SCHEMA_VERSION: u32 = 1;
+pub(crate) const COMPATIBILITY_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
 pub(crate) enum CompatibilityFormat {
@@ -26,6 +26,7 @@ struct CompatibilityReport {
 struct CompatibilitySupported {
     manifest_api_versions: Vec<&'static str>,
     project_lock_api_versions: Vec<&'static str>,
+    conformance_receipt_api_versions: Vec<&'static str>,
     trust_lanes: Vec<&'static str>,
     report_sources: Vec<&'static str>,
     output_formats: Vec<&'static str>,
@@ -62,6 +63,7 @@ struct CompatibilityChecks {
     builtin_packs: usize,
     external_metadata_only: bool,
     external_locked_near_only: bool,
+    external_receipt_exact: bool,
     external_influence_blockers: Vec<&'static str>,
 }
 
@@ -81,6 +83,9 @@ impl CompatibilityReport {
                 manifest_api_versions: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS
                     .to_vec(),
                 project_lock_api_versions: vec![nose_semantics::SEMANTIC_PACK_LOCK_API_VERSION_V1],
+                conformance_receipt_api_versions: vec![
+                    nose_semantics::SEMANTIC_PACK_RECEIPT_API_VERSION_V1,
+                ],
                 trust_lanes: vec!["builtin-default", "builtin-optional", "external-opt-in"],
                 report_sources: vec!["policy"],
                 output_formats: vec!["human", "json"],
@@ -90,7 +95,8 @@ impl CompatibilityReport {
                 manifest_schema_changes: "breaking-change-requires-new-api-version",
                 kernel_vocabulary_changes: "document-and-rehearse-with-builtin-packs-first",
                 capabilities_changes: "additive-or-schema-versioned",
-                external_pack_influence: "metadata-or-locked-near-only",
+                external_pack_influence:
+                    "metadata-or-locked-near-or-receipt-backed-external-claim-exact",
                 external_pack_authorization: "content-pinned-project-lock-required",
                 external_pack_execution: "none",
                 external_packs_enabled_by_default: false,
@@ -104,6 +110,7 @@ impl CompatibilityReport {
                     "local-manifest-disabled-by-default",
                     "no-duplicate-or-reserved-pack-id",
                     "v1-influence-requires-valid-project-lock",
+                    "external-exact-requires-matching-kernel-conformance-receipt",
                     "v0-lock-cannot-authorize-influence",
                 ],
                 kernel: vec![
@@ -112,6 +119,7 @@ impl CompatibilityReport {
                     "unknown-fields-and-enums-rejected",
                     "external-execution-none",
                     "unlocked-or-v0-external-rows-do-not-influence-analysis",
+                    "external-exact-limited-to-kernel-collection-factory-v1",
                 ],
                 migration: vec![
                     "builtin-pack-migration-before-external-influence",
@@ -127,6 +135,7 @@ impl CompatibilityReport {
                 builtin_packs: inventory.totals.builtin_packs,
                 external_metadata_only: false,
                 external_locked_near_only: true,
+                external_receipt_exact: true,
                 external_influence_blockers: blockers,
             },
         }

--- a/crates/nose-cli/src/semantic_pack/kernel_conformance.rs
+++ b/crates/nose-cli/src/semantic_pack/kernel_conformance.rs
@@ -1,0 +1,289 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Serialize)]
+pub(super) struct KernelConformanceReport {
+    pub status: &'static str,
+    pub receipts: Vec<nose_semantics::SemanticPackConformanceReceiptV1>,
+}
+
+impl KernelConformanceReport {
+    pub(super) fn passed(&self) -> bool {
+        self.receipts.iter().all(|receipt| receipt.passed)
+    }
+
+    pub(super) fn fixture_count(&self) -> usize {
+        self.receipts
+            .iter()
+            .map(|receipt| receipt.fixtures.len())
+            .sum()
+    }
+
+    pub(super) fn passed_fixture_count(&self) -> usize {
+        self.receipts
+            .iter()
+            .flat_map(|receipt| &receipt.fixtures)
+            .filter(|fixture| fixture.passed)
+            .count()
+    }
+}
+
+pub(super) fn run(paths: &[PathBuf]) -> Result<KernelConformanceReport> {
+    let packs = nose_semantics::SemanticPackSet::new_local(paths)?;
+    let manifest_paths = packs
+        .packs()
+        .iter()
+        .filter_map(|summary| {
+            summary
+                .manifest_path
+                .as_ref()
+                .map(|path| (summary.id.as_str(), path.as_path()))
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut receipts = Vec::new();
+    for pack in packs.compiled_external_v1_packs() {
+        if pack.conformance_fixtures().is_empty() {
+            continue;
+        }
+        let manifest_path = manifest_paths
+            .get(pack.pack_id())
+            .copied()
+            .context("compiled v1 pack is missing its manifest path")?;
+        receipts.push(run_pack(pack, manifest_path));
+    }
+    let status = if receipts.is_empty() {
+        "unavailable"
+    } else if receipts.iter().all(|receipt| receipt.passed) {
+        "ok"
+    } else {
+        "failed"
+    };
+    Ok(KernelConformanceReport { status, receipts })
+}
+
+fn run_pack(
+    pack: &nose_semantics::CompiledSemanticPackV1,
+    manifest_path: &Path,
+) -> nose_semantics::SemanticPackConformanceReceiptV1 {
+    let root = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut fixtures = pack
+        .conformance_fixtures()
+        .iter()
+        .map(|fixture| run_fixture(pack, root, fixture))
+        .collect::<Vec<_>>();
+    fixtures.sort_by(|left, right| left.id.cmp(&right.id));
+    let mut rows = pack
+        .contracts_by_id()
+        .values()
+        .filter(|contract| contract.channel == nose_semantics::SemanticPackV1Channel::ExternalExact)
+        .map(
+            |contract| nose_semantics::SemanticPackConformanceReceiptRow {
+                row_id: contract.id.clone(),
+                row_digest: pack
+                    .row_digest(&contract.id)
+                    .expect("compiled row has a digest")
+                    .to_string(),
+                channel: contract.channel,
+            },
+        )
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.row_id.cmp(&right.row_id));
+    let passed = !fixtures.is_empty() && fixtures.iter().all(|fixture| fixture.passed);
+    nose_semantics::SemanticPackConformanceReceiptV1 {
+        api_version: nose_semantics::SEMANTIC_PACK_RECEIPT_API_VERSION_V1.to_string(),
+        nose_version: env!("CARGO_PKG_VERSION").to_string(),
+        kernel_capability: nose_semantics::SEMANTIC_PACK_EXACT_KERNEL_CAPABILITY_V1.to_string(),
+        pack_id: pack.pack_id().to_string(),
+        pack_version: pack.pack_version().to_string(),
+        semantic_digest: pack.semantic_digest().to_string(),
+        rows,
+        fixtures,
+        passed,
+    }
+}
+
+fn run_fixture(
+    pack: &nose_semantics::CompiledSemanticPackV1,
+    root: &Path,
+    fixture: &nose_semantics::SemanticPackV1ConformanceFixture,
+) -> nose_semantics::SemanticPackConformanceReceiptFixture {
+    let fixture_path = nose_semantics::resolve_fixture_path(root, &fixture.path);
+    let dependency_path = nose_semantics::resolve_fixture_path(root, &fixture.dependency);
+    let fixture_digest = fixture_path
+        .as_ref()
+        .map_err(Clone::clone)
+        .and_then(|path| nose_semantics::semantic_pack_fixture_digest(path));
+    let dependency_digest = dependency_path
+        .as_ref()
+        .map_err(Clone::clone)
+        .and_then(|path| nose_semantics::semantic_pack_file_digest(path));
+    let observed = match (
+        fixture_path.as_ref(),
+        dependency_path.as_ref(),
+        fixture_digest.as_ref(),
+        dependency_digest.as_ref(),
+    ) {
+        (Ok(fixture_path), Ok(dependency_path), Ok(_), Ok(_)) => {
+            observe_fixture(pack, fixture, fixture_path, dependency_path)
+        }
+        _ if [
+            fixture_digest.as_ref().err(),
+            dependency_digest.as_ref().err(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|message| message.contains("exceeds")) =>
+        {
+            nose_semantics::SemanticPackV1ObservedExpectation::ResourceLimit
+        }
+        _ => nose_semantics::SemanticPackV1ObservedExpectation::AnalysisFailure,
+    };
+    let passed = matches!(
+        (fixture.expectation, observed),
+        (
+            nose_semantics::SemanticPackV1Expectation::ExternalExactMatch,
+            nose_semantics::SemanticPackV1ObservedExpectation::ExternalExactMatch
+        ) | (
+            nose_semantics::SemanticPackV1Expectation::NoExternalExactMatch,
+            nose_semantics::SemanticPackV1ObservedExpectation::NoExternalExactMatch
+        )
+    );
+    nose_semantics::SemanticPackConformanceReceiptFixture {
+        id: fixture.id.clone(),
+        row_id: fixture.row_id.clone(),
+        kind: fixture.kind,
+        path: fixture.path.clone(),
+        dependency: fixture.dependency.clone(),
+        fixture_digest: fixture_digest.unwrap_or_default(),
+        dependency_digest: dependency_digest.unwrap_or_default(),
+        expectation: fixture.expectation,
+        observed,
+        passed,
+    }
+}
+
+fn observe_fixture(
+    pack: &nose_semantics::CompiledSemanticPackV1,
+    fixture: &nose_semantics::SemanticPackV1ConformanceFixture,
+    fixture_path: &Path,
+    dependency_path: &Path,
+) -> nose_semantics::SemanticPackV1ObservedExpectation {
+    let discovered = nose_frontend::discover_unique_paths(&[fixture_path], &[]);
+    if discovered.is_empty()
+        || discovered
+            .iter()
+            .any(|(_, language)| *language != nose_il::Lang::Java)
+        || discovered.iter().any(|(path, _)| {
+            std::fs::read(path)
+                .map(|source| !nose_frontend::java_source_parses_cleanly(&source))
+                .unwrap_or(true)
+        })
+    {
+        return nose_semantics::SemanticPackV1ObservedExpectation::AnalysisFailure;
+    }
+    let mut corpus = nose_frontend::lower_corpus_filtered(&[fixture_path], &[]);
+    if corpus.files.len() != discovered.len() {
+        return nose_semantics::SemanticPackV1ObservedExpectation::AnalysisFailure;
+    }
+    let evidence = nose_semantics::SemanticPackEvidenceIndex::build_for_conformance(
+        pack,
+        &fixture.row_id,
+        &[dependency_path.to_path_buf()],
+        &corpus,
+    );
+    let registry = nose_semantics::SemanticPackExternalExactRegistry::build_for_conformance(
+        pack, &evidence, &corpus,
+    );
+    let opts = nose_detect::DetectOptions {
+        min_lines: 1,
+        min_tokens: 1,
+        block_units: false,
+        shape_features: false,
+        emit_pairs: false,
+        ..Default::default()
+    };
+    let baseline_pairs = exact_family_pairs(&detect_exact_families(&corpus, &opts));
+    registry.apply(&mut corpus);
+    let families = detect_exact_families(&corpus, &opts);
+    let has_external_exact_match = families.iter().any(|family| {
+        if family.witness.as_ref().map(|witness| witness.kind) != Some("exact-value-graph") {
+            return false;
+        }
+        let claims = family
+            .locations
+            .iter()
+            .map(|location| {
+                !registry
+                    .claims_for_unit(&location.file, location.start_line, location.end_line)
+                    .is_empty()
+            })
+            .collect::<Vec<_>>();
+        claims.iter().any(|claimed| *claimed)
+            && claims.iter().any(|claimed| !*claimed)
+            && family_pairs(family)
+                .iter()
+                .any(|pair| !baseline_pairs.contains(pair))
+    });
+    if has_external_exact_match {
+        nose_semantics::SemanticPackV1ObservedExpectation::ExternalExactMatch
+    } else {
+        nose_semantics::SemanticPackV1ObservedExpectation::NoExternalExactMatch
+    }
+}
+
+type LocationKey = (String, u32, u32);
+type LocationPair = (LocationKey, LocationKey);
+
+fn detect_exact_families(
+    corpus: &nose_il::Corpus,
+    opts: &nose_detect::DetectOptions,
+) -> Vec<nose_detect::RefactorFamily> {
+    let features = nose_detect::corpus_features(corpus, opts);
+    let report = nose_detect::detect_from_units(
+        features.units,
+        features.files,
+        &features.streams,
+        opts,
+        &nose_detect::ExactBehaviorDetector,
+    )
+    .0;
+    nose_detect::rank_families(&report)
+}
+
+fn exact_family_pairs(
+    families: &[nose_detect::RefactorFamily],
+) -> std::collections::BTreeSet<LocationPair> {
+    families
+        .iter()
+        .filter(|family| {
+            family.witness.as_ref().map(|witness| witness.kind) == Some("exact-value-graph")
+        })
+        .flat_map(family_pairs)
+        .collect()
+}
+
+fn family_pairs(family: &nose_detect::RefactorFamily) -> Vec<LocationPair> {
+    let locations = family
+        .locations
+        .iter()
+        .map(|location| {
+            (
+                location.file.clone(),
+                location.start_line,
+                location.end_line,
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut pairs = Vec::new();
+    for (index, left) in locations.iter().enumerate() {
+        for right in locations.iter().skip(index + 1) {
+            pairs.push(if left <= right {
+                (left.clone(), right.clone())
+            } else {
+                (right.clone(), left.clone())
+            });
+        }
+    }
+    pairs
+}

--- a/crates/nose-cli/src/semantic_pack/project_lock.rs
+++ b/crates/nose-cli/src/semantic_pack/project_lock.rs
@@ -110,6 +110,12 @@ impl LockStatusReport {
             influence: if lock.authorizations().iter().any(|authorization| {
                 authorization
                     .allowed_channels()
+                    .contains(&nose_semantics::SemanticPackV1Channel::ExternalExact)
+            }) {
+                "external-claim-exact"
+            } else if lock.authorizations().iter().any(|authorization| {
+                authorization
+                    .allowed_channels()
                     .contains(&nose_semantics::SemanticPackV1Channel::Near)
             }) {
                 "near-only"

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -12,7 +12,7 @@ fn capabilities_command_emits_machine_readable_contract() {
     let json: serde_json::Value =
         serde_json::from_str(&out).expect("capabilities must emit valid JSON");
 
-    assert_eq!(json["schema_version"], 6);
+    assert_eq!(json["schema_version"], 7);
     assert_eq!(json["tool"]["name"], "nose");
     assert_eq!(json["tool"]["version"], env!("CARGO_PKG_VERSION"));
     assert!(
@@ -63,7 +63,7 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
         vec!["capabilities", "il", "query", "semantic-pack", "stats"]
     );
     assert!(json_array_strings(&json["commands"], "deprecated").is_empty());
-    assert_eq!(json["schemas"]["capabilities"][0], 6);
+    assert_eq!(json["schemas"]["capabilities"][0], 7);
     assert_eq!(json["schemas"]["query_json"], serde_json::json!([7, 8]));
     assert_eq!(
         json["schemas"]["semantic_packs"],
@@ -77,10 +77,10 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
         json["schemas"]["semantic_pack_lock_status"],
         serde_json::json!([1])
     );
-    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 3);
+    assert_eq!(json["schemas"]["semantic_pack_conformance"][0], 4);
     assert_eq!(json["schemas"]["semantic_pack_inventory"][0], 1);
-    assert_eq!(json["schemas"]["semantic_pack_adoption_gates"][0], 1);
-    assert_eq!(json["schemas"]["semantic_pack_compatibility"][0], 1);
+    assert_eq!(json["schemas"]["semantic_pack_adoption_gates"][0], 2);
+    assert_eq!(json["schemas"]["semantic_pack_compatibility"][0], 2);
 }
 
 #[test]
@@ -132,6 +132,10 @@ fn capabilities_command_reports_query_surface() {
         true
     );
     assert_eq!(
+        json["query"]["capabilities"]["semantic_pack_external_claim_exact"],
+        true
+    );
+    assert_eq!(
         json["query"]["capabilities"]["semantic_pack_project_lock"],
         true
     );
@@ -151,7 +155,7 @@ fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
     assert_semantic_pack_project_lock_capabilities(&json);
     assert_eq!(
         json["semantic_packs"]["external_pack_influence"],
-        "metadata-or-locked-near-only"
+        "metadata-or-locked-near-or-receipt-backed-external-claim-exact"
     );
     assert_eq!(
         json_array_strings(&json["semantic_packs"], "external_influence_blockers"),
@@ -166,7 +170,13 @@ fn capabilities_command_reports_semantic_pack_il_and_stats_surfaces() {
     assert_eq!(json["semantic_packs"]["external_pack_execution"], "none");
     assert_eq!(
         json_array_strings(&json["semantic_packs"], "conformance"),
-        vec!["local-manifest-file", "local-manifest-directory"]
+        vec![
+            "local-manifest-file",
+            "local-manifest-directory",
+            "v0-fixture-metadata",
+            "v1-kernel-source-analysis",
+            "receipt-output"
+        ]
     );
     assert_eq!(
         json_array_strings(&json["semantic_packs"], "conformance_output_formats"),

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -198,5 +198,7 @@ mod builtin_report;
 mod external_cases_0;
 #[path = "config_packs/external_cases_v1.rs"]
 mod external_cases_v1;
+#[path = "config_packs/external_exact.rs"]
+mod external_exact;
 #[path = "config_packs/project_lock.rs"]
 mod project_lock;

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_0.rs
@@ -229,7 +229,7 @@ fn semantic_pack_check_json_reports_conformance_success() {
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
-    assert_eq!(json["schema_version"], 3);
+    assert_eq!(json["schema_version"], 4);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["manifests"], 1);
     assert_eq!(json["totals"]["positive_fixtures"], 1);
@@ -338,7 +338,7 @@ fn semantic_pack_check_json_reports_passed_executable_gates_without_opening_infl
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("check should emit JSON");
-    assert_eq!(json["schema_version"], 3);
+    assert_eq!(json["schema_version"], 4);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["totals"]["executable_conformance_rows"], 2);
     assert_eq!(json["totals"]["passed_executable_conformance_rows"], 2);

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_cases_v1.rs
@@ -51,7 +51,7 @@ fn typed_v1_pack_compiles_and_reports_digest_without_changing_families() {
         .expect("v1 semantic-pack check");
     assert!(check.status.success());
     let check_json: serde_json::Value = serde_json::from_slice(&check.stdout).unwrap();
-    assert_eq!(check_json["schema_version"], 3);
+    assert_eq!(check_json["schema_version"], 4);
     assert_eq!(check_json["influence_preflight"]["status"], "unavailable");
     assert_eq!(
         check_json["manifests"][0]["api_version"],

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_exact.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_exact.rs
@@ -1,0 +1,403 @@
+use super::*;
+
+fn exact_manifest() -> String {
+    r#"{
+  "api_version":"nose.semantic-pack.v1",
+  "pack":{
+    "id":"com.example.fast-list",
+    "kind":"LibraryPack",
+    "version":"1.0.0",
+    "display_name":"Fast List",
+    "trust":"external-opt-in",
+    "enabled_by_default":false
+  },
+  "provenance":{
+    "provider":{"name":"Example"},
+    "license":"MIT",
+    "repository":"https://example.invalid/fast-list"
+  },
+  "compatibility":{"nose":">=0.19.0 <0.21.0"},
+  "supported_languages":["java"],
+  "packages":[{
+    "ecosystem":"maven",
+    "name":"com.example:fast-list",
+    "versions":">=1.2.0 <2.0.0"
+  }],
+  "declares":{"api_contracts":[{
+    "id":"java.fast-list.of-five",
+    "language":"java",
+    "package":{"ecosystem":"maven","name":"com.example:fast-list"},
+    "anchor":"call-node",
+    "matcher":"imported-api",
+    "import":{"role":"type","module":"com.example.collect","name":"FastList"},
+    "call":{
+      "shape":"static-method",
+      "member":"of",
+      "arity":{"kind":"set","values":[5]},
+      "receiver":"imported-type"
+    },
+    "operation":"collection-factory",
+    "result_domain":"collection",
+    "profiles":{
+      "demand":"eager",
+      "effects":"pure",
+      "exceptions":"no-throw",
+      "mutation":"none",
+      "identity":"fresh"
+    },
+    "channel":"external-exact"
+  }]},
+  "conformance":{"fixtures":[{
+    "id":"factory-positive",
+    "row_id":"java.fast-list.of-five",
+    "kind":"positive",
+    "path":"fixtures/positive",
+    "dependency":"pom.xml",
+    "expectation":"external-exact-match"
+  },{
+    "id":"wrong-member-negative",
+    "row_id":"java.fast-list.of-five",
+    "kind":"hard-negative",
+    "path":"fixtures/wrong-member",
+    "dependency":"pom.xml",
+    "expectation":"no-external-exact-match"
+  }]}
+}"#
+    .to_string()
+}
+
+fn prepare_exact_project(tag: &str) -> PathBuf {
+    let dir = make_project(tag);
+    for child in ["a", "b", "c", "tests"] {
+        let _ = fs::remove_dir_all(dir.join(child));
+    }
+    fs::create_dir_all(dir.join("packs/fixtures/positive")).unwrap();
+    fs::create_dir_all(dir.join("packs/fixtures/wrong-member")).unwrap();
+    fs::write(dir.join("packs/fast-list.json"), exact_manifest()).unwrap();
+    fs::write(
+        dir.join("packs/pom.xml"),
+        "<project><modelVersion>4.0.0</modelVersion><dependencies><dependency>\
+         <groupId>com.example</groupId><artifactId>fast-list</artifactId>\
+         <version>1.2.3</version></dependency></dependencies></project>\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packs/fixtures/positive/Fixture.java"),
+        "import com.example.collect.FastList;\n\
+         import java.util.List;\n\
+         class Fixture {\n\
+           static boolean externalFactory(int value) {\n\
+             return FastList.of(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+           static boolean builtinFactory(int value) {\n\
+             return List.of(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+         }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packs/fixtures/wrong-member/Fixture.java"),
+        "import com.example.collect.FastList;\n\
+         import java.util.List;\n\
+         class Fixture {\n\
+           static boolean externalFactory(int value) {\n\
+             return FastList.copyOf(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+           static boolean builtinFactory(int value) {\n\
+             return List.of(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+         }\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn check_with_receipt(dir: &Path) -> std::process::Output {
+    Command::new(bin())
+        .args([
+            "semantic-pack",
+            "check",
+            "packs/fast-list.json",
+            "--receipt-out",
+            "packs/receipt.json",
+            "--format",
+            "json",
+        ])
+        .current_dir(dir)
+        .output()
+        .unwrap()
+}
+
+fn create_exact_lock(dir: &Path, with_receipt: bool) -> std::process::Output {
+    let mut command = Command::new(bin());
+    command.args([
+        "semantic-pack",
+        "lock",
+        "packs/fast-list.json",
+        "--dependency",
+        "packs/pom.xml",
+        "--channel",
+        "external-exact",
+        "--output",
+        "nose.semantic-pack-lock.json",
+        "--format",
+        "json",
+    ]);
+    if with_receipt {
+        command.args(["--exact-receipt", "packs/receipt.json"]);
+    }
+    command.current_dir(dir).output().unwrap()
+}
+
+#[test]
+fn kernel_check_receipt_and_exact_lock_open_only_external_claim_lane() {
+    let dir = prepare_exact_project("semantic_pack_external_exact");
+    let checked = check_with_receipt(&dir);
+    assert!(
+        checked.status.success(),
+        "{}",
+        String::from_utf8_lossy(&checked.stderr)
+    );
+    let check_json: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap();
+    assert_eq!(check_json["schema_version"], 4);
+    assert_eq!(check_json["kernel_conformance"]["status"], "ok");
+    assert_eq!(check_json["totals"]["kernel_conformance_fixtures"], 2);
+    assert_eq!(
+        check_json["totals"]["passed_kernel_conformance_fixtures"],
+        2
+    );
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(dir.join("packs/receipt.json")).unwrap()).unwrap();
+    assert_eq!(
+        receipt["api_version"],
+        "nose.semantic-pack-conformance-receipt.v1"
+    );
+    assert_eq!(receipt["passed"], true);
+
+    let missing_receipt = create_exact_lock(&dir, false);
+    assert!(!missing_receipt.status.success());
+    assert!(String::from_utf8_lossy(&missing_receipt.stderr)
+        .contains("has no exact conformance receipt"));
+
+    let locked = create_exact_lock(&dir, true);
+    assert!(
+        locked.status.success(),
+        "{}",
+        String::from_utf8_lossy(&locked.stderr)
+    );
+    let lock_json: serde_json::Value = serde_json::from_slice(&locked.stdout).unwrap();
+    assert_eq!(lock_json["influence"], "external-claim-exact");
+
+    let query = |locked: bool| {
+        let mut command = Command::new(bin());
+        command.args([
+            "query",
+            "packs/fixtures/positive",
+            "all",
+            "top=0",
+            "--mode",
+            "semantic",
+            "--min-lines",
+            "1",
+            "--min-size",
+            "1",
+            "--format",
+            "json",
+        ]);
+        if locked {
+            command.args(["--semantic-pack-lock", "nose.semantic-pack-lock.json"]);
+        }
+        let output = command.current_dir(&dir).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap()
+    };
+    let without = query(false);
+    assert!(without["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|family| family.get("semantic_pack_external_exact").is_none()));
+    let with = query(true);
+    let family = with["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|family| family.get("semantic_pack_external_exact").is_some())
+        .unwrap_or_else(|| panic!("exact lock should expose external-claim family: {with}"));
+    assert_eq!(family["witness"], "exact");
+    assert_eq!(
+        family["semantic_pack_external_exact"][0]["assurance"],
+        "external-claim-exact"
+    );
+    assert_eq!(
+        family["semantic_pack_external_exact"][0]["lane"],
+        "external-exact"
+    );
+    let pack = semantic_pack_by_id(&with, "com.example.fast-list");
+    assert_eq!(pack["influence"], "external-claim-exact");
+    assert_eq!(
+        pack["external_exact_influence"]["influential_occurrences"],
+        1
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn exact_receipt_content_and_fixture_drift_fail_closed() {
+    let dir = prepare_exact_project("semantic_pack_external_exact_stale");
+    assert!(check_with_receipt(&dir).status.success());
+    assert!(create_exact_lock(&dir, true).status.success());
+
+    let receipt_path = dir.join("packs/receipt.json");
+    let receipt = fs::read(&receipt_path).unwrap();
+    let mut tampered: serde_json::Value = serde_json::from_slice(&receipt).unwrap();
+    tampered["kernel_capability"] = serde_json::json!("provider-defined");
+    fs::write(&receipt_path, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+    let tampered_status = Command::new(bin())
+        .args(["semantic-pack", "status", "nose.semantic-pack-lock.json"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    assert!(!tampered_status.status.success());
+    assert!(String::from_utf8_lossy(&tampered_status.stderr).contains("locked file"));
+    fs::write(&receipt_path, receipt).unwrap();
+
+    fs::write(
+        dir.join("packs/fixtures/positive/Fixture.java"),
+        "class Fixture { static Object changed() { return null; } }\n",
+    )
+    .unwrap();
+    let stale = Command::new(bin())
+        .args(["semantic-pack", "status", "nose.semantic-pack-lock.json"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    assert!(!stale.status.success());
+    assert!(String::from_utf8_lossy(&stale.stderr).contains("content changed"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn source_conformance_resource_limit_fails_closed() {
+    let dir = prepare_exact_project("semantic_pack_external_exact_resource_cap");
+    fs::write(
+        dir.join("packs/fixtures/positive/oversized.java"),
+        vec![b' '; nose_semantics::MAX_SEMANTIC_PACK_FIXTURE_BYTES + 1],
+    )
+    .unwrap();
+    let checked = check_with_receipt(&dir);
+    assert!(!checked.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap();
+    let positive = json["kernel_conformance"]["receipts"][0]["fixtures"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|fixture| fixture["id"] == "factory-positive")
+        .unwrap();
+    assert_eq!(positive["observed"], "resource-limit");
+    assert_eq!(positive["passed"], false);
+    assert!(!dir.join("packs/receipt.json").exists());
+
+    fs::remove_file(dir.join("packs/fixtures/positive/oversized.java")).unwrap();
+    fs::write(
+        dir.join("packs/pom.xml"),
+        vec![b' '; nose_semantics::MAX_SEMANTIC_PACK_DEPENDENCY_BYTES + 1],
+    )
+    .unwrap();
+    let dependency_limited = check_with_receipt(&dir);
+    assert!(!dependency_limited.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&dependency_limited.stdout).unwrap();
+    assert!(json["kernel_conformance"]["receipts"][0]["fixtures"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|fixture| fixture["observed"] == "resource-limit"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn malformed_hard_negative_is_an_analysis_failure() {
+    let dir = prepare_exact_project("semantic_pack_external_exact_malformed");
+    fs::write(
+        dir.join("packs/fixtures/wrong-member/Fixture.java"),
+        "class Fixture { static boolean broken( { return false; }\n",
+    )
+    .unwrap();
+    let checked = check_with_receipt(&dir);
+    assert!(!checked.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap();
+    let negative = json["kernel_conformance"]["receipts"][0]["fixtures"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|fixture| fixture["id"] == "wrong-member-negative")
+        .unwrap();
+    assert_eq!(negative["observed"], "analysis-failure");
+    assert_eq!(negative["passed"], false);
+    assert!(!dir.join("packs/receipt.json").exists());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn positive_requires_new_cross_boundary_exact_evidence() {
+    let dir = prepare_exact_project("semantic_pack_external_exact_causal_positive");
+    fs::write(
+        dir.join("packs/fixtures/positive/Fixture.java"),
+        "import com.example.collect.FastList;\n\
+         class Fixture {\n\
+           static boolean first(int value) {\n\
+             return FastList.of(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+           static boolean second(int value) {\n\
+             return FastList.of(1, 2, 3, 4, 5).contains(value);\n\
+           }\n\
+         }\n",
+    )
+    .unwrap();
+    let checked = check_with_receipt(&dir);
+    assert!(!checked.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap();
+    let positive = json["kernel_conformance"]["receipts"][0]["fixtures"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|fixture| fixture["id"] == "factory-positive")
+        .unwrap();
+    assert_eq!(positive["observed"], "no-external-exact-match");
+    assert_eq!(positive["passed"], false);
+    assert!(!dir.join("packs/receipt.json").exists());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_fixture_root_fails_closed() {
+    use std::os::unix::fs::symlink;
+
+    let dir = prepare_exact_project("semantic_pack_external_exact_symlink");
+    fs::rename(
+        dir.join("packs/fixtures/wrong-member"),
+        dir.join("packs/fixtures/wrong-member-real"),
+    )
+    .unwrap();
+    symlink("wrong-member-real", dir.join("packs/fixtures/wrong-member")).unwrap();
+    let checked = check_with_receipt(&dir);
+    assert!(!checked.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&checked.stdout).unwrap();
+    let negative = json["kernel_conformance"]["receipts"][0]["fixtures"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|fixture| fixture["id"] == "wrong-member-negative")
+        .unwrap();
+    assert_eq!(negative["observed"], "analysis-failure");
+    assert_eq!(negative["passed"], false);
+    assert!(!dir.join("packs/receipt.json").exists());
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_adoption_gates.rs
@@ -16,12 +16,12 @@ fn semantic_pack_adoption_gates_json_reports_builtin_gate_status() {
 }
 
 fn assert_adoption_gate_totals(json: &serde_json::Value) {
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["policy"]["scope"], "compiled-builtin");
     assert_eq!(
         json["policy"]["external_influence"],
-        "unlocked-metadata-or-locked-near-only"
+        "unlocked-metadata-or-locked-near-or-receipt-backed-external-claim-exact"
     );
     assert_eq!(json["totals"]["builtin_packs"], 49);
     assert_eq!(json["totals"]["builtin_default_packs"], 49);

--- a/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
+++ b/crates/nose-cli/tests/cli/commands/semantic_pack_compatibility.rs
@@ -6,9 +6,16 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
     let json: serde_json::Value =
         serde_json::from_str(&out).expect("compatibility must emit valid JSON");
 
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(json["status"], "ok");
     assert_eq!(json["current_nose_version"], env!("CARGO_PKG_VERSION"));
+    assert_supported_contract(&json);
+    assert_policy_and_requirements(&json);
+    assert_compatibility_checks(&json);
+    assert_fail_closed_modes(&json);
+}
+
+fn assert_supported_contract(json: &serde_json::Value) {
     assert_eq!(
         json_array_strings(&json["supported"], "manifest_api_versions"),
         vec!["nose.semantic-pack.v0", "nose.semantic-pack.v1"]
@@ -21,13 +28,16 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
         json_array_strings(&json["supported"], "report_sources"),
         vec!["policy"]
     );
+}
+
+fn assert_policy_and_requirements(json: &serde_json::Value) {
     assert_eq!(
         json["policy"]["manifest_nose_version"],
         "must-include-installed-version"
     );
     assert_eq!(
         json["policy"]["external_pack_influence"],
-        "metadata-or-locked-near-only"
+        "metadata-or-locked-near-or-receipt-backed-external-claim-exact"
     );
     assert_eq!(
         json["policy"]["external_pack_authorization"],
@@ -41,10 +51,14 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
         .contains(&"unsupported-capability-fail-closed"));
     assert!(json_array_strings(&json["requirements"], "kernel")
         .contains(&"unlocked-or-v0-external-rows-do-not-influence-analysis"));
+}
+
+fn assert_compatibility_checks(json: &serde_json::Value) {
     assert_eq!(json["checks"]["builtin_inventory_status"], "ok");
     assert_eq!(json["checks"]["builtin_packs"], 49);
     assert_eq!(json["checks"]["external_metadata_only"], false);
     assert_eq!(json["checks"]["external_locked_near_only"], true);
+    assert_eq!(json["checks"]["external_receipt_exact"], true);
     assert_eq!(
         json_array_strings(&json["checks"], "external_influence_blockers"),
         vec![
@@ -55,8 +69,6 @@ fn semantic_pack_compatibility_json_reports_fail_closed_policy() {
             "row-conflict"
         ]
     );
-
-    assert_fail_closed_modes(&json);
 }
 
 fn assert_fail_closed_modes(json: &serde_json::Value) {

--- a/crates/nose-detect/src/model.rs
+++ b/crates/nose-detect/src/model.rs
@@ -77,6 +77,10 @@ pub struct Loc {
     /// External near-lane evidence that contributed to this member's structural family.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub semantic_pack_near: Vec<nose_semantics::SemanticPackNearProvenance>,
+    /// Receipt-backed provider claims that contributed to this member's exact
+    /// fingerprint. This is distinct from builtin-certified exact evidence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_pack_external_exact: Vec<nose_semantics::SemanticPackExternalExactProvenance>,
 }
 
 /// Inclusive source-line range used to construct a [`Loc`].
@@ -158,6 +162,7 @@ impl Loc {
             looks_generated: false,
             shared_subdag: None,
             semantic_pack_near: Vec::new(),
+            semantic_pack_external_exact: Vec::new(),
         }
     }
 }

--- a/crates/nose-detect/src/report/model.rs
+++ b/crates/nose-detect/src/report/model.rs
@@ -105,6 +105,10 @@ pub struct RefactorFamily {
     /// Deduplicated external near-lane evidence that contributed to this family.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub semantic_pack_near: Vec<nose_semantics::SemanticPackNearProvenance>,
+    /// Receipt-backed, user-authorized external claims that contributed to this
+    /// exact family. Never presented as builtin certification.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub semantic_pack_external_exact: Vec<nose_semantics::SemanticPackExternalExactProvenance>,
     /// WHY the members merged — the agent-facing equivalence witness (#222): an
     /// exact value-graph proof, a shared heavy sub-DAG, a token-identical
     /// copy-paste run, or structural similarity with its value/shape components.

--- a/crates/nose-detect/src/report/ranking.rs
+++ b/crates/nose-detect/src/report/ranking.rs
@@ -133,6 +133,7 @@ fn family_of_with_edges(group: &Group, group_edges: &[AcceptedEdge]) -> Refactor
             .filter_map(|&law| value_law_provenance(law))
             .collect(),
         semantic_pack_near: Vec::new(),
+        semantic_pack_external_exact: Vec::new(),
     }
 }
 

--- a/crates/nose-detect/src/report/tests/support.rs
+++ b/crates/nose-detect/src/report/tests/support.rs
@@ -119,6 +119,7 @@ pub(super) fn fam(
         varying_spots: Vec::new(),
         semantic_laws: Vec::new(),
         semantic_pack_near: Vec::new(),
+        semantic_pack_external_exact: Vec::new(),
     }
 }
 

--- a/crates/nose-detect/src/strict_exact.rs
+++ b/crates/nose-detect/src/strict_exact.rs
@@ -11,7 +11,7 @@ use nose_il::{
 };
 use nose_normalize::module_facts::collect_module_mutations;
 use nose_semantics::{
-    admitted_builtin_semantics_at_call_with_interner,
+    admitted_builtin_semantics_at_call_with_interner, admitted_external_collection_factory_at_call,
     admitted_free_name_collection_factory_at_call, admitted_free_name_map_factory_at_call,
     admitted_hof_demand_effect_profile_at_node_with_interner,
     admitted_imported_collection_factory_at_call, admitted_iterator_identity_adapter_at_call,
@@ -73,11 +73,11 @@ use collections::{
     strict_exact_proven_map_receiver_safe,
 };
 use factories::{
-    strict_exact_go_literal_zero_map_index_safe, strict_exact_java_collection_constructor_safe,
-    strict_exact_map_constructor_entries_safe, strict_exact_ruby_set_factory_safe,
-    strict_exact_rust_std_collection_factory_safe, strict_exact_rust_std_map_factory_safe,
-    strict_exact_rust_vec_macro_collection_safe, strict_exact_rust_vec_new_safe,
-    strict_exact_swift_default_subscript_index_safe,
+    strict_exact_external_collection_factory_safe, strict_exact_go_literal_zero_map_index_safe,
+    strict_exact_java_collection_constructor_safe, strict_exact_map_constructor_entries_safe,
+    strict_exact_ruby_set_factory_safe, strict_exact_rust_std_collection_factory_safe,
+    strict_exact_rust_std_map_factory_safe, strict_exact_rust_vec_macro_collection_safe,
+    strict_exact_rust_vec_new_safe, strict_exact_swift_default_subscript_index_safe,
     strict_exact_swift_membership_collection_factory_safe,
 };
 pub(crate) use factories::{

--- a/crates/nose-detect/src/strict_exact/collections.rs
+++ b/crates/nose-detect/src/strict_exact/collections.rs
@@ -539,7 +539,8 @@ pub(super) fn strict_exact_collection_factory_call_safe(
     facts: &StrictFacts,
     node: NodeId,
 ) -> bool {
-    strict_exact_set_constructor_collection_safe(il, interner, facts, node)
+    strict_exact_external_collection_factory_safe(il, interner, facts, node)
+        || strict_exact_set_constructor_collection_safe(il, interner, facts, node)
         || strict_exact_python_collection_factory_safe(il, interner, facts, node)
         || strict_exact_ruby_set_factory_safe(il, interner, facts, node)
         || strict_exact_rust_vec_macro_collection_safe(il, interner, facts, node)

--- a/crates/nose-detect/src/strict_exact/factories.rs
+++ b/crates/nose-detect/src/strict_exact/factories.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+pub(super) fn strict_exact_external_collection_factory_safe(
+    il: &Il,
+    interner: &Interner,
+    facts: &StrictFacts,
+    node: NodeId,
+) -> bool {
+    admitted_external_collection_factory_at_call(il, node).is_some()
+        && il
+            .children(node)
+            .iter()
+            .skip(1)
+            .all(|&argument| strict_exact_safe_tree(il, interner, facts, argument))
+}
+
 pub(crate) fn strict_exact_set_constructor_collection_safe(
     il: &Il,
     interner: &Interner,

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -111,6 +111,19 @@ pub fn lower_source(
     }
 }
 
+/// Parse a Java conformance fixture with the product grammar and reject error
+/// recovery. Product analysis may preserve partial trees fail-closed, but a
+/// negative conformance expectation must not pass merely because its fixture is
+/// malformed.
+pub fn java_source_parses_cleanly(src: &[u8]) -> bool {
+    lower::parse(
+        lower::grammar::JAVA,
+        || tree_sitter_java::LANGUAGE.into(),
+        src,
+    )
+    .is_ok_and(|tree| !tree.root_node().has_error())
+}
+
 /// Whether a Raw surface tag is an intentional protocol/effect boundary rather than a
 /// fixable lowering gap. Exposed for CLI diagnostics that rank gap work.
 pub fn is_protocol_boundary_tag(tag: &str) -> bool {

--- a/crates/nose-il/src/node/evidence.rs
+++ b/crates/nose-il/src/node/evidence.rs
@@ -86,6 +86,14 @@ impl EvidenceProvenance {
             rule_hash: Some(stable_symbol_hash(rule)),
         }
     }
+
+    pub fn external(pack_id: &str, row_id: &str) -> Self {
+        Self {
+            emitter: EvidenceEmitter::External,
+            pack_hash: Some(stable_symbol_hash(pack_id)),
+            rule_hash: Some(stable_symbol_hash(row_id)),
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
@@ -269,6 +277,14 @@ pub enum LibraryApiEvidenceKind {
         callee_hash: u64,
         arity: u16,
     },
+    /// Query-local authorization for one closed kernel operation claimed by an
+    /// external semantic pack. The kernel creates this only after project-lock,
+    /// receipt, dependency, import, call-shape, and conflict checks pass.
+    ///
+    /// It deliberately cannot name a private value-graph node or provider
+    /// callback. Exact consumers still validate provenance, dependencies, the
+    /// current call arity, and the operation-specific safety obligations.
+    ExternalCollectionFactory { arity: u16 },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/nose-normalize/src/value_graph.rs
+++ b/crates/nose-normalize/src/value_graph.rs
@@ -86,7 +86,8 @@ use nose_il::{
 };
 use nose_semantics::{
     admitted_builder_append_method_call_args, admitted_builtin_semantics_at_call_with_interner,
-    admitted_free_function_builtin_at_call, admitted_free_name_collection_factory_at_call,
+    admitted_external_collection_factory_at_call, admitted_free_function_builtin_at_call,
+    admitted_free_name_collection_factory_at_call,
     admitted_free_name_collection_factory_at_call_span,
     admitted_free_name_map_factory_at_call_span,
     admitted_hof_demand_effect_profile_at_node_with_interner,

--- a/crates/nose-normalize/src/value_graph/eval/calls.rs
+++ b/crates/nose-normalize/src/value_graph/eval/calls.rs
@@ -170,6 +170,14 @@ impl<'a> Builder<'a> {
         kids: &[NodeId],
         env: &FxHashMap<u32, ValueId>,
     ) -> Option<ValueId> {
+        if admitted_external_collection_factory_at_call(self.il, expr).is_some() {
+            let values = kids
+                .iter()
+                .skip(1)
+                .map(|&argument| self.eval(argument, env))
+                .collect();
+            return Some(self.mk(ValOp::Seq(SEQ_VALUE_COLLECTION), values));
+        }
         if let Some(r) = self.eval_count_call(expr, kids, env) {
             return Some(r);
         }

--- a/crates/nose-semantics/src/effects.rs
+++ b/crates/nose-semantics/src/effects.rs
@@ -222,7 +222,13 @@ fn library_api_suppresses_opaque_argument_escape(api: LibraryApiEvidenceKind) ->
         contract_hash,
         arity,
         ..
-    } = api;
+    } = api
+    else {
+        return matches!(
+            api,
+            LibraryApiEvidenceKind::ExternalCollectionFactory { .. }
+        );
+    };
     contract_hash != library_api_contract_id_hash(LibraryApiContractId::PromiseThen)
         && contract_hash != library_api_contract_id_hash(LibraryApiContractId::PromiseCatch)
         && contract_hash != library_api_contract_id_hash(LibraryApiContractId::PromiseFinally)

--- a/crates/nose-semantics/src/library_api.rs
+++ b/crates/nose-semantics/src/library_api.rs
@@ -12,6 +12,7 @@ mod callee_shape;
 mod contract_keys;
 mod contracts;
 mod dependency_facts;
+mod external_exact;
 mod imported_occurrences;
 mod receiver_dependencies;
 mod registry;
@@ -23,6 +24,7 @@ pub(in crate::library_api) use callee_dependencies::*;
 pub(in crate::library_api) use callee_shape::*;
 pub use contracts::*;
 pub(in crate::library_api) use dependency_facts::*;
+pub use external_exact::admitted_external_collection_factory_at_call;
 pub(in crate::library_api) use receiver_dependencies::{
     async_receiver_dependencies_at_span, domain_dependency_anchor_matches_receiver,
     iterator_adapter_receiver_dependencies_at_span, method_receiver_dependencies_at_span,

--- a/crates/nose-semantics/src/library_api/external_exact.rs
+++ b/crates/nose-semantics/src/library_api/external_exact.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+/// Admit the one external exact operation exposed by semantic-pack v1.
+///
+/// The product lock/receipt/evidence pipeline is the only producer of this
+/// record. Consumers nevertheless re-check its query-local provenance,
+/// dependency closure, anchor, and arity against the current IL so a stale or
+/// transplanted record cannot affect normalization.
+pub fn admitted_external_collection_factory_at_call(
+    il: &Il,
+    call: NodeId,
+) -> Option<&EvidenceRecord> {
+    if il.kind(call) != NodeKind::Call {
+        return None;
+    }
+    let span = il.node(call).span;
+    let actual_arity = il.children(call).len().saturating_sub(1);
+    let mut admitted = il.evidence_anchored_at(span).filter(|record| {
+        let EvidenceKind::LibraryApi(LibraryApiEvidenceKind::ExternalCollectionFactory { arity }) =
+            record.kind
+        else {
+            return false;
+        };
+        record.anchor == EvidenceAnchor::node(span, NodeKind::Call)
+            && record.status == EvidenceStatus::Asserted
+            && record.provenance.emitter == EvidenceEmitter::External
+            && record.provenance.pack_hash.is_some()
+            && record.provenance.rule_hash.is_some()
+            && usize::from(arity) == actual_arity
+            && il.evidence_dependencies_asserted(record)
+    });
+    let first = admitted.next()?;
+    admitted.next().is_none().then_some(first)
+}

--- a/crates/nose-semantics/src/packs.rs
+++ b/crates/nose-semantics/src/packs.rs
@@ -103,19 +103,19 @@ use nose_il::stable_symbol_hash;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-
 mod compiled;
 mod conformance;
 mod evidence_index;
+mod exact_registry;
 mod external;
 mod loading;
 mod lock;
 mod manifest;
 mod near_registry;
+mod receipt;
 mod result_domain_semantics;
 mod v1;
 mod validation;
-
 pub use compiled::{
     builtin_compat_semantic_pack, builtin_pack_descriptor, builtin_pack_descriptors,
     first_party_semantic_pack, first_party_value_law_pack, python_stdlib_type_domain_pack,
@@ -131,6 +131,10 @@ pub use evidence_index::{
     SemanticPackDependencyEvidence, SemanticPackDependencyEvidenceId, SemanticPackDependencySource,
     SemanticPackEvidenceBlocker, SemanticPackEvidenceIndex, SemanticPackEvidenceRow,
     SemanticPackOccurrenceEvidence,
+};
+pub use exact_registry::{
+    SemanticPackExternalExactPackCounts, SemanticPackExternalExactProvenance,
+    SemanticPackExternalExactRegistry, SemanticPackExternalExactReport,
 };
 pub use external::{
     ExternalContractRow, ExternalEvidenceProducerRow, ExternalInfluenceBlocker,
@@ -152,13 +156,23 @@ pub use near_registry::{
     SemanticPackNearDependency, SemanticPackNearPackCounts, SemanticPackNearProtocol,
     SemanticPackNearProvenance, SemanticPackNearRegistry, SemanticPackNearReport,
 };
+pub use receipt::{
+    read_semantic_pack_conformance_receipt, resolve_fixture_path, semantic_pack_file_digest,
+    semantic_pack_fixture_digest, validate_semantic_pack_conformance_receipt,
+    SemanticPackConformanceReceiptFixture, SemanticPackConformanceReceiptRow,
+    SemanticPackConformanceReceiptV1, SemanticPackV1ObservedExpectation,
+    MAX_SEMANTIC_PACK_DEPENDENCY_BYTES, MAX_SEMANTIC_PACK_FIXTURE_BYTES,
+    MAX_SEMANTIC_PACK_FIXTURE_FILES, SEMANTIC_PACK_EXACT_KERNEL_CAPABILITY_V1,
+    SEMANTIC_PACK_RECEIPT_API_VERSION_V1,
+};
 use v1::{compile_manifest_v1, SemanticPackManifestV1};
 pub use v1::{
     CompiledSemanticPackV1, SemanticPackV1Anchor, SemanticPackV1Arity, SemanticPackV1ArityKind,
-    SemanticPackV1Call, SemanticPackV1CallShape, SemanticPackV1Channel, SemanticPackV1Contract,
-    SemanticPackV1Coordinate, SemanticPackV1DemandProfile, SemanticPackV1EffectProfile,
-    SemanticPackV1ExceptionProfile, SemanticPackV1IdentityProfile, SemanticPackV1Import,
-    SemanticPackV1ImportRole, SemanticPackV1Language, SemanticPackV1Matcher,
+    SemanticPackV1Call, SemanticPackV1CallShape, SemanticPackV1Channel, SemanticPackV1Conformance,
+    SemanticPackV1ConformanceFixture, SemanticPackV1Contract, SemanticPackV1Coordinate,
+    SemanticPackV1DemandProfile, SemanticPackV1EffectProfile, SemanticPackV1ExceptionProfile,
+    SemanticPackV1Expectation, SemanticPackV1FixtureKind, SemanticPackV1IdentityProfile,
+    SemanticPackV1Import, SemanticPackV1ImportRole, SemanticPackV1Language, SemanticPackV1Matcher,
     SemanticPackV1MutationProfile, SemanticPackV1Package, SemanticPackV1PackageCoordinate,
     SemanticPackV1PackageEcosystem, SemanticPackV1Profiles, SemanticPackV1ProtocolOperation,
     SemanticPackV1ReceiverRole, SemanticPackV1ResultDomain, SEMANTIC_PACK_API_VERSION_V1,
@@ -207,6 +221,7 @@ impl SemanticPackSource {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SemanticPackInfluence {
     EvidenceAndContracts,
+    ExternalClaimExact,
     NearOnly,
     MetadataOnly,
 }
@@ -215,6 +230,7 @@ impl SemanticPackInfluence {
     pub const fn as_str(self) -> &'static str {
         match self {
             SemanticPackInfluence::EvidenceAndContracts => "evidence-and-contracts",
+            SemanticPackInfluence::ExternalClaimExact => "external-claim-exact",
             SemanticPackInfluence::NearOnly => "near-only",
             SemanticPackInfluence::MetadataOnly => "metadata-only",
         }
@@ -459,8 +475,16 @@ impl SemanticPackSummary {
                 evidence_producers: 0,
                 contracts: manifest.declares.api_contracts.len(),
                 value_laws: 0,
-                positive_fixtures: 0,
-                hard_negatives: 0,
+                positive_fixtures: compiled
+                    .conformance_fixtures()
+                    .iter()
+                    .filter(|fixture| fixture.kind == SemanticPackV1FixtureKind::Positive)
+                    .count(),
+                hard_negatives: compiled
+                    .conformance_fixtures()
+                    .iter()
+                    .filter(|fixture| fixture.kind == SemanticPackV1FixtureKind::HardNegative)
+                    .count(),
             },
             api_version: Some(SEMANTIC_PACK_API_VERSION_V1),
             semantic_digest: Some(compiled.semantic_digest().to_string()),

--- a/crates/nose-semantics/src/packs/evidence_index.rs
+++ b/crates/nose-semantics/src/packs/evidence_index.rs
@@ -8,6 +8,7 @@ use super::*;
 use nose_il::{Corpus, EvidenceId, Span};
 use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 mod maven;
 mod occurrences;
@@ -114,6 +115,24 @@ impl SemanticPackEvidenceIndex {
                     builder.push_row(pack, contract, corpus);
                 }
             }
+        }
+        builder.finish()
+    }
+
+    /// Build the same dependency/occurrence evidence used by product queries for
+    /// one declared source-conformance row. This does not authorize product
+    /// influence; it exists only so the CLI's kernel runner can exercise the
+    /// normal matcher and admission path before issuing a receipt.
+    pub fn build_for_conformance(
+        pack: &CompiledSemanticPackV1,
+        row_id: &str,
+        dependency_paths: &[PathBuf],
+        corpus: &Corpus,
+    ) -> Self {
+        let mut builder =
+            EvidenceIndexBuilder::new(MavenCatalog::from_conformance_paths(dependency_paths));
+        if let Some(contract) = pack.contracts_by_id().get(row_id) {
+            builder.push_row(pack, contract, corpus);
         }
         builder.finish()
     }

--- a/crates/nose-semantics/src/packs/evidence_index/maven.rs
+++ b/crates/nose-semantics/src/packs/evidence_index/maven.rs
@@ -1,6 +1,7 @@
 use super::{SemanticPackDependencyEvidence, SemanticPackDependencyEvidenceId};
 use crate::{
     SemanticPackDependencySource, SemanticPackV1Authorization, SemanticPackV1PackageEcosystem,
+    MAX_SEMANTIC_PACK_DEPENDENCY_BYTES,
 };
 use quick_xml::events::Event;
 use quick_xml::Reader;
@@ -9,7 +10,6 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 
-const MAX_POM_BYTES: usize = 2 * 1024 * 1024;
 const MAX_XML_DEPTH: usize = 64;
 const MAX_PROPERTY_EXPANSIONS: usize = 16;
 
@@ -69,6 +69,16 @@ impl MavenCatalog {
         catalog
     }
 
+    pub(super) fn from_conformance_paths(paths: &[std::path::PathBuf]) -> Self {
+        let mut catalog = Self::default();
+        for path in paths {
+            let Ok(bytes) = fs::read(path) else { continue };
+            let content_digest = digest(&bytes);
+            catalog.read_bytes(&bytes, &path.to_string_lossy(), &content_digest);
+        }
+        catalog
+    }
+
     pub(super) fn resolve(&self, coordinate: &str, requirement: &str) -> MavenResolution {
         let Some(declarations) = self.declarations.get(coordinate) else {
             return MavenResolution::Missing;
@@ -120,18 +130,25 @@ impl MavenCatalog {
         let Ok(bytes) = fs::read(file.resolved_path()) else {
             return;
         };
-        if bytes.len() > MAX_POM_BYTES || digest(&bytes) != file.content_digest() {
+        if digest(&bytes) != file.content_digest() {
             return;
         }
-        let Ok(text) = std::str::from_utf8(&bytes) else {
+        self.read_bytes(&bytes, file.declared_path(), file.content_digest());
+    }
+
+    fn read_bytes(&mut self, bytes: &[u8], declared_path: &str, content_digest: &str) {
+        if bytes.len() > MAX_SEMANTIC_PACK_DEPENDENCY_BYTES {
+            return;
+        }
+        let Ok(text) = std::str::from_utf8(bytes) else {
             return;
         };
         let Ok(pom) = parse_pom(text) else {
             return;
         };
         let source = SemanticPackDependencySource {
-            declared_path: file.declared_path().to_string(),
-            content_digest: file.content_digest().to_string(),
+            declared_path: declared_path.to_string(),
+            content_digest: content_digest.to_string(),
         };
         for dependency in pom.direct_dependencies() {
             self.declarations

--- a/crates/nose-semantics/src/packs/exact_registry.rs
+++ b/crates/nose-semantics/src/packs/exact_registry.rs
@@ -1,0 +1,313 @@
+//! Query-local kernel evidence and provenance for external-claim exact rows.
+
+use super::*;
+use nose_il::{
+    Corpus, DomainEvidence, EvidenceAnchor, EvidenceId, EvidenceKind, EvidenceProvenance,
+    EvidenceRecord, EvidenceStatus, LibraryApiEvidenceKind, NodeId, NodeKind, Span,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+const EXACT_CAVEATS: &[&str] = &[
+    "external-claim-not-builtin-certification",
+    "provider-claim-user-authorized",
+    "kernel-conformance-receipt",
+    "local-content-pinned",
+];
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SemanticPackExternalExactProvenance {
+    pub pack_id: String,
+    pub row_id: String,
+    pub semantic_digest: String,
+    pub row_digest: String,
+    pub lane: SemanticPackV1Channel,
+    pub assurance: String,
+    pub trust: String,
+    pub dependency: SemanticPackNearDependency,
+    pub receipt_digest: String,
+    pub occurrence_file: String,
+    pub call_start_line: u32,
+    pub call_end_line: u32,
+    pub caveats: Vec<String>,
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct SemanticPackExternalExactPackCounts {
+    pub selected_rows: usize,
+    pub admitted_rows: usize,
+    pub rejected_rows: usize,
+    pub admitted_occurrences: usize,
+    pub influential_occurrences: usize,
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct SemanticPackExternalExactReport {
+    packs: BTreeMap<String, SemanticPackExternalExactPackCounts>,
+}
+
+impl SemanticPackExternalExactReport {
+    pub fn pack(&self, pack_id: &str) -> Option<&SemanticPackExternalExactPackCounts> {
+        self.packs.get(pack_id)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct ExactOccurrence {
+    span: Span,
+    arity: u16,
+    provenance: SemanticPackExternalExactProvenance,
+    dependencies: Vec<EvidenceId>,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct SemanticPackExternalExactRegistry {
+    by_file: BTreeMap<String, Vec<ExactOccurrence>>,
+    report: SemanticPackExternalExactReport,
+}
+
+impl SemanticPackExternalExactRegistry {
+    pub fn build(
+        packs: &SemanticPackSet,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &Corpus,
+    ) -> Self {
+        let mut registry = Self::default();
+        for row in evidence
+            .rows()
+            .iter()
+            .filter(|row| row.channel == SemanticPackV1Channel::ExternalExact)
+        {
+            let Some(authorization) = packs.external_v1_authorization(&row.pack_id) else {
+                continue;
+            };
+            let Some(receipt) = authorization.exact_receipt() else {
+                continue;
+            };
+            registry.index_row(
+                packs,
+                evidence,
+                corpus,
+                row,
+                receipt.content_digest().to_string(),
+            );
+        }
+        registry.finish()
+    }
+
+    pub fn build_for_conformance(
+        pack: &CompiledSemanticPackV1,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &Corpus,
+    ) -> Self {
+        let mut registry = Self::default();
+        for row in evidence
+            .rows()
+            .iter()
+            .filter(|row| row.channel == SemanticPackV1Channel::ExternalExact)
+        {
+            registry.index_compiled_row(
+                pack,
+                evidence,
+                corpus,
+                row,
+                "kernel-conformance-run".to_string(),
+            );
+        }
+        registry.finish()
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.by_file.is_empty()
+    }
+
+    pub fn apply(&self, corpus: &mut Corpus) {
+        for il in &mut corpus.files {
+            let Some(occurrences) = self.by_file.get(&il.meta.path) else {
+                continue;
+            };
+            let mut next_id = il
+                .evidence
+                .iter()
+                .map(|record| record.id.0)
+                .max()
+                .unwrap_or(0)
+                .saturating_add(1);
+            for occurrence in occurrences {
+                let Some(call) =
+                    (0..il.nodes.len())
+                        .map(|index| NodeId(index as u32))
+                        .find(|&node| {
+                            il.kind(node) == NodeKind::Call && il.node(node).span == occurrence.span
+                        })
+                else {
+                    continue;
+                };
+                let api_id = EvidenceId(next_id);
+                il.evidence.push(EvidenceRecord::new(
+                    api_id,
+                    EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+                    EvidenceKind::LibraryApi(LibraryApiEvidenceKind::ExternalCollectionFactory {
+                        arity: occurrence.arity,
+                    }),
+                    EvidenceProvenance::external(
+                        &occurrence.provenance.pack_id,
+                        &occurrence.provenance.row_id,
+                    ),
+                    occurrence.dependencies.clone(),
+                    EvidenceStatus::Asserted,
+                ));
+                next_id = next_id.saturating_add(1);
+                il.evidence.push(EvidenceRecord::new(
+                    EvidenceId(next_id),
+                    EvidenceAnchor::node(il.node(call).span, NodeKind::Call),
+                    EvidenceKind::Domain(DomainEvidence::Collection),
+                    EvidenceProvenance::external(
+                        &occurrence.provenance.pack_id,
+                        &occurrence.provenance.row_id,
+                    ),
+                    vec![api_id],
+                    EvidenceStatus::Asserted,
+                ));
+                next_id = next_id.saturating_add(1);
+            }
+        }
+    }
+
+    pub fn claims_for_unit(
+        &self,
+        path: &str,
+        start_line: u32,
+        end_line: u32,
+    ) -> Vec<SemanticPackExternalExactProvenance> {
+        let Some(occurrences) = self.by_file.get(path) else {
+            return Vec::new();
+        };
+        let mut claims = occurrences
+            .iter()
+            .filter(|occurrence| {
+                start_line <= occurrence.span.start_line && occurrence.span.end_line <= end_line
+            })
+            .map(|occurrence| occurrence.provenance.clone())
+            .collect::<Vec<_>>();
+        claims.sort();
+        claims.dedup();
+        claims
+    }
+
+    pub fn report_with_influential<'a>(
+        &self,
+        influential: impl IntoIterator<Item = &'a SemanticPackExternalExactProvenance>,
+    ) -> SemanticPackExternalExactReport {
+        let mut report = self.report.clone();
+        for provenance in influential.into_iter().collect::<BTreeSet<_>>() {
+            if let Some(counts) = report.packs.get_mut(&provenance.pack_id) {
+                counts.influential_occurrences += 1;
+            }
+        }
+        report
+    }
+
+    fn index_row(
+        &mut self,
+        packs: &SemanticPackSet,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &Corpus,
+        row: &SemanticPackEvidenceRow,
+        receipt_digest: String,
+    ) {
+        let Some(pack) = packs
+            .compiled_external_v1_packs()
+            .iter()
+            .find(|pack| pack.pack_id() == row.pack_id)
+        else {
+            return;
+        };
+        self.index_compiled_row(pack, evidence, corpus, row, receipt_digest);
+    }
+
+    fn index_compiled_row(
+        &mut self,
+        pack: &CompiledSemanticPackV1,
+        evidence: &SemanticPackEvidenceIndex,
+        corpus: &Corpus,
+        row: &SemanticPackEvidenceRow,
+        receipt_digest: String,
+    ) {
+        let counts = self.report.packs.entry(row.pack_id.clone()).or_default();
+        counts.selected_rows += 1;
+        let Some(contract) = pack.contracts_by_id().get(&row.row_id) else {
+            counts.rejected_rows += 1;
+            return;
+        };
+        if row.blocker.is_some()
+            || contract.operation != SemanticPackV1ProtocolOperation::CollectionFactory
+            || contract.channel != SemanticPackV1Channel::ExternalExact
+        {
+            counts.rejected_rows += 1;
+            return;
+        }
+        counts.admitted_rows += 1;
+        for occurrence in evidence.occurrences_for_row(&row.pack_id, &row.row_id) {
+            let Some(dependency) = evidence.dependency(occurrence.dependency) else {
+                continue;
+            };
+            let Some(file) = corpus.files.get(occurrence.call_span.file.0 as usize) else {
+                continue;
+            };
+            let mut dependencies = vec![occurrence.import_evidence, occurrence.symbol_evidence];
+            dependencies.extend(occurrence.receiver_evidence);
+            dependencies.extend(occurrence.effect_evidence.iter().copied());
+            dependencies.extend(occurrence.call_target_evidence.iter().copied());
+            dependencies.extend(occurrence.domain_evidence.iter().copied());
+            dependencies.extend(occurrence.place_evidence.iter().copied());
+            dependencies.sort_by_key(|id| id.0);
+            dependencies.dedup();
+            counts.admitted_occurrences += 1;
+            self.by_file
+                .entry(file.meta.path.clone())
+                .or_default()
+                .push(ExactOccurrence {
+                    span: occurrence.call_span,
+                    arity: occurrence.arity,
+                    provenance: SemanticPackExternalExactProvenance {
+                        pack_id: row.pack_id.clone(),
+                        row_id: row.row_id.clone(),
+                        semantic_digest: row.semantic_digest.clone(),
+                        row_digest: row.row_digest.clone(),
+                        lane: SemanticPackV1Channel::ExternalExact,
+                        assurance: "external-claim-exact".to_string(),
+                        trust: PackTrust::ExternalOptIn.as_manifest_str().to_string(),
+                        dependency: SemanticPackNearDependency {
+                            coordinate: dependency.coordinate.clone(),
+                            declared_version: dependency.declared_version.clone(),
+                            matched_version: dependency.matched_version.clone(),
+                            sources: dependency.sources.clone(),
+                        },
+                        receipt_digest: receipt_digest.clone(),
+                        occurrence_file: file.meta.path.clone(),
+                        call_start_line: occurrence.call_span.start_line,
+                        call_end_line: occurrence.call_span.end_line,
+                        caveats: EXACT_CAVEATS
+                            .iter()
+                            .map(|caveat| (*caveat).to_string())
+                            .collect(),
+                    },
+                    dependencies,
+                });
+        }
+    }
+
+    fn finish(mut self) -> Self {
+        for occurrences in self.by_file.values_mut() {
+            occurrences.sort_by(|left, right| {
+                (left.span.start_byte, left.span.end_byte, &left.provenance).cmp(&(
+                    right.span.start_byte,
+                    right.span.end_byte,
+                    &right.provenance,
+                ))
+            });
+            occurrences.dedup();
+        }
+        self
+    }
+}

--- a/crates/nose-semantics/src/packs/lock.rs
+++ b/crates/nose-semantics/src/packs/lock.rs
@@ -148,14 +148,26 @@ impl ValidatedSemanticPackProjectLock {
 
     pub fn into_semantic_packs(mut self) -> SemanticPackSet {
         for pack in &mut self.semantic_packs.packs {
-            if self.authorizations.iter().any(|authorization| {
-                authorization.pack_id == pack.id
-                    && authorization
-                        .allowed_channels
-                        .binary_search(&SemanticPackV1Channel::Near)
-                        .is_ok()
-            }) {
-                pack.influence = super::SemanticPackInfluence::NearOnly;
+            if let Some(authorization) = self
+                .authorizations
+                .iter()
+                .find(|authorization| authorization.pack_id == pack.id)
+            {
+                pack.influence = if authorization
+                    .allowed_channels
+                    .binary_search(&SemanticPackV1Channel::ExternalExact)
+                    .is_ok()
+                {
+                    super::SemanticPackInfluence::ExternalClaimExact
+                } else if authorization
+                    .allowed_channels
+                    .binary_search(&SemanticPackV1Channel::Near)
+                    .is_ok()
+                {
+                    super::SemanticPackInfluence::NearOnly
+                } else {
+                    super::SemanticPackInfluence::MetadataOnly
+                };
             }
         }
         self.semantic_packs.external_v1_authorizations = self

--- a/crates/nose-semantics/src/packs/lock/validation.rs
+++ b/crates/nose-semantics/src/packs/lock/validation.rs
@@ -2,8 +2,9 @@ use super::paths::*;
 use super::version_ranges::requirements_may_overlap;
 use super::*;
 use crate::packs::{
-    discover_manifest_paths, CompiledSemanticPackV1, SemanticPackV1Arity, SemanticPackV1ArityKind,
-    SemanticPackV1Contract, SEMANTIC_PACK_API_VERSION_V1,
+    discover_manifest_paths, read_semantic_pack_conformance_receipt,
+    validate_semantic_pack_conformance_receipt, CompiledSemanticPackV1, SemanticPackV1Arity,
+    SemanticPackV1ArityKind, SemanticPackV1Contract, SEMANTIC_PACK_API_VERSION_V1,
 };
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -348,6 +349,13 @@ fn validate_authorizations(
             .as_ref()
             .map(|pin| validate_pin(root, pin, lock_path))
             .transpose()?;
+        validate_exact_receipt(
+            entry,
+            pack,
+            &resolved_manifest,
+            exact_receipt.as_ref(),
+            lock_path,
+        )?;
         authorizations.push(SemanticPackV1Authorization {
             pack_id: entry.pack_id.clone(),
             allowed_channels: entry.allowed_channels.clone(),
@@ -357,6 +365,57 @@ fn validate_authorizations(
         });
     }
     Ok(authorizations)
+}
+
+fn validate_exact_receipt(
+    entry: &SemanticPackLockedEntryV1,
+    pack: &CompiledSemanticPackV1,
+    manifest_path: &Path,
+    receipt_file: Option<&SemanticPackLockedFile>,
+    lock_path: &Path,
+) -> Result<(), SemanticPackLockError> {
+    let exact_rows = entry
+        .selected_rows
+        .iter()
+        .filter(|row_id| {
+            pack.contracts_by_id()[*row_id].channel == SemanticPackV1Channel::ExternalExact
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if exact_rows.is_empty() {
+        if receipt_file.is_some() {
+            return invalid(
+                lock_path,
+                format!(
+                    "pack `{}` pins an exact receipt without a selected external-exact row",
+                    entry.pack_id
+                ),
+            );
+        }
+        return Ok(());
+    }
+    let receipt_file = receipt_file.ok_or_else(|| SemanticPackLockError::Invalid {
+        path: lock_path.to_path_buf(),
+        message: format!(
+            "pack `{}` selects external-exact rows but has no exact conformance receipt",
+            entry.pack_id
+        ),
+    })?;
+    let receipt = read_semantic_pack_conformance_receipt(receipt_file.resolved_path()).map_err(
+        |message| SemanticPackLockError::Invalid {
+            path: lock_path.to_path_buf(),
+            message,
+        },
+    )?;
+    validate_semantic_pack_conformance_receipt(&receipt, pack, manifest_path, &exact_rows).map_err(
+        |message| SemanticPackLockError::Invalid {
+            path: lock_path.to_path_buf(),
+            message: format!(
+                "pack `{}` exact receipt is invalid: {message}",
+                entry.pack_id
+            ),
+        },
+    )
 }
 
 fn validate_entry_identity(

--- a/crates/nose-semantics/src/packs/receipt.rs
+++ b/crates/nose-semantics/src/packs/receipt.rs
@@ -1,0 +1,319 @@
+//! Kernel conformance receipts for the external-claim exact lane.
+
+use super::{
+    CompiledSemanticPackV1, SemanticPackV1Channel, SemanticPackV1Expectation,
+    SemanticPackV1FixtureKind,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+pub const SEMANTIC_PACK_RECEIPT_API_VERSION_V1: &str = "nose.semantic-pack-conformance-receipt.v1";
+pub const SEMANTIC_PACK_EXACT_KERNEL_CAPABILITY_V1: &str =
+    "nose.kernel.external-collection-factory-exact.v1";
+pub const MAX_SEMANTIC_PACK_FIXTURE_FILES: usize = 64;
+pub const MAX_SEMANTIC_PACK_FIXTURE_BYTES: usize = 1024 * 1024;
+pub const MAX_SEMANTIC_PACK_DEPENDENCY_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackConformanceReceiptV1 {
+    pub api_version: String,
+    pub nose_version: String,
+    pub kernel_capability: String,
+    pub pack_id: String,
+    pub pack_version: String,
+    pub semantic_digest: String,
+    pub rows: Vec<SemanticPackConformanceReceiptRow>,
+    pub fixtures: Vec<SemanticPackConformanceReceiptFixture>,
+    pub passed: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackConformanceReceiptRow {
+    pub row_id: String,
+    pub row_digest: String,
+    pub channel: SemanticPackV1Channel,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1ObservedExpectation {
+    ExternalExactMatch,
+    NoExternalExactMatch,
+    ResourceLimit,
+    AnalysisFailure,
+}
+
+impl SemanticPackV1ObservedExpectation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExternalExactMatch => "external-exact-match",
+            Self::NoExternalExactMatch => "no-external-exact-match",
+            Self::ResourceLimit => "resource-limit",
+            Self::AnalysisFailure => "analysis-failure",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackConformanceReceiptFixture {
+    pub id: String,
+    pub row_id: String,
+    pub kind: SemanticPackV1FixtureKind,
+    pub path: String,
+    pub dependency: String,
+    pub fixture_digest: String,
+    pub dependency_digest: String,
+    pub expectation: SemanticPackV1Expectation,
+    pub observed: SemanticPackV1ObservedExpectation,
+    pub passed: bool,
+}
+
+pub fn read_semantic_pack_conformance_receipt(
+    path: &Path,
+) -> Result<SemanticPackConformanceReceiptV1, String> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        format!(
+            "reading exact conformance receipt {}: {error}",
+            path.display()
+        )
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        format!(
+            "parsing exact conformance receipt {}: {error}",
+            path.display()
+        )
+    })
+}
+
+pub fn validate_semantic_pack_conformance_receipt(
+    receipt: &SemanticPackConformanceReceiptV1,
+    pack: &CompiledSemanticPackV1,
+    manifest_path: &Path,
+    selected_exact_rows: &[String],
+) -> Result<(), String> {
+    if receipt.api_version != SEMANTIC_PACK_RECEIPT_API_VERSION_V1
+        || receipt.nose_version != env!("CARGO_PKG_VERSION")
+        || receipt.kernel_capability != SEMANTIC_PACK_EXACT_KERNEL_CAPABILITY_V1
+        || receipt.pack_id != pack.pack_id()
+        || receipt.pack_version != pack.pack_version()
+        || receipt.semantic_digest != pack.semantic_digest()
+        || !receipt.passed
+    {
+        return Err("receipt identity, kernel capability, or pass status is stale".to_string());
+    }
+    let mut expected_rows = selected_exact_rows.to_vec();
+    expected_rows.sort();
+    expected_rows.dedup();
+    let mut actual_rows = receipt.rows.clone();
+    actual_rows.sort_by(|left, right| left.row_id.cmp(&right.row_id));
+    if actual_rows.len() != expected_rows.len() {
+        return Err("receipt rows do not match the selected external-exact rows".to_string());
+    }
+    for (actual, row_id) in actual_rows.iter().zip(&expected_rows) {
+        if actual.row_id != *row_id
+            || actual.channel != SemanticPackV1Channel::ExternalExact
+            || pack.row_digest(row_id) != Some(actual.row_digest.as_str())
+        {
+            return Err(format!("receipt row `{row_id}` is stale or mismatched"));
+        }
+    }
+    validate_receipt_fixtures(receipt, pack, manifest_path, &expected_rows)
+}
+
+fn validate_receipt_fixtures(
+    receipt: &SemanticPackConformanceReceiptV1,
+    pack: &CompiledSemanticPackV1,
+    manifest_path: &Path,
+    selected_rows: &[String],
+) -> Result<(), String> {
+    let root = manifest_path
+        .parent()
+        .ok_or_else(|| "semantic-pack manifest has no parent directory".to_string())?;
+    let expected = pack
+        .conformance_fixtures()
+        .iter()
+        .filter(|fixture| selected_rows.binary_search(&fixture.row_id).is_ok())
+        .collect::<Vec<_>>();
+    if receipt.fixtures.len() != expected.len() {
+        return Err("receipt fixtures do not match the manifest".to_string());
+    }
+    for fixture in expected {
+        let actual = receipt
+            .fixtures
+            .iter()
+            .find(|actual| actual.id == fixture.id)
+            .ok_or_else(|| format!("receipt is missing fixture `{}`", fixture.id))?;
+        let observed_matches = matches!(
+            (actual.expectation, actual.observed),
+            (
+                SemanticPackV1Expectation::ExternalExactMatch,
+                SemanticPackV1ObservedExpectation::ExternalExactMatch
+            ) | (
+                SemanticPackV1Expectation::NoExternalExactMatch,
+                SemanticPackV1ObservedExpectation::NoExternalExactMatch
+            )
+        );
+        if actual.row_id != fixture.row_id
+            || actual.kind != fixture.kind
+            || actual.path != fixture.path
+            || actual.dependency != fixture.dependency
+            || actual.expectation != fixture.expectation
+            || !actual.passed
+            || !observed_matches
+        {
+            return Err(format!(
+                "receipt fixture `{}` is stale or mismatched",
+                fixture.id
+            ));
+        }
+        let fixture_path = resolve_fixture_path(root, &fixture.path)?;
+        let dependency_path = resolve_fixture_path(root, &fixture.dependency)?;
+        if semantic_pack_fixture_digest(&fixture_path)? != actual.fixture_digest
+            || semantic_pack_file_digest(&dependency_path)? != actual.dependency_digest
+        {
+            return Err(format!("receipt fixture `{}` content changed", fixture.id));
+        }
+    }
+    Ok(())
+}
+
+pub fn resolve_fixture_path(root: &Path, declared: &str) -> Result<PathBuf, String> {
+    let root = root
+        .canonicalize()
+        .map_err(|error| format!("resolving semantic-pack root {}: {error}", root.display()))?;
+    reject_symlink_components(&root, declared)?;
+    let path = root.join(declared);
+    let resolved = path
+        .canonicalize()
+        .map_err(|error| format!("resolving conformance path {}: {error}", path.display()))?;
+    if !resolved.starts_with(&root) {
+        return Err(format!(
+            "conformance path `{declared}` escapes the pack root"
+        ));
+    }
+    Ok(resolved)
+}
+
+fn reject_symlink_components(root: &Path, declared: &str) -> Result<(), String> {
+    let mut path = root.to_path_buf();
+    for component in Path::new(declared).components() {
+        use std::path::Component;
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(part) => path.push(part),
+            _ => return Err(format!("conformance path `{declared}` is not relative")),
+        }
+        let metadata = std::fs::symlink_metadata(&path)
+            .map_err(|error| format!("reading conformance path {}: {error}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "conformance path `{declared}` must not contain symlinks"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn semantic_pack_file_digest(path: &Path) -> Result<String, String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| format!("reading conformance file {}: {error}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "conformance dependency {} is not a regular file",
+            path.display()
+        ));
+    }
+    if metadata.len() > MAX_SEMANTIC_PACK_DEPENDENCY_BYTES as u64 {
+        return Err(format!(
+            "dependency exceeds {MAX_SEMANTIC_PACK_DEPENDENCY_BYTES} bytes"
+        ));
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|error| format!("reading conformance file {}: {error}", path.display()))?;
+    Ok(digest(&bytes))
+}
+
+pub fn semantic_pack_fixture_digest(path: &Path) -> Result<String, String> {
+    let mut files = Vec::new();
+    collect_files(path, path, &mut files)?;
+    if files.is_empty() || files.len() > MAX_SEMANTIC_PACK_FIXTURE_FILES {
+        return Err(format!(
+            "fixture must contain 1..={MAX_SEMANTIC_PACK_FIXTURE_FILES} regular files"
+        ));
+    }
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut total = 0usize;
+    let mut hasher = Sha256::new();
+    for (relative, file) in files {
+        let bytes = std::fs::read(&file)
+            .map_err(|error| format!("reading fixture file {}: {error}", file.display()))?;
+        total = total.saturating_add(bytes.len());
+        if total > MAX_SEMANTIC_PACK_FIXTURE_BYTES {
+            return Err(format!(
+                "fixture exceeds {MAX_SEMANTIC_PACK_FIXTURE_BYTES} bytes"
+            ));
+        }
+        hasher.update((relative.len() as u64).to_le_bytes());
+        hasher.update(relative.as_bytes());
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    }
+    Ok(format_digest(hasher.finalize()))
+}
+
+fn collect_files(root: &Path, path: &Path, out: &mut Vec<(String, PathBuf)>) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("reading fixture metadata {}: {error}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "fixture path {} must not contain symlinks",
+            path.display()
+        ));
+    }
+    if metadata.is_file() {
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        out.push((relative, path.to_path_buf()));
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        return Err(format!(
+            "fixture path {} is not a file or directory",
+            path.display()
+        ));
+    }
+    let mut entries = std::fs::read_dir(path)
+        .map_err(|error| format!("reading fixture directory {}: {error}", path.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("reading fixture directory {}: {error}", path.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        if out.len() >= MAX_SEMANTIC_PACK_FIXTURE_FILES {
+            return Err(format!(
+                "fixture exceeds {MAX_SEMANTIC_PACK_FIXTURE_FILES} files"
+            ));
+        }
+        collect_files(root, &entry.path(), out)?;
+    }
+    Ok(())
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format_digest(Sha256::digest(bytes))
+}
+
+fn format_digest(bytes: impl IntoIterator<Item = u8>) -> String {
+    let mut hex = String::with_capacity(64);
+    for byte in bytes {
+        write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    format!("sha256:{hex}")
+}

--- a/crates/nose-semantics/src/packs/v1.rs
+++ b/crates/nose-semantics/src/packs/v1.rs
@@ -17,6 +17,8 @@ pub(super) struct SemanticPackManifestV1 {
     pub(super) supported_languages: Vec<SemanticPackV1Language>,
     pub(super) packages: Vec<SemanticPackV1Package>,
     pub(super) declares: ManifestV1Declares,
+    #[serde(default)]
+    pub(super) conformance: Option<SemanticPackV1Conformance>,
 }
 
 #[derive(Clone, Deserialize)]
@@ -66,6 +68,55 @@ pub(super) struct ManifestV1Compatibility {
 #[serde(deny_unknown_fields)]
 pub(super) struct ManifestV1Declares {
     pub(super) api_contracts: Vec<SemanticPackV1Contract>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1Conformance {
+    pub fixtures: Vec<SemanticPackV1ConformanceFixture>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1FixtureKind {
+    Positive,
+    HardNegative,
+}
+
+impl SemanticPackV1FixtureKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Positive => "positive",
+            Self::HardNegative => "hard-negative",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticPackV1Expectation {
+    ExternalExactMatch,
+    NoExternalExactMatch,
+}
+
+impl SemanticPackV1Expectation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExternalExactMatch => "external-exact-match",
+            Self::NoExternalExactMatch => "no-external-exact-match",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticPackV1ConformanceFixture {
+    pub id: String,
+    pub row_id: String,
+    pub kind: SemanticPackV1FixtureKind,
+    pub path: String,
+    pub dependency: String,
+    pub expectation: SemanticPackV1Expectation,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
@@ -272,6 +323,7 @@ pub struct CompiledSemanticPackV1 {
     contracts_by_id: BTreeMap<String, SemanticPackV1Contract>,
     contract_ids_by_coordinate: BTreeMap<SemanticPackV1Coordinate, Vec<String>>,
     contract_ids_by_operation: BTreeMap<SemanticPackV1ProtocolOperation, Vec<String>>,
+    conformance_fixtures: Vec<SemanticPackV1ConformanceFixture>,
 }
 
 impl CompiledSemanticPackV1 {
@@ -313,6 +365,10 @@ impl CompiledSemanticPackV1 {
         &self,
     ) -> &BTreeMap<SemanticPackV1ProtocolOperation, Vec<String>> {
         &self.contract_ids_by_operation
+    }
+
+    pub fn conformance_fixtures(&self) -> &[SemanticPackV1ConformanceFixture] {
+        &self.conformance_fixtures
     }
 }
 

--- a/crates/nose-semantics/src/packs/v1/compiler.rs
+++ b/crates/nose-semantics/src/packs/v1/compiler.rs
@@ -58,6 +58,11 @@ pub(in crate::packs) fn compile_manifest_v1(
         contracts_by_id,
         contract_ids_by_coordinate,
         contract_ids_by_operation,
+        conformance_fixtures: manifest
+            .conformance
+            .as_ref()
+            .map(|conformance| conformance.fixtures.clone())
+            .unwrap_or_default(),
     })
 }
 
@@ -159,7 +164,8 @@ fn validate_manifest_v1(manifest: &SemanticPackManifestV1) -> Result<(), String>
     )?;
     validate_version_requirement("compatibility.nose", &manifest.compatibility.nose, true)?;
     validate_targets(manifest)?;
-    validate_contracts(manifest)
+    validate_contracts(manifest)?;
+    validate_conformance(manifest)
 }
 
 fn validate_targets(manifest: &SemanticPackManifestV1) -> Result<(), String> {
@@ -243,6 +249,7 @@ fn validate_contracts(manifest: &SemanticPackManifestV1) -> Result<(), String> {
         validate_call_shape(contract)?;
         contract.call.arity.validate(&contract.id)?;
         validate_operation_domain(contract)?;
+        validate_external_exact_contract(contract)?;
         let mut arity = contract.call.arity.clone();
         arity.canonicalize();
         let exact_key = (contract.coordinate(), arity);
@@ -252,6 +259,112 @@ fn validate_contracts(manifest: &SemanticPackManifestV1) -> Result<(), String> {
                 contract.id
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_external_exact_contract(contract: &SemanticPackV1Contract) -> Result<(), String> {
+    if contract.channel != SemanticPackV1Channel::ExternalExact {
+        return Ok(());
+    }
+    if contract.operation != SemanticPackV1ProtocolOperation::CollectionFactory {
+        return Err(format!(
+            "contract `{}` requests external exact for an operation outside the v1 kernel perimeter",
+            contract.id
+        ));
+    }
+    let profiles = contract.profiles;
+    if profiles.demand != SemanticPackV1DemandProfile::Eager
+        || profiles.effects != SemanticPackV1EffectProfile::Pure
+        || profiles.exceptions != SemanticPackV1ExceptionProfile::NoThrow
+        || profiles.mutation != SemanticPackV1MutationProfile::None
+        || profiles.identity != SemanticPackV1IdentityProfile::Fresh
+    {
+        return Err(format!(
+            "contract `{}` external exact requires eager, pure, no-throw, non-mutating, fresh semantics",
+            contract.id
+        ));
+    }
+    Ok(())
+}
+
+fn validate_conformance(manifest: &SemanticPackManifestV1) -> Result<(), String> {
+    let exact_rows = manifest
+        .declares
+        .api_contracts
+        .iter()
+        .filter(|contract| contract.channel == SemanticPackV1Channel::ExternalExact)
+        .map(|contract| contract.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let fixtures = manifest
+        .conformance
+        .as_ref()
+        .map(|conformance| conformance.fixtures.as_slice())
+        .unwrap_or_default();
+    if exact_rows.is_empty() {
+        if fixtures.is_empty() {
+            return Ok(());
+        }
+        return Err("`conformance.fixtures` requires an external-exact row".to_string());
+    }
+    let mut ids = BTreeSet::new();
+    let mut coverage = BTreeMap::<&str, (usize, usize)>::new();
+    for fixture in fixtures {
+        require_stable_id("conformance.fixtures[].id", &fixture.id)?;
+        if !ids.insert(fixture.id.as_str()) {
+            return Err(format!("duplicate conformance fixture id `{}`", fixture.id));
+        }
+        if !exact_rows.contains(fixture.row_id.as_str()) {
+            return Err(format!(
+                "fixture `{}` references non-external-exact row `{}`",
+                fixture.id, fixture.row_id
+            ));
+        }
+        validate_relative_path("conformance.fixtures[].path", &fixture.path)?;
+        validate_relative_path("conformance.fixtures[].dependency", &fixture.dependency)?;
+        let expected = match fixture.kind {
+            SemanticPackV1FixtureKind::Positive => SemanticPackV1Expectation::ExternalExactMatch,
+            SemanticPackV1FixtureKind::HardNegative => {
+                SemanticPackV1Expectation::NoExternalExactMatch
+            }
+        };
+        if fixture.expectation != expected {
+            return Err(format!(
+                "fixture `{}` kind and expectation disagree",
+                fixture.id
+            ));
+        }
+        let counts = coverage.entry(&fixture.row_id).or_default();
+        match fixture.kind {
+            SemanticPackV1FixtureKind::Positive => counts.0 += 1,
+            SemanticPackV1FixtureKind::HardNegative => counts.1 += 1,
+        }
+    }
+    for row_id in exact_rows {
+        if coverage.get(row_id).copied().unwrap_or_default().0 == 0
+            || coverage.get(row_id).copied().unwrap_or_default().1 == 0
+        {
+            return Err(format!(
+                "external-exact row `{row_id}` requires positive and hard-negative source fixtures"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_path(label: &str, value: &str) -> Result<(), String> {
+    use std::path::{Component, Path};
+    let path = Path::new(value);
+    if value.is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(format!("`{label}` must be a non-escaping relative path"));
     }
     Ok(())
 }

--- a/crates/nose-semantics/src/packs/v1/tests.rs
+++ b/crates/nose-semantics/src/packs/v1/tests.rs
@@ -150,13 +150,44 @@ fn every_supported_semantic_change_changes_the_digest() {
             "\"exceptions\":\"may-throw\"",
             "\"exceptions\":\"no-throw\"",
         ),
-        original.replace("\"channel\":\"near\"", "\"channel\":\"external-exact\""),
     ];
 
     for candidate in changed {
         let compiled = parse_and_compile(&candidate).expect("changed manifest remains valid");
         assert_ne!(baseline.semantic_digest(), compiled.semantic_digest());
     }
+}
+
+#[test]
+fn external_exact_requires_closed_profiles_and_source_fixture_coverage() {
+    let baseline = parse_and_compile(&manifest_json()).unwrap();
+    let mut value: serde_json::Value = serde_json::from_str(&manifest_json()).unwrap();
+    value["declares"]["api_contracts"][0]["channel"] = serde_json::json!("external-exact");
+    value["declares"]["api_contracts"][0]["profiles"]["exceptions"] = serde_json::json!("no-throw");
+    value["conformance"] = serde_json::json!({
+        "fixtures": [{
+            "id": "positive",
+            "row_id": "java.guava.immutable-list.of",
+            "kind": "positive",
+            "path": "fixtures/positive",
+            "dependency": "pom.xml",
+            "expectation": "external-exact-match"
+        }, {
+            "id": "negative",
+            "row_id": "java.guava.immutable-list.of",
+            "kind": "hard-negative",
+            "path": "fixtures/negative",
+            "dependency": "pom.xml",
+            "expectation": "no-external-exact-match"
+        }]
+    });
+    let exact = parse_and_compile(&serde_json::to_string(&value).unwrap()).unwrap();
+    assert_ne!(baseline.semantic_digest(), exact.semantic_digest());
+    assert_eq!(exact.conformance_fixtures().len(), 2);
+
+    value["declares"]["api_contracts"][0]["profiles"]["exceptions"] =
+        serde_json::json!("may-throw");
+    assert!(parse_and_compile(&serde_json::to_string(&value).unwrap()).is_err());
 }
 
 #[test]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -26,7 +26,7 @@ nose capabilities
 
 ```json
 {
-  "schema_version": 6,
+  "schema_version": 7,
   "tool": {
     "name": "nose",
     "version": "<version>"
@@ -46,15 +46,16 @@ nose capabilities
     "deprecated": []
   },
   "schemas": {
-    "capabilities": [6],
+    "capabilities": [7],
     "query_json": [7, 8],
     "semantic_packs": ["nose.semantic-pack.v0", "nose.semantic-pack.v1"],
     "semantic_pack_locks": ["nose.semantic-pack-lock.v1"],
+    "semantic_pack_receipts": ["nose.semantic-pack-conformance-receipt.v1"],
     "semantic_pack_lock_status": [1],
-    "semantic_pack_conformance": [3],
+    "semantic_pack_conformance": [4],
     "semantic_pack_inventory": [1],
-    "semantic_pack_adoption_gates": [1],
-    "semantic_pack_compatibility": [1]
+    "semantic_pack_adoption_gates": [2],
+    "semantic_pack_compatibility": [2]
   },
   "query": {
     "modes": ["syntax", "semantic", "near"],
@@ -89,6 +90,8 @@ nose capabilities
       "query_base_structured_ignores": true,
       "reinvented_view": true,
       "semantic_pack_dependency_evidence": true,
+      "semantic_pack_external_claim_exact": true,
+      "semantic_pack_kernel_conformance_receipt": true,
       "semantic_pack_locked_near_influence": true,
       "semantic_pack_loading": true,
       "semantic_pack_project_lock": true,
@@ -108,7 +111,10 @@ nose capabilities
     "project_lock_output_formats": ["human", "json"],
     "conformance": [
       "local-manifest-file",
-      "local-manifest-directory"
+      "local-manifest-directory",
+      "v0-fixture-metadata",
+      "v1-kernel-source-analysis",
+      "receipt-output"
     ],
     "conformance_output_formats": ["human", "json"],
     "inventory": ["compiled-builtin"],
@@ -123,7 +129,8 @@ nose capabilities
       "external-opt-in"
     ],
     "external_packs_enabled_by_default": false,
-    "external_pack_influence": "metadata-or-locked-near-only",
+    "external_pack_influence": "metadata-or-locked-near-or-receipt-backed-external-claim-exact",
+    "external_exact_operations": ["collection-factory"],
     "external_influence_blockers": [
       "data-only-registration",
       "dependency-backed-evidence-unavailable",
@@ -155,11 +162,11 @@ release so it can't drift.
 The JSON example above is compared against `nose capabilities` by the CLI integration test;
 only `tool.version` and the platform values are normalized for the local build.
 
-## Version 6 Fields
+## Version 7 Fields
 
 | field | type | meaning |
 |---|---|---|
-| `schema_version` | integer | Capabilities contract version. Version 6 is documented here. |
+| `schema_version` | integer | Capabilities contract version. Version 7 is documented here. |
 | `tool.name` | string | Always `nose`. |
 | `tool.version` | string | Package version of the installed binary. |
 | `platform.os` | string | Rust target OS name, such as `linux`, `macos`, or `windows`. |
@@ -169,16 +176,17 @@ only `tool.version` and the platform values are normalized for the local build.
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
 | `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query), with its versioned [query-JSON](query-json.md) contract). Hidden research commands are intentionally omitted. |
-| `commands.deprecated` | array | Commands that still work but are being retired. Version 6 reports an empty array. |
+| `commands.deprecated` | array | Commands that still work but are being retired. Version 7 reports an empty array. |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
 | `schemas.query_json` | array | Supported `nose query --format json` schema versions ([query-json](query-json.md)). |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0` and `nose.semantic-pack.v1`. |
 | `schemas.semantic_pack_locks` | array | Supported project-lock API versions, currently `nose.semantic-pack-lock.v1`. |
+| `schemas.semantic_pack_receipts` | array | Supported kernel source-conformance receipt APIs, currently `nose.semantic-pack-conformance-receipt.v1`. |
 | `schemas.semantic_pack_lock_status` | array | Supported `nose semantic-pack status --format json` schemas. |
-| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schema versions. Version 3 adds per-manifest API version and semantic digest reporting to the v0 structural/gate/preflight report and v1 typed compilation check. |
+| `schemas.semantic_pack_conformance` | array | Supported `nose semantic-pack check --format json` schemas. Version 4 adds bounded v1 kernel source-conformance observations and optional receipt output. |
 | `schemas.semantic_pack_inventory` | array | Supported `nose semantic-pack inventory --format json` schema versions. Version 1 reports compiled builtin pack declarations, conformance refs, coverage status, and audit gaps. |
-| `schemas.semantic_pack_adoption_gates` | array | Supported `nose semantic-pack adoption-gates --format json` schema versions. Version 1 reports compiled builtin pack optional/default promotion gates, rollback actions, and blocker status. |
-| `schemas.semantic_pack_compatibility` | array | Supported `nose semantic-pack compatibility --format json` schema versions. Version 1 reports manifest API, installed-version, kernel-vocabulary, and external-influence compatibility policy. |
+| `schemas.semantic_pack_adoption_gates` | array | Supported `nose semantic-pack adoption-gates --format json` schemas. Version 2 updates the external-influence policy for receipt-backed exact claims. |
+| `schemas.semantic_pack_compatibility` | array | Supported `nose semantic-pack compatibility --format json` schemas. Version 2 reports receipt-backed external-claim exact support. |
 | `query.modes` | array | Supported `--mode` values. |
 | `query.default_modes` | array | Modes used by `nose query` when `--mode` is omitted. |
 | `query.output_formats` | array | Supported `nose query --format` values. |
@@ -187,22 +195,23 @@ only `tool.version` and the platform values are normalized for the local build.
 | `query.capabilities` | object | Stable boolean capability flags for query workflows. |
 | `semantic_packs.api_versions` | array | Supported semantic-pack manifest API versions. |
 | `semantic_packs.lock_api_versions` | array | Supported content-pinned project-lock API versions. |
-| `semantic_packs.loading` | array | Supported loading sources. Schema version 6 adds validated local project locks to compiled builtins and local v0/v1 manifest files/directories. |
+| `semantic_packs.loading` | array | Supported loading sources, including validated local project locks. |
 | `semantic_packs.project_lock` | array | Supported local project-lock operations: `create` and `status`. |
 | `semantic_packs.project_lock_output_formats` | array | Supported lock/status report formats. |
 | `semantic_packs.conformance` | array | Supported conformance input sources: local manifest files/directories. |
 | `semantic_packs.conformance_output_formats` | array | Supported `nose semantic-pack check --format` values. |
-| `semantic_packs.inventory` | array | Supported inventory sources. Version 6 reports `compiled-builtin`. |
+| `semantic_packs.inventory` | array | Supported inventory sources. Version 7 reports `compiled-builtin`. |
 | `semantic_packs.inventory_output_formats` | array | Supported `nose semantic-pack inventory --format` values. |
-| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 6 may report `compiled-builtin`; consumers should treat absence as unsupported. |
+| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 7 reports `compiled-builtin`. |
 | `semantic_packs.adoption_gate_output_formats` | array | Supported `nose semantic-pack adoption-gates --format` values. |
-| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 6 may report `policy`; consumers should treat absence as unsupported. |
+| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 7 reports `policy`. |
 | `semantic_packs.compatibility_output_formats` | array | Supported `nose semantic-pack compatibility --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
-| `semantic_packs.external_pack_influence` | string | Current external boundary: unlocked/v0 metadata, or dependency-backed locked v1 near-only influence. |
+| `semantic_packs.external_pack_influence` | string | Current external boundary: unlocked/v0 metadata, dependency-backed locked v1 near influence, or receipt-backed external-claim exact. |
+| `semantic_packs.external_exact_operations` | array | Closed external-exact kernel operations; version 7 contains only `collection-factory`. |
 | `semantic_packs.external_influence_blockers` | array | Stable blocker labels that currently prevent external rows from influencing analysis. |
-| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 6 reports `none`; local external packs do not run recognizers, parser/lowering plugins, producer code, sandboxed code, or fixture contents. |
+| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 7 reports `none`; nose analyzes fixture source but never executes fixture programs, recognizers, parser/lowering plugins, producer code, or sandboxed code. |
 | `il.output_formats` | array | Supported `nose il --format` values. |
 | `il.normalized` | boolean | Whether `nose il --normalized` is supported. |
 | `il.cfg_norm_toggle` | boolean | Whether `nose il --no-cfg-norm` is supported. |
@@ -214,15 +223,17 @@ consumers. New fields may be added to existing objects without changing
 `schema_version`; changing a documented field's type or meaning requires a new
 capabilities schema version.
 
-The blocker list describes rows outside the admitted locked-near slice,
-especially opaque v0/unlocked rows and external exact. A locked typed v1 query
+The blocker list describes rows outside the admitted locked-near or
+receipt-backed exact slices, especially opaque v0/unlocked rows. A locked typed v1 query
 can build the dependency/occurrence index advertised by
 `semantic_pack_dependency_evidence`; `semantic_pack_locked_near_influence`
-means its admitted near rows may support existing near candidates.
+means its admitted near rows may support existing near candidates. Exact
+influence additionally requires `semantic_pack_kernel_conformance_receipt` and
+is limited to the operation advertised by `external_exact_operations`.
 
 ## Query Capability Flags
 
-Version 6 defines these `query.capabilities` keys:
+Version 7 defines these `query.capabilities` keys:
 
 | key | meaning |
 |---|---|
@@ -241,7 +252,9 @@ Version 6 defines these `query.capabilities` keys:
 | `query_base_structured_ignores` | Structured ignores are applied before the `base=<ref>` divergent-edit gate. |
 | `reinvented_view` | The `reinvented` query view is supported. |
 | `semantic_pack_dependency_evidence` | A content-pinned v1 lock can build a local-only immutable Maven dependency/import/symbol/receiver/effect occurrence index; lane authorization and a consumer are still required for influence. |
-| `semantic_pack_locked_near_influence` | Near-authorized dependency-backed v1 occurrences may support existing near candidates with family/member provenance; exact output remains unchanged. |
+| `semantic_pack_external_claim_exact` | Receipt-backed, dependency-backed, user-authorized v1 collection-factory rows may enter the existing exact kernel and report distinct external-claim provenance. |
+| `semantic_pack_kernel_conformance_receipt` | `semantic-pack check --receipt-out` can bind bounded product source-analysis observations for later exact lock validation. |
+| `semantic_pack_locked_near_influence` | Near-authorized dependency-backed v1 occurrences may support existing near candidates with family/member provenance. |
 | `semantic_pack_loading` | local v0 manifests can be loaded as metadata and typed v1 manifests can be compiled for metadata/digest reporting. |
 | `semantic_pack_project_lock` | local v1 project locks can be created, validated, and supplied to query before analysis. |
 | `structured_ignores` | `nose.ignore.json` / `--ignore-file` audited suppressions are supported. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,8 @@ directory of direct `*.json` manifests. v0 rows remain data-only; v1 rows
 compile to typed indexes and a semantic digest. Unlocked external packs are
 `metadata-only`: they do not emit evidence or enable near/exact contracts. A
 valid `semantic-pack-lock` may authorize eligible v1 rows to support existing
-near candidates; external exact remains closed. The
+near candidates or, with a matching kernel receipt, the closed
+collection-factory external-claim exact operation. The
 [semantic-pack loading guide](semantic-pack-loading.md) defines the full boundary.
 
 `semantic-pack-lock` selects one content-pinned

--- a/docs/examples/semantic-packs/v1/guava-immutable-collections.json
+++ b/docs/examples/semantic-packs/v1/guava-immutable-collections.json
@@ -6,7 +6,7 @@
     "kind": "LibraryPack",
     "version": "1.0.0",
     "display_name": "Typed Guava immutable collection factories",
-    "description": "Typed v1 example. A project lock can build immutable occurrence evidence, but no lane consumes it yet and the pack remains metadata-only.",
+    "description": "Typed v1 near example. It remains metadata-only unless a project lock authorizes its dependency-backed rows.",
     "trust": "external-opt-in",
     "enabled_by_default": false
   },

--- a/docs/home.md
+++ b/docs/home.md
@@ -100,10 +100,10 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-adoption](semantic-pack-adoption.md) — promotion, rollback, and adoption-gate reports for moving external or optional packs into official builtin support without forking semantic vocabulary.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
-- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence, semantic/row digests, and the bounded locked near-only consumer.
+- [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence, bounded locked near influence, and receipt-backed collection-factory exact claims.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, deterministic conflict rejection, and evidence input boundary.
-- [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for checking local pack manifests and the builtin inventory workflow for auditing shipped pack coverage.
-- [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and metadata-or-locked-near-only limits.
+- [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for structural and bounded kernel source checks, receipt output, and builtin inventory audits.
+- [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and fail-closed near/external-claim-exact boundaries.
 
 #### Planning and pricing
 

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -49,18 +49,22 @@ Each entry has:
 | `trust` | string | `builtin-default`, `builtin-optional`, or `external-opt-in`. Local manifests must still use `external-opt-in`; builtin trust is reserved for packs shipped and gated with nose. |
 | `enabled_by_default` | boolean | Whether the pack is default-enabled. Local manifests are rejected unless this is `false`; compiled builtin packs report `true`. |
 | `source` | string | `compiled-builtin` for compiled builtin packs, or `local-manifest` for local manifest opt-ins. |
-| `influence` | string | `evidence-and-contracts` for compiled builtin semantics, `metadata-only` for unlocked/v0 external packs, or `near-only` for a v1 pack with valid near authorization. |
+| `influence` | string | `evidence-and-contracts` for compiled builtin semantics, `metadata-only` for unlocked/v0 external packs, `near-only` for valid near authorization, or `external-claim-exact` for a receipt-backed exact authorization. |
 | `path` | string or null | Canonical local manifest path for loaded manifests; `null` for compiled builtin packs. |
 | `provider`, `repository`, `license` | string | Pack provenance fields. |
 | `supported_languages` | array | Language ids declared by the pack. |
 | `counts` | object | Counts of declared `evidence_producers`, `contracts`, `value_laws`, `positive_fixtures`, and `hard_negatives`. |
 | `lock` | object, locked v1 only | Valid project-lock API/decision digest, allowed channels, selected rows, dependency pins, and optional receipt. |
 | `near_influence` | object, near-authorized v1 only | `{lane,trust,selected_rows,admitted_rows,rejected_rows,admitted_occurrences,influential_occurrences,caveats[]}`. Counts distinguish authorization/evidence from occurrences that contributed to retained near families. |
+| `external_exact_influence` | object, exact-authorized v1 only | Separately assured `{lane,trust,assurance,selected_rows,admitted_rows,rejected_rows,admitted_occurrences,influential_occurrences,caveats[]}` counts. `lane` is `external-claim-exact`; this is never builtin certification. |
 
 Local external packs must not change families, ranking, witnesses, surfaces, or
 exact/near results while their `influence` is `metadata-only`. `near-only` rows
 may support an existing near candidate but cannot create candidates or change
 fingerprints, exact results, or `nose verify`.
+`external-claim-exact` requires a matching kernel receipt and exact lock. Only
+the closed collection-factory kernel operation can affect fingerprints, and
+every affected family/member exposes its external provenance and caveats.
 
 For a locked v1 pack, `lock.status` is `valid`; invalid locks fail before a query
 report exists. `lock.decision_digest` is independent of workspace location and
@@ -252,7 +256,8 @@ Composition rules for v8:
 | `subsumes` | (present when this family has folded slices, in any view) the `id=` handles of the slice families this one subsumes — open any to inspect |
 | `subsumed_by` | (present when this family is a slice, in any view) the `id=` handle of the fuller overlapping family this one is a slice of |
 | `semantic_pack_near` | affected near families only: deduplicated provenance rows with pack/row semantic digests, lane/trust/operation, dependency coordinate and pinned source digests, occurrence span, and caveats |
-| `locations[]` | every copy: `{id, file, start, end, name, lang}` where `id` is the member id used by baseline diagnostics; when the frontend knows source-origin facts the location also carries `origin` (domains/body/region facets such as `type-contract`, `style`, `markup`, `declaration-only`, or `vue-sfc`); a near-influenced member carries `semantic_pack_near`; the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
+| `semantic_pack_external_exact` | affected exact families only: receipt-backed external provider-claim provenance with pack/row/receipt digests, dependency evidence, lane `external-exact`, assurance `external-claim-exact`, occurrence span, and non-certification caveats |
+| `locations[]` | every copy: `{id, file, start, end, name, lang}` where `id` is the member id used by baseline diagnostics; when the frontend knows source-origin facts the location also carries `origin` (domains/body/region facets such as `type-contract`, `style`, `markup`, `declaration-only`, or `vue-sfc`); influenced members may carry `semantic_pack_near` or `semantic_pack_external_exact`; the `existing_helper` member also carries `role: "existing-helper"`; a sub-dag clone's member carries `shared_subdag: [start, end]` — where the proven shared computation lives at that site |
 | `skeleton` | (only with `full`) the all-copies extraction-skeleton lines, each varying spot a `⟨param N: class⟩` placeholder (`class` = `literal`/`name`/`call`/`expr`/`block` — a coarse value-class hint for the helper signature) |
 
 `metrics` carries the raw `RefactorFamily` features before query's view-specific display fields

--- a/docs/schemas/semantic-pack-conformance-receipt-v1.schema.json
+++ b/docs/schemas/semantic-pack-conformance-receipt-v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/corca-ai/nose/docs/schemas/semantic-pack-conformance-receipt-v1.schema.json",
+  "title": "nose semantic-pack kernel conformance receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "nose_version",
+    "kernel_capability",
+    "pack_id",
+    "pack_version",
+    "semantic_digest",
+    "rows",
+    "fixtures",
+    "passed"
+  ],
+  "properties": {
+    "api_version": {
+      "const": "nose.semantic-pack-conformance-receipt.v1"
+    },
+    "nose_version": { "type": "string", "minLength": 1 },
+    "kernel_capability": {
+      "const": "nose.kernel.external-collection-factory-exact.v1"
+    },
+    "pack_id": { "type": "string", "minLength": 1 },
+    "pack_version": { "type": "string", "minLength": 1 },
+    "semantic_digest": { "$ref": "#/$defs/digest" },
+    "rows": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/row" }
+    },
+    "fixtures": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/fixture" }
+    },
+    "passed": { "const": true }
+  },
+  "$defs": {
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["row_id", "row_digest", "channel"],
+      "properties": {
+        "row_id": { "type": "string", "minLength": 1 },
+        "row_digest": { "$ref": "#/$defs/digest" },
+        "channel": { "const": "external-exact" }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "row_id",
+        "kind",
+        "path",
+        "dependency",
+        "fixture_digest",
+        "dependency_digest",
+        "expectation",
+        "observed",
+        "passed"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "row_id": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["positive", "hard-negative"] },
+        "path": { "type": "string", "minLength": 1 },
+        "dependency": { "type": "string", "minLength": 1 },
+        "fixture_digest": { "$ref": "#/$defs/digest" },
+        "dependency_digest": { "$ref": "#/$defs/digest" },
+        "expectation": {
+          "enum": ["external-exact-match", "no-external-exact-match"]
+        },
+        "observed": {
+          "enum": ["external-exact-match", "no-external-exact-match"]
+        },
+        "passed": { "const": true }
+      }
+    }
+  }
+}

--- a/docs/schemas/semantic-pack-v1.schema.json
+++ b/docs/schemas/semantic-pack-v1.schema.json
@@ -57,6 +57,9 @@
           }
         }
       }
+    },
+    "conformance": {
+      "$ref": "#/$defs/conformance"
     }
   },
   "$defs": {
@@ -274,6 +277,52 @@
         }
       }
     },
+    "conformance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixtures"],
+      "properties": {
+        "fixtures": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/conformance_fixture"
+          }
+        }
+      }
+    },
+    "conformance_fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "row_id",
+        "kind",
+        "path",
+        "dependency",
+        "expectation"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "row_id": {
+          "$ref": "#/$defs/stable_id"
+        },
+        "kind": {
+          "enum": ["positive", "hard-negative"]
+        },
+        "path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "dependency": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "expectation": {
+          "enum": ["external-exact-match", "no-external-exact-match"]
+        }
+      }
+    },
     "api_contract": {
       "type": "object",
       "additionalProperties": false,
@@ -324,7 +373,25 @@
         "channel": {
           "enum": ["near", "external-exact"]
         }
-      }
+      },
+      "allOf": [{
+        "if": {
+          "properties": {
+            "channel": { "const": "external-exact" }
+          }
+        },
+        "then": {
+          "properties": {
+            "operation": { "const": "collection-factory" },
+            "result_domain": { "const": "collection" },
+            "profiles": {
+              "properties": {
+                "exceptions": { "const": "no-throw" }
+              }
+            }
+          }
+        }
+      }]
     }
   }
 }

--- a/docs/semantic-kernel-roadmap.md
+++ b/docs/semantic-kernel-roadmap.md
@@ -2096,8 +2096,10 @@ justifies a tranche ([design §2c](design.md)).
   shadowed, and rebound cases fail closed. The first bounded consumer maps
   admitted `collection-factory`/`map-factory` occurrences onto existing near
   candidates only; it cannot create candidates or affect exact/verify output.
-- Start with data-only external packs for simple APIs once producer execution and
-  executable fixture/oracle checks exist.
+  A separate receipt-backed path admits only the existing collection-factory
+  operation to external-claim exact after bounded product source conformance.
+- Keep provider execution closed; external packs for simple APIs use typed data,
+  dependency evidence, kernel source conformance, and explicit user locks.
 - Add restricted recognizer hooks only after the manifest path is stable.
 - Require pack metadata: provider, license, version range, supported analysis
   channels, evidence status, conformance commands, and semantic provenance ids.
@@ -2108,8 +2110,9 @@ justifies a tranche ([design §2c](design.md)).
   `semantic-pack-lock`/`--semantic-pack-lock` select a mutually exclusive,
   content-pinned v1 set.
 - Query JSON reports active pack provenance and whether each pack is builtin,
-  metadata-only, or locked near-only. Affected near families/members report row
-  and dependency provenance; external-claim exact remains open.
+  metadata-only, locked near-only, or receipt-backed external-claim exact.
+  Affected families/members report row and dependency provenance; exact claims
+  also report receipt assurance and never imply builtin certification.
 
 The external schema must make proof obligations first-class. For example, a pack
 claiming `pkg.Foo.map` maps to the `Map` protocol must say how `pkg.Foo` is

--- a/docs/semantic-kernel-snapshot.md
+++ b/docs/semantic-kernel-snapshot.md
@@ -639,13 +639,16 @@ still being migrated toward it.
   path escapes and overlapping cross-pack coordinates; and exposes local
   create/status commands. Locked queries now use a bounded Maven POM reader and
   builtin Java evidence matcher to build an immutable dependency/import/symbol/
-  receiver/effect occurrence index. The first bounded consumer maps admitted
-  collection/map factory occurrences onto existing near candidates; normalize,
-  fingerprints, exact, and verify remain disconnected.
-  `nose semantic-pack check` validates local manifests plus declared fixture
-  assets, and `nose query --format json` reports active builtin/local packs in
-  top-level `semantic_packs`. Unlocked/v0 packs stay `metadata-only`, while a
-  valid near lock reports `near-only`; builtin
+  receiver/effect occurrence index. The near consumer maps admitted
+  collection/map factory occurrences onto existing candidates. The exact
+  consumer admits only receipt-backed collection-factory rows through the
+  existing kernel normalization/value-graph operation and reports distinct
+  external-claim provenance.
+  `nose semantic-pack check` validates local manifests and analyzes bounded v1
+  fixture source without executing programs; `nose query --format json` reports
+  active builtin/local packs in top-level `semantic_packs`. Unlocked/v0 packs
+  stay `metadata-only`, a valid near lock reports `near-only`, and a receipt-backed
+  exact lock reports `external-claim-exact`; builtin
   producers remain compiled Rust and are expected to map onto the same
   vocabulary. The first compiled pilots are the `nose.lang.*` builtin language
   descriptor/source-fact producer set, with `nose.lang.c` also carrying C
@@ -1660,8 +1663,8 @@ language.
   families/members expose external row/dependency provenance.
 - Builtin and external responsibility boundaries are documented and represented
   in the internal facade as provenance/trust policy. Unlocked/v0 manifests stay
-  metadata-only; external exact remains closed until the executable
-  fixture/oracle workflow exists.
+  metadata-only; external exact is limited to the receipt-backed
+  collection-factory operation and remains distinct from builtin assurance.
 
 ## Current fail-closed choices
 

--- a/docs/semantic-kernel.md
+++ b/docs/semantic-kernel.md
@@ -317,8 +317,10 @@ invalid. Changing public strings requires a schema/capabilities update.
 
 External packs may declare their intended eligibility, but users choose whether
 to trust that declaration. Explicitly loaded unlocked packs are reported as
-`metadata-only`. A content-pinned v1 project lock may authorize the narrow
-near-only protocol consumer; external exact matching remains closed.
+`metadata-only`. A content-pinned v1 project lock may authorize the narrow near
+protocol consumer. Receipt-backed exact authorization is limited to the
+existing collection-factory operation and reports external-claim rather than
+builtin-certified assurance.
 
 ## Pack conformance
 

--- a/docs/semantic-pack-adoption.md
+++ b/docs/semantic-pack-adoption.md
@@ -11,7 +11,7 @@ responsibility. It must not create a second implementation path.
 
 | lane | owner | default | meaning |
 |---|---|---|---|
-| `external-opt-in` | provider/user | off | Local manifests are explicit opt-ins. Unlocked manifests are metadata-only; a valid v1 project lock may authorize the narrow near-only consumer. |
+| `external-opt-in` | provider/user | off | Local manifests are explicit opt-ins. Unlocked manifests are metadata-only; a valid v1 project lock may authorize narrow near influence or a receipt-backed collection-factory exact claim. |
 | `builtin-optional` | nose | off | Shipped with nose, but not default-enabled until product risk is accepted. |
 | `builtin-default` | nose | on | Shipped with nose and enabled by default. |
 
@@ -171,7 +171,7 @@ The report reads compiled builtin descriptors through the same static inventory
 surface as `nose semantic-pack inventory`. It does not run queries, parse
 external manifests, execute provider code, or enable external influence.
 
-JSON schema version 1 reports:
+JSON schema version 2 reports:
 
 - current builtin lane counts;
 - optional/default PR checklist requirements;
@@ -188,7 +188,7 @@ Important fields:
 
 | Field | Values |
 |---|---|
-| `schema_version` | `1` |
+| `schema_version` | `2` |
 | `status` | `ok` or `needs-evidence` |
 | `totals.builtin_packs` | Number of compiled builtin packs inspected. |
 | `totals.builtin_default_packs` | Builtin packs in the `builtin-default` trust lane. |
@@ -199,7 +199,7 @@ Important fields:
 | `policy.scope` | `compiled-builtin` |
 | `policy.default_lane` | `builtin-default` |
 | `policy.optional_lane` | `builtin-optional` |
-| `policy.external_influence` | `unlocked-metadata-or-locked-near-only` |
+| `policy.external_influence` | `unlocked-metadata-or-locked-near-or-receipt-backed-external-claim-exact` |
 | `policy.product_behavior_gate` | `required-for-builtin-default-promotion` |
 | `policy.performance_gate` | `required-for-builtin-default-promotion` |
 | `packs[].adoption_status` | `default-gated`, `optional-gated`, `blocked`, or `tracked` |

--- a/docs/semantic-pack-architecture.md
+++ b/docs/semantic-pack-architecture.md
@@ -198,10 +198,14 @@ Behavior-change defaults:
 - Metadata-only external packs must not change families, ranking, witnesses,
   surfaces, or exact/near results.
 
-The first explicitly opened consumer is locked near-only protocol support.
-It may raise only an existing near candidate with dependency/occurrence evidence
-and must leave fingerprints, exact groups, and oracle behavior untouched. Lock
-validation still finishes before lowering; missing, stale, escaped, or
+The first explicitly opened consumer is locked near protocol support. It may
+raise only an existing near candidate with dependency/occurrence evidence and
+must leave fingerprints, exact groups, and oracle behavior untouched. The
+second is receipt-backed external-claim exact for the existing
+collection-factory kernel operation. It requires bounded product source
+conformance, matching dependency and fixture content, and a separate user lock;
+it cannot introduce a new operation, value law, recognizer, or canonical node.
+Lock validation still finishes before lowering; missing, stale, escaped, or
 conflicting configured locks fail before analysis rather than falling back to
 unlocked metadata or precedence.
 
@@ -214,7 +218,8 @@ Builtin descriptors should be static data or once-built indexes. External
 manifest loading and near-registry construction should happen before detection.
 Metadata-only packs must not add work inside normalize, detect, value-graph,
 fragment, or oracle loops; locked near rows may add only indexed unit annotation
-and existing-candidate scoring work.
+and existing-candidate scoring work. Exact locks may add only query-local indexed
+evidence and constant-time admission checks on matched occurrences.
 
 Use the product query-regression path when a corpus is available:
 
@@ -428,8 +433,10 @@ previous semantic-kernel tranches.
    overlapping coordinates, and still opens no analysis influence by itself.
    The next completed boundary is a query-local immutable evidence index: a
    bounded kernel Maven reader connects pinned dependency versions to builtin
-   Java import/symbol/receiver/effect facts, but no lane consumes those facts
-   yet.
+   Java import/symbol/receiver/effect facts. Locked near rows consume those facts
+   only as existing-candidate support. Receipt-backed external-exact rows consume
+   only the existing collection-factory kernel operation and report distinct
+   external-claim provenance.
 8. **Phase 7, adoption gates:** define `external-opt-in -> builtin-optional` and
    `builtin-optional -> builtin-default` promotion criteria, rollback behavior,
    corpus regression, docs, and performance budgets.
@@ -448,9 +455,10 @@ previous semantic-kernel tranches.
   the versioned external schema boundary.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) defines
   the first closed typed declaration compiler, locked occurrence-evidence
-  index, and bounded near-only consumer.
+  index, bounded near consumer, source-conformance receipt, and closed
+  collection-factory external-claim exact consumer.
 - [semantic-pack-loading](semantic-pack-loading.md) describes manifest loading
-  and the metadata-or-locked-near-only external behavior.
+  and the metadata/near/receipt-backed exact external behavior.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) defines the
   content-addressed user authorization between manifest claims and future
   evidence/influence consumers.

--- a/docs/semantic-pack-compatibility.md
+++ b/docs/semantic-pack-compatibility.md
@@ -46,7 +46,7 @@ The command reads only compiled policy and builtin inventory metadata. It does
 not load external manifests, execute provider code, run queries, parse source
 files, or enable external influence.
 
-JSON schema version 1 reports:
+JSON schema version 2 reports:
 
 - the current nose version;
 - supported semantic-pack manifest API versions;
@@ -60,17 +60,18 @@ Important fields:
 
 | Field | Values |
 |---|---|
-| `schema_version` | `1` |
+| `schema_version` | `2` |
 | `status` | `ok` or `blocked` |
 | `current_nose_version` | Installed binary package version. |
 | `supported.manifest_api_versions[]` | Supported manifest API versions, currently `nose.semantic-pack.v0` and `nose.semantic-pack.v1`. |
 | `supported.project_lock_api_versions[]` | Supported project-lock APIs, currently `nose.semantic-pack-lock.v1`. |
+| `supported.conformance_receipt_api_versions[]` | Supported receipt APIs, currently `nose.semantic-pack-conformance-receipt.v1`. |
 | `supported.report_sources[]` | Report data sources, currently `policy`. |
 | `policy.manifest_nose_version` | `must-include-installed-version` |
 | `policy.manifest_schema_changes` | `breaking-change-requires-new-api-version` |
 | `policy.kernel_vocabulary_changes` | `document-and-rehearse-with-builtin-packs-first` |
 | `policy.capabilities_changes` | `additive-or-schema-versioned` |
-| `policy.external_pack_influence` | `metadata-or-locked-near-only` |
+| `policy.external_pack_influence` | `metadata-or-locked-near-or-receipt-backed-external-claim-exact` |
 | `policy.external_pack_authorization` | `content-pinned-project-lock-required` |
 | `policy.external_pack_execution` | `none` |
 | `policy.external_packs_enabled_by_default` | `false` |
@@ -81,7 +82,8 @@ Important fields:
 | `failure_modes[].action` | `reject-before-analysis` or `block-external-influence`. |
 | `checks.builtin_inventory_status` | Current builtin inventory status. |
 | `checks.external_metadata_only` | `false` now that a locked near consumer exists. |
-| `checks.external_locked_near_only` | Whether locked v1 near influence is available while exact remains closed. |
+| `checks.external_locked_near_only` | Whether locked v1 near influence is available. |
+| `checks.external_receipt_exact` | Whether receipt-backed v1 external-claim exact is available for the closed collection-factory kernel operation. |
 | `checks.external_influence_blockers[]` | Stable blocker labels preventing external influence. |
 
 ## Version Policy
@@ -107,6 +109,8 @@ Only typed v1 rows can be authorized by a project lock; locking a v0 manifest is
 rejected and v0 remains permanently metadata-only. The lock separately pins API,
 pack id/version, the original nose compatibility range, canonical semantic
 digest, selected rows/channels, dependency file content, and an optional receipt.
+A receipt is mandatory whenever an `external-exact` row is selected and must
+bind the same rows, fixtures, dependencies, nose version, and kernel capability.
 Manifest and dependency coordinates must stay under the lock directory.
 
 The lock decision is independent of JSON key/array order, load order, workspace
@@ -120,16 +124,17 @@ precedence. See [semantic-pack-project-lock](semantic-pack-project-lock.md).
 Kernel vocabulary changes must keep builtin packs ahead of external influence:
 
 - add or migrate builtin descriptors, tests, conformance refs, and docs first;
-- keep unlocked manifests metadata-only and keep locked near rows non-influential
-  while new vocabulary is being proven;
+- keep unlocked manifests metadata-only and keep unsupported locked rows
+  non-influential while new vocabulary is being proven;
 - add compatibility notes for renamed fields, aliases, or enum values;
 - use additive capabilities fields for additive reporting;
 - require a new manifest API version for breaking manifest changes.
 
 External packs can use the same evidence and contract vocabulary as builtin
-packs, but they do not gain product influence until dependency-backed evidence,
-conflict handling, executable conformance, trust gates, and compatibility gates
-all exist.
+packs, but they gain product influence only where dependency-backed evidence,
+conflict handling, kernel source conformance, explicit lock authorization,
+trust gates, and compatibility gates all exist. Version 2 opens only the
+collection-factory operation; every other exact operation stays closed.
 
 ## Product And Performance Invariants
 

--- a/docs/semantic-pack-conformance.md
+++ b/docs/semantic-pack-conformance.md
@@ -1,17 +1,17 @@
 # Semantic pack conformance
 
-Status: nose provides a local semantic-pack v0 conformance harness and a typed
-v1 compile check. The v0 harness covers manifest structure, declared fixture
-assets, and declarative fixture-expectation gates for exact-capable rows. These
-are provider/user workflows, not nose approval of third-party semantic
-correctness. v0 and unlocked v1 external packs remain `metadata-only` when
-loaded by `nose query`. A separately validated v1 project lock may authorize
-the narrow near-only consumer; conformance checking alone never does.
+Status: nose provides the historical semantic-pack v0 metadata harness and a v1
+kernel source-conformance runner. The v0 harness covers manifest structure,
+declared fixture assets, and declarative fixture-expectation gates. v1 compiles
+its closed typed grammar and analyzes bounded source fixtures through the
+product frontend, evidence matcher, normalizer, strict exact gate, value graph,
+and detector. These are provider/user workflows, not nose approval of
+third-party semantic correctness.
 
-Typed v1 manifests use the same command to validate and compile their closed
-contract grammar. v1 does not inherit v0's opaque fixture/gate rows; its later
-source-analyzing receipts are separate work. Compilation or conformance alone
-remains `metadata-only`.
+Typed v1 manifests do not inherit v0's opaque fixture/gate rows. A passing v1
+run may write a content-bound receipt, but exact influence still requires a
+separately validated project lock that selects the same external-exact rows and
+pins that receipt. Compilation or conformance alone remains `metadata-only`.
 
 ## Goal
 
@@ -44,8 +44,9 @@ The harness does not:
 - register external contract rows with exact consumers;
 - treat a passing structural check as permission for external rows to influence
   analysis;
-- execute fixture contents, provider commands, recognizers, parser/lowering
-  plugins, producer code, or sandboxed code as an oracle;
+- execute fixture programs, provider commands, recognizers, parser/lowering
+  plugins, producer code, or sandboxed code as an oracle; v1 only parses and
+  analyzes fixture source;
 - prove that the provider's semantic claims are complete or true;
 - certify, approve, rank, or endorse external packs.
 
@@ -65,6 +66,8 @@ manifests:
 ```sh
 nose semantic-pack check semantic-packs/python-math-prod.json
 nose semantic-pack check docs/examples/semantic-packs/v0 --format json
+nose semantic-pack check semantic-packs/typed-exact.json \
+  --receipt-out semantic-packs/typed-exact.receipt.json
 ```
 
 Directory checking follows the same local discovery rule as pack loading: direct
@@ -79,6 +82,24 @@ expectation oracle. For `--format json`, the command still writes the report
 before returning the non-zero exit after manifests have loaded. Manifest parse,
 schema, compatibility, reserved-id, or duplicate-id errors that prevent report
 creation are returned as load errors instead.
+
+For v1 external-exact rows the command additionally requires positive and
+hard-negative fixtures with closed expectations. Fixture roots must stay below
+the manifest directory, contain no symlinks, parse cleanly as Java, and fit
+within 64 files and 1 MiB. Each local Maven dependency input is capped at 2 MiB;
+the runner never invokes Maven or uses a network. `resource-limit` and
+`analysis-failure` observations always fail; they cannot masquerade as a
+passing hard negative.
+
+The optional receipt uses the [`nose.semantic-pack-conformance-receipt.v1`
+schema](schemas/semantic-pack-conformance-receipt-v1.schema.json), which keeps
+the bound inputs and observations machine-readable.
+It binds nose and kernel capability, pack and row digests, channels, fixture and
+dependency content digests, expectations, observations, and pass state. Only
+one source-conformant v1 pack may be written by one `--receipt-out` invocation.
+See [typed manifest v1](semantic-pack-extension-api-v1.md) and
+[project locks](semantic-pack-project-lock.md) for exact authorization and
+reporting semantics.
 The example [law pack](examples/semantic-packs/v0/law-pack.json) uses this
 workflow to declare value-law positives and hard negatives. Passing the check
 confirms only that the law metadata and fixture assets are structurally present;
@@ -215,13 +236,13 @@ Important fields:
 
 ## Check JSON Report
 
-`--format json` emits schema version 3. Version 3 adds `api_version` and the
-optional v1 `semantic_digest` to each manifest entry; the rest of this example
-shows the unchanged v0 fixture and influence-preflight structure:
+`--format json` emits schema version 4. Version 4 adds the distinct
+`kernel_conformance` report and its fixture totals; v0 metadata gates remain in
+`executable_conformance`:
 
 ```json
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "status": "ok",
   "totals": {
     "manifests": 1,
@@ -232,7 +253,9 @@ shows the unchanged v0 fixture and influence-preflight structure:
     "passed_executable_conformance_rows": 1,
     "executable_conformance_issues": 0,
     "influence_rows": 1,
-    "blocked_influence_rows": 1
+    "blocked_influence_rows": 1,
+    "kernel_conformance_fixtures": 0,
+    "passed_kernel_conformance_fixtures": 0
   },
   "executable_conformance": {
     "status": "ok",
@@ -253,6 +276,10 @@ shows the unchanged v0 fixture and influence-preflight structure:
         "issues": []
       }
     ]
+  },
+  "kernel_conformance": {
+    "status": "unavailable",
+    "receipts": []
   },
   "influence_preflight": {
     "status": "blocked",

--- a/docs/semantic-pack-ecosystem-candidates.md
+++ b/docs/semantic-pack-ecosystem-candidates.md
@@ -29,9 +29,10 @@ Create an implementation issue only when the candidate can name:
 - adoption-gate and rollback evidence.
 
 External ecosystem packs remain explicit opt-ins. Unlocked packs are
-metadata-only; locked v1 rows may enter only the narrow near-only consumer after
+metadata-only; locked v1 rows may enter the narrow near consumer after
 compatibility, dependency-backed evidence, trust, and conflict gates pass.
-External exact remains closed until its separate conformance-receipt gate exists.
+Receipt-backed external-claim exact is limited to the existing
+collection-factory kernel operation; other operations remain closed.
 
 ## Candidate Matrix
 

--- a/docs/semantic-pack-extension-api-v1.md
+++ b/docs/semantic-pack-extension-api-v1.md
@@ -1,8 +1,8 @@
 # Typed semantic pack influence manifest v1
 
 Status: implemented typed manifest, deterministic compiler, content-pinned
-project authorization, kernel-owned dependency/occurrence evidence, and the
-first locked near-only consumer.
+project authorization, kernel-owned dependency/occurrence evidence, locked near
+influence, and receipt-backed external-claim exact influence.
 `nose.semantic-pack.v0` remains permanently metadata-only.
 
 ## Purpose
@@ -11,11 +11,13 @@ v1 is the first semantic-pack format that nose can interpret without executing
 provider code. It replaces v0's opaque `surface` and `semantics` JSON with a
 small closed grammar. Loading a v1 file validates and compiles that grammar
 before analysis starts. A validated project lock pins and authorizes rows,
-channels, dependency files, and an optional receipt. During a locked query nose
+channels, dependency files, and a kernel conformance receipt. During a locked query nose
 can now read the pinned Maven inputs and bind selected rows to builtin Java
 import/symbol/receiver/effect facts. For near-authorized rows, the resulting
-immutable index may support an existing near candidate; unlocked v1 and every
-v0 manifest remain `metadata-only`.
+immutable index may support an existing near candidate. A much narrower
+`external-exact` row may enter the existing exact kernel only when source
+conformance produced a matching receipt and the project lock pins it. Unlocked
+v1 and every v0 manifest remain `metadata-only`.
 
 The schema is [semantic-pack-v1.schema.json](schemas/semantic-pack-v1.schema.json).
 The [Guava example](examples/semantic-packs/v1/guava-immutable-collections.json)
@@ -47,6 +49,11 @@ free function with no receiver. Collection and map factory operations must use
 their corresponding fixed result domain. Map-factory arities must contain only
 even positional key/value counts.
 
+`external-exact` is narrower still: v1 accepts only `collection-factory` with
+`eager`, `pure`, `no-throw`, `none`, and `fresh` profiles, plus at least one
+positive and one hard-negative source fixture per row. Map, HOF, lazy, async,
+stream, provider value-law, and new-canon exact claims remain closed.
+
 Exact coordinates use validated Maven `group:artifact` names and exact Java
 module, imported-name, and member segments. There is no regex, expression,
 callback, provider matcher, selector, fingerprint, value law, generic HOF
@@ -74,10 +81,10 @@ compilation. Duplicate ids, duplicate package coordinates, duplicate exact
 contract coordinates plus arity, invalid cross-field combinations, and
 out-of-range arities fail before analysis.
 
-The compiled indexes feed the dependency/occurrence index and the locked near
-registry. Unlocked v1 summaries remain `metadata-only`; a valid lock that allows
-`near` reports `near-only`. Neither path changes normalization, fingerprints,
-exact value graphs, exact membership, witnesses, or oracle behavior.
+The compiled indexes feed the dependency/occurrence index and the two locked
+consumers. Unlocked v1 summaries remain `metadata-only`; a valid lock that
+allows only `near` reports `near-only`. Near authorization never changes
+normalization, fingerprints, exact membership, witnesses, or oracle behavior.
 
 ## Locked dependency and occurrence evidence
 
@@ -147,6 +154,54 @@ binds the implementation and release-binary identities, focused lock/rollback
 fixture, 9-repository no-pack parity, official-v0.19.0 semantic and near runtime
 measurements, and the zero-false-merge verify result.
 
+## Kernel source conformance and external-claim exact
+
+An exact-capable v1 manifest declares closed source fixtures under
+`conformance.fixtures`. Each fixture binds one row, a non-escaping source path,
+a checked-in Maven dependency input, a `positive` or `hard-negative` kind, and
+the matching closed expectation (`external-exact-match` or
+`no-external-exact-match`). Run:
+
+```sh
+nose semantic-pack check semantic-packs/example.json \
+  --receipt-out semantic-packs/example.receipt.json
+```
+
+The runner enforces 64 files and 1 MiB of fixture content plus a 2 MiB Maven
+input cap, rejects symlinks, path escapes, and parse-error recovery, lowers
+source with the product frontend, builds the ordinary
+dependency/occurrence evidence index, injects only the kernel-owned collection
+factory contract, then uses the product normalizer, strict exact-safety gate,
+value graph, and exact detector. It never runs fixture programs, Maven,
+provider commands, or downloaded code. Resource-limit and analysis failures
+cannot satisfy a negative expectation.
+
+The v1 receipt uses the [semantic-pack conformance receipt
+schema](schemas/semantic-pack-conformance-receipt-v1.schema.json), which is
+validated again at lock creation, status, and query time.
+It binds the nose version, kernel capability, pack/version/semantic digest,
+external-exact row and row digests, fixture paths and content digests,
+dependency digests, expected and observed outcomes, and pass status. Lock
+creation and every later status/query validation reparse the receipt and rehash
+the declared fixtures. Missing, edited, stale, failed, differently selected, or
+wrong-capability receipts fail before analysis.
+
+After validation, nose emits a query-local external evidence record for each
+dependency/import/symbol/receiver/arity-matched occurrence. The record can only
+select the existing collection-sequence operation; it cannot name a private
+value-graph node, fingerprint, new law, callback, or rewrite. Normalization and
+strict exact safety independently recheck the record's external provenance,
+dependency closure, current call anchor, unique admission, and arity.
+
+Affected exact families and members use `semantic_pack_external_exact`, not
+builtin semantic-law provenance. The payload names lane `external-exact`,
+assurance `external-claim-exact`, pack/row digests, receipt and dependency
+digests, occurrence span, and caveats including
+`external-claim-not-builtin-certification`. This is a provider claim tested by
+nose and explicitly authorized by the user; it is not nose certification of
+the external API's universal behavior. Removing the lock restores ordinary
+output.
+
 ## Semantic content digest
 
 v1 reports a lowercase `sha256:<64 hex digits>` digest over canonical typed
@@ -168,15 +223,16 @@ being locked.
 
 ## Reporting and current limits
 
-`nose capabilities` schema v6 lists both `nose.semantic-pack.v0` and
+`nose capabilities` schema v7 lists both `nose.semantic-pack.v0` and
 `nose.semantic-pack.v1`. `nose semantic-pack compatibility` lists the same
 accepted versions. Query semantic-pack summaries conditionally add
 `api_version`; v1 also adds `semantic_digest`. Compiled builtin summaries keep
 their existing shape so no-pack product output is unchanged.
 
-`nose semantic-pack check --format json` schema v3 includes `api_version` and
-`semantic_digest` for each manifest. For v1 it validates and compiles the typed
-content, but it does not invent v0 fixture rows or report an influence grant.
+`nose semantic-pack check --format json` schema v4 includes `api_version`,
+`semantic_digest`, and a separate `kernel_conformance` result. For v0 it keeps
+the historical fixture-metadata behavior; v0 never receives a kernel receipt or
+influence grant.
 
 The project-lock layer is now defined by
 [semantic-pack-project-lock](semantic-pack-project-lock.md). It pins API,
@@ -184,10 +240,8 @@ pack/version, nose compatibility, semantic digest, selected rows/channels,
 dependency content, and optional receipts; it also rejects overlapping
 cross-pack coordinates independent of load order.
 
-The following work remains outside this slice:
-
-- the separate external-claim exact lane;
-- source-analyzing conformance receipts and a real external reference pack.
+Shipping and measuring a reviewed real external reference pack remains outside
+this implementation slice.
 
 ## See also
 

--- a/docs/semantic-pack-loading.md
+++ b/docs/semantic-pack-loading.md
@@ -4,17 +4,15 @@ Status: nose can validate local semantic-pack v0 manifests, compile typed v1
 manifests, and validate content-pinned v1 project locks before `nose query`.
 It also provides separate local check/lock/status commands. External packs are
 explicit opt-ins. Unlocked v0/v1 packs are `metadata-only`; a content-pinned v1
-lock may authorize the narrow near-only consumer. External packs do not emit IL
-evidence, open exact contracts, mint fingerprints, or approve exact clone
-pairs. Local `declares.evidence_producers`,
-`declares.contracts`, and `declares.value_laws` entries are registered as
-data-only rows on the active `SemanticPackSet`, but no normalize, value-graph,
-or exact consumer reads those external rows yet. v1 contracts compile into
-deterministic typed indexes and a semantic digest; the near consumer reads only
-locked dependency-backed occurrences. `nose capabilities` reports the
-same boundary with `external_pack_influence = "metadata-or-locked-near-only"`,
-the current external influence blocker labels, and
-`external_pack_execution = "none"`.
+lock may authorize narrow near influence, and a matching kernel conformance
+receipt may additionally authorize a closed collection-factory exact claim.
+Opaque v0 producer, contract, and value-law declarations remain data-only.
+Typed v1 contracts compile into deterministic indexes and a semantic digest;
+consumers read only locked, dependency-backed occurrences. `nose capabilities`
+reports the same boundary with
+`external_pack_influence = "metadata-or-locked-near-or-receipt-backed-external-claim-exact"`,
+`external_exact_operations = ["collection-factory"]`, the current blocker
+labels, and `external_pack_execution = "none"`.
 
 ## Local entry points
 
@@ -60,13 +58,17 @@ them into an analysis run:
 ```sh
 nose semantic-pack check semantic-packs/python-math-prod.json
 nose semantic-pack check semantic-packs --format json
+nose semantic-pack check semantic-packs/typed-exact.json \
+  --receipt-out semantic-packs/typed-exact.receipt.json
 ```
 
 The conformance command validates manifest structure, trust policy, dependency
-references, exact-capable contract obligations, conformance fixture references,
-fixture expectation labels, executable fixture-expectation gates, and fixture
-file existence. It does not execute external producers, provider commands, or
-fixture contents, and it does not certify semantic correctness. See [semantic-pack-conformance](semantic-pack-conformance.md).
+references, exact-capable contract obligations, fixture references, and closed
+expectations. For v1 external-exact rows it analyzes bounded fixture source
+through the product kernel and may write a content-bound receipt. It does not
+execute fixture programs, external producers, provider commands, or downloaded
+code, and it does not certify semantic correctness. The [semantic-pack
+conformance guide](semantic-pack-conformance.md) defines its exact boundary.
 
 For v1, the command validates the closed Java/Maven package-API grammar and
 builds its canonical digest and indexes. v1 does not reuse v0's opaque row or
@@ -85,7 +87,7 @@ nose semantic-pack status nose.semantic-pack-lock.json --format json
 Trust is separate from channel eligibility.
 
 - Compiled builtin packs are enabled by default and are the only packs that
-  currently influence evidence and contracts. Machine output reports them with
+  influence builtin evidence and contracts. Machine output reports them with
   `compiled-builtin` source and `builtin-default` trust. Older v0 manifest
   examples may still use legacy first-party trust aliases, but local manifests
   that claim builtin trust are rejected after parsing. `nose.first_party` remains
@@ -217,14 +219,15 @@ Trust is separate from channel eligibility.
 paths before analysis and reports the active builtin/local pack set in the
 top-level `semantic_packs` array. Unlocked local external packs remain
 metadata-only while builtin compiled packs report `evidence-and-contracts`
-influence. A
-validated v1 project lock additionally builds a query-local, immutable Maven
+influence. A validated v1 project lock builds a query-local, immutable Maven
 dependency and Java occurrence-evidence index from content-pinned inputs and
-builtin frontend facts. External producer, contract, and value-law rows are
-available to the loaded pack set for future conflict checks and adoption gates,
-Those rows cannot enter exact/value-law consumers. Near-authorized admitted
-occurrences may support existing near candidates and are serialized as separate
-family/member near provenance. Builtin pack order in
+builtin frontend facts. Near-authorized admitted occurrences may support
+existing near candidates and are serialized as separate family/member
+provenance. Receipt-backed external-exact collection-factory occurrences may
+select only the kernel's existing collection value and exact detector path;
+affected results carry separate external-claim provenance and are never
+reported as builtin certification. Opaque v0 rows and unsupported v1 operations
+cannot enter normalize, value-graph, or exact consumers. Builtin pack order in
 this array follows the compiled registry's stable reporting order; roadmap and
 snapshot prose may group packs by migration narrative instead.
 
@@ -239,26 +242,26 @@ and requires required `LibraryApi.Contract` evidence for those rows. The v0
 preflight still blocks opaque external rows. For locked typed v1 rows, a
 kernel-owned Maven reader and Java matcher produce dependency-backed occurrence
 facts. The near lane consumes only admitted `collection-factory` and
-`map-factory` occurrences matched to builtin protocol evidence. A project lock
-supplies explicit content/row/lane authorization and rejects
-semantic-coordinate conflicts before analysis; the evidence index alone cannot
-influence a result. Exact-capable rows also remain blocked until they have passed
-declarative executable conformance.
-`nose semantic-pack check --format json` exposes that row-level preflight to
-providers and integrations, but normalize, value-graph, and exact consumers do
-not read it. It does not yet:
+`map-factory` occurrences matched to builtin protocol evidence. The exact lane
+consumes only receipt-backed `collection-factory` rows with the closed
+eager/pure/no-throw/non-mutating/fresh profile. A project lock supplies explicit
+content/row/lane authorization and rejects semantic-coordinate conflicts before
+analysis; the evidence index alone cannot influence a result. `nose
+semantic-pack check --format json` exposes source observations to providers and
+integrations. It does not:
 
 - execute external evidence producers;
-- register external contract rows with exact consumers;
-- register external value-law rows with value-graph or exact consumers;
+- register arbitrary external contract rows with exact consumers;
+- register provider value-law rows or new canonical value-graph operations;
 - execute fixture contents, provider commands, recognizers, parser/lowering
   plugins, producer code, or sandboxed code;
 - install packs from a registry or remote source.
 
 Future loader work should keep this boundary: external pack claims can become
-usable only through dependency-backed evidence records and fail-closed kernel
-contracts, never through raw selectors, arbitrary recognizer hooks, sandboxed
-code execution, parser/lowering plugins, or manifest presence alone.
+usable only through dependency-backed evidence records, product source
+conformance, explicit user authorization, and fail-closed kernel contracts,
+never through raw selectors, arbitrary recognizer hooks, sandboxed code
+execution, parser/lowering plugins, or manifest presence alone.
 
 ## See also
 
@@ -273,4 +276,4 @@ code execution, parser/lowering plugins, or manifest presence alone.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) records local
   content pins, authorization, deterministic conflict handling, and rollback.
 - [semantic-kernel](semantic-kernel.md) owns the exact-admission boundary that
-  loaded external manifests cannot bypass.
+  loaded external manifests and receipts cannot bypass.

--- a/docs/semantic-pack-project-lock.md
+++ b/docs/semantic-pack-project-lock.md
@@ -1,9 +1,9 @@
 # Semantic-pack project locks
 
 Status: project lock v1, local creation/status commands, pre-analysis
-validation, a locked Maven evidence reader, and the first near-only consumer are
-implemented. A valid near lock may support existing near candidates; v0 can
-never become influential through a lock.
+validation, a locked Maven evidence reader, near influence, and receipt-backed
+external-claim exact are implemented. v0 can never become influential through
+a lock.
 
 ## Why a separate lock exists
 
@@ -45,8 +45,19 @@ nose semantic-pack lock semantic-packs/guava.json \
 Omit `--row` to select every declared row whose requested channel is allowed.
 Repeat `--row ROW_ID` for one pack. With multiple packs, qualify each selection
 as `PACK_ID/ROW_ID`. Repeat `--dependency` for every checked-in input whose
-change must invalidate the decision. `--exact-receipt` only content-pins a local
-receipt at this stage; it does not open exact influence.
+change must invalidate the decision. To authorize selected `external-exact`
+rows, first create a passing receipt with `semantic-pack check --receipt-out`,
+then pass it with `--exact-receipt`. Exact selection without that matching
+receipt fails.
+
+```sh
+nose semantic-pack check semantic-packs/example.json \
+  --receipt-out semantic-packs/example.receipt.json
+nose semantic-pack lock semantic-packs/example.json \
+  --dependency pom.xml \
+  --channel external-exact \
+  --exact-receipt semantic-packs/example.receipt.json
+```
 
 Inspect or automate the decision:
 
@@ -89,14 +100,19 @@ pin set and rechecks content digests before using dependency facts. Missing,
 ambiguous, invalid, or out-of-range versions keep selected rows closed rather
 than consulting Maven or a registry.
 
-Query JSON reports `influence: "near-only"` when a lock authorizes near rows and
-adds a `lock` object containing `status: "valid"`, lock API and decision digest,
-authorized channels, selected rows, dependency pins, and optional receipt. Its
+Query JSON reports `influence: "near-only"` for a near-only lock and
+`influence: "external-claim-exact"` when an exact receipt-backed row is
+authorized. It adds a `lock` object containing `status: "valid"`, lock API and
+decision digest, authorized channels, selected rows, dependency pins, and the
+receipt pin. Its
 `near_influence` object reports admitted/rejected rows and admitted/influential
 occurrences. Removing the lock or narrowing a regenerated selection removes the
 authorization, evidence, and supported near results without changing the
-manifest. Exact-only authorization remains metadata-only until its separate
-consumer lands.
+manifest. `external_exact_influence` reports separately assured row and
+occurrence counts; affected families and members carry
+`semantic_pack_external_exact` provenance. These fields describe a provider
+claim tested by the kernel and authorized by the user, not builtin
+certification.
 
 ## Determinism and conflicts
 
@@ -114,10 +130,12 @@ decision.
 
 ## Update and rollback
 
-Regenerate the lock after an intentional manifest, dependency, row, channel, or
-receipt change, review the diff, and run `semantic-pack status`. Do not hand-edit
-digests. To roll back, remove `semantic-pack-lock` from config or restore the
-previous lock; external packs then return to unlocked metadata-only behavior.
+Regenerate the receipt and then the lock after an intentional manifest,
+fixture, dependency, row, channel, nose version, or kernel-capability change.
+Review both diffs and run `semantic-pack status`; stale fixture content is
+rehashed even though it is not a separate lock entry. Do not hand-edit digests.
+To roll back, remove `semantic-pack-lock` from config or restore the previous
+lock; external packs then return to unlocked metadata-only behavior.
 
 ## See also
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -251,7 +251,7 @@ mode flags are documented under [Ranking](#ranking) and [Detection modes](#detec
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--ignore-file <file>` | suppress accepted families using a structured ignore file with reason/owner/expiry metadata |
 | `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; unlocked external packs are metadata-only |
-| `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; eligible rows may support existing near candidates, and unlocked pack paths cannot be mixed in |
+| `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; eligible rows may support near candidates or receipt-backed collection-factory exact claims, and unlocked pack paths cannot be mixed in |
 
 **Output**
 
@@ -294,9 +294,11 @@ and may change to improve readability. The stable contract is documented in
   the top unhandled surface kinds (`--top`, default 30; `--format json` for machine output —
   the same `--format` contract as `query`/`il`).
   Use it to spot a language/construct that isn't lowering well; see [languages](languages.md).
-- `nose semantic-pack check <file-or-dir> [--format human|json]` — validate local
-  semantic-pack v0 structure/fixtures or compile a typed v1 manifest. It is a
-  pack-author/user workflow, not external pack certification; see [semantic-pack-conformance](semantic-pack-conformance.md).
+- `nose semantic-pack check <file-or-dir> [--format human|json] [--receipt-out <file>]` — validate local
+  semantic-pack v0 structure/fixtures or compile and source-check typed v1
+  fixtures. `--receipt-out` writes a content-bound receipt only after a passing
+  single-pack v1 run; it is a pack-author/user workflow, not external pack
+  certification. See [semantic-pack-conformance](semantic-pack-conformance.md).
 - `nose semantic-pack lock <file-or-dir> --dependency <file> [--channel near|external-exact] [--row ID] [--output <file>] [--format human|json]` — create a local content-pinned v1 project lock without fetching or installing anything.
 - `nose semantic-pack status <lock> [--format human|json]` — revalidate pinned manifests, dependency inputs, selected rows/channels, optional receipts, path containment, and conflicts. See [semantic-pack-project-lock](semantic-pack-project-lock.md).
 - `nose semantic-pack inventory [--format human|json]` — inspect compiled


### PR DESCRIPTION
Closes #868

## What changed
- run v1 source conformance through nose's parser, evidence matcher, normalizer, and exact detector without executing fixture/provider code
- bind exact authorization to content-addressed kernel receipts and a project-lock `external-exact` channel
- add one closed external-claim exact operation (`collection-factory`) with separate provenance and fail-closed resource/conflict checks
- document the trust boundary and record the official-v0.19 performance closeout

## Validation
- `cargo test --workspace`
- `cargo test -p nose-cli --test cli commands::config_packs::external_exact` (6 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-docs.sh`
- `python3 scripts/check-file-lengths.py`
- `RAYON_NUM_THREADS=1 target/release/nose verify crates --max-violations 0` (790 groups, 0 false merges)
- official v0.19.0 aggregate: semantic -0.31%, near -0.21%; focused Swift near control +0.37%
- no-pack parent/candidate output equality: semantic 9/9, near 9/9