### PR TITLE
docs: attribute the etcd Go frontend residual

### DIFF
--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -6,6 +6,12 @@ the checked-in files record the command, selected surface, hard gate, reason
 rollups, and representative fixtures needed to reproduce or review a semantic
 kernel PR.
 
+Performance attribution records also live here when a frozen product-level result must
+remain reviewable without retaining large raw profiles. For example,
+`issue-907-etcd-frontend-attribution-2026-07-19.v1.json` binds the #892 r40 rows to exact
+binary/build identities, normalized instruction hashes, the compact profile summary,
+and the resulting no-go optimization decision.
+
 Scheduling lifecycle audit artifacts use a separate source-prevalence status
 vocabulary:
 

--- a/bench/recall_loss/issue-907-etcd-frontend-attribution-2026-07-19.v1.json
+++ b/bench/recall_loss/issue-907-etcd-frontend-attribution-2026-07-19.v1.json
@@ -1,0 +1,151 @@
+{
+  "schema": "nose.issue-907.etcd_frontend_attribution/v1",
+  "issue": 907,
+  "generated_on": "2026-07-19",
+  "outcome": "no-structural-work/build-provenance-and-control-subtraction",
+  "frozen_reproduction": {
+    "performance_artifact": {
+      "path": "bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json",
+      "sha256": "e603d720d77f0d2e9d69d7aa4bf2f679fbfc1a30c2fc178c8434613a0c8f6b04"
+    },
+    "r40_checker_status_sha256": "021b949bd1a9a3b4fef512af268f683e799e7b2103f21ec857c21db165a8b8f2",
+    "command": "nose query bench/repos/etcd all top=0 --format json",
+    "corpus": {
+      "repository": "etcd",
+      "source_sha": "9ed485d3e37bbdddff471f5c6d6d7f62048c07d1",
+      "non_git_files": 1473
+    },
+    "rows": [
+      {
+        "stage": "lower",
+        "baseline_median_ms": 85.15,
+        "candidate_median_ms": 87.65,
+        "raw_delta_ms": 2.50,
+        "control_delta_ms": -3.05,
+        "control_adjusted_delta_ms": 5.55,
+        "control_adjusted_delta_pct": 6.5179
+      },
+      {
+        "stage": "parse+lower",
+        "baseline_median_ms": 55.90,
+        "candidate_median_ms": 58.45,
+        "raw_delta_ms": 2.55,
+        "control_delta_ms": -3.35,
+        "control_adjusted_delta_ms": 5.90,
+        "control_adjusted_delta_pct": 10.5546
+      }
+    ],
+    "thresholds": {
+      "maximum_delta_pct": 5.0,
+      "minimum_absolute_delta_ms": 5.0,
+      "changed": false
+    },
+    "rerun_for_verdict": false
+  },
+  "binaries": {
+    "baseline": {
+      "release": "v0.19.0",
+      "source_sha": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+      "file_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "macho_minimum_os": "11.0",
+      "macho_sdk": "14.5",
+      "text_segment_bytes": 19693568,
+      "text_section_bytes": 7045316
+    },
+    "candidate": {
+      "source_sha": "8c37b8f9c75b9543dc746e3eb6b9b18209810059",
+      "file_sha256": "111c6507dd028a194c000fbc279e05e6b9b2899552a9dca7f56a15d23c5ad38c",
+      "code_sha256": "e8f592a00519b27d1bd4ff4a52911806c1180e8f9a72be68232157adca7dc63f",
+      "macho_minimum_os": "11.0",
+      "macho_sdk": "26.2",
+      "text_segment_bytes": 19972096,
+      "text_section_bytes": 7289744
+    }
+  },
+  "source_identity": {
+    "go_frontend_files": 7,
+    "go_frontend_tree_sha256": "f0afe26105810c0bbc5feca7d46a13e49785c51fc05b92ab6e5f23f2bfecb36a",
+    "tree_identical_at_baseline_candidate_and_current": true,
+    "tree_sitter_go": {
+      "version": "0.25.0",
+      "identical": true
+    },
+    "tree_sitter_runtime": {
+      "version": "0.25.10",
+      "identical": true
+    },
+    "tree_sitter_language": {
+      "version": "0.1.7",
+      "identical": true
+    },
+    "release_profile_identical": true
+  },
+  "machine_code_identity": {
+    "go_symbol_count": {
+      "baseline": 41,
+      "candidate": 41
+    },
+    "go_module_relative_span_bytes": {
+      "baseline": 55344,
+      "candidate": 55344
+    },
+    "normalized_instruction_sha256": {
+      "go_lower_stmt": {
+        "baseline": "27889fe4bac71d2e6f64015689ea617d35866f69cad48f1594c5943e44deb1a3",
+        "candidate": "27889fe4bac71d2e6f64015689ea617d35866f69cad48f1594c5943e44deb1a3"
+      },
+      "go_lower_expr_with_iota": {
+        "baseline": "1818303459902841d70ab7b06ec5e717fb0ba13e48c85d112960e5d8ffc5b9ba",
+        "candidate": "1818303459902841d70ab7b06ec5e717fb0ba13e48c85d112960e5d8ffc5b9ba"
+      },
+      "go_lower_block": {
+        "baseline": "7d7020abed833f676a28102d581b3dc233d5c0cb7349c45fb7aa3a14bfaea839",
+        "candidate": "7d7020abed833f676a28102d581b3dc233d5c0cb7349c45fb7aa3a14bfaea839"
+      },
+      "tree_sitter_parse_with_options": {
+        "baseline": "0e57710d692b12a1f6d4cd5c3b0bdcc7dc8b01b98d91e696d7f3b4baeb0140ff",
+        "candidate": "0e57710d692b12a1f6d4cd5c3b0bdcc7dc8b01b98d91e696d7f3b4baeb0140ff"
+      },
+      "tree_sitter_parse": {
+        "baseline": "12b742ac8f876e902ef1a5430f4806e537417db55dfc2b1969c7c316395d1115",
+        "candidate": "2bdc1b23341dab09a647c93d16b8c1096e828c2a89dfa0308bb982c0b75c245b"
+      }
+    },
+    "normalization": "Branch and PC-relative targets, plus the address-forming ADD after ADRP, were removed; all other instruction bytes were retained.",
+    "interpretation": "The Rust Go lowering hot paths are instruction-identical. Source-identical tree-sitter parser code differs under the two whole-program build environments."
+  },
+  "diagnostic_profile": {
+    "tool": "/usr/bin/sample",
+    "duration_seconds": 1,
+    "interval_ms": 1,
+    "rayon_num_threads": 1,
+    "performance_verdict": false,
+    "baseline": {
+      "raw_sha256": "e92b90b44129dd3021c9010a0b8d39d92e6f111fc341ee5115bce16b2af5fff5",
+      "go_lower_source_inclusive_samples": 410,
+      "parser_inclusive_samples": 251,
+      "derived_post_parser_lower_samples": 159,
+      "tree_sitter_parse_top_stack_samples": 58
+    },
+    "candidate": {
+      "raw_sha256": "93b956c4fe3b49549f7a5e1eb420fea561c884f6a6dbc4495c7ff3989926e6de",
+      "go_lower_source_inclusive_samples": 395,
+      "parser_inclusive_samples": 231,
+      "derived_post_parser_lower_samples": 164,
+      "tree_sitter_parse_top_stack_samples": 52
+    },
+    "interpretation": "The one-shot diagnostic profile exposes no added Go call path. Candidate parser and total frontend samples are lower; post-parser lowering differs by five samples and is not an independent performance verdict."
+  },
+  "decision": {
+    "structural_go_frontend_regression_proven": false,
+    "product_code_changed": false,
+    "reason": "The frozen raw deltas are below 5 ms, the Go source and hot lowering instruction streams are identical, and only a negative same-binary control raises the adjusted rows above both gates. Different SDK provenance explains source-identical native parser code and binary-layout differences.",
+    "output_contract_preserved": true,
+    "follow_up": {
+      "issue": 927,
+      "url": "https://github.com/corca-ai/nose/issues/927",
+      "scope": "Preregister an order-aware same-binary control estimator without changing the 5%/5 ms product gate or rerunning #892."
+    }
+  }
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -197,6 +197,7 @@ fundamentals; the rest is grouped by area.
 - [0.17.0 post-release runtime triage](runtime-triage-0.17.0.md) — focused follow-up on the largest release-candidate query-runtime regressions, including the `arrow` hot-path fix and remaining no-family-growth follow-ups.
 - [20-optimization runtime pass](runtime-performance-20-optimizations-2026-07-02.md) — the post-0.17.0 profile-guided optimization sequence, all-120-repo before/after run, focused recheck, and noise-aware interpretation.
 - [default-query performance closeout](runtime-performance-issue-892-2026-07-18.md) — #892's output-preserving surface-membership optimization, official-v0.19.0 all-120/r40 measurements, semantic smoke, and bounded independent residual split.
+- [etcd Go frontend attribution](runtime-performance-issue-907-2026-07-19.md) — #907's frozen-r40 source, executable, machine-code, and profile evidence attributing the residual to build provenance plus control subtraction.
 - [experiments](experiments.md) — the measured log of what was tried and what happened.
 
 ### Field evidence & audits

--- a/docs/runtime-performance-issue-892-2026-07-18.md
+++ b/docs/runtime-performance-issue-892-2026-07-18.md
@@ -100,3 +100,9 @@ These execute before the query classification changed by #892. The Go frontend w
 untouched by this fix, while normalization grew materially after v0.19.0 in #900 and
 #859. The split therefore follows the issue's explicit independent-cause rule rather
 than broadening one query optimization into unrelated frontend and semantic work.
+
+The [#907 closeout](runtime-performance-issue-907-2026-07-19.md) found no structural Go
+frontend regression: source and hot lowering instructions are identical, the exact
+binaries have different SDK provenance, and signed negative controls lift sub-5-ms raw
+deltas over the absolute gate. The measurement-contract consequence is isolated in
+[#927](https://github.com/corca-ai/nose/issues/927).

--- a/docs/runtime-performance-issue-907-2026-07-19.md
+++ b/docs/runtime-performance-issue-907-2026-07-19.md
@@ -1,0 +1,86 @@
+# etcd Go frontend attribution for #907
+
+Generated on 2026-07-19. The [durable attribution
+artifact](../bench/recall_loss/issue-907-etcd-frontend-attribution-2026-07-19.v1.json)
+binds the frozen measurements, executable identities, disassembly hashes, and sampling
+summary below.
+
+## Outcome
+
+The inherited etcd signal is not a proven structural Go frontend regression, so #907
+does not change product code. The frozen #892 r40 run measured raw increases of only
+`2.50 ms` in `lower` and `2.55 ms` in `parse+lower`, both below the unchanged `5 ms`
+absolute gate. Negative same-binary controls of `-3.05 ms` and `-3.35 ms` inflated the
+control-adjusted rows to `5.55 ms` and `5.90 ms`.
+
+Source and executable inspection found no new Go lowering work. The official v0.19.0
+binary and the #892 candidate were built with different macOS SDKs, however, and their
+source-identical native parser code and whole-binary layout differ. The residual is
+therefore attributed to build provenance plus signed control subtraction, not to a
+product path that warrants speculative optimization.
+
+## Frozen reproduction
+
+No timing run was repeated to seek a different verdict. The source of truth remains the
+#892 r40 checker status (`SHA-256 021b949b…8b8f2`) and its durable performance artifact
+(`SHA-256 e603d720…f6b04`).
+
+| Stage | v0.19.0 | Candidate | Raw delta | Control | Adjusted delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `lower` | 85.15 ms | 87.65 ms | +2.50 ms | -3.05 ms | +5.55 ms / +6.52% |
+| `parse+lower` | 55.90 ms | 58.45 ms | +2.55 ms | -3.35 ms | +5.90 ms / +10.55% |
+
+The unchanged checker contract is `5%` and `5 ms`. The raw rows cross only the relative
+gate; applying the signed negative control makes them cross the absolute gate too.
+
+## Source and build identity
+
+The seven Go frontend files have the same tree digest at v0.19.0, the #892 candidate,
+and current main. `tree-sitter-go 0.25.0`, `tree-sitter 0.25.10`,
+`tree-sitter-language 0.1.7`, and the release profile are also unchanged.
+
+The two exact binaries do not share a build environment:
+
+| Identity | Official v0.19.0 | #892 candidate |
+| --- | ---: | ---: |
+| Source | `0985e696…ef9` | `8c37b8f9…59` |
+| macOS minimum | 11.0 | 11.0 |
+| macOS SDK | 14.5 | 26.2 |
+| `__text` bytes | 7,045,316 | 7,289,744 |
+| `__TEXT` bytes | 19,693,568 | 19,972,096 |
+| Go symbols | 41 | 41 |
+| Go module span | 55,344 bytes | 55,344 bytes |
+
+Normalized LLVM disassembly is identical for the hot Rust Go functions
+`lower_stmt`, `lower_expr_with_iota`, and `lower_block`. The
+`ts_parser_parse_with_options` wrapper is also identical. `ts_parser_parse` differs even
+though its dependency source version is the same, consistent with the SDK and
+whole-program code-generation difference rather than a Go frontend source delta.
+
+## Diagnostic profile
+
+A single sequential `/usr/bin/sample` profile per exact binary used the frozen etcd
+command with `RAYON_NUM_THREADS=1`. This was call-path attribution, not a new timing
+verdict.
+
+| Inclusive samples | Official v0.19.0 | #892 candidate |
+| --- | ---: | ---: |
+| Go `lower_source` | 410 | 395 |
+| parser | 251 | 231 |
+| derived post-parser lower | 159 | 164 |
+| `ts_parser_parse` on top | 58 | 52 |
+
+The candidate exposes no added call path: total frontend and parser samples are lower,
+while post-parser lowering differs by five samples in a one-second diagnostic profile.
+
+## Decision and follow-up
+
+Changing Go lowering in response to this evidence would be speculative and would risk
+semantic output for a signal the source does not own. #907 therefore records a no-go
+optimization decision and preserves family IDs, ordering, surfaces, metadata, output
+bytes, and determinism by making no product change.
+
+[#927](https://github.com/corca-ai/nose/issues/927) separately preregisters an
+order-aware same-binary control estimator. It keeps the `5%` / `5 ms` product gate,
+must replay the frozen #892 evidence without rerunning it, and may not special-case etcd
+or any stage.

--- a/docs/runtime-triage.md
+++ b/docs/runtime-triage.md
@@ -33,6 +33,12 @@ rebuild of the release tag is useful for diagnosis but is not the release
 baseline. A pre-change `main` binary may be retained as a secondary attribution
 comparison; it does not replace the official release binary.
 
+Record native build provenance as well as source and binary digests. On Mach-O, capture
+`LC_BUILD_VERSION`'s minimum OS and SDK plus the `__text` size. Source-identical C/C++
+parser code can differ when an official release and a local candidate use different
+SDKs or linker/code-generation environments; do not attribute that difference to a
+frontend source change without call-path or normalized-disassembly evidence.
+
 Use `scripts/runtime-triage-harness.py` when comparing two binaries on one or more corpus
 repos. It runs `nose query <repo> all top=0 --mode semantic --format json` with
 `NOSE_TIME=1` and `NOSE_TIME_UNIT_SUMMARY=1`, stores raw runs, aggregates median stage


### PR DESCRIPTION
## Summary

- bind the frozen #892 r40 etcd rows to exact source, binary, SDK, machine-code, and diagnostic-profile evidence
- record that no structural Go frontend regression is proven and avoid a speculative product-code change
- document native build-provenance checks in the runtime-triage contract
- isolate the prospective control-estimator change in #927 without changing the 5% / 5 ms gate or rerunning #892

## Validation

- `jq empty bench/recall_loss/issue-907-etcd-frontend-attribution-2026-07-19.v1.json`
- `python3 scripts/check-query-regression.py --self-test`
- `python3 scripts/binary_identity.py --self-test`
- `./scripts/check-docs.sh`

Closes #907
