### PR TITLE
feat: ship the Vavr semantic-pack reference

### DIFF
--- a/bench/semantic_pack/issue-869-vavr-reference-pack-closeout-2026-07-19.v1.json
+++ b/bench/semantic_pack/issue-869-vavr-reference-pack-closeout-2026-07-19.v1.json
@@ -1,0 +1,182 @@
+{
+  "schema": "nose.semantic-pack.issue-869-closeout/v1",
+  "issue": 869,
+  "generated_at": "2026-07-19",
+  "candidate": {
+    "status": "priced-ready",
+    "pack_id": "org.corca.reference.java-vavr-list",
+    "implementation_commit": "4aeb5a3cb76f78dfaac00450c228295a530e58d3",
+    "manifest_sha256": "5107b07e289d472ed736327ade951bd45204eeefc0d000fa0f60f9c48eecc413",
+    "semantic_digest": "sha256:e0abacf8a1f01dc5d1cc417b1bd7a47e9decfce0f9f700dd5322dd6ddd7cd597",
+    "decision_digest": "sha256:3182e5d41acfd3e66d3d14fb906b212370b80737302b30b198aa6cf35522d823",
+    "receipt_sha256": "90e1f1fb4df090cfac2ca1134556a4c1ff78b5dae9819774b79e468b1340955e",
+    "lock_sha256": "19ee051580d60bd65dc1bfc0d4dbc653e448da9dc971b90fae6e6abdd343ce6c",
+    "dependency_sha256": "9d5c9a4a52d83b72acfd0021a86d6b5ece0ffa3091d1054678b0d63f0d3f8d33",
+    "enabled_by_default": false,
+    "trust": "external-opt-in"
+  },
+  "pinned_real_consumer": {
+    "repository": "https://github.com/dhinojosa/vavr-study",
+    "commit": "10c8b1c649c672e69a75c60669f442f97b8a555e",
+    "dependency": "io.vavr:vavr:0.9.1",
+    "dependency_kind": "direct-maven",
+    "source_execution": false,
+    "matched_import": "io.vavr.collection.List",
+    "near_admitted_occurrences": 9,
+    "external_exact_admitted_occurrences": 1,
+    "standalone_influential_occurrences": 0,
+    "interpretation": "the real repository prices dependency, import, member, arity, and occurrence availability; checked-in same-binary controls isolate observable result changes"
+  },
+  "supported_slice": {
+    "coordinate": "io.vavr:vavr",
+    "versions": ">=0.9.0 <0.10.0",
+    "language": "java",
+    "import_role": "type",
+    "receiver": "imported-type",
+    "member": "of",
+    "operation": "collection-factory",
+    "near_arities": [3, 4],
+    "external_exact_arities": [5],
+    "non_overlap": "the builtin Guava coordinate and rows remain distinct",
+    "unsupported": [
+      "Vavr versions outside 0.9.x",
+      "wildcard, static, aliased, shadowed, rebound, or fully-qualified uses",
+      "other members, arities, receivers, packages, collection types, callbacks, streams, or lazy APIs",
+      "provider code, network resolution, registries, parser plugins, or new canonicalization"
+    ]
+  },
+  "controlled_product_evaluation": {
+    "roots": [
+      "pinned dhinojosa/vavr-study source",
+      "bench/semantic_pack/reference/vavr-study-control"
+    ],
+    "semantic": {
+      "without_lock_families": 0,
+      "with_lock_families": 1,
+      "attributed_external_exact_families": 1,
+      "admitted_occurrences": 2,
+      "influential_occurrences": 1,
+      "without_lock_sha256": "9d16dcbd39994e20716c654c0ceee0eac05b911de37ae24afe857158a3109a70",
+      "with_lock_sha256": "0cf6c13b9577d397b84b5d078df4516abff39468399df6920dd675154ab3ea50"
+    },
+    "near": {
+      "without_lock_families": 8,
+      "with_lock_families": 10,
+      "attributed_near_families": 1,
+      "attributed_external_exact_families": 1,
+      "near_admitted_occurrences": 11,
+      "near_influential_occurrences": 2,
+      "without_lock_sha256": "b54ec5255cde38e659c3f5c19d0a0d6c332ed80cc2350ea5f32fe0ee7f9b53af",
+      "with_lock_sha256": "bd1b1e9752cc6200e5e14dccff1ec399180769e9362b3436c1ae9ee555991226"
+    },
+    "deterministic_repeat": true,
+    "removing_lock_restores_without_lock_output": true,
+    "provenance_includes": [
+      "pack_id",
+      "row_id",
+      "semantic_digest",
+      "row_digest",
+      "trust",
+      "lane",
+      "assurance",
+      "dependency coordinate/version/source digest",
+      "receipt_digest",
+      "occurrence file/span",
+      "caveats"
+    ]
+  },
+  "fail_closed_evidence": {
+    "source_conformance": "2/2 fixtures passed",
+    "reference_hard_negatives": [
+      "wrong arity",
+      "wrong member",
+      "shadowed imported type"
+    ],
+    "epic_matrix_covered_by_workspace_tests": [
+      "missing dependency",
+      "unsupported dependency version",
+      "wrong package or import",
+      "alias, shadow, and rebind",
+      "receiver, dynamic-dispatch, arity, and overload mismatch",
+      "demand, effect, exception, mutation, and identity mismatch",
+      "row or semantic-coordinate conflict",
+      "missing, stale, or tampered receipt",
+      "fixture and dependency digest drift",
+      "symlink and resource-limit rejection"
+    ],
+    "pack_check_sha256": "9849ef8ad2a49b43cbc1853fc50f0f028e2beca90f46fb00f158693c6c0c5328",
+    "lock_status_sha256": "1cfcfadd3ed07f4ee2949bdf52b248bd1ce0a235f44092109e97e12269ae6762"
+  },
+  "official_release_performance": {
+    "baseline": {
+      "version": "v0.19.0",
+      "source_tag_object": "54f8a67436e39e24c777a85e14224273116add6b",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate": {
+      "source_commit": "4aeb5a3cb76f78dfaac00450c228295a530e58d3",
+      "binary_sha256": "68f903b639a61e8fa9b1a318b1f1a0ad2e4cb77acddad7f0404c138b7a605edb"
+    },
+    "corpus": "pinned dhinojosa/vavr-study",
+    "repeats": 15,
+    "warmups": 2,
+    "threads": 1,
+    "no_pack_semantic": {
+      "baseline_median_ms": 17.0187,
+      "candidate_median_ms": 17.0574,
+      "delta_ms": 0.0387,
+      "delta_pct": 0.2272,
+      "outputs_identical": true,
+      "measurement_sha256": "a93a238fb2e75f9201a60a07f722dfa38df3157bfbb3ed26b69651aa6711de1c"
+    },
+    "no_pack_near": {
+      "baseline_median_ms": 23.8591,
+      "candidate_median_ms": 23.732,
+      "delta_ms": -0.1271,
+      "delta_pct": -0.5328,
+      "outputs_identical": true,
+      "measurement_sha256": "c57c73e3173fb101d19725ef6a90e49aec51dd3600873e692184ca05b945bf98"
+    },
+    "same_binary_enabled_semantic": {
+      "without_lock_median_ms": 16.7848,
+      "with_lock_median_ms": 19.9171,
+      "delta_ms": 3.1323,
+      "delta_pct": 18.6617,
+      "measurement_sha256": "3f02f852bd04ee7120b4727a4cba5a8e59c73f75687bdb3385e1ce4026a8ada9"
+    },
+    "same_binary_enabled_near": {
+      "without_lock_median_ms": 23.2987,
+      "with_lock_median_ms": 26.7177,
+      "delta_ms": 3.419,
+      "delta_pct": 14.6745,
+      "measurement_sha256": "cf7b7f06c9f5e4a6349291828b466830ce6146cf4e230e84e9b719656ea835d3"
+    },
+    "gate": {
+      "limit_pct": 5.0,
+      "floor_ms": 5.0,
+      "passed": true,
+      "reason": "both enabled deltas are below the 5 ms measurement floor; no-pack deltas are below 1%"
+    }
+  },
+  "soundness": {
+    "command": "RAYON_NUM_THREADS=1 nose verify crates --max-violations 0",
+    "fingerprint_groups": 791,
+    "false_merges": 0,
+    "canon_changed_units_preserved": true,
+    "output_sha256": "8f4830cfacb76adbc73eb7f1e6d37ee2520306e9cd11e12f904876e09ffb5c6b"
+  },
+  "rollback": {
+    "action": "remove --semantic-pack-lock or the semantic-pack-lock config entry; optionally regenerate a narrower row/channel lock",
+    "network_or_install_cleanup": false,
+    "provider_code_cleanup": false
+  },
+  "validation": {
+    "focused_reference_test": "1 passed",
+    "cargo_test_workspace": "passed",
+    "cargo_clippy_workspace_all_targets_deny_warnings": "passed",
+    "cargo_fmt_check": "passed",
+    "docs": "passed",
+    "file_lengths": "passed",
+    "git_diff_check": "passed"
+  }
+}

