### PR TITLE
Close semantic-pack 0.20 release gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ break.
   semantic packs. `nose semantic-pack lock/status` content-pin manifest identity,
   semantic digest, selected rows/channels, dependency files, and optional receipts;
   query validates configured locks before analysis, rejects stale/escaped/conflicting
-  decisions independent of load order, and keeps all external rows metadata-only.
+  decisions independent of load order, and can admit dependency-backed near rows or
+  receipt-backed, separately attributed external-claim exact collection factories.
+  v0 and unlocked v1 remain metadata-only. External packs are local, explicit opt-ins,
+  disabled by default, and data-only: nose adds no provider-code execution, registry,
+  network resolver, installer, or parser plugin. A shipped Vavr 0.9.x `List.of`
+  reference pack demonstrates the complete lock, receipt, attribution, and rollback
+  workflow without claiming builtin certification.
 - Closed the #847 divergent-edit precision-first cycle without overstating readiness.
   Direct changed-to-skipped targets, bounded semantic-change evidence, and pair-local
   variant signals now give users more precise review context, while one internal policy

--- a/bench/semantic_pack/issue-870-epic-closeout-2026-07-19.v1.json
+++ b/bench/semantic_pack/issue-870-epic-closeout-2026-07-19.v1.json
@@ -1,0 +1,200 @@
+{
+  "schema": "nose.semantic-pack.issue-870-closeout/v1",
+  "issue": 870,
+  "epic": 863,
+  "generated_at": "2026-07-19",
+  "implementation": {
+    "product_source_commit": "07825bcb7a9f03ec34c9c1e93b0ccfe5b5cdf925",
+    "product_binary_sha256": "68f903b639a61e8fa9b1a318b1f1a0ad2e4cb77acddad7f0404c138b7a605edb",
+    "closeout_scope": "documentation, release evidence, checked-example validation, and test-fixture deduplication; no Rust product change",
+    "manifest_apis": [
+      "nose.semantic-pack.v0",
+      "nose.semantic-pack.v1"
+    ],
+    "lock_api": "nose.semantic-pack-lock.v1",
+    "receipt_api": "nose.semantic-pack-conformance-receipt.v1",
+    "query_json_schemas": [
+      7,
+      8
+    ],
+    "capabilities_schema": 7
+  },
+  "release_contract": {
+    "v0": "metadata-only permanently",
+    "v1_unlocked": "compiled metadata and preflight only",
+    "v1_locked_near": "selected dependency-backed near influence",
+    "v1_external_exact": "selected receipt-backed collection-factory influence in the external-claim-exact lane",
+    "builtin_certification": false,
+    "local_explicit_opt_in": true,
+    "external_enabled_by_default": false,
+    "provider_code_execution": false,
+    "registry_or_network_resolution": false,
+    "parser_or_lowering_plugins": false
+  },
+  "schema_and_example_gate": {
+    "script_sha256": "aa73ce6cf3309803b4a4540f29ad3f12a98dbc39e897452cd46161600632f94e",
+    "v0_schema_sha256": "8e6e015bee91556d6dea9425ef9bd8db4746109cdfca555c0684baab6033ad60",
+    "v1_schema_sha256": "fa36b25025d6a990e484d0b40985e6b772f59ffddb9aebe94f7170e99a7c7a70",
+    "lock_schema_sha256": "cdacb924991dda970c3a435bea1bc33227408ca419526d831c95b8a95f022498",
+    "receipt_schema_sha256": "8dcca89ba9269fb4c013f37ede67fd421618cd2df33148cac323526fc8f563d7",
+    "validated_examples": {
+      "v0_manifests": 5,
+      "v1_manifests": 2,
+      "project_locks": 2,
+      "conformance_receipts": 1
+    },
+    "checked_bindings": [
+      "strict lock and receipt fields",
+      "lowercase sha256 pins and current file content",
+      "manifest API, pack identity, version, compatibility, rows, and channels",
+      "receipt identity and selected external-exact rows",
+      "unique dependency, pack, row, and fixture identities",
+      "passing positive and hard-negative receipt observations"
+    ]
+  },
+  "compatibility_matrix": [
+    {
+      "case": "no-pack",
+      "result": "passed",
+      "evidence": "issue-868 nine-repository semantic and near outputs were identical between official v0.19.0 and the candidate"
+    },
+    {
+      "case": "v0 metadata",
+      "result": "passed",
+      "evidence": "valid, executable-gated, value-law, and builtin-vocabulary mirror manifests did not change families or semantic provenance"
+    },
+    {
+      "case": "v1 unlocked",
+      "result": "passed",
+      "evidence": "typed manifest compiled and reported a semantic digest without changing families"
+    },
+    {
+      "case": "v1 locked near",
+      "result": "passed",
+      "evidence": "dependency-backed selected rows changed only the supported near family with complete provenance; semantic output stayed unchanged"
+    },
+    {
+      "case": "v1 receipt-backed external exact",
+      "result": "passed",
+      "evidence": "kernel source conformance opened only the separately attributed external-claim exact lane"
+    },
+    {
+      "case": "conflict and order",
+      "result": "passed",
+      "evidence": "overlapping coordinates failed independent of order; narrowing resolved the conflict; reordered non-conflicting documents preserved the decision digest"
+    },
+    {
+      "case": "stale or broken evidence",
+      "result": "passed",
+      "evidence": "dependency, manifest, receipt, fixture, path, symlink, analysis-failure, and resource-limit cases failed closed"
+    },
+    {
+      "case": "API and nose version",
+      "result": "passed",
+      "evidence": "unsupported APIs and compatibility ranges excluding the installed binary were rejected before loading"
+    },
+    {
+      "case": "base query",
+      "result": "passed",
+      "evidence": "base=<ref> rejected configured semantic packs"
+    },
+    {
+      "case": "disable and rollback",
+      "result": "passed",
+      "evidence": "removing the lock restored the no-lock result; narrowing selected rows or channels reduced authority deterministically"
+    }
+  ],
+  "command_contracts": {
+    "guava_lock_status": {
+      "status": "ok",
+      "selected_rows": 3,
+      "exact_receipts": 0,
+      "output_sha256": "fb7f78604d003924412131a8736215098549a7280a8b802fddb6c8a1a6a7637a"
+    },
+    "vavr_lock_status": {
+      "status": "ok",
+      "selected_rows": 2,
+      "exact_receipts": 1,
+      "output_sha256": "1cfcfadd3ed07f4ee2949bdf52b248bd1ce0a235f44092109e97e12269ae6762"
+    },
+    "vavr_source_conformance": {
+      "status": "ok",
+      "fixtures": "2/2 passed",
+      "output_sha256": "9849ef8ad2a49b43cbc1853fc50f0f028e2beca90f46fb00f158693c6c0c5328"
+    },
+    "compatibility": {
+      "schema": 2,
+      "status": "ok",
+      "output_sha256": "dab504e46c5f695ce971d85eacf53bc3bd312ba06c6f2b3ee62ccb5a56450ef0"
+    },
+    "capabilities": {
+      "schema": 7,
+      "external_exact_operations": [
+        "collection-factory"
+      ],
+      "output_sha256": "033832e2911cf8ac07c7b792904fea506af51a8c6a48d2bed2810051060a2242"
+    }
+  },
+  "official_release_performance": {
+    "baseline": {
+      "version": "v0.19.0",
+      "source_commit": "54f8a67436e39e24c777a85e14224273116add6b",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3"
+    },
+    "candidate_binary_sha256": "68f903b639a61e8fa9b1a318b1f1a0ad2e4cb77acddad7f0404c138b7a605edb",
+    "no_pack_nine_repository": {
+      "semantic_delta_pct": -0.3099,
+      "near_delta_pct": -0.2063,
+      "outputs_identical": true,
+      "source": "issue-868 closeout"
+    },
+    "vavr_no_pack": {
+      "semantic_delta_ms": 0.0387,
+      "near_delta_ms": -0.1271,
+      "outputs_identical": true,
+      "source": "issue-869 closeout"
+    },
+    "vavr_enabled_same_binary": {
+      "semantic_delta_ms": 3.1323,
+      "near_delta_ms": 3.419,
+      "source": "issue-869 closeout"
+    },
+    "gate": {
+      "limit_pct": 5.0,
+      "floor_ms": 5.0,
+      "passed": true
+    }
+  },
+  "soundness": {
+    "command": "RAYON_NUM_THREADS=1 nose verify crates --max-violations 0",
+    "fingerprint_groups": 791,
+    "false_merges": 0,
+    "canon_changed_units_preserved": true,
+    "source": "issue-869 closeout",
+    "product_code_changed_after_measurement": false
+  },
+  "validation": {
+    "full_local_ci": "passed",
+    "semantic_pack_cli_matrix": "26 passed",
+    "base_rejection": "1 passed",
+    "compatibility_contract": "1 passed",
+    "capabilities_contract": "2 passed",
+    "cargo_test_workspace": "passed",
+    "cargo_clippy_workspace_all_targets_deny_warnings": "passed",
+    "cargo_fmt_check": "passed",
+    "line_coverage_pct": 87.46,
+    "duplication_gate": "27/27 passed without a budget increase",
+    "msrv": "passed",
+    "dependency_policy": "passed",
+    "docs": "passed",
+    "formal_obligations_and_lean": "passed",
+    "file_lengths": "passed",
+    "git_diff_check": "passed"
+  },
+  "rollback": {
+    "action": "remove --semantic-pack-lock or the semantic-pack-lock config entry; optionally regenerate a narrower row/channel lock",
+    "restores_no_lock_output": true,
+    "network_or_install_cleanup": false,
+    "provider_code_cleanup": false
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "1beac2e3034b4b7f901c56f34b134732f023bc53",
+  "product_crates_tree": "525977506cf6d1ed73130885f83e761ad2bac129",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/tests/cli/commands/config_packs/external_exact.rs
+++ b/crates/nose-cli/tests/cli/commands/config_packs/external_exact.rs
@@ -1,69 +1,21 @@
 use super::*;
 
 fn exact_manifest() -> String {
-    r#"{
-  "api_version":"nose.semantic-pack.v1",
-  "pack":{
-    "id":"com.example.fast-list",
-    "kind":"LibraryPack",
-    "version":"1.0.0",
-    "display_name":"Fast List",
-    "trust":"external-opt-in",
-    "enabled_by_default":false
-  },
-  "provenance":{
-    "provider":{"name":"Example"},
-    "license":"MIT",
-    "repository":"https://example.invalid/fast-list"
-  },
-  "compatibility":{"nose":">=0.19.0 <0.21.0"},
-  "supported_languages":["java"],
-  "packages":[{
-    "ecosystem":"maven",
-    "name":"com.example:fast-list",
-    "versions":">=1.2.0 <2.0.0"
-  }],
-  "declares":{"api_contracts":[{
-    "id":"java.fast-list.of-five",
-    "language":"java",
-    "package":{"ecosystem":"maven","name":"com.example:fast-list"},
-    "anchor":"call-node",
-    "matcher":"imported-api",
-    "import":{"role":"type","module":"com.example.collect","name":"FastList"},
-    "call":{
-      "shape":"static-method",
-      "member":"of",
-      "arity":{"kind":"set","values":[5]},
-      "receiver":"imported-type"
-    },
-    "operation":"collection-factory",
-    "result_domain":"collection",
-    "profiles":{
-      "demand":"eager",
-      "effects":"pure",
-      "exceptions":"no-throw",
-      "mutation":"none",
-      "identity":"fresh"
-    },
-    "channel":"external-exact"
-  }]},
-  "conformance":{"fixtures":[{
-    "id":"factory-positive",
-    "row_id":"java.fast-list.of-five",
-    "kind":"positive",
-    "path":"fixtures/positive",
-    "dependency":"pom.xml",
-    "expectation":"external-exact-match"
-  },{
-    "id":"wrong-member-negative",
-    "row_id":"java.fast-list.of-five",
-    "kind":"hard-negative",
-    "path":"fixtures/wrong-member",
-    "dependency":"pom.xml",
-    "expectation":"no-external-exact-match"
-  }]}
-}"#
-    .to_string()
+    include_str!("../../../../../../docs/examples/semantic-packs/v1/vavr-list.json")
+        .replace(
+            "org.corca.reference.java-vavr-list",
+            "com.example.fast-list",
+        )
+        .replace("io.vavr:vavr", "com.example:fast-list")
+        .replace(">=0.9.0 <0.10.0", ">=1.2.0 <2.0.0")
+        .replace("java.vavr.list.of-five-exact", "java.fast-list.of-five")
+        .replace("io.vavr.collection", "com.example.collect")
+        .replace("List", "FastList")
+        .replace("vavr-list-hard-negatives", "wrong-member-negative")
+        .replace("vavr-list-of-five-positive", "factory-positive")
+        .replace("vavr-list-fixtures/hard-negatives", "fixtures/wrong-member")
+        .replace("vavr-list-fixtures/positive", "fixtures/positive")
+        .replace("vavr-list-pom.xml", "pom.xml")
 }
 
 fn prepare_exact_project(tag: &str) -> PathBuf {

--- a/docs/dogfooding-history.md
+++ b/docs/dogfooding-history.md
@@ -1290,3 +1290,22 @@ by #854. Sharing either pair would couple independent engines or numeric
 policies for the sake of incidental structure, so no new abstraction is
 accepted. The baseline records the corrected detector behavior rather than
 hiding the query-compatibility fix.
+
+The #870 semantic-pack epic closeout keeps the reviewed count at 27. Its first
+self-query found one avoidable test family: the external-exact CLI fixture and
+the v1 compiler unit fixture each carried a nearly complete inline manifest.
+The CLI test now derives its isolated FastList scenario from the shipped Vavr
+v1 reference manifest, then changes only the pack-specific coordinates and
+fixture names. All six exact-lane tests retain their source, receipt, stale,
+resource, and symlink assertions, while family `346987af8dd29546` disappears.
+
+The final ID delta replaces the returning numeric `int_bin` / `float_bin`
+representative `aa2b95cf822a1cd2` with `2bca2e8582b7d7a7`, a broad whole-impl
+overlap between `SemanticPackNearRegistry` and
+`SemanticPackExternalExactRegistry`. The two registries share 21 lines across
+roughly 200-line implementations, but own different trust mechanics: near
+builds protocol evidence and joins builtins, while exact requires a receipt,
+records separate assurance, and adds kernel evidence to the corpus. A common
+base registry would couple those security boundaries for incidental structure.
+The members are kept separate, the stale numeric ID is replaced, and no budget
+increase or new avoidable duplication is accepted.

--- a/docs/home.md
+++ b/docs/home.md
@@ -102,6 +102,7 @@ fundamentals; the rest is grouped by area.
 - [semantic-pack-extension-api-v0](semantic-pack-extension-api-v0.md) — versioned v0 schema and provider-facing extension API for language/library semantic packs.
 - [semantic-pack-extension-api-v1](semantic-pack-extension-api-v1.md) — closed typed Java/Maven package-API grammar, deterministic compiler, local dependency/occurrence evidence, bounded locked near influence, and receipt-backed collection-factory exact claims.
 - [semantic-pack-reference-vavr](semantic-pack-reference-vavr.md) — shipped, disabled-by-default Vavr `List.of` reference pack, pinned lock/receipt, measured value, boundaries, and rollback.
+- [semantic-pack-0.20-release-gate](semantic-pack-0.20-release-gate.md) — the #863 compatibility, provenance, soundness, performance, responsibility, and rollback closeout for influential local packs.
 - [semantic-pack-project-lock](semantic-pack-project-lock.md) — local content-pinned v1 authorization, row/channel selection, dependency/receipt pins, path containment, deterministic conflict rejection, and evidence input boundary.
 - [semantic-pack-conformance](semantic-pack-conformance.md) — provider/user workflow for structural and bounded kernel source checks, receipt output, and builtin inventory audits.
 - [semantic-pack-loading](semantic-pack-loading.md) — local pack manifest loading, explicit opt-in trust policy, and fail-closed near/external-claim-exact boundaries.

--- a/docs/semantic-pack-0.20-release-gate.md
+++ b/docs/semantic-pack-0.20-release-gate.md
@@ -1,0 +1,88 @@
+# Semantic packs 0.20 release gate
+
+Status: #863 is closed for the 0.20 contract. The released surface is deliberately
+narrow: local data-only Java/Maven collection-factory rows, explicit project
+authorization, and no provider execution.
+
+## What users can rely on
+
+| Input | Analysis effect | Assurance and failure behavior |
+| --- | --- | --- |
+| no pack | existing builtin analysis only | output and runtime stay on the ordinary product path |
+| v0 manifest | metadata only, permanently | strict loading may fail, but a valid manifest cannot change families |
+| unlocked v1 manifest | compile/check metadata only | no row is authorized to influence analysis |
+| valid v1 near lock | selected dependency-backed near rows | each affected result names its pack, row, evidence, and caveats |
+| valid v1 external-exact lock | selected receipt-backed collection-factory rows | reported as `external-claim-exact`, never builtin-certified exact |
+| missing, stale, incompatible, escaped, unsupported, or conflicting input | no analysis | the complete lock is rejected before source analysis |
+
+The manifest grammar is closed and typed. It can select only kernel-owned Java
+Maven import, receiver, member, arity, operation, domain, and profile mechanics.
+It cannot add callbacks, regex matchers, parser behavior, value-graph nodes,
+fingerprints, or canonicalization algorithms.
+
+## Responsibility and trust
+
+nose owns strict parsing and compilation, content and row digests, project-lock
+validation, local dependency evidence, source occurrence checks, conflict
+rejection, channel separation, deterministic output, conformance-runner behavior,
+and result provenance. Pack providers own the truth and maintenance of their API
+claims and fixtures. Users review, pin, enable, limit, update, and remove those
+claims for a project.
+
+A passing receipt means that the installed nose kernel reproduced the declared
+positive and hard-negative observations for the pinned content. It is not nose
+certification of a provider or a universal semantic claim.
+
+## Update, disable, and roll back
+
+Regenerate the receipt and then the lock after changing nose, a manifest, selected
+rows or channels, fixtures, dependency evidence, or kernel capability. Review both
+diffs and run `nose semantic-pack status LOCK --format json`. Hand-edited or stale
+digests fail closed, as do overlapping semantic coordinates; load order never
+chooses a winner.
+
+To disable the pack, remove `--semantic-pack-lock` or the
+`semantic-pack-lock` configuration entry. To narrow authority, regenerate the
+lock with fewer rows or only the `near` channel. No uninstaller, registry cleanup,
+provider process shutdown, or network cleanup is needed because none exists.
+
+`base=<ref>` queries reject semantic packs. nose does not pretend that one local
+dependency/receipt decision establishes compatible evidence for both revisions.
+
+## Release evidence
+
+The closeout matrix covers no-pack, v0 metadata, unlocked v1, locked near,
+receipt-backed external exact, conflicts, stale content, incompatible versions,
+`base=` rejection, deterministic replay, disablement, and rollback. The checked
+example gate validates every v0/v1 manifest plus every project lock and receipt,
+including lock-to-manifest and receipt-to-selected-row bindings.
+
+The official v0.19.0 binary is the performance baseline:
+
+- the nine-repository no-pack comparison is output-identical in semantic and near
+  modes; aggregate runtime changes are -0.31% and -0.21%;
+- the Vavr consumer comparison is output-identical without a pack and changes
+  runtime by +0.04 ms semantic and -0.13 ms near;
+- enabling the reference lock on its small evaluation corpus adds +3.13 ms
+  semantic and +3.42 ms near, below the 5 ms measurement floor;
+- `nose verify crates --max-violations 0` reports zero false merges and preserves
+  canonical changed units.
+
+The immutable inputs and measurements are split by purpose:
+
+- [#868 external-exact evidence](../bench/semantic_pack/issue-868-external-exact-closeout-2026-07-19.v1.json) records the lane, no-pack comparison, and nine-repository runtime gate.
+- [#869 Vavr evidence](../bench/semantic_pack/issue-869-vavr-reference-pack-closeout-2026-07-19.v1.json) records the real consumer, controlled value, enabled overhead, and rollback.
+- [#870 epic closeout](../bench/semantic_pack/issue-870-epic-closeout-2026-07-19.v1.json) records the final contract and test matrix.
+
+## Explicit non-goals
+
+0.20 does not ship provider code or commands, remote registries, downloads,
+installation or signing services, dependency resolution, parser/lowering plugins,
+sandboxed pack execution, arbitrary matchers, default-enabled external packs, or
+broad Vavr/library coverage. Future capabilities require new evidence and explicit
+versioned contracts; this closeout does not imply them.
+
+See [loading](semantic-pack-loading.md), [typed manifest v1](semantic-pack-extension-api-v1.md),
+[project locks](semantic-pack-project-lock.md), [conformance](semantic-pack-conformance.md),
+[compatibility](semantic-pack-compatibility.md), and the
+[Vavr reference pack](semantic-pack-reference-vavr.md) for operational details.

--- a/docs/semantic-pack-project-lock.md
+++ b/docs/semantic-pack-project-lock.md
@@ -16,6 +16,9 @@ The [semantic-pack lock v1 schema](schemas/semantic-pack-lock-v1.schema.json)
 defines the machine-readable contract.
 A [checked-in Guava lock example](examples/semantic-pack-lock-v1.json) pins the
 typed v1 example and a local Maven dependency file.
+The [Vavr reference lock](examples/vavr-list-project-lock-v1.json) additionally
+pins an external-exact conformance receipt and demonstrates a mixed near/exact
+decision.
 A lock pins:
 
 - the manifest's project-relative coordinate, API version, pack id/version,

--- a/docs/semantic-pack-reference-vavr.md
+++ b/docs/semantic-pack-reference-vavr.md
@@ -45,7 +45,8 @@ same-binary comparison controls. With no lock, the controlled semantic result
 is absent. With the lock, one attributed external-claim exact family appears;
 near adds one family with two attributed occurrences. Removing the lock restores
 the original output. The closeout artifact records hashes, counts, negative
-matrices, verification, and official-v0.19 runtime comparisons.
+matrices, verification, and official-v0.19 runtime comparisons; see the
+[#869 machine-readable evidence](../bench/semantic_pack/issue-869-vavr-reference-pack-closeout-2026-07-19.v1.json) for the immutable values.
 
 ## Closed boundaries
 

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -263,6 +263,11 @@ set -euo pipefail
 # candidate-pair representative moves from `8462d08908be9e8a` to `3fefab5ac16598ec`, and the
 # long-standing numeric `int_bin` / `float_bin` family `aa2b95cf822a1cd2` crosses value 40.
 # Neither family was introduced or modified here; see docs/dogfooding-history.md.
+# 27 -> 27 (#870 semantic-pack closeout): reusing the shipped Vavr manifest removes an
+# avoidable exact-pack test fixture family. The final self-query replaces the reviewed numeric
+# dispatcher representative with an exact/near registry whole-impl overlap. Those registries
+# intentionally keep receipt-backed exact mutation separate from near-protocol evidence; no shared
+# base registry or budget increase is accepted. See docs/dogfooding-history.md.
 BIN="${NOSE_BIN:-./target/release/nose}"
 BASELINE="${NOSE_DUP_BASELINE:-scripts/duplication-baseline.json}"
 

--- a/scripts/check-semantic-pack-examples.py
+++ b/scripts/check-semantic-pack-examples.py
@@ -18,7 +18,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "docs" / "schemas" / "semantic-pack-v0.schema.json"
 SCHEMA_V1 = ROOT / "docs" / "schemas" / "semantic-pack-v1.schema.json"
 LOCK_SCHEMA_V1 = ROOT / "docs" / "schemas" / "semantic-pack-lock-v1.schema.json"
-LOCK_EXAMPLE_V1 = ROOT / "docs" / "examples" / "semantic-pack-lock-v1.json"
+RECEIPT_SCHEMA_V1 = (
+    ROOT / "docs" / "schemas" / "semantic-pack-conformance-receipt-v1.schema.json"
+)
+LOCK_EXAMPLES_V1 = sorted((ROOT / "docs" / "examples").glob("*lock-v1.json"))
+RECEIPT_EXAMPLES_V1 = sorted(
+    (ROOT / "docs" / "examples" / "semantic-pack-receipts").glob("*.json")
+)
 EXAMPLES = sorted(
     (ROOT / "docs" / "examples" / "semantic-packs" / "v0").glob("*.json")
 )
@@ -76,6 +82,8 @@ EVIDENCE_PREFIXES = (
     "SequenceSurface.",
 )
 ALLOWED_REQUIREMENT_PREFIXES = EVIDENCE_PREFIXES + ("nose.",)
+DIGEST_PREFIX = "sha256:"
+DIGEST_LENGTH = len(DIGEST_PREFIX) + 64
 
 
 def fail(path: Path, message: str) -> None:
@@ -127,6 +135,32 @@ def require_enum(path: Path, value: Any, allowed: set[str], label: str) -> str:
     if not isinstance(value, str) or value not in allowed:
         fail(path, f"`{label}` must be one of {sorted(allowed)}")
     return value
+
+
+def require_digest(path: Path, value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != DIGEST_LENGTH
+        or not value.startswith(DIGEST_PREFIX)
+        or any(character not in "0123456789abcdef" for character in value[len(DIGEST_PREFIX) :])
+    ):
+        fail(path, f"`{label}` must be a lowercase sha256 digest")
+    return value
+
+
+def require_exact_keys(
+    path: Path,
+    value: dict[str, Any],
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    missing = required - value.keys()
+    unknown = value.keys() - required - optional
+    if missing:
+        fail(path, f"`{label}` is missing fields {sorted(missing)}")
+    if unknown:
+        fail(path, f"`{label}` has unknown fields {sorted(unknown)}")
 
 
 def require_unique_ids(path: Path, items: list[Any], label: str) -> set[str]:
@@ -376,26 +410,169 @@ def resolve_lock_path(lock_path: Path, declared: str) -> Path:
 def validate_file_pin(lock_path: Path, pin: Any) -> None:
     if not isinstance(pin, dict):
         fail(lock_path, "file pin must be an object")
+    require_exact_keys(lock_path, pin, {"path", "content_digest"}, set(), "file pin")
     declared = require_string(lock_path, pin, "path")
-    expected = require_string(lock_path, pin, "content_digest")
+    expected = require_digest(lock_path, pin.get("content_digest"), "file pin content_digest")
     resolved = resolve_lock_path(lock_path, declared)
     actual = "sha256:" + hashlib.sha256(resolved.read_bytes()).hexdigest()
     if expected != actual:
         fail(lock_path, f"locked file `{declared}` digest is stale")
 
 
+def validate_v1_receipt(path: Path, doc: dict[str, Any]) -> None:
+    require_exact_keys(
+        path,
+        doc,
+        {
+            "api_version",
+            "nose_version",
+            "kernel_capability",
+            "pack_id",
+            "pack_version",
+            "semantic_digest",
+            "rows",
+            "fixtures",
+            "passed",
+        },
+        set(),
+        "receipt",
+    )
+    if doc.get("api_version") != "nose.semantic-pack-conformance-receipt.v1":
+        fail(path, "receipt `api_version` must be nose.semantic-pack-conformance-receipt.v1")
+    require_string(path, doc, "nose_version")
+    if doc.get("kernel_capability") != "nose.kernel.external-collection-factory-exact.v1":
+        fail(path, "receipt has an unsupported kernel capability")
+    require_string(path, doc, "pack_id")
+    require_string(path, doc, "pack_version")
+    require_digest(path, doc.get("semantic_digest"), "receipt semantic_digest")
+    if require_bool(path, doc, "passed") is not True:
+        fail(path, "checked-in receipt must have passed")
+
+    rows = require_array(path, doc, "rows", min_items=1)
+    row_ids: set[str] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            fail(path, f"`rows[{index}]` must be an object")
+        require_exact_keys(
+            path,
+            row,
+            {"row_id", "row_digest", "channel"},
+            set(),
+            f"rows[{index}]",
+        )
+        row_id = require_string(path, row, "row_id")
+        if row_id in row_ids:
+            fail(path, f"duplicate receipt row `{row_id}`")
+        row_ids.add(row_id)
+        require_digest(path, row.get("row_digest"), f"rows[{index}].row_digest")
+        require_enum(path, row.get("channel"), {"external-exact"}, f"rows[{index}].channel")
+
+    fixtures = require_array(path, doc, "fixtures", min_items=2)
+    fixture_ids: set[str] = set()
+    fixture_kinds = {row_id: set() for row_id in row_ids}
+    expectations = {"external-exact-match", "no-external-exact-match"}
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            fail(path, f"`fixtures[{index}]` must be an object")
+        require_exact_keys(
+            path,
+            fixture,
+            {
+                "id",
+                "row_id",
+                "kind",
+                "path",
+                "dependency",
+                "fixture_digest",
+                "dependency_digest",
+                "expectation",
+                "observed",
+                "passed",
+            },
+            set(),
+            f"fixtures[{index}]",
+        )
+        fixture_id = require_string(path, fixture, "id")
+        if fixture_id in fixture_ids:
+            fail(path, f"duplicate receipt fixture `{fixture_id}`")
+        fixture_ids.add(fixture_id)
+        row_id = require_string(path, fixture, "row_id")
+        if row_id not in row_ids:
+            fail(path, f"receipt fixture `{fixture_id}` references unknown row `{row_id}`")
+        kind = require_enum(
+            path,
+            fixture.get("kind"),
+            {"positive", "hard-negative"},
+            f"fixtures[{index}].kind",
+        )
+        fixture_kinds[row_id].add(kind)
+        require_string(path, fixture, "path")
+        require_string(path, fixture, "dependency")
+        require_digest(path, fixture.get("fixture_digest"), f"fixtures[{index}].fixture_digest")
+        require_digest(
+            path,
+            fixture.get("dependency_digest"),
+            f"fixtures[{index}].dependency_digest",
+        )
+        expectation = require_enum(
+            path,
+            fixture.get("expectation"),
+            expectations,
+            f"fixtures[{index}].expectation",
+        )
+        observed = require_enum(
+            path,
+            fixture.get("observed"),
+            expectations,
+            f"fixtures[{index}].observed",
+        )
+        if expectation != observed or require_bool(path, fixture, "passed") is not True:
+            fail(path, f"receipt fixture `{fixture_id}` is not a passing observation")
+    for row_id, kinds in fixture_kinds.items():
+        if kinds != {"positive", "hard-negative"}:
+            fail(path, f"receipt row `{row_id}` must have positive and hard-negative fixtures")
+
+
 def validate_v1_lock(path: Path, doc: dict[str, Any]) -> None:
+    require_exact_keys(
+        path,
+        doc,
+        {"api_version", "dependencies", "packs"},
+        {"$schema"},
+        "project lock",
+    )
     if doc.get("api_version") != "nose.semantic-pack-lock.v1":
         fail(path, "lock `api_version` must be nose.semantic-pack-lock.v1")
     dependencies = require_array(path, doc, "dependencies", min_items=1)
+    dependency_paths: set[str] = set()
     for dependency in dependencies:
         validate_file_pin(path, dependency)
+        declared = dependency["path"]
+        if declared in dependency_paths:
+            fail(path, f"duplicate dependency path `{declared}`")
+        dependency_paths.add(declared)
     packs = require_array(path, doc, "packs", min_items=1)
     ids: set[str] = set()
     manifests: set[str] = set()
     for entry in packs:
         if not isinstance(entry, dict):
             fail(path, "lock pack entries must be objects")
+        require_exact_keys(
+            path,
+            entry,
+            {
+                "manifest",
+                "manifest_api_version",
+                "pack_id",
+                "pack_version",
+                "nose_compatibility",
+                "semantic_digest",
+                "allowed_channels",
+                "selected_rows",
+            },
+            {"exact_receipt"},
+            "lock pack entry",
+        )
         pack_id = require_string(path, entry, "pack_id")
         manifest_path = require_string(path, entry, "manifest")
         if pack_id in ids or manifest_path in manifests:
@@ -407,6 +584,7 @@ def validate_v1_lock(path: Path, doc: dict[str, Any]) -> None:
             fail(path, f"lock entry `{pack_id}` must pin manifest v1")
         if manifest.get("api_version") != "nose.semantic-pack.v1":
             fail(path, f"lock entry `{pack_id}` references a non-v1 manifest")
+        validate_v1_pack(resolve_lock_path(path, manifest_path), manifest)
         if require_object(path, manifest, "pack").get("id") != pack_id:
             fail(path, f"lock entry `{pack_id}` does not match its manifest")
         if require_string(path, entry, "pack_version") != manifest["pack"]["version"]:
@@ -414,17 +592,42 @@ def validate_v1_lock(path: Path, doc: dict[str, Any]) -> None:
         compatibility = require_object(path, manifest, "compatibility")
         if require_string(path, entry, "nose_compatibility") != compatibility.get("nose"):
             fail(path, f"lock entry `{pack_id}` compatibility range is stale")
-        digest = require_string(path, entry, "semantic_digest")
-        if len(digest) != 71 or not digest.startswith("sha256:"):
-            fail(path, f"lock entry `{pack_id}` semantic digest is malformed")
+        require_digest(path, entry.get("semantic_digest"), f"lock entry {pack_id} semantic_digest")
         channels = require_array(path, entry, "allowed_channels", min_items=1)
         if len(channels) != len(set(channels)) or not set(channels) <= {"near", "external-exact"}:
             fail(path, f"lock entry `{pack_id}` has invalid allowed channels")
         rows = require_array(path, entry, "selected_rows", min_items=1)
         if len(rows) != len(set(rows)):
             fail(path, f"lock entry `{pack_id}` has duplicate selected rows")
-        if "exact_receipt" in entry:
-            validate_file_pin(path, entry["exact_receipt"])
+        manifest_rows = {
+            contract["id"]: contract["channel"]
+            for contract in require_object(path, manifest, "declares")["api_contracts"]
+        }
+        for row_id in rows:
+            if row_id not in manifest_rows:
+                fail(path, f"lock entry `{pack_id}` selects unknown row `{row_id}`")
+            if manifest_rows[row_id] not in channels:
+                fail(path, f"lock entry `{pack_id}` does not allow row `{row_id}` channel")
+        exact_rows = sorted(row_id for row_id in rows if manifest_rows[row_id] == "external-exact")
+        receipt_pin = entry.get("exact_receipt")
+        if exact_rows and receipt_pin is None:
+            fail(path, f"lock entry `{pack_id}` selects exact rows without a receipt")
+        if not exact_rows and receipt_pin is not None:
+            fail(path, f"lock entry `{pack_id}` pins a receipt without exact rows")
+        if receipt_pin is not None:
+            validate_file_pin(path, receipt_pin)
+            receipt_path = resolve_lock_path(path, receipt_pin["path"])
+            receipt = read_json(receipt_path)
+            validate_v1_receipt(receipt_path, receipt)
+            if (
+                receipt["pack_id"] != pack_id
+                or receipt["pack_version"] != entry["pack_version"]
+                or receipt["semantic_digest"] != entry["semantic_digest"]
+            ):
+                fail(path, f"lock entry `{pack_id}` receipt identity is stale")
+            receipt_rows = sorted(row["row_id"] for row in receipt["rows"])
+            if receipt_rows != exact_rows:
+                fail(path, f"lock entry `{pack_id}` receipt rows do not match selected exact rows")
 
 
 def main() -> int:
@@ -445,10 +648,25 @@ def main() -> int:
     lock_schema = read_json(LOCK_SCHEMA_V1)
     if lock_schema.get("$id") is None or lock_schema.get("title") is None:
         fail(LOCK_SCHEMA_V1, "schema must declare $id and title")
-    validate_v1_lock(LOCK_EXAMPLE_V1, read_json(LOCK_EXAMPLE_V1))
+    receipt_schema = read_json(RECEIPT_SCHEMA_V1)
+    if receipt_schema.get("$id") is None or receipt_schema.get("title") is None:
+        fail(RECEIPT_SCHEMA_V1, "schema must declare $id and title")
+    if not LOCK_EXAMPLES_V1:
+        fail(ROOT / "docs" / "examples", "no project lock v1 examples found")
+    if not RECEIPT_EXAMPLES_V1:
+        fail(
+            ROOT / "docs" / "examples" / "semantic-pack-receipts",
+            "no conformance receipt v1 examples found",
+        )
+    for receipt in RECEIPT_EXAMPLES_V1:
+        validate_v1_receipt(receipt, read_json(receipt))
+    for lock in LOCK_EXAMPLES_V1:
+        validate_v1_lock(lock, read_json(lock))
     print(
         f"validated {len(EXAMPLES)} semantic-pack v0 example(s) and "
-        f"{len(EXAMPLES_V1)} semantic-pack v1 example(s), plus project lock v1"
+        f"{len(EXAMPLES_V1)} semantic-pack v1 example(s), "
+        f"{len(LOCK_EXAMPLES_V1)} project lock(s), and "
+        f"{len(RECEIPT_EXAMPLES_V1)} conformance receipt(s)"
     )
     return 0
 

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -12,7 +12,7 @@
     "3fefab5ac16598ec",
     "8d3e36bdd11cf2c0",
     "95e83331abfa623f",
-    "aa2b95cf822a1cd2",
+    "2bca2e8582b7d7a7",
     "a679fd9cdbda1be2",
     "b59e5826da2acff8",
     "c8961b547fcb59c7",


### PR DESCRIPTION
Closes #870

## Summary

- finalize the 0.20 compatibility, provenance, responsibility, rollback, and non-goal contract
- validate every checked-in semantic-pack manifest, project lock, conformance receipt, and their cross-file bindings
- record immutable v0.19-baselined performance and soundness evidence
- remove the duplicated external-exact test manifest while keeping the near/exact trust registries separate and the duplication budget at 27

## Validation

- `./scripts/check-ci-local.sh --full`
- semantic-pack CLI matrix: 26 passed
- line coverage: 87.46%
- duplication gate: 27/27 without a budget increase
- MSRV, dependency policy, documentation, formal obligations, and Lean proofs passed