### PR TITLE
perf(detect): clear inherited normalize-and-extract residuals

### DIFF
--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -11,6 +11,9 @@ remain reviewable without retaining large raw profiles. For example,
 `issue-907-etcd-frontend-attribution-2026-07-19.v1.json` binds the #892 r40 rows to exact
 binary/build identities, normalized instruction hashes, the compact profile summary,
 and the resulting no-go optimization decision.
+`issue-908-normalize-extract-performance-2026-07-19.v1.json` binds the inherited Guava
+and MinIO rows to the shared MinHash hot path, the output-identical optimization, and
+the fixed r40 checker evidence.
 
 Scheduling lifecycle audit artifacts use a separate source-prevalence status
 vocabulary:

--- a/bench/recall_loss/issue-908-normalize-extract-performance-2026-07-19.v1.json
+++ b/bench/recall_loss/issue-908-normalize-extract-performance-2026-07-19.v1.json
@@ -1,0 +1,166 @@
+{
+  "schema": "nose.issue-908.normalize_extract_performance/v1",
+  "issue": 908,
+  "generated_on": "2026-07-19",
+  "outcome": "shared-minhash-hot-path-optimized",
+  "frozen_reproduction": {
+    "source_issue": 892,
+    "performance_artifact_sha256": "e603d720d77f0d2e9d69d7aa4bf2f679fbfc1a30c2fc178c8434613a0c8f6b04",
+    "rows": [
+      {
+        "repo": "guava",
+        "stage": "normalize+extract",
+        "baseline_median_ms": 358.4,
+        "candidate_median_ms": 377.7,
+        "raw_delta_ms": 19.3,
+        "control_delta_ms": -7.2,
+        "control_adjusted_delta_ms": 26.5,
+        "control_adjusted_delta_pct": 7.393973214285715
+      },
+      {
+        "repo": "minio",
+        "stage": "normalize+extract",
+        "baseline_median_ms": 110.4,
+        "candidate_median_ms": 113.6,
+        "raw_delta_ms": 3.2,
+        "control_delta_ms": -3.85,
+        "control_adjusted_delta_ms": 7.05,
+        "control_adjusted_delta_pct": 6.385869565217376
+      }
+    ],
+    "rerun_to_change_reproduction": false
+  },
+  "binaries": {
+    "official_v0_19_0": {
+      "source_sha": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+      "file_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6"
+    },
+    "issue_892_candidate": {
+      "source_sha": "8c37b8f9c75b9543dc746e3eb6b9b18209810059",
+      "file_sha256": "111c6507dd028a194c000fbc279e05e6b9b2899552a9dca7f56a15d23c5ad38c",
+      "code_sha256": "e8f592a00519b27d1bd4ff4a52911806c1180e8f9a72be68232157adca7dc63f"
+    },
+    "isolated_fixed_candidate": {
+      "source_base_sha": "8c37b8f9c75b9543dc746e3eb6b9b18209810059",
+      "isolated_commit_sha": "e89606874bf616e09c9dc5bede6bb235bef2c9ef",
+      "shipping_commit_sha": "fbd248f23471936248eae65c48a36cbcf06504cd",
+      "file_sha256": "8a234bba9a3504721ccf1a4937ab8e0807a741998f12e6a4e26bf2e0f8c07194",
+      "code_sha256": "e5c06c37b5cee7ebf9d5b73f55e2411052680bfb2224dd7d45c88c95615432b3"
+    }
+  },
+  "pre_edit_profile": {
+    "method": "One sequential instrumented run and one sequential /usr/bin/sample run per frozen binary and repository with RAYON_NUM_THREADS=1.",
+    "performance_verdict": false,
+    "instrumented": {
+      "guava": {
+        "files": 3218,
+        "value_graph_builds": 69835,
+        "baseline_normalize_extract_ms": 5980.0,
+        "candidate_normalize_extract_ms": 6056.0,
+        "baseline_value_graph_total_ms": 299.7,
+        "candidate_value_graph_total_ms": 307.4,
+        "baseline_log_sha256": "b7de4a64c52cb31f6a09dd166143a7eeddd09706b3de510939e2a016ccebd601",
+        "candidate_log_sha256": "1f0fb14842661f58d9aa9471bc8c65e7a79c8896bd140cde8ffc79ca55037dc8"
+      },
+      "minio": {
+        "files": 796,
+        "value_graph_builds": 11945,
+        "baseline_normalize_extract_ms": 1426.3,
+        "candidate_normalize_extract_ms": 1447.3,
+        "baseline_value_graph_total_ms": 113.3,
+        "candidate_value_graph_total_ms": 113.8,
+        "baseline_log_sha256": "0dd65bdcfa7b89bf585af5fd65ce65d46a65b9f7c4a15893f65226daa3cd16bf",
+        "candidate_log_sha256": "5dd349a7bf95d8d2aec6f1461827a4f2aa475175e04888e3df16fd8fc1066b42"
+      }
+    },
+    "call_stack": {
+      "shared_hot_path": "nose_detect::minhash::sign",
+      "top_stack_samples": {
+        "guava": {
+          "baseline": 322,
+          "candidate": 302
+        },
+        "minio": {
+          "baseline": 112,
+          "candidate": 114
+        }
+      },
+      "baseline_guava_sha256": "1da2e6899004f547c56f176899717144300edd28cf20541ef5bf4bfad7602b19",
+      "candidate_guava_sha256": "c554ffc85a6fff18b7058d620138b6a53e31a7c2c081a9817ee71dce20bccaff",
+      "baseline_minio_sha256": "081a56114b2220ba04f3c3dd43430bc54a45d6acd6ebc968237ab990915421f0",
+      "candidate_minio_sha256": "8f8de396720a547814f94c927b86925d9486f00161a89a0e756c556414a0e2b3",
+      "interpretation": "No candidate-only soundness path dominates either repository. MinHash signing is the largest shared optimizable normalize+extract owner in both versions."
+    }
+  },
+  "implementation": {
+    "description": "Transpose MinHash signing from feature-major conditional signature writes to seed-major accumulation, keeping each minimum in a register and writing it once.",
+    "hash_function_changed": false,
+    "seed_order_changed": false,
+    "feature_set_changed": false,
+    "signature_changed": false,
+    "regression_test": "The seed-major implementation is compared with the previous feature-major algorithm for empty and representative feature sets at 0, 1, 2, 64, and 128 seeds."
+  },
+  "fixed_r40": {
+    "thresholds": {
+      "maximum_delta_pct": 5.0,
+      "minimum_absolute_delta_ms": 5.0,
+      "changed": false
+    },
+    "guava": {
+      "iterations": 40,
+      "warmups": 2,
+      "stage": "normalize+extract",
+      "baseline_median_ms": 341.85,
+      "candidate_median_ms": 321.25,
+      "raw_delta_ms": -20.6,
+      "control_delta_ms": -2.8,
+      "control_adjusted_delta_ms": -17.8,
+      "control_adjusted_delta_pct": -5.206962117887966,
+      "repo_adjusted_delta_ms": -35.3197495569475,
+      "repo_adjusted_delta_pct": -2.2741913551952795,
+      "checker_status": "pass",
+      "primary_sha256": "2abad8419c62880ee72c6dcbafea2e93321b51ae2fc95e55f2635d80b5e6c697",
+      "control_sha256": "07eff7589ee9cdfe83baf0cc9911a41d8f6056fa473ce581059df26759ddce74",
+      "checker_status_sha256": "bb2e3c1848a6b934753ff90cba2ad9ff0c79eaf8d9f592c8803e7d5fd3ec0a35"
+    },
+    "minio": {
+      "iterations": 40,
+      "warmups": 2,
+      "stage": "normalize+extract",
+      "baseline_median_ms": 105.55,
+      "candidate_median_ms": 102.9,
+      "raw_delta_ms": -2.65,
+      "control_delta_ms": 3.4,
+      "control_adjusted_delta_ms": -6.05,
+      "control_adjusted_delta_pct": -5.731880625296078,
+      "repo_adjusted_delta_ms": -2.050895942375064,
+      "repo_adjusted_delta_pct": -0.46238445470099543,
+      "triggered": false,
+      "primary_sha256": "20fa5fa2f2a8d97cb0e7616b7ac57b3f5264e2e6cb13a69bfd00f3e88f3907bc",
+      "control_sha256": "8649431f03e38250b23e909aa677f34ff4b893c2563dda007cc9eac377f49f3a"
+    },
+    "decision": "Both inherited normalize+extract signals are removed at the unchanged checker contract. The final Guava-only checker passes; the corrected two-repository r40 has no MinIO trigger and requested follow-up only for Guava, which the final run cleared."
+  },
+  "output_invariance": {
+    "pre_post_current_main_byte_identical": true,
+    "issue_892_candidate_vs_isolated_fix_byte_identical": true,
+    "guava_sha256": "cf37a623d44a66c6b59c192adc8fe04d7d6d7cd331ecb2bff4a6a19937ffbcf5",
+    "minio_sha256": "3dd186074c1ba4d4dc9ca5c98f7361673fd5ce47f5830e197d55fc77dd72159f",
+    "preserved": [
+      "families",
+      "order",
+      "surfaces",
+      "metadata",
+      "output bytes",
+      "determinism"
+    ]
+  },
+  "measurement_scope": {
+    "excluded_report": {
+      "sha256": "6464d00b32cdb42d604f7ba4a3a01cc949f21f53ef0810caa9d7228c77019b7d",
+      "reason": "The first post-fix run used current main rather than the frozen #892 source and was excluded before the corrected isolated build was measured."
+    },
+    "bounded_escalation": "One corrected frozen two-repository r40 plus the one Guava-only r40 primary/control requested by the unchanged checker; no further performance run was taken."
+  }
+}

--- a/crates/nose-detect/src/minhash.rs
+++ b/crates/nose-detect/src/minhash.rs
@@ -21,14 +21,47 @@ pub(crate) fn seeds(k: usize) -> Vec<u64> {
 
 /// MinHash signature of a *distinct* feature set: `sig[i] = min_f h_i(f)`.
 pub(crate) fn sign(distinct: &[u64], seeds: &[u64]) -> Vec<u64> {
-    let mut sig = vec![u64::MAX; seeds.len()];
-    for &f in distinct {
-        for (i, &s) in seeds.iter().enumerate() {
-            let h = splitmix64(f ^ s);
-            if h < sig[i] {
-                sig[i] = h;
+    let mut sig = Vec::with_capacity(seeds.len());
+    for &seed in seeds {
+        let mut minimum = u64::MAX;
+        for &feature in distinct {
+            minimum = minimum.min(splitmix64(feature ^ seed));
+        }
+        sig.push(minimum);
+    }
+    sig
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feature_major_sign(distinct: &[u64], seeds: &[u64]) -> Vec<u64> {
+        let mut signature = vec![u64::MAX; seeds.len()];
+        for &feature in distinct {
+            for (index, &seed) in seeds.iter().enumerate() {
+                signature[index] = signature[index].min(splitmix64(feature ^ seed));
+            }
+        }
+        signature
+    }
+
+    #[test]
+    fn seed_major_sign_preserves_feature_major_signature() {
+        let feature_sets: &[&[u64]] = &[
+            &[],
+            &[0],
+            &[1, 2, 3, u64::MAX],
+            &[0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210],
+        ];
+        for &features in feature_sets {
+            for seed_count in [0, 1, 2, 64, 128] {
+                let permutation_seeds = seeds(seed_count);
+                assert_eq!(
+                    sign(features, &permutation_seeds),
+                    feature_major_sign(features, &permutation_seeds)
+                );
             }
         }
     }
-    sig
 }

--- a/crates/nose-detect/src/minhash.rs
+++ b/crates/nose-detect/src/minhash.rs
@@ -23,6 +23,8 @@ pub(crate) fn seeds(k: usize) -> Vec<u64> {
 pub(crate) fn sign(distinct: &[u64], seeds: &[u64]) -> Vec<u64> {
     let mut sig = Vec::with_capacity(seeds.len());
     for &seed in seeds {
+        // Keep one minimum in a register and write it once. The feature-major form
+        // revisited and conditionally wrote the whole signature for every feature.
         let mut minimum = u64::MAX;
         for &feature in distinct {
             minimum = minimum.min(splitmix64(feature ^ seed));

--- a/docs/home.md
+++ b/docs/home.md
@@ -198,6 +198,7 @@ fundamentals; the rest is grouped by area.
 - [20-optimization runtime pass](runtime-performance-20-optimizations-2026-07-02.md) — the post-0.17.0 profile-guided optimization sequence, all-120-repo before/after run, focused recheck, and noise-aware interpretation.
 - [default-query performance closeout](runtime-performance-issue-892-2026-07-18.md) — #892's output-preserving surface-membership optimization, official-v0.19.0 all-120/r40 measurements, semantic smoke, and bounded independent residual split.
 - [etcd Go frontend attribution](runtime-performance-issue-907-2026-07-19.md) — #907's frozen-r40 source, executable, machine-code, and profile evidence attributing the residual to build provenance plus control subtraction.
+- [normalize-and-extract closeout](runtime-performance-issue-908-2026-07-19.md) — #908's output-identical MinHash hot-loop optimization and frozen Guava/MinIO r40 closeout against official v0.19.0.
 - [experiments](experiments.md) — the measured log of what was tried and what happened.
 
 ### Field evidence & audits

--- a/docs/runtime-performance-issue-892-2026-07-18.md
+++ b/docs/runtime-performance-issue-892-2026-07-18.md
@@ -106,3 +106,8 @@ frontend regression: source and hot lowering instructions are identical, the exa
 binaries have different SDK provenance, and signed negative controls lift sub-5-ms raw
 deltas over the absolute gate. The measurement-contract consequence is isolated in
 [#927](https://github.com/corca-ai/nose/issues/927).
+
+The [#908 closeout](runtime-performance-issue-908-2026-07-19.md) removes both remaining
+`normalize+extract` rows with an output-identical MinHash loop transposition. Final
+control-adjusted r40 movement is `-5.21%` for Guava and `-5.73%` for MinIO at the
+unchanged `5%` / `5 ms` contract.

--- a/docs/runtime-performance-issue-908-2026-07-19.md
+++ b/docs/runtime-performance-issue-908-2026-07-19.md
@@ -1,0 +1,74 @@
+# Normalize-and-extract closeout for #908
+
+Generated on 2026-07-19. The [durable #908 performance
+artifact](../bench/recall_loss/issue-908-normalize-extract-performance-2026-07-19.v1.json)
+binds the frozen reproduction, exact binaries, pre-edit profiles, r40 results, and output
+hashes below.
+
+## Outcome
+
+#908 removes the inherited Guava and MinIO `normalize+extract` signals without changing
+semantic output. A shared MinHash signing loop was the largest optimizable function in
+both call-stack profiles. Transposing its loops keeps one minimum in a register and
+writes each signature element once instead of revisiting the whole mutable signature
+for every feature.
+
+At the unchanged `5%` / `5 ms` contract, the final control-adjusted stage movement is:
+
+| Repository | Frozen #892 residual | Fixed r40 |
+| --- | ---: | ---: |
+| Guava | +26.50 ms / +7.39% | -17.80 ms / -5.21% |
+| MinIO | +7.05 ms / +6.39% | -6.05 ms / -5.73% |
+
+The final Guava checker status is `pass`. The corrected two-repository r40 has no MinIO
+trigger; its only requested follow-up was a Guava frontend signal, and the single
+Guava-only focused primary/control run cleared it. No threshold changed.
+
+## Pre-edit attribution
+
+The frozen #892 candidate and official v0.19.0 binary were each profiled once per
+repository, sequentially with `RAYON_NUM_THREADS=1`. Pass-level logging was diagnostic,
+not a replacement performance verdict: emitting tens of thousands of per-unit lines
+substantially increases elapsed time.
+
+| Profile evidence | Guava v0.19 → candidate | MinIO v0.19 → candidate |
+| --- | ---: | ---: |
+| Instrumented `normalize+extract` | 5,980.0 → 6,056.0 ms | 1,426.3 → 1,447.3 ms |
+| Summed value-graph build | 299.7 → 307.4 ms | 113.3 → 113.8 ms |
+| `minhash::sign` top-stack samples | 322 → 302 | 112 → 114 |
+
+There was no candidate-only soundness function dominating either repository. MinHash
+signing was instead the largest common product function in both versions. This made it
+the smallest shared optimization that could help both corpora without weakening #900 or
+#859 semantics.
+
+## Implementation and safety
+
+MinHash still computes exactly `sig[i] = min_f h_i(f)` with the same SplitMix64 hash,
+seed order, feature set, and result order. Only traversal changes:
+
+- before: visit every feature, conditionally updating all 128 signature slots;
+- after: visit every seed, retain its minimum locally, then write that slot once.
+
+A unit test compares both algorithms over empty and representative feature sets with
+`0`, `1`, `2`, `64`, and `128` seeds. Direct product replay is also byte-identical:
+
+- Guava SHA-256: `cf37a623…fbcf5`;
+- MinIO SHA-256: `3dd18607…159f`.
+
+That equality holds both for current-main pre/post binaries and for the exact #892
+candidate versus the isolated #908 fix. Family count, order, surfaces, metadata, output
+bytes, and determinism are unchanged.
+
+## Measurement discipline
+
+The official v0.19.0 binary remains the product baseline. To isolate this fix from work
+merged after #892, the shipping commit was cherry-picked onto the exact #892 candidate
+source in a detached worktree and built once. The resulting fixed binary has file
+SHA-256 `8a234bba…07194` and normalized code SHA-256 `e5c06c37…432b3`.
+
+An initial r40 used current main and was excluded because post-#892 divergence and pack
+work changed independent stages; it was not replaced to seek a better sample. The
+corrected frozen two-repository r40 was followed by exactly one Guava primary/control
+r40 because the unchanged checker requested that focused confirmation. No additional
+performance run was taken.


### PR DESCRIPTION
## Summary
- transpose MinHash signing to keep each seed minimum local and write its output once
- preserve exact signatures and byte-identical Guava/MinIO product output
- bind the frozen #892 reproduction, profiles, binary identities, and corrected r40 results in durable docs

## Results
- Guava normalize+extract: -17.80 ms / -5.21% control-adjusted
- MinIO normalize+extract: -6.05 ms / -5.73% control-adjusted
- unchanged 5% / 5 ms checker contract; final status pass

## Validation
- cargo test --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- ./scripts/check-docs.sh
- jq empty bench/recall_loss/issue-908-normalize-extract-performance-2026-07-19.v1.json

Closes #908