--- a/bench/semantic_pack/reference/vavr-study-control/BuiltinNear.java
+++ b/bench/semantic_pack/reference/vavr-study-control/BuiltinNear.java
@@ -1,0 +1,14 @@
+package com.evolutionnext.control;
+
+import java.util.Arrays;
+
+final class BuiltinNear {
+    Object gather(Object first, Object second, Object third) {
+        Object values = Arrays.asList(first, second, third);
+        int size = first.hashCode() + second.hashCode();
+        if (size > 0) {
+            return values;
+        }
+        return Arrays.asList(first, second, third, null);
+    }
+}

--- a/bench/semantic_pack/reference/vavr-study-control/ExactControl.java
+++ b/bench/semantic_pack/reference/vavr-study-control/ExactControl.java
@@ -1,0 +1,15 @@
+package com.evolutionnext.control;
+
+import io.vavr.collection.List;
+import java.util.Arrays;
+
+/** Same-binary exact control for the pinned vavr-study List.of(1..5) call. */
+final class ExactControl {
+    static boolean vavrFactory(int value) {
+        return List.of(1, 2, 3, 4, 5).contains(value);
+    }
+
+    static boolean jdkFactory(int value) {
+        return Arrays.asList(1, 2, 3, 4, 5).contains(value);
+    }
+}

