### PR TITLE
feat(cli): preserve caller-generated path findings

### DIFF
--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -14,6 +14,9 @@ and the resulting no-go optimization decision.
 `issue-908-normalize-extract-performance-2026-07-19.v1.json` binds the inherited Guava
 and MinIO rows to the shared MinHash hot path, the output-identical optimization, and
 the fixed r40 checker evidence.
+`issue-925-caller-generated-path-closeout-2026-07-19.v1.json` binds the root-anchored
+caller provenance contract to fresh Check/Pydantic outcomes, determinism hashes, and its
+published-v0.19.0 66-repository runtime price with same-binary control.
 
 Scheduling lifecycle audit artifacts use a separate source-prevalence status
 vocabulary:

--- a/bench/recall_loss/issue-925-caller-generated-path-closeout-2026-07-19.v1.json
+++ b/bench/recall_loss/issue-925-caller-generated-path-closeout-2026-07-19.v1.json
@@ -1,0 +1,116 @@
+{
+  "schema": "nose.issue-925.caller_generated_path_closeout/v1",
+  "issue": 925,
+  "generated_on": "2026-07-19",
+  "outcome": "root-anchored-path-contract-shipped",
+  "design": {
+    "published_before_implementation_commit": "e95959abe90016911d4d4dc08075542465ecf7a4",
+    "implementation_commit": "6617f99e7c03884f098b3be73f2207b3c3049bf4",
+    "cli": "--generated-path <GLOB>",
+    "config": "[query].generated-paths",
+    "composition": "config-and-cli-union",
+    "pattern_anchor": "each-explicit-query-root",
+    "canonical_containment": true,
+    "all_member_quantifier": true,
+    "mixed_missing_unreadable_out_of_root_policy": "fail-open",
+    "family_universe_preserved": true,
+    "producer_manifest_in_scope": false,
+    "producer_or_repository_allowlists": false,
+    "query_json_schema": 9,
+    "base_query_schema": 8
+  },
+  "field_validation": {
+    "check": {
+      "root": "target/issue-846-fresh-repos/check-fresh",
+      "pattern": "m4/**",
+      "families_before": 22,
+      "families_after": 22,
+      "surface_counts_before": {
+        "default": 10,
+        "divergence": 2,
+        "hidden": 10
+      },
+      "surface_counts_after": {
+        "default": 7,
+        "divergence": 2,
+        "generated": 3,
+        "hidden": 10
+      },
+      "caller_generated_families": 3,
+      "m4_default_to_generated": 3,
+      "normalized_family_sha256_before": "ba7028c16850e7bc60936cdb71463c3e21949a9a657201cd32486378750ef6fe",
+      "normalized_family_sha256_after": "ba7028c16850e7bc60936cdb71463c3e21949a9a657201cd32486378750ef6fe",
+      "normalization": "delete only surface and generated_provenance from each ordered family object",
+      "rayon_1_output_sha256": "3fd4923a408aec765ec09a16560411e0292e908180b7794c7f34a7ca60986d07",
+      "rayon_4_output_sha256": "3fd4923a408aec765ec09a16560411e0292e908180b7794c7f34a7ca60986d07"
+    },
+    "pydantic": {
+      "root": "target/issue-846-fresh-repos/pydantic-fresh",
+      "pattern": "tests/mypy/outputs/**",
+      "families_before": 167,
+      "families_after": 167,
+      "surface_counts_before": {
+        "default": 64,
+        "divergence": 5,
+        "hidden": 98
+      },
+      "surface_counts_after": {
+        "default": 64,
+        "divergence": 5,
+        "hidden": 98
+      },
+      "mixed_output_input_families_failing_open": 4,
+      "caller_generated_families": 0,
+      "normalized_family_sha256_before": "69d0b31a4f6cbf13d57245a36bc7789ab35efe9d01cc2569035cdf6eea185a58",
+      "normalized_family_sha256_after": "69d0b31a4f6cbf13d57245a36bc7789ab35efe9d01cc2569035cdf6eea185a58",
+      "normalization": "delete only surface and generated_provenance from each ordered family object"
+    }
+  },
+  "performance": {
+    "command": "nose query <repo> all top=0 --mode semantic --format json",
+    "cohort_repositories": 66,
+    "cohort_source_artifact": "bench/recall_loss/issue-891-official-v0.19.0-dev-query-regression-2026-07-19.v1.json",
+    "cohort_source_artifact_sha256": "480c52b1c98a7c12c01e62098f1ab0a06af46b050616d582a421eee0c49f3a3f",
+    "corpus_selection_sha256": "8971c7d5eae88d243d3317665ef5ef24eb78973c816400992179470d1184325c",
+    "iterations": 3,
+    "warmups": 1,
+    "baseline": {
+      "version": "v0.19.0",
+      "source_sha": "54f8a67436e39e24c777a85e14224273116add6b",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "query_json_schema": 7
+    },
+    "candidate": {
+      "source_sha": "6617f99e7c03884f098b3be73f2207b3c3049bf4",
+      "binary_sha256": "e28e47336690c28d39f3fe8841f1b98cf7882ad9654fc30f01bf9477f9a70af0",
+      "code_sha256": "c0aa1d6a75566886ffcd5a67c93b1368327f606a4dc84ae79395a618b7aa5aaa",
+      "query_json_schema": 9
+    },
+    "primary": {
+      "aggregate_baseline_median_ms": 15724.017669796012,
+      "aggregate_candidate_median_ms": 15682.598076877184,
+      "raw_delta_ms": -41.41959291882813,
+      "raw_delta_pct": -0.26341609243030994,
+      "report_sha256": "dbd63b54bf0dfcadac8b5824cd0e24c0ae19d68490ba32454e71d4a50feee65d",
+      "schema_only_output_drift_repositories": 66
+    },
+    "same_binary_control": {
+      "aggregate_first_median_ms": 16054.2420061538,
+      "aggregate_second_median_ms": 16010.97113196738,
+      "delta_ms": -43.27087418641895,
+      "delta_pct": -0.2695292257948564,
+      "output_drift_repositories": 0,
+      "report_sha256": "ce0c35183d09535d04d8b7612a06e17f9f8603130f64a07c2b017b8218aa92e0"
+    },
+    "control_adjusted_delta_ms": 1.8512812675908208,
+    "control_adjusted_delta_pct": 0.006113133364546441,
+    "material_regression_thresholds": {
+      "maximum_delta_pct": 5.0,
+      "minimum_absolute_delta_ms": 5.0
+    },
+    "material_regression": false,
+    "focused_escalation": false,
+    "interpretation": "The default path adds no generated-path matching work when no assertion exists. Aggregate release-relative movement is inside same-binary noise after control subtraction. All primary byte hashes differ because the strict non-base query schema intentionally changes from v7 to v9, not because a caller assertion changed the family universe."
+  }
+}

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -131,6 +131,7 @@ impl Report {
                 sort_keys: vec!["extractability", "value", "sites", "hazard"],
                 config_keys: vec![
                     "exclude",
+                    "generated-paths",
                     "ignore-file",
                     "min-lines",
                     "min-members",
@@ -160,8 +161,8 @@ fn current_schemas() -> Schemas {
     Schemas {
         capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
         query_json: vec![
-            crate::schema_versions::QUERY_JSON_SCHEMA_VERSION,
             crate::schema_versions::QUERY_BASE_JSON_SCHEMA_VERSION,
+            crate::schema_versions::QUERY_JSON_SCHEMA_VERSION,
         ],
         semantic_packs: nose_semantics::SUPPORTED_SEMANTIC_PACK_API_VERSIONS.to_vec(),
         semantic_pack_locks: vec![nose_semantics::SEMANTIC_PACK_LOCK_API_VERSION_V1],
@@ -216,6 +217,7 @@ fn query_capability_flags() -> std::collections::BTreeMap<&'static str, bool> {
         ("baseline_changed_detection", true),
         ("baseline_member_digest", true),
         ("cache", true),
+        ("caller_generated_paths", true),
         ("ci_fail_gate", true),
         ("family_drilldown", true),
         ("inline_suppression", true),

--- a/crates/nose-cli/src/cli_args.rs
+++ b/crates/nose-cli/src/cli_args.rs
@@ -124,6 +124,9 @@ pub(crate) enum Cmd {
         /// Skip paths matching a gitignore-style glob (repeatable). (.gitignore is already respected.)
         #[arg(long)]
         exclude: Vec<String>,
+        /// Classify files matching a root-anchored gitignore glob as generated (repeatable; findings remain recoverable).
+        #[arg(long = "generated-path", value_name = "GLOB")]
+        generated_path: Vec<String>,
         /// Cache per-file analysis under this directory; re-runs reuse it for unchanged files.
         #[arg(long, value_name = "DIR")]
         cache_dir: Option<PathBuf>,
@@ -450,6 +453,7 @@ pub(crate) struct QueryArgs {
     pub(crate) write_baseline: bool,
     pub(crate) format: ReportFormat,
     pub(crate) exclude: Vec<String>,
+    pub(crate) generated_path: Vec<String>,
     pub(crate) min_size: Option<usize>,
     pub(crate) min_lines: Option<u32>,
     pub(crate) scope: ScopeFilter,

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -5,6 +5,7 @@
 //! ```toml
 //! [query]
 //! exclude = ["tests/**", "**/*.generated.ts", "vendor/**"]
+//! generated-paths = ["generated/**", "**/snapshots/mypy/**"]
 //! mode = ["syntax", "semantic", "near:0.8"] # fuzzy thresholds ride on the mode
 //! min-value = 200
 //! sort = "extractability"
@@ -26,6 +27,8 @@ use crate::query_options::{DetectionMode, SortKey};
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub(crate) struct QueryConfig {
     pub exclude: Vec<String>,
+    /// Root-anchored caller assertions; unlike excludes, these retain findings.
+    pub generated_paths: Vec<String>,
     pub mode: Vec<DetectionMode>,
     pub min_value: Option<f64>,
     pub sort: Option<SortKey>,
@@ -128,11 +131,12 @@ mod tests {
     fn valid_config_still_loads() {
         let p = write_cfg(
             "ok",
-            "[query]\nmin-value = 200\nmin-size = 30\nignore-file = \"nose.ignore.json\"\nsemantic-packs = [\"packs\"]\n",
+            "[query]\nmin-value = 200\nmin-size = 30\ngenerated-paths = [\"generated/**\"]\nignore-file = \"nose.ignore.json\"\nsemantic-packs = [\"packs\"]\n",
         );
         let cfg = load_query(Some(&p)).expect("valid config must load");
         assert_eq!(cfg.min_value, Some(200.0));
         assert_eq!(cfg.min_size, Some(30));
+        assert_eq!(cfg.generated_paths, vec!["generated/**"]);
         assert_eq!(
             cfg.ignore_file,
             Some(p.parent().unwrap().join("nose.ignore.json"))

--- a/crates/nose-cli/src/main_tests/query_family.rs
+++ b/crates/nose-cli/src/main_tests/query_family.rs
@@ -58,6 +58,7 @@ fn compiled_css_pipeline_demotes_source_plus_outputs_but_not_cross_source() {
     let ov = SurfaceOverrides {
         generated_sources: gen.clone(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
@@ -104,6 +105,7 @@ fn partial_jazzy_provenance_keeps_the_family_on_its_ranked_surface() {
         ]
         .into_iter()
         .collect(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
@@ -126,6 +128,7 @@ fn jazzy_surface_classification_preserves_the_opportunity_fold_input() {
         ]
         .into_iter()
         .collect(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
@@ -146,6 +149,7 @@ fn query_family_json_carries_fold_navigation() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
@@ -195,6 +199,7 @@ fn query_family_json_carries_proof_depth() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };
@@ -230,6 +235,7 @@ fn query_family_json_carries_raw_detector_metrics() {
     let ov = SurfaceOverrides {
         generated_sources: rustc_hash::FxHashSet::default(),
         additional_generated_surface_sources: rustc_hash::FxHashSet::default(),
+        caller_generated_surface_sources: rustc_hash::FxHashSet::default(),
         declaration_run_families: rustc_hash::FxHashSet::default(),
         declaration_only_type_contract_families: rustc_hash::FxHashSet::default(),
     };

--- a/crates/nose-cli/src/query_commands.rs
+++ b/crates/nose-cli/src/query_commands.rs
@@ -15,8 +15,8 @@ use crate::query_views::render_query_base;
 use crate::query_witness::enrich_graded_witnesses;
 use crate::source_lines::family_anchor;
 use crate::surfaces::{
-    classify_surface_overrides, is_default_opportunity_family, is_default_report_family,
-    SurfaceOverrides,
+    classify_surface_overrides_with_generated_paths, is_default_opportunity_family,
+    is_default_report_family, SurfaceOverrides,
 };
 use crate::timing::time_stage;
 use anyhow::Result;
@@ -113,6 +113,12 @@ fn validate_base_query(q: &Query, args: &QueryArgs) -> Result<()> {
     }
     if !args.semantic_pack.is_empty() {
         unsupported_flags.push("--semantic-pack");
+    }
+    if !cfg.generated_paths.is_empty() {
+        unsupported_flags.push("generated-paths config");
+    }
+    if !args.generated_path.is_empty() {
+        unsupported_flags.push("--generated-path");
     }
     if cfg.semantic_pack_lock.is_some() {
         unsupported_flags.push("semantic-pack-lock config");
@@ -292,6 +298,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
         min_value,
         min_members,
         exclude,
+        generated_path,
         cache_dir,
         ignore_file,
         semantic_pack,
@@ -326,6 +333,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
         write_baseline,
         format,
         exclude,
+        generated_path,
         min_size,
         min_lines,
         scope: ScopeFilter::All,
@@ -343,9 +351,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
     let baseline_comparison = time_stage("query_activate", || {
         activate_query_families(&args, &mut dataset)
     })?;
-    let overrides = time_stage("query_surface", || {
-        classify_surface_overrides(&mut dataset.families)
-    });
+    let overrides = time_stage("query_surface", || query_surface_overrides(&mut dataset));
     if query_needs_spotclass(&q) {
         time_stage("query_spot", || {
             enrich_graded_witnesses(&mut dataset.families, &dataset.opts)
@@ -387,4 +393,11 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
     }
     time_stage("query_gate", || enforce_query_fail_on(&output))?;
     Ok(())
+}
+
+fn query_surface_overrides(dataset: &mut QueryDataset) -> SurfaceOverrides {
+    classify_surface_overrides_with_generated_paths(
+        &mut dataset.families,
+        &dataset.settings.generated_paths,
+    )
 }

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -10,6 +10,7 @@ use crate::source_lines::{
     corpus_line_idf, family_anchor, is_trivial_line, shared_lines_of, varying_spots_of,
     FileLineCache,
 };
+use crate::surfaces::GeneratedPathAssertions;
 use crate::timing::{time_lower, time_stage};
 use crate::{cache, config, ignores};
 use std::collections::BTreeSet;
@@ -151,6 +152,7 @@ pub(super) struct QuerySettings {
     pub(super) min_lines: u32,
     pub(super) min_tokens: usize,
     pub(super) exclude: Vec<String>,
+    pub(super) generated_paths: GeneratedPathAssertions,
     pub(super) ignore_set: Option<ignores::IgnoreSet>,
 }
 
@@ -208,6 +210,9 @@ fn resolve_query_settings(
     let mut exclude = cfg.exclude;
     exclude.extend(args.exclude.iter().cloned());
     validate_exclude_globs(&exclude)?;
+    let mut generated_path_patterns = cfg.generated_paths;
+    generated_path_patterns.extend(args.generated_path.iter().cloned());
+    let generated_paths = GeneratedPathAssertions::new(&args.paths, generated_path_patterns)?;
     let ignore_set = ignores::load_for_query(ignore_file.as_deref())?;
     if let Some(ignore_set) = &ignore_set {
         ignore_set.warn_expired();
@@ -221,6 +226,7 @@ fn resolve_query_settings(
             min_lines,
             min_tokens,
             exclude,
+            generated_paths,
             ignore_set,
         },
         semantic_packs,

--- a/crates/nose-cli/src/query_model.rs
+++ b/crates/nose-cli/src/query_model.rs
@@ -6,7 +6,7 @@ use crate::query_opportunities::OpportunityGroups;
 use crate::query_terms::{QFilter, QOp};
 use crate::source_lines::{anti_unify_all, read_lines, FileLineCache};
 use crate::style;
-use crate::surfaces::{effective_surface, SurfaceOverrides};
+use crate::surfaces::{effective_surface, generated_provenance_json, SurfaceOverrides};
 
 /// Canonical `witness.kind` for a friendly filter token (`exact`→`exact-value-graph`, …).
 fn witness_alias(v: &str) -> &str {
@@ -331,6 +331,9 @@ pub(super) fn query_family_json_with_counts(
         "folds": opp.slices_of.get(&id).map(Vec::len).unwrap_or(0),
         "locations": locations,
     });
+    if let Some(provenance) = generated_provenance_json(f, ov) {
+        obj["generated_provenance"] = provenance;
+    }
     // Proof depth: for the exact channel, how much is proven identical — the size of the shared
     // value multiset. Lets a caller act now on the strongest evidence (subdag families carry the
     // proven span per location instead). Evidence, not a verdict.

--- a/crates/nose-cli/src/query_output.rs
+++ b/crates/nose-cli/src/query_output.rs
@@ -302,6 +302,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
+            caller_generated_surface_sources: Default::default(),
             declaration_run_families: Default::default(),
             declaration_only_type_contract_families: Default::default(),
         };

--- a/crates/nose-cli/src/schema_versions.rs
+++ b/crates/nose-cli/src/schema_versions.rs
@@ -1,2 +1,2 @@
-pub(crate) const QUERY_JSON_SCHEMA_VERSION: u32 = 7;
+pub(crate) const QUERY_JSON_SCHEMA_VERSION: u32 = 9;
 pub(crate) const QUERY_BASE_JSON_SCHEMA_VERSION: u32 = 8;

--- a/crates/nose-cli/src/surfaces.rs
+++ b/crates/nose-cli/src/surfaces.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashSet;
 use crate::source_lines::FileLineCache;
 
 mod generated;
+mod generated_paths;
 
 use generated::{generated_source_indexes, GeneratedSourceIndexes};
 #[cfg(test)]
@@ -11,18 +12,27 @@ pub(crate) use generated::{
     has_version_tag, head_has_declared_generator_provenance, head_has_jazzy_generated_provenance,
     looks_compiled_css,
 };
+pub(crate) use generated_paths::GeneratedPathAssertions;
 
 /// Compute the surface overrides for every output format and flag generated
 /// locations. The generated indexes are one head-read per discovered file
 /// (#224 — the #216 audit's re2c case) and the declaration analysis is one
 /// span-read per family; both run only when families exist.
+#[cfg(test)]
 pub(crate) fn classify_surface_overrides(
     families: &mut [nose_detect::RefactorFamily],
+) -> SurfaceOverrides {
+    classify_surface_overrides_with_generated_paths(families, &GeneratedPathAssertions::default())
+}
+
+pub(crate) fn classify_surface_overrides_with_generated_paths(
+    families: &mut [nose_detect::RefactorFamily],
+    caller_generated_paths: &GeneratedPathAssertions,
 ) -> SurfaceOverrides {
     let generated = if families.is_empty() {
         GeneratedSourceIndexes::default()
     } else {
-        generated_source_indexes(families)
+        generated_source_indexes(families, caller_generated_paths)
     };
     for f in families.iter_mut() {
         for l in &mut f.locations {
@@ -36,6 +46,7 @@ pub(crate) fn classify_surface_overrides(
     SurfaceOverrides {
         generated_sources: generated.sources,
         additional_generated_surface_sources: generated.additional_surface_sources,
+        caller_generated_surface_sources: generated.caller_surface_sources,
         declaration_run_families: declaration_run_families(families),
         declaration_only_type_contract_families: declaration_only_type_contract_families(families),
     }
@@ -64,6 +75,9 @@ pub(crate) struct SurfaceOverrides {
     /// files deliberately do not set `Loc::looks_generated`, which has semantic effects on
     /// helper selection and folding beyond presentation (#842).
     pub(crate) additional_generated_surface_sources: FxHashSet<String>,
+    /// Caller assertions from root-anchored `--generated-path` / config globs. Like
+    /// other presentation-only provenance, these never set `Loc::looks_generated`.
+    pub(crate) caller_generated_surface_sources: FxHashSet<String>,
     /// Families whose every member span is provably only import/include/
     /// use/re-export declarations — duplication the language mandates per
     /// file, with no extraction action to take.
@@ -415,11 +429,13 @@ fn family_all_generated_source(
     family: &nose_detect::RefactorFamily,
     generated_sources: &FxHashSet<String>,
     additional_generated_surface_sources: &FxHashSet<String>,
+    caller_generated_surface_sources: &FxHashSet<String>,
 ) -> bool {
     !family.locations.is_empty()
         && family.locations.iter().all(|loc| {
             generated_sources.contains(&loc.file)
                 || additional_generated_surface_sources.contains(&loc.file)
+                || caller_generated_surface_sources.contains(&loc.file)
         })
 }
 
@@ -431,7 +447,49 @@ fn family_generated_source(
         family,
         &overrides.generated_sources,
         &overrides.additional_generated_surface_sources,
+        &overrides.caller_generated_surface_sources,
     ) || family_is_compiled_css_pipeline(family, &overrides.generated_sources)
+}
+
+pub(crate) fn generated_provenance_json(
+    family: &nose_detect::RefactorFamily,
+    overrides: &SurfaceOverrides,
+) -> Option<serde_json::Value> {
+    let all_members = family_all_generated_source(
+        family,
+        &overrides.generated_sources,
+        &overrides.additional_generated_surface_sources,
+        &overrides.caller_generated_surface_sources,
+    );
+    let compiled_css_pipeline =
+        family_is_compiled_css_pipeline(family, &overrides.generated_sources);
+    if !all_members && !compiled_css_pipeline {
+        return None;
+    }
+
+    let caller = family.locations.iter().any(|location| {
+        overrides
+            .caller_generated_surface_sources
+            .contains(&location.file)
+    });
+    let inferred = compiled_css_pipeline
+        || family.locations.iter().any(|location| {
+            overrides.generated_sources.contains(&location.file)
+                || overrides
+                    .additional_generated_surface_sources
+                    .contains(&location.file)
+        });
+    let mut sources = Vec::with_capacity(2);
+    if caller {
+        sources.push("caller-path");
+    }
+    if inferred {
+        sources.push("nose-inferred");
+    }
+    Some(serde_json::json!({
+        "basis": if all_members { "all-members" } else { "compiled-css-pipeline" },
+        "sources": sources,
+    }))
 }
 
 fn family_established_generated_source(

--- a/crates/nose-cli/src/surfaces/generated.rs
+++ b/crates/nose-cli/src/surfaces/generated.rs
@@ -1,12 +1,14 @@
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 
+use super::generated_paths::GeneratedPathAssertions;
 use crate::path_utils::relativize;
 
 #[derive(Default)]
 pub(super) struct GeneratedSourceIndexes {
     pub(super) sources: FxHashSet<String>,
     pub(super) additional_surface_sources: FxHashSet<String>,
+    pub(super) caller_surface_sources: FxHashSet<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -17,6 +19,7 @@ enum GeneratedSourceKind {
 
 pub(super) fn generated_source_indexes(
     families: &[nose_detect::RefactorFamily],
+    caller_generated_paths: &GeneratedPathAssertions,
 ) -> GeneratedSourceIndexes {
     let cwd = std::env::current_dir().ok();
     let mut generated = GeneratedSourceIndexes::default();
@@ -34,19 +37,32 @@ pub(super) fn generated_source_indexes(
         .collect::<Vec<_>>();
     let generated_files = files
         .into_par_iter()
-        .filter_map(|path| generated_source_kind(&path).map(|kind| (path, kind)))
+        .map(|path| {
+            let kind = generated_source_kind(&path);
+            let caller = caller_generated_paths.matches(&path);
+            (path, kind, caller)
+        })
         .collect::<Vec<_>>();
-    for (path, kind) in generated_files {
-        let index = match kind {
-            GeneratedSourceKind::Established => &mut generated.sources,
-            GeneratedSourceKind::AdditionalSurface => &mut generated.additional_surface_sources,
-        };
-        index.insert(path.clone());
-        if let Some(cwd) = &cwd {
-            index.insert(relativize(&path, cwd));
+    for (path, kind, caller) in generated_files {
+        if let Some(kind) = kind {
+            let index = match kind {
+                GeneratedSourceKind::Established => &mut generated.sources,
+                GeneratedSourceKind::AdditionalSurface => &mut generated.additional_surface_sources,
+            };
+            insert_path_aliases(index, &path, cwd.as_deref());
+        }
+        if caller {
+            insert_path_aliases(&mut generated.caller_surface_sources, &path, cwd.as_deref());
         }
     }
     generated
+}
+
+fn insert_path_aliases(index: &mut FxHashSet<String>, path: &str, cwd: Option<&std::path::Path>) {
+    index.insert(path.to_string());
+    if let Some(cwd) = cwd {
+        index.insert(relativize(path, cwd));
+    }
 }
 
 fn generated_source_kind(file: &str) -> Option<GeneratedSourceKind> {

--- a/crates/nose-cli/src/surfaces/generated_paths.rs
+++ b/crates/nose-cli/src/surfaces/generated_paths.rs
@@ -1,0 +1,268 @@
+use anyhow::{Context, Result};
+use ignore::overrides::{Override, OverrideBuilder};
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Default)]
+pub(crate) struct GeneratedPathAssertions {
+    matcher: Option<Override>,
+    roots: Vec<AssertionRoot>,
+}
+
+struct AssertionRoot {
+    display: PathBuf,
+    canonical: PathBuf,
+    is_file: bool,
+}
+
+impl GeneratedPathAssertions {
+    pub(crate) fn new(roots: &[PathBuf], patterns: Vec<String>) -> Result<Self> {
+        let patterns = patterns.into_iter().collect::<BTreeSet<_>>();
+        if patterns.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let mut builder = OverrideBuilder::new(".");
+        for pattern in &patterns {
+            validate_pattern(pattern)?;
+            builder
+                .add(&format!("/{pattern}"))
+                .with_context(|| format!("invalid generated-path glob {pattern:?}"))?;
+        }
+        let matcher = builder
+            .build()
+            .context("building generated-path glob matcher")?;
+        let roots = roots
+            .iter()
+            .filter_map(|root| {
+                let display = absolute_lexical(root)?;
+                let canonical = std::fs::canonicalize(root).ok()?;
+                let is_file = std::fs::metadata(root).ok()?.is_file();
+                Some(AssertionRoot {
+                    display,
+                    canonical,
+                    is_file,
+                })
+            })
+            .collect();
+        Ok(Self {
+            matcher: Some(matcher),
+            roots,
+        })
+    }
+
+    pub(crate) fn matches(&self, file: &str) -> bool {
+        let Some(matcher) = &self.matcher else {
+            return false;
+        };
+        let Ok(open) = std::fs::File::open(file) else {
+            return false;
+        };
+        if !open.metadata().is_ok_and(|metadata| metadata.is_file()) {
+            return false;
+        }
+        let Ok(canonical) = std::fs::canonicalize(file) else {
+            return false;
+        };
+        let Some(display) = absolute_lexical(Path::new(file)) else {
+            return false;
+        };
+
+        self.roots.iter().any(|root| {
+            root.relative_path(&display, &canonical)
+                .is_some_and(|relative| matcher.matched(relative, false).is_whitelist())
+        })
+    }
+}
+
+impl AssertionRoot {
+    fn relative_path<'a>(&'a self, display: &'a Path, canonical: &'a Path) -> Option<&'a Path> {
+        if self.is_file {
+            if canonical != self.canonical {
+                return None;
+            }
+            return self.display.file_name().map(Path::new);
+        }
+        let canonical_relative = canonical.strip_prefix(&self.canonical).ok()?;
+        if canonical_relative.as_os_str().is_empty() {
+            return None;
+        }
+        display
+            .strip_prefix(&self.display)
+            .ok()
+            .filter(|relative| !relative.as_os_str().is_empty())
+            .or(Some(canonical_relative))
+    }
+}
+
+fn validate_pattern(pattern: &str) -> Result<()> {
+    let invalid = if pattern.is_empty() {
+        Some("it is empty")
+    } else if pattern.starts_with('!') {
+        Some("negation is not supported")
+    } else if pattern.contains('\\') {
+        Some("use `/` as the portable path separator")
+    } else if Path::new(pattern).is_absolute() || pattern.starts_with('/') {
+        Some("absolute patterns are not supported")
+    } else if pattern
+        .split('/')
+        .any(|component| matches!(component, "." | ".."))
+    {
+        Some("`.` and `..` path components are not supported")
+    } else {
+        None
+    };
+    if let Some(reason) = invalid {
+        anyhow::bail!("invalid generated-path glob {pattern:?}: {reason}");
+    }
+    Ok(())
+}
+
+fn absolute_lexical(path: &Path) -> Option<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    let mut cleaned = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                cleaned.pop();
+            }
+            other => cleaned.push(other.as_os_str()),
+        }
+    }
+    Some(cleaned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "nose_generated_paths_{tag}_{}_{}",
+            std::process::id(),
+            sequence
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "def example():\n    return 1\n").unwrap();
+    }
+
+    #[test]
+    fn patterns_are_anchored_to_each_root_and_fail_open_outside() {
+        let first = temp_dir("anchored_first");
+        let second = temp_dir("anchored_second");
+        let direct = first.join("generated/direct.py");
+        let nested = first.join("pkg/generated/nested.py");
+        let other_root = second.join("generated/other.py");
+        let outside = temp_dir("anchored_outside").join("generated/outside.py");
+        for path in [&direct, &nested, &other_root, &outside] {
+            write(path);
+        }
+
+        let assertions = GeneratedPathAssertions::new(
+            &[first.clone(), second.clone()],
+            vec!["generated/**".to_string()],
+        )
+        .unwrap();
+        assert!(assertions.matches(direct.to_str().unwrap()));
+        assert!(assertions.matches(other_root.to_str().unwrap()));
+        assert!(!assertions.matches(nested.to_str().unwrap()));
+        assert!(!assertions.matches(outside.to_str().unwrap()));
+
+        let nested_assertions = GeneratedPathAssertions::new(
+            std::slice::from_ref(&first),
+            vec!["**/generated/**".to_string()],
+        )
+        .unwrap();
+        assert!(nested_assertions.matches(nested.to_str().unwrap()));
+
+        let _ = std::fs::remove_dir_all(first);
+        let _ = std::fs::remove_dir_all(second);
+        let _ = std::fs::remove_dir_all(outside.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn file_roots_and_missing_files_have_explicit_behavior() {
+        let dir = temp_dir("file_root");
+        let file = dir.join("snapshot.py");
+        write(&file);
+        let assertions = GeneratedPathAssertions::new(
+            std::slice::from_ref(&file),
+            vec!["snapshot.py".to_string()],
+        )
+        .unwrap();
+        assert!(assertions.matches(file.to_str().unwrap()));
+        std::fs::remove_file(&file).unwrap();
+        assert!(!assertions.matches(file.to_str().unwrap()));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn invalid_or_ambiguous_patterns_are_rejected() {
+        let root = temp_dir("invalid");
+        for pattern in [
+            "",
+            "!generated/**",
+            "/generated/**",
+            "../generated/**",
+            ".\\x",
+        ] {
+            assert!(
+                GeneratedPathAssertions::new(
+                    std::slice::from_ref(&root),
+                    vec![pattern.to_string()],
+                )
+                .is_err(),
+                "{pattern:?}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_symlink_roots_work_but_nested_escapes_fail_open() {
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_dir("symlink");
+        let target = parent.join("target");
+        let outside = parent.join("outside");
+        let inside_file = target.join("generated/inside.py");
+        let outside_file = outside.join("generated/outside.py");
+        write(&inside_file);
+        write(&outside_file);
+
+        let alias = parent.join("alias");
+        symlink(&target, &alias).unwrap();
+        let explicit = GeneratedPathAssertions::new(
+            std::slice::from_ref(&alias),
+            vec!["generated/**".to_string()],
+        )
+        .unwrap();
+        assert!(explicit.matches(alias.join("generated/inside.py").to_str().unwrap()));
+
+        let escape = target.join("escape");
+        symlink(&outside, &escape).unwrap();
+        let contained = GeneratedPathAssertions::new(
+            std::slice::from_ref(&target),
+            vec!["**/generated/**".to_string()],
+        )
+        .unwrap();
+        assert!(!contained.matches(escape.join("generated/outside.py").to_str().unwrap()));
+        let _ = std::fs::remove_dir_all(parent);
+    }
+}

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -64,7 +64,7 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
     );
     assert!(json_array_strings(&json["commands"], "deprecated").is_empty());
     assert_eq!(json["schemas"]["capabilities"][0], 7);
-    assert_eq!(json["schemas"]["query_json"], serde_json::json!([7, 8]));
+    assert_eq!(json["schemas"]["query_json"], serde_json::json!([8, 9]));
     assert_eq!(
         json["schemas"]["semantic_packs"],
         serde_json::json!(["nose.semantic-pack.v0", "nose.semantic-pack.v1"])
@@ -105,6 +105,7 @@ fn capabilities_command_reports_query_surface() {
         json_array_strings(&json["query"], "sort_keys"),
         vec!["extractability", "value", "sites", "hazard"]
     );
+    assert_caller_generated_path_capability(&json);
     assert_eq!(json["query"]["capabilities"]["baseline"], true);
     assert_eq!(
         json["query"]["capabilities"]["baseline_member_digest"],
@@ -140,6 +141,14 @@ fn capabilities_command_reports_query_surface() {
         true
     );
     assert_eq!(json["query"]["capabilities"]["structured_ignores"], true);
+}
+
+fn assert_caller_generated_path_capability(json: &serde_json::Value) {
+    assert!(json_array_strings(&json["query"], "config_keys").contains(&"generated-paths"));
+    assert_eq!(
+        json["query"]["capabilities"]["caller_generated_paths"],
+        true
+    );
 }
 
 #[test]
@@ -409,6 +418,6 @@ fn recursive_hof_callback_fragment_does_not_overflow() {
         "top=0",
     ]);
     let json = query_json(&out);
-    assert_eq!(json["schema_version"], 7);
+    assert_eq!(json["schema_version"], 9);
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/nose-cli/tests/cli/commands/proposal_query.rs
+++ b/crates/nose-cli/tests/cli/commands/proposal_query.rs
@@ -407,8 +407,8 @@ fn query_dashboard_filter_and_family() {
     let dash: serde_json::Value =
         serde_json::from_str(&run_raw(&["query", p, "--format", "json"])).unwrap();
     assert_eq!(
-        dash["schema_version"], 7,
-        "dashboard json is schema v7: {dash}"
+        dash["schema_version"], 9,
+        "dashboard json is schema v9: {dash}"
     );
     assert_eq!(dash["view"], "dashboard");
     assert_query_json_reports_semantic_packs(&dash);
@@ -438,17 +438,14 @@ fn query_dashboard_filter_and_family() {
     // A filtered list emits structured family objects (not human `where` strings).
     let list: serde_json::Value =
         serde_json::from_str(&run(&["query", p, "members>1", "--format", "json"])).unwrap();
-    assert_eq!(
-        list["schema_version"], 7,
-        "list json stays schema v7: {list}"
-    );
+    assert_eq!(list["schema_version"], 9, "list json is schema v9: {list}");
     assert_eq!(list["view"], "list");
     assert_query_json_reports_semantic_packs(&list);
     let grouped: serde_json::Value =
         serde_json::from_str(&run(&["query", p, "group=dir", "--format", "json"])).unwrap();
     assert_eq!(
-        grouped["schema_version"], 7,
-        "group json stays schema v7: {grouped}"
+        grouped["schema_version"], 9,
+        "group json is schema v9: {grouped}"
     );
     assert_eq!(grouped["view"], "group");
     assert_query_json_reports_semantic_packs(&grouped);
@@ -469,8 +466,8 @@ fn query_dashboard_filter_and_family() {
     ]))
     .unwrap();
     assert_eq!(
-        opened["schema_version"], 7,
-        "family json stays schema v7: {opened}"
+        opened["schema_version"], 9,
+        "family json is schema v9: {opened}"
     );
     assert_eq!(opened["view"], "family");
     assert_query_json_reports_semantic_packs(&opened);

--- a/crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs
+++ b/crates/nose-cli/tests/cli/commands/query_reinvented/diagnostics.rs
@@ -119,10 +119,7 @@ fn query_reinvented_view_lists_call_the_helper_findings() {
         "json",
     ]))
     .unwrap();
-    assert_eq!(
-        j["schema_version"], 7,
-        "reinvented json stays schema v7: {j}"
-    );
+    assert_eq!(j["schema_version"], 9, "reinvented json is schema v9: {j}");
     assert_eq!(j["view"], "reinvented");
     assert_query_json_reports_semantic_packs(&j);
     assert_eq!(

--- a/crates/nose-cli/tests/cli/generated_surfaces.rs
+++ b/crates/nose-cli/tests/cli/generated_surfaces.rs
@@ -70,5 +70,196 @@ fn query_declared_generator_provenance_is_reason_coded_and_recoverable() {
             .all(|family| family["surface"] == "generated"),
         "every source-coherent declared generated family is reason-coded generated: {all}"
     );
+    assert!(families.iter().all(|family| {
+        family["generated_provenance"]
+            == serde_json::json!({"basis": "all-members", "sources": ["nose-inferred"]})
+    }));
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn caller_generated_paths_are_additive_recoverable_and_surface_only() {
+    let dir = make_project("caller_generated_paths");
+    let root = dir.to_str().unwrap();
+    let base = query_json(&run(&[
+        "query", root, "--mode", "semantic", "all", "top=0", "--format", "json",
+    ]));
+    let base_family = project_clone_family(&base).clone();
+
+    let partial = query_json(&run(&[
+        "query",
+        root,
+        "--mode",
+        "semantic",
+        "--generated-path",
+        "a/**",
+        "all",
+        "top=0",
+        "--format",
+        "json",
+    ]));
+    let partial_family = project_clone_family(&partial);
+    assert_eq!(partial_family["surface"], base_family["surface"]);
+    assert!(partial_family.get("generated_provenance").is_none());
+
+    let config = dir.join("caller.toml");
+    fs::write(&config, "[query]\ngenerated-paths = [\"a/**\"]\n").unwrap();
+    let asserted = query_json(&run(&[
+        "query",
+        root,
+        "--mode",
+        "semantic",
+        "--config",
+        config.to_str().unwrap(),
+        "--generated-path",
+        "b/**",
+        "--generated-path",
+        "tests/**",
+        "all",
+        "top=0",
+        "--format",
+        "json",
+    ]));
+    let asserted_family = project_clone_family(&asserted);
+    assert_eq!(asserted_family["surface"], "generated");
+    assert_eq!(
+        asserted_family["generated_provenance"],
+        serde_json::json!({"basis": "all-members", "sources": ["caller-path"]})
+    );
+
+    let mut before = base_family;
+    let mut after = asserted_family.clone();
+    before.as_object_mut().unwrap().remove("surface");
+    before
+        .as_object_mut()
+        .unwrap()
+        .remove("recommended_surface");
+    after.as_object_mut().unwrap().remove("surface");
+    after.as_object_mut().unwrap().remove("recommended_surface");
+    after
+        .as_object_mut()
+        .unwrap()
+        .remove("generated_provenance");
+    assert_eq!(
+        after, before,
+        "caller assertions change only surface metadata"
+    );
+
+    let human = run(&[
+        "query",
+        root,
+        "--mode",
+        "semantic",
+        "--config",
+        config.to_str().unwrap(),
+        "--generated-path",
+        "b/**",
+        "--generated-path",
+        "tests/**",
+    ]);
+    assert!(human.contains("generated-code"));
+    assert!(!human.contains("a/f.py"));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn caller_generated_paths_reject_invalid_and_base_view_inputs() {
+    let dir = make_project("caller_generated_path_errors");
+    let root = dir.to_str().unwrap();
+    let invalid = run_fail(&["query", root, "--generated-path", "../outside/**", "top=0"]);
+    assert!(invalid.contains("invalid generated-path glob"), "{invalid}");
+
+    let invalid_config = dir.join("invalid.toml");
+    fs::write(
+        &invalid_config,
+        "[query]\ngenerated-paths = [\"!generated/**\"]\n",
+    )
+    .unwrap();
+    let invalid = run_fail(&[
+        "query",
+        root,
+        "--config",
+        invalid_config.to_str().unwrap(),
+        "top=0",
+    ]);
+    assert!(invalid.contains("invalid generated-path glob"), "{invalid}");
+
+    let base = run_fail(&["query", root, "--generated-path", "a/**", "base=HEAD"]);
+    assert!(base.contains("does not support --generated-path"), "{base}");
+
+    let base_config = dir.join("base.toml");
+    fs::write(
+        &base_config,
+        "[query]\ngenerated-paths = [\"generated/**\"]\n",
+    )
+    .unwrap();
+    let base = run_fail(&[
+        "query",
+        root,
+        "--config",
+        base_config.to_str().unwrap(),
+        "base=HEAD",
+    ]);
+    assert!(
+        base.contains("does not support generated-paths config"),
+        "{base}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn caller_generated_paths_apply_independently_to_every_query_root() {
+    let first = make_project("caller_generated_multi_first");
+    let second = make_project("caller_generated_multi_second");
+    let report = query_json(&run(&[
+        "query",
+        "--root",
+        first.to_str().unwrap(),
+        "--root",
+        second.to_str().unwrap(),
+        "--mode",
+        "semantic",
+        "--generated-path",
+        "a/**",
+        "--generated-path",
+        "b/**",
+        "--generated-path",
+        "tests/**",
+        "all",
+        "top=0",
+        "--format",
+        "json",
+    ]));
+    let family = query_families(&report)
+        .iter()
+        .find(|family| {
+            family["members"]
+                .as_u64()
+                .is_some_and(|members| members >= 6)
+        })
+        .expect("the cross-root clone family");
+    assert_eq!(family["surface"], "generated");
+    assert_eq!(
+        family["generated_provenance"],
+        serde_json::json!({"basis": "all-members", "sources": ["caller-path"]})
+    );
+    let _ = fs::remove_dir_all(first);
+    let _ = fs::remove_dir_all(second);
+}
+
+fn project_clone_family(report: &serde_json::Value) -> &serde_json::Value {
+    query_families(report)
+        .iter()
+        .find(|family| {
+            let files = family["locations"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|location| location["file"].as_str())
+                .collect::<Vec<_>>();
+            ["a/f.py", "b/f.py", "tests/f.py"]
+                .iter()
+                .all(|suffix| files.iter().any(|file| file.ends_with(suffix)))
+        })
+        .expect("the three-copy fixture family")
 }

--- a/crates/nose-cli/tests/cli/support.rs
+++ b/crates/nose-cli/tests/cli/support.rs
@@ -241,6 +241,7 @@ fn query_json_list_args(args: &[&str]) -> Vec<String> {
                 | "--cache-dir"
                 | "--semantic-pack"
                 | "--exclude"
+                | "--generated-path"
                 | "--fail-on"
         ) {
             skip_next = true;

--- a/docs/caller-generated-path-provenance.md
+++ b/docs/caller-generated-path-provenance.md
@@ -83,3 +83,22 @@ would add a new lifecycle, source/output identity model, and schema without impr
 boundary. The path contract is therefore independently sufficient for this slice. A future
 manifest should start only from evidence that source/output relationships enable a safer
 decision the path contract cannot express; it is not part of #925.
+
+## Measured result
+
+The checked [#925 closeout artifact](../bench/recall_loss/issue-925-caller-generated-path-closeout-2026-07-19.v1.json)
+binds exact commits, binaries, field queries, output hashes, and performance reports.
+
+On the fresh Check checkout, `m4/**` moves all three Autoconf Archive HTML families from
+`default` to `generated`; the ordered family count stays 22, and deleting only `surface` and
+`generated_provenance` produces the same SHA-256 before and after. On Pydantic,
+`tests/mypy/outputs/**` moves no family: all four affected families also contain maintained
+`tests/mypy/modules` inputs and therefore fail open. Check output is byte-identical with
+`RAYON_NUM_THREADS=1` and `4`.
+
+The default query path was priced on the same frozen 66-repository cohort used by #891. The
+baseline is the published v0.19.0 binary and the control compares the candidate binary with
+itself, each with one warmup and three alternating iterations. The published comparison is
+`-41.42 ms / -0.263%`; the same-binary control is `-43.27 ms / -0.270%`, leaving a
+control-adjusted `+1.85 ms / +0.006%`. That is below both the unchanged `5 ms` and
+`5%` material-regression gates, so no focused escalation was taken.

--- a/docs/caller-generated-path-provenance.md
+++ b/docs/caller-generated-path-provenance.md
@@ -70,8 +70,8 @@ Every generated family in non-`base` query JSON has additive provenance:
 ```
 
 `basis` is `all-members` or `compiled-css-pipeline`. `sources` is a sorted, deduplicated list
-containing `caller-path`, `nose-inferred`, or both. This distinguishes caller trust from
-nose inference without changing the meaning or type of any existing schema-v7 field.
+containing `caller-path`, `nose-inferred`, or both. This is query JSON schema v9: the existing
+strict v7 contract is not silently extended, and no v7 field changes meaning or type.
 `base=<ref>` is a separate divergent-edit contract and rejects generated-path inputs rather
 than silently ignoring them.
 

--- a/docs/caller-generated-path-provenance.md
+++ b/docs/caller-generated-path-provenance.md
@@ -1,0 +1,85 @@
+# Caller-provided generated-path provenance
+
+Issue [#925](https://github.com/corca-ai/nose/issues/925) defines the smallest
+caller-supplied provenance contract that can classify checked-in generated artifacts without
+deleting their findings. It complements nose's source-derived generated-file rules; it does
+not add repository, producer, language, symbol, or filename allowlists to the detector.
+
+## Contract
+
+Local users can repeat `--generated-path <GLOB>`. Projects can commit the same assertions in
+`nose.toml` or `.nose.toml`:
+
+```toml
+[query]
+generated-paths = ["generated/**", "**/snapshots/mypy/**"]
+```
+
+Command-line and config patterns are additive. Duplicate patterns collapse before matching.
+`--config` selects the config file by the existing config rules; patterns remain relative to
+the analyzed roots, not to the config file, so a committed contract is portable across
+checkout locations.
+
+Patterns use gitignore glob syntax but are positive, root-relative assertions. nose anchors
+each pattern automatically to every explicit analysis root:
+
+- `generated/**` matches only a `generated` directory immediately below a root;
+- `**/generated/**` also matches nested `generated` directories;
+- a file root is matched by its file name;
+- a path is marked when it matches relative to any containing root, so overlapping and
+  multi-root queries have deterministic union semantics.
+
+Empty patterns, negation (`!`), absolute paths, `.` or `..` path components, and backslashes
+are rejected before analysis. This keeps one portable spelling and prevents a pattern from
+escaping or changing meaning with the current directory.
+
+## Trust, containment, and failure
+
+A generated-path entry is a caller assertion, not a nose inference and not proof that a
+producer ran. nose canonicalizes both roots and candidate files before matching. A symlink
+supplied as an explicit root therefore describes the tree it resolves to, while a symlink
+inside a root that escapes that tree cannot acquire generated provenance. Files that are
+missing, unreadable, not regular files, or outside every canonical root fail open.
+
+The assertion changes only presentation. A family receives `surface: "generated"` when
+every member has either caller-supplied or nose-inferred generated provenance. Partial and
+mixed families retain their prior surface. The existing compiled-CSS source/output rule
+remains nose-inferred and unchanged. No assertion changes discovery, lowering, candidates,
+family construction, family IDs, ordering, witnesses, ranking, helper selection, baseline
+identity, or existing non-surface fields.
+
+Generated families remain recoverable with `all top=0` or `surface=generated`. The human
+default continues to explain their omission as `generated-code`; Markdown, SARIF, and
+`--fail-on` use the same effective surface instead of deleting the family. Structured
+ignores and `--exclude` remain separate contracts: ignores suppress accepted findings with
+an audit record, while excludes prune inputs before analysis.
+
+## Machine contract
+
+`nose capabilities` advertises the `caller_generated_paths` query capability and the
+`generated-paths` config key. Integrations should preflight that capability before passing
+`--generated-path`.
+
+Every generated family in non-`base` query JSON has additive provenance:
+
+```json
+"generated_provenance": {
+  "basis": "all-members",
+  "sources": ["caller-path"]
+}
+```
+
+`basis` is `all-members` or `compiled-css-pipeline`. `sources` is a sorted, deduplicated list
+containing `caller-path`, `nose-inferred`, or both. This distinguishes caller trust from
+nose inference without changing the meaning or type of any existing schema-v7 field.
+`base=<ref>` is a separate divergent-edit contract and rejects generated-path inputs rather
+than silently ignoring them.
+
+## Why no producer manifest yet
+
+The audited Check and Pydantic residuals are already identified by stable project paths, and
+the all-member rule still protects mixed maintained/generated families. A producer manifest
+would add a new lifecycle, source/output identity model, and schema without improving that
+boundary. The path contract is therefore independently sufficient for this slice. A future
+manifest should start only from evidence that source/output relationships enable a safer
+decision the path contract cannot express; it is not part of #925.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -47,7 +47,7 @@ nose capabilities
   },
   "schemas": {
     "capabilities": [7],
-    "query_json": [7, 8],
+    "query_json": [8, 9],
     "semantic_packs": ["nose.semantic-pack.v0", "nose.semantic-pack.v1"],
     "semantic_pack_locks": ["nose.semantic-pack-lock.v1"],
     "semantic_pack_receipts": ["nose.semantic-pack-conformance-receipt.v1"],
@@ -64,6 +64,7 @@ nose capabilities
     "sort_keys": ["extractability", "value", "sites", "hazard"],
     "config_keys": [
       "exclude",
+      "generated-paths",
       "ignore-file",
       "min-lines",
       "min-members",
@@ -80,6 +81,7 @@ nose capabilities
       "baseline_changed_detection": true,
       "baseline_member_digest": true,
       "cache": true,
+      "caller_generated_paths": true,
       "ci_fail_gate": true,
       "family_drilldown": true,
       "inline_suppression": true,
@@ -242,6 +244,7 @@ Version 7 defines these `query.capabilities` keys:
 | `baseline_changed_detection` | Baseline comparisons can classify changed and resolved families. |
 | `baseline_member_digest` | Baselines use accepted member source digests, so reshaped accepted families stay hidden while edited members report as changed. |
 | `cache` | `--cache-dir` file analysis caching is supported. |
+| `caller_generated_paths` | Repeatable `--generated-path` and `[query].generated-paths` assertions classify all-member families without deleting them; non-base JSON distinguishes caller and nose provenance. |
 | `ci_fail_gate` | `--fail-on any|new` gate behavior is supported. |
 | `family_drilldown` | Opening a family with `id=<fam>` / `at=FILE:LINE` is supported. |
 | `inline_suppression` | Source-level `nose-ignore` markers are supported. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,14 +3,15 @@
 Real projects shouldn't carry 200-character command lines. Put a `nose.toml`
 (or `.nose.toml`) in the directory where you invoke nose and it is read
 automatically. The config supplies defaults for supported query settings; most CLI flags
-override those defaults, while `exclude` globs are additive. Anything unset falls back to
-the built-in default.
+override those defaults, while `exclude` and `generated-paths` globs are additive. Anything
+unset falls back to the built-in default.
 
 ## `nose.toml`
 
 ```toml
 [query]
 exclude     = ["tests/**", "**/*.generated.ts", "vendor/**"]
+generated-paths = ["generated/**", "**/snapshots/mypy/**"]
 mode        = ["syntax", "semantic"]
 sort        = "extractability"
 min-value   = 200
@@ -25,8 +26,8 @@ semantic-packs = ["semantic-packs/python-math-prod.json"]
 Pass an alternate file with `--config <file>`. A malformed config is a **hard
 error** — a silently-ignored typo'd setting would be worse than a crash.
 
-Put stable project policy in `nose.toml`: excludes, detection modes, ranking, size/value
-thresholds, the structured-ignore file, and explicit local
+Put stable project policy in `nose.toml`: excludes, generated-artifact assertions, detection
+modes, ranking, size/value thresholds, the structured-ignore file, and explicit local
 semantic-pack opt-ins. Keep one-off workflow choices on the command line or in query terms:
 output format, the drill/view terms (`id=`, `group=`, `full`), baselines, cache location, and
 CI failure mode.
@@ -42,6 +43,7 @@ term — `nose query` spells `sort` as the DSL term `sort=`, not `--sort`).
 | key | type | default | CLI override |
 |---|---|---|---|
 | `exclude` | list of globs | `[]` | `--exclude` |
+| `generated-paths` | list of root-anchored globs | `[]` | `--generated-path` |
 | `mode` | list of `syntax`\|`semantic`\|`near[:T]` | `["syntax", "semantic", "near"]` | `--mode` |
 | `sort` | `extractability`\|`value`\|`sites`\|`hazard` | `extractability` | `sort=` (query term) |
 | `min-value` | finite non-negative float | `0.0` | `--min-value` |
@@ -84,7 +86,8 @@ Config file paths are resolved from the config file's directory, so committed
 project paths do not depend on where `nose` was invoked. This applies to
 `ignore-file`, `semantic-packs`, and `semantic-pack-lock`. CLI path flags such
 as `--ignore-file`, `--semantic-pack`, and `--semantic-pack-lock` remain
-current-working-directory relative.
+current-working-directory relative. `generated-paths` entries are globs rather than config
+file paths: they are always anchored to each analyzed root.
 
 `semantic-packs` is additive with repeated `--semantic-pack` flags. Each entry is
 an explicit local opt-in to a semantic-pack v0 or v1 manifest file, or a
@@ -117,6 +120,21 @@ worse than failing early.
 tree is not a git checkout, so vendored dependencies, build output, and the like are
 skipped without any configuration. Parent ignore files above the analyzed root are not
 applied; pointing nose at an ignored subdirectory intentionally still analyzes it.
+
+## Generated paths
+
+`generated-paths` is additive: config assertions and repeated `--generated-path` flags are
+combined. Unlike `exclude`, these patterns do not prune files or delete findings. A family
+moves to `surface=generated` only when every member is covered by caller or nose provenance;
+recover it with `all top=0` or `surface=generated`.
+
+Patterns use positive gitignore syntax and are automatically anchored to each query root.
+Use `generated/**` for an immediate child or `**/generated/**` at any depth. Empty,
+negated, absolute, parent-relative, and backslash patterns are hard errors. Matching first
+checks canonical root containment: an explicitly supplied symlink root works, while a symlink
+below a root cannot mark a file outside that root. Missing, unreadable, out-of-root, and mixed
+families fail open. See [caller-provided generated paths](caller-generated-path-provenance.md)
+for the trust, JSON, multi-root, and portability contract.
 
 ## Structured ignores
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -186,7 +186,7 @@ at least detectable; `top=0` avoids the cap entirely.
 
 `--format json` is the general machine-readable form for any other tooling. The forward
 versioned contract is [query-json](query-json.md) (`nose query --format json`; schema v8
-for `base=<ref>`, schema v7 for the other query views).
+for `base=<ref>`, schema v9 for the other query views).
 It is truncated by the active top limit in the same way.
 
 ## Divergent-edit v2 gate tiers

--- a/docs/home.md
+++ b/docs/home.md
@@ -154,6 +154,9 @@ fundamentals; the rest is grouped by area.
 - [0.20 checked-in generated artifact provenance](generated-artifact-provenance-891.md) — the
   producer-independent HTML generator declaration, mixed-family fail-open boundary,
   fresh-repository confirmation, exact transition ledger, and residual API no-go.
+- [0.20 caller-provided generated paths](caller-generated-path-provenance.md) — the
+  root-anchored CLI/config assertion contract, canonical containment and fail-open rules,
+  all-member recovery semantics, and machine-readable trust boundary.
 - [0.20 declaration-only type contracts](declaration-only-type-contracts-843.md) — the
   all-member `UnitOrigin` classifier, cross-language fail-open boundaries, exact dev
   surface/origin drift, worthy-recall preservation, and official-v0.19.0 runtime price.

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -1,4 +1,4 @@
-# nose query JSON (schemas v7 and v8)
+# nose query JSON (schemas v8 and v9)
 
 `nose query <path> [terms…] --format json` emits a structured, versioned contract over the
 duplicated-code family dataset — the **machine** form of the
@@ -8,7 +8,7 @@ For multi-root analysis, use repeated roots:
 `nose query --root <path> --root <path> [terms…] --format json`.
 
 Discover support with [`nose capabilities`](capabilities.md): `schemas.query_json` lists the
-versions the installed binary emits (currently `[7, 8]`). CI wrappers for the
+versions the installed binary emits (currently `[8, 9]`). CI wrappers for the
 divergent-edit gate should also require `query.capabilities.query_base_json_v8`,
 `query.capabilities.query_base_gate_fail_default`, and, for SARIF uploads,
 `query.capabilities.query_base_sarif`.
@@ -19,7 +19,7 @@ Every response is an object with:
 
 | field | meaning |
 |---|---|
-| `schema_version` | `7` for the non-`base` query views; `8` for `base=<ref>` |
+| `schema_version` | `9` for the non-`base` query views; `8` for `base=<ref>` |
 | `tool` | `"nose"` |
 | `view` | which surface produced it: `dashboard` \| `list` \| `group` \| `family` \| `reinvented` \| `base` |
 | `path` | the analyzed path expression, as given; multi-root commands render the repeated `--root`/`-r` flags |
@@ -28,7 +28,9 @@ Every response is an object with:
 plus the view-specific body below. Like the human surface, a result is a pure function of
 (repo state, command); an unknown field or enum value is a hard error.
 
-Schema v8 adds the divergent-edit `base=<ref>` tier contract. Schema v7 adds
+Schema v9 adds explicit `generated_provenance` to generated families so callers can
+distinguish caller path assertions from nose inference without silently extending the strict
+v7 contract. Schema v8 adds the divergent-edit `base=<ref>` tier contract. Schema v7 adds
 on-demand family-level `graded` and `graded_pair` evidence for
 `spotclass` enrichment. Schema v6 added the top-level `semantic_packs`
 reporting field and renamed pack-facing trust/source values from legacy
@@ -231,6 +233,7 @@ Composition rules for v8:
 | `scope` | `prod` \| `test` \| `mixed` (context, never a worthiness penalty; conventional test paths such as `tests/`, `spec/`, `__tests__/`, `*_test.go`, `*.test.*`, `*.spec.*`, `conftest.py`, and Rust modular `test.rs`/`tests.rs` count as test scope, as do Rust inline `mod test`/`mod tests` spans) |
 | `witness` | why the copies merged: `exact` (same unit behavior) \| `subdag` (shared computation inside each site) \| `connected` (pair-local mapped cross-unit region) \| `bounded-window` (two disjoint mapped regions in one enclosing unit; a near/refactoring witness, not exact-fragment proof) \| `copy-paste` \| `similar` |
 | `surface` | `default` \| `divergence` \| `hidden` \| `shallow` \| `generated` \| `declaration` \| `debug` (curation tier; `debug` is a reserved diagnostic tier normal runs don't emit) |
+| `generated_provenance` | schema v9, generated families only: `{basis,sources[]}`. `basis` is `all-members` or `compiled-css-pipeline`; sorted `sources[]` contains `caller-path`, `nose-inferred`, or both, so integrations do not confuse a caller assertion with nose-derived evidence. |
 | `members` | number of copies |
 | `files` / `dirs` / `languages` | distinct files / directories / languages the copies span |
 | `source_comparable` | `false` for cross-language families, where source lines cannot be anti-unified directly; those rows display repeated semantic volume rather than shared/removable source lines |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,6 +250,7 @@ mode flags are documented under [Ranking](#ranking) and [Detection modes](#detec
 | `--mode MODE` | one or more of `syntax`, `semantic`, `near[:T]`; comma-list or repeatable; when present, replaces the default. Experimental `abstraction[:T]` is accepted but not a stable capabilities mode. |
 | `--root <path>` / `-r <path>` | analyze another root; repeat for multi-root query runs. With `--root`, bare positional arguments are query terms. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
+| `--generated-path <glob>` | assert that files matching this root-anchored glob are generated; repeatable and recoverable with `all top=0` |
 | `--ignore-file <file>` | suppress accepted families using a structured ignore file with reason/owner/expiry metadata |
 | `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; unlocked external packs are metadata-only |
 | `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; eligible rows may support near candidates or receipt-backed collection-factory exact claims, and unlocked pack paths cannot be mixed in |
@@ -264,7 +265,7 @@ Use terms for report shaping: `sort=KEY`, `top=N`, `scope=prod|test|mixed`, `gro
 `id=<fam> full`, and `reinvented`. `--format json` emits the stable
 [query-json](query-json.md) contract.
 
-**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--semantic-pack`, `--semantic-pack-lock`) is covered in
+**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--generated-path`, `--semantic-pack`, `--semantic-pack-lock`) is covered in
 [continuous-integration](continuous-integration.md), [configuration](configuration.md), and [semantic-pack-loading](semantic-pack-loading.md).
 Structured suppressions are covered in [structured-ignores](structured-ignores.md).
 


### PR DESCRIPTION
## Summary

- add repeatable `--generated-path <GLOB>` and `[query].generated-paths` as a root-anchored caller assertion
- classify a family as generated only when every member has caller or nose-inferred provenance, while preserving discovery, IDs, ordering, and every non-surface field
- publish query JSON schema v9 provenance, capability/config discovery, strict invalid-input and base-view rejection, and full documentation
- bind fresh Check/Pydantic field outcomes plus the published-v0.19.0 performance comparison and same-binary control in the checked closeout artifact

## Validation

- `cargo test --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./scripts/check-docs.sh`
- fresh Check/Pydantic field validation and RAYON 1/4 determinism
- frozen 66-repository performance cohort: control-adjusted +1.85 ms / +0.006%

Closes #925