--- a/bench/semantic_pack/reference/vavr-study-control/ExternalNear.java
+++ b/bench/semantic_pack/reference/vavr-study-control/ExternalNear.java
@@ -1,0 +1,14 @@
+package com.evolutionnext.control;
+
+import io.vavr.collection.List;
+
+final class ExternalNear {
+    Object collect(Object first, Object second, Object third) {
+        Object values = List.of(first, second, third);
+        int size = first.hashCode() + second.hashCode();
+        if (size > 0) {
+            return values;
+        }
+        return List.of(third, second, first);
+    }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "3d16b42919c365a229f634af629388746d6d9da1",
+  "product_crates_tree": "1beac2e3034b4b7f901c56f34b134732f023bc53",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/tests/cli/commands/config_packs.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs.rs
@@ -202,3 +202,5 @@ mod external_cases_v1;
 mod external_exact;
 #[path = "config_packs/project_lock.rs"]
 mod project_lock;
+#[path = "config_packs/reference_vavr.rs"]
+mod reference_vavr;

--- a/crates/nose-cli/tests/cli/commands/config_packs/reference_vavr.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/reference_vavr.rs
@@ -1,0 +1,90 @@
+use super::*;
+
+fn workspace() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn query(mode: &str, locked: bool) -> serde_json::Value {
+    let mut command = Command::new(bin());
+    command.args([
+        "query",
+        "bench/semantic_pack/reference/vavr-study-control",
+        "all",
+        "top=0",
+        "--mode",
+        mode,
+        "--min-size",
+        "1",
+        "--format",
+        "json",
+    ]);
+    if locked {
+        command.args([
+            "--semantic-pack-lock",
+            "docs/examples/vavr-list-project-lock-v1.json",
+        ]);
+    }
+    let output = command.current_dir(workspace()).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn shipped_vavr_reference_pack_changes_only_explicitly_locked_controls() {
+    let status = Command::new(bin())
+        .args([
+            "semantic-pack",
+            "status",
+            "docs/examples/vavr-list-project-lock-v1.json",
+            "--format",
+            "json",
+        ])
+        .current_dir(workspace())
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "{}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let semantic_without = query("semantic", false);
+    let semantic_with = query("semantic", true);
+    assert!(semantic_without["families"].as_array().unwrap().is_empty());
+    let exact_family = semantic_with["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|family| family.get("semantic_pack_external_exact").is_some())
+        .expect("locked reference pack should produce one attributed exact family");
+    assert_eq!(
+        exact_family["semantic_pack_external_exact"][0]["row_id"],
+        "java.vavr.list.of-five-exact"
+    );
+
+    let near_without = query("near", false);
+    let near_with = query("near", true);
+    let influenced = near_with["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|family| family.get("semantic_pack_near").is_some())
+        .count();
+    assert!(influenced >= 1);
+    assert!(
+        near_with["families"].as_array().unwrap().len()
+            > near_without["families"].as_array().unwrap().len()
+    );
+
+    let pack = semantic_pack_by_id(&near_with, "org.corca.reference.java-vavr-list");
+    assert_eq!(pack["enabled_by_default"], false);
+    assert_eq!(pack["near_influence"]["influential_occurrences"], 2);
+    assert_eq!(
+        pack["external_exact_influence"]["influential_occurrences"],
+        1
+    );
+}

--- a/docs/examples/semantic-pack-receipts/vavr-list.v1.json
+++ b/docs/examples/semantic-pack-receipts/vavr-list.v1.json
@@ -1,0 +1,42 @@
+{
+  "api_version": "nose.semantic-pack-conformance-receipt.v1",
+  "nose_version": "0.19.0",
+  "kernel_capability": "nose.kernel.external-collection-factory-exact.v1",
+  "pack_id": "org.corca.reference.java-vavr-list",
+  "pack_version": "1.0.0",
+  "semantic_digest": "sha256:e0abacf8a1f01dc5d1cc417b1bd7a47e9decfce0f9f700dd5322dd6ddd7cd597",
+  "rows": [
+    {
+      "row_id": "java.vavr.list.of-five-exact",
+      "row_digest": "sha256:f985154dd824eee880a03151e00b5324be4131ce5406538ccf449819a6e20d10",
+      "channel": "external-exact"
+    }
+  ],
+  "fixtures": [
+    {
+      "id": "vavr-list-hard-negatives",
+      "row_id": "java.vavr.list.of-five-exact",
+      "kind": "hard-negative",
+      "path": "vavr-list-fixtures/hard-negatives",
+      "dependency": "vavr-list-pom.xml",
+      "fixture_digest": "sha256:644350648918e712c4dbb60288a052ca5b74b73a5d2e4e9dec7beb34aca62da0",
+      "dependency_digest": "sha256:9d5c9a4a52d83b72acfd0021a86d6b5ece0ffa3091d1054678b0d63f0d3f8d33",
+      "expectation": "no-external-exact-match",
+      "observed": "no-external-exact-match",
+      "passed": true
+    },
+    {
+      "id": "vavr-list-of-five-positive",
+      "row_id": "java.vavr.list.of-five-exact",
+      "kind": "positive",
+      "path": "vavr-list-fixtures/positive",
+      "dependency": "vavr-list-pom.xml",
+      "fixture_digest": "sha256:4e969e76ba68c1515e2e5f40d42eb87fa199791e156f0b20c7e15428f7a58613",
+      "dependency_digest": "sha256:9d5c9a4a52d83b72acfd0021a86d6b5ece0ffa3091d1054678b0d63f0d3f8d33",
+      "expectation": "external-exact-match",
+      "observed": "external-exact-match",
+      "passed": true
+    }
+  ],
+  "passed": true
+}

--- a/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/ShadowedType.java
+++ b/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/ShadowedType.java
@@ -1,0 +1,17 @@
+import io.vavr.collection.List;
+
+final class ShadowedType {
+    static final class List {
+        static java.util.List<Integer> of(int first, int second, int third) {
+            return java.util.List.of(first, second, third);
+        }
+    }
+
+    static boolean externalFactory(int value) {
+        return List.of(1, 2, 3).contains(value);
+    }
+
+    static boolean builtinFactory(int value) {
+        return java.util.List.of(1, 2, 3).contains(value);
+    }
+}

--- a/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/WrongArity.java
+++ b/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/WrongArity.java
@@ -1,0 +1,11 @@
+import io.vavr.collection.List;
+
+final class WrongArity {
+    static boolean externalFactory(int value) {
+        return List.of(1, 2).contains(value);
+    }
+
+    static boolean builtinFactory(int value) {
+        return java.util.List.of(1, 2, 3).contains(value);
+    }
+}

--- a/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/WrongMember.java
+++ b/docs/examples/semantic-packs/v1/vavr-list-fixtures/hard-negatives/WrongMember.java
@@ -1,0 +1,11 @@
+import io.vavr.collection.List;
+
+final class WrongMember {
+    static boolean externalFactory(int value) {
+        return List.ofAll(java.util.List.of(1, 2, 3)).contains(value);
+    }
+
+    static boolean builtinFactory(int value) {
+        return java.util.List.of(1, 2, 3).contains(value);
+    }
+}

--- a/docs/examples/semantic-packs/v1/vavr-list-fixtures/positive/VavrListPositive.java
+++ b/docs/examples/semantic-packs/v1/vavr-list-fixtures/positive/VavrListPositive.java
@@ -1,0 +1,12 @@
+import io.vavr.collection.List;
+import java.util.Arrays;
+
+final class VavrListPositive {
+    static boolean externalFactory(int value) {
+        return List.of(1, 2, 3, 4, 5).contains(value);
+    }
+
+    static boolean builtinFactory(int value) {
+        return Arrays.asList(1, 2, 3, 4, 5).contains(value);
+    }
+}

--- a/docs/examples/semantic-packs/v1/vavr-list-pom.xml
+++ b/docs/examples/semantic-packs/v1/vavr-list-pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.corca.reference</groupId>
+  <artifactId>vavr-list-conformance</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>io.vavr</groupId>
+      <artifactId>vavr</artifactId>
+      <version>0.9.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/docs/examples/semantic-packs/v1/vavr-list.json
+++ b/docs/examples/semantic-packs/v1/vavr-list.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "../../../schemas/semantic-pack-v1.schema.json",
+  "api_version": "nose.semantic-pack.v1",
+  "pack": {
+    "id": "org.corca.reference.java-vavr-list",
+    "kind": "LibraryPack",
+    "version": "1.0.0",
+    "display_name": "Vavr List factories",
+    "description": "Reference external pack for a bounded Vavr List.of slice.",
+    "trust": "external-opt-in",
+    "enabled_by_default": false
+  },
+  "provenance": {
+    "provider": {
+      "name": "Corca nose reference packs",
+      "contact": "https://github.com/corca-ai/nose/issues"
+    },
+    "license": "MIT",
+    "repository": "https://github.com/corca-ai/nose"
+  },
+  "compatibility": {
+    "nose": ">=0.19.0 <0.21.0"
+  },
+  "supported_languages": ["java"],
+  "packages": [
+    {
+      "ecosystem": "maven",
+      "name": "io.vavr:vavr",
+      "versions": ">=0.9.0 <0.10.0"
+    }
+  ],
+  "declares": {
+    "api_contracts": [
+      {
+        "id": "java.vavr.list.of-five-exact",
+        "language": "java",
+        "package": {
+          "ecosystem": "maven",
+          "name": "io.vavr:vavr"
+        },
+        "anchor": "call-node",
+        "matcher": "imported-api",
+        "import": {
+          "role": "type",
+          "module": "io.vavr.collection",
+          "name": "List"
+        },
+        "call": {
+          "shape": "static-method",
+          "member": "of",
+          "arity": {
+            "kind": "set",
+            "values": [5]
+          },
+          "receiver": "imported-type"
+        },
+        "operation": "collection-factory",
+        "result_domain": "collection",
+        "profiles": {
+          "demand": "eager",
+          "effects": "pure",
+          "exceptions": "no-throw",
+          "mutation": "none",
+          "identity": "fresh"
+        },
+        "channel": "external-exact"
+      },
+      {
+        "id": "java.vavr.list.of-three-four-near",
+        "language": "java",
+        "package": {
+          "ecosystem": "maven",
+          "name": "io.vavr:vavr"
+        },
+        "anchor": "call-node",
+        "matcher": "imported-api",
+        "import": {
+          "role": "type",
+          "module": "io.vavr.collection",
+          "name": "List"
+        },
+        "call": {
+          "shape": "static-method",
+          "member": "of",
+          "arity": {
+            "kind": "set",
+            "values": [3, 4]
+          },
+          "receiver": "imported-type"
+        },
+        "operation": "collection-factory",
+        "result_domain": "collection",
+        "profiles": {
+          "demand": "eager",
+          "effects": "pure",
+          "exceptions": "no-throw",
+          "mutation": "none",
+          "identity": "fresh"
+        },
+        "channel": "near"
+      }
+    ]
+  },
+  "conformance": {
+    "fixtures": [
+      {
+        "id": "vavr-list-of-five-positive",
+        "row_id": "java.vavr.list.of-five-exact",
+        "kind": "positive",
+        "path": "vavr-list-fixtures/positive",
+        "dependency": "vavr-list-pom.xml",
+        "expectation": "external-exact-match"
+      },
+      {
+        "id": "vavr-list-hard-negatives",
+        "row_id": "java.vavr.list.of-five-exact",
+        "kind": "hard-negative",
+        "path": "vavr-list-fixtures/hard-negatives",
+        "dependency": "vavr-list-pom.xml",
+        "expectation": "no-external-exact-match"
+      }
+    ]
+  }
+}

--- a/docs/examples/vavr-list-project-lock-v1.json
+++ b/docs/examples/vavr-list-project-lock-v1.json
@@ -1,0 +1,31 @@
+{
+  "api_version": "nose.semantic-pack-lock.v1",
+  "dependencies": [
+    {
+      "path": "semantic-packs/v1/vavr-list-pom.xml",
+      "content_digest": "sha256:9d5c9a4a52d83b72acfd0021a86d6b5ece0ffa3091d1054678b0d63f0d3f8d33"
+    }
+  ],
+  "packs": [
+    {
+      "manifest": "semantic-packs/v1/vavr-list.json",
+      "manifest_api_version": "nose.semantic-pack.v1",
+      "pack_id": "org.corca.reference.java-vavr-list",
+      "pack_version": "1.0.0",
+      "nose_compatibility": ">=0.19.0 <0.21.0",
+      "semantic_digest": "sha256:e0abacf8a1f01dc5d1cc417b1bd7a47e9decfce0f9f700dd5322dd6ddd7cd597",
+      "allowed_channels": [
+        "near",
+        "external-exact"
+      ],
+      "selected_rows": [
+        "java.vavr.list.of-five-exact",
+        "java.vavr.list.of-three-four-near"
+      ],
+      "exact_receipt": {
+        "path": "semantic-pack-receipts/vavr-list.v1.json",
+        "content_digest": "sha256:90e1f1fb4df090cfac2ca1134556a4c1ff78b5dae9819774b79e468b1340955e"
+      }
+    }
+  ]
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -101,6 +101,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-compatibility](semantic-pack-compatibility.md) — manifest API, installed-version, kernel-vocabulary, and fail-closed external-influence compatibility policy for semantic packs.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence, bounded locked near influence, and receipt-backed collection-factory exact claims.
+- [semantic-pack-reference-vavr](semantic-pack-reference-vavr.md) — shipped, disabled-by-default Vavr `List.of` reference pack, pinned lock/receipt, measured value, boundaries, and rollback.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, deterministic conflict rejection, and evidence input boundary.
 - [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for structural and bounded kernel source checks, receipt output, and builtin inventory audits.
 - [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and fail-closed near/external-claim-exact boundaries.

--- a/docs/semantic-pack-ecosystem-candidates.md
+++ b/docs/semantic-pack-ecosystem-candidates.md
@@ -39,6 +39,7 @@ collection-factory kernel operation; other operations remain closed.
 | ecosystem | first narrow slice | candidate status | target lane/channel | value | risk | evidence availability | tracking issue |
 |---|---|---|---|---|---|---|---|
 | Guava | `nose.java.ecosystem.guava.immutable_collection_factories`: immutable `of` factories (`ImmutableList.of`, `ImmutableSet.of`, `ImmutableMap.of`) | first slice implemented | builtin default narrow slice | high for Java collection equivalence | medium | good: existing Java collection/map-factory vocabulary is reused with exact Guava import proof; `copyOf` remains closed | [#496](https://github.com/corca-ai/nose/issues/496) |
+| Vavr | `org.corca.reference.java-vavr-list`: imported `List.of` at arity 3–5 | `priced-ready`; local reference pack shipped | locked near plus external-claim exact | concrete Java collection-factory equivalence without builtin overlap | low-medium within the pinned slice | good: Maven coordinate/version, import, arity, source conformance, receipt, and real consumer evidence are pinned | [#869](https://github.com/corca-ai/nose/issues/869) |
 | Lodash | collection projection/predicate helpers (`map`, `filter`, `some`, `every`) | deferred until fixture evidence | undecided | high for JS/TS repos | high | mixed: callback demand, shorthand iteratees, object order, and lazy chains need hard negatives | [#497](https://github.com/corca-ai/nose/issues/497) |
 | NumPy | scalar integer ufuncs or array clip/min/max laws | deferred | undecided | high for Python data/science repos | high | mixed: dtype, broadcasting, NaN, signed-zero, overflow, and mutation boundaries must be explicit | [#498](https://github.com/corca-ai/nose/issues/498) |
 | RxJS | Observable identity/projection protocol slices | deferred | likely `near-only` before exact-capable rows | medium-high for JS/TS reactive code | high | limited: scheduler, subscription, hot/cold stream, error, and completion behavior need proof boundaries | [#499](https://github.com/corca-ai/nose/issues/499) |
@@ -74,6 +75,17 @@ Future Guava work must still prove the exact package coordinate, static-import
 path, arity/overload identity, version policy, source/result domain, and
 unsupported cases. It must not admit exact equivalence from selector names
 alone.
+
+## External reference candidate
+
+The first shipped external reference pack is the bounded Vavr `List.of` slice.
+It is documented in [Vavr reference pack](semantic-pack-reference-vavr.md) and
+remains disabled unless a user supplies its checked-in project lock. It does
+not duplicate the builtin Guava surface: its package coordinate is
+`io.vavr:vavr`, exact is limited to arity five, and near is limited to arities
+three and four. The `priced-ready` decision is supported by a pinned Maven
+consumer and same-binary product controls; it is not a claim about the rest of
+Vavr.
 
 ## Deferred Candidates
 

--- a/docs/semantic-pack-reference-vavr.md
+++ b/docs/semantic-pack-reference-vavr.md
@@ -1,0 +1,73 @@
+# Vavr `List.of` reference semantic pack
+
+Status: shipped local reference pack, `priced-ready`, explicit opt-in, disabled
+by default.
+
+## What it adds
+
+The reference pack teaches the existing Java collection-factory kernel about a
+small non-builtin surface from `io.vavr:vavr` 0.9.x:
+
+| row | channel | supported calls |
+| --- | --- | --- |
+| `java.vavr.list.of-five-exact` | external-claim exact | imported `io.vavr.collection.List.of` with exactly five arguments |
+| `java.vavr.list.of-three-four-near` | near | the same imported factory with three or four arguments |
+
+No Vavr API is enabled globally. The manifest, Maven evidence, source fixtures,
+kernel receipt, selected rows, and channels are content-pinned by the checked-in
+[project lock](examples/vavr-list-project-lock-v1.json). The exact result is an
+external provider claim tested by nose and authorized by the user; it is not
+builtin certification.
+
+## Try it
+
+Run a query with the pack:
+
+```sh
+nose query src all top=0 --mode near \
+  --semantic-pack-lock docs/examples/vavr-list-project-lock-v1.json
+```
+
+Copy the manifest, receipt, dependency evidence, fixtures, and lock together
+when using the example outside this repository. Regenerate the receipt and lock
+with the installed `nose` after any intentional content or version change.
+
+## Evidence and measured value
+
+Candidate pricing used the pinned Maven consumer
+`dhinojosa/vavr-study@10c8b1c649c672e69a75c60669f442f97b8a555e`.
+Its `pom.xml` declares `io.vavr:vavr` 0.9.1 directly and its Java tests contain
+explicit `io.vavr.collection.List` imports plus arity-three, four, and five
+`List.of` calls. The repository is not vendored or executed.
+
+The product evaluation analyzes that pinned source together with checked-in
+same-binary comparison controls. With no lock, the controlled semantic result
+is absent. With the lock, one attributed external-claim exact family appears;
+near adds one family with two attributed occurrences. Removing the lock restores
+the original output. The closeout artifact records hashes, counts, negative
+matrices, verification, and official-v0.19 runtime comparisons.
+
+## Closed boundaries
+
+The pack does not cover:
+
+- Vavr 1.x, transitive or unresolved dependencies, wildcard imports, fully
+  qualified calls, static imports, aliases, local shadows, or rebound names;
+- arities outside the selected rows, `ofAll`, ranges, streams, maps, sets,
+  tuples, options, functional interfaces, lazy operations, or callbacks;
+- arbitrary provider matchers, executable provider code, Maven/network access,
+  new value-graph nodes, or new canonicalization algorithms.
+
+Wrong dependency versions, imports, members, arities, shadows, receipt content,
+fixture content, conflicts, and resource limits fail closed.
+
+## Disable and roll back
+
+Remove `--semantic-pack-lock` or the `semantic-pack-lock` configuration entry.
+The manifest may remain present for metadata inspection but cannot influence
+analysis without its valid lock. To narrow authority, regenerate the lock with
+only `near` or only selected rows. Do not hand-edit digests.
+
+See [semantic-pack project locks](semantic-pack-project-lock.md) for authority,
+[conformance](semantic-pack-conformance.md) for receipts, and
+[extension API v1](semantic-pack-extension-api-v1.md) for the closed grammar.


### PR DESCRIPTION
## Summary

- ship a disabled-by-default Vavr 0.9.x `List.of` v1 reference pack
- pin its Maven evidence, conformance receipt, selected rows, channels, and project lock
- add same-binary near/external-exact controls, product tests, rollback guidance, and measured closeout evidence

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `NOSE_BIN=target/release/nose ./scripts/check-docs.sh`
- `python3 scripts/check-file-lengths.py --ratchet-base origin/main`
- `RAYON_NUM_THREADS=1 target/release/nose verify crates --max-violations 0` (791 groups, 0 false merges)
- official v0.19 no-pack: semantic +0.23%, near -0.53%; enabled same-binary overhead +3.13 ms / +3.42 ms (within 5 ms floor)

Closes #869