### PR TITLE
test(ci): align post-#925 product contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           python3 bench/labels/query_schema.py --self-test
           python3 bench/labels/default_head_query_schema.py --self-test
+          python3 bench/labels/live_query_schema.py --self-test
           python3 bench/labels/eval_by_language.py --self-test
           python3 bench/labels/check_default_head_baseline.py --self-test
           python3 bench/labels/check_default_head_baseline.py
@@ -246,8 +247,7 @@ jobs:
         run: cargo build --release
       - name: product query JSON schema
         run: |
-          python3 bench/labels/query_schema.py --self-test --nose target/release/nose
-          python3 bench/labels/default_head_query_schema.py --self-test --nose target/release/nose
+          python3 bench/labels/live_query_schema.py --self-test --nose target/release/nose
       - name: semantic-pack example conformance
         run: |
           target/release/nose semantic-pack check docs/examples/semantic-packs/v0 docs/examples/semantic-packs/v1 --format json

--- a/bench/labels/live_query_schema.py
+++ b/bench/labels/live_query_schema.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Validate the current query JSON contract without rewriting frozen evidence.
+
+Historical quality artifacts bind the v7 adapter by content hash. This module
+layers the live v9 envelope and generated provenance on that frozen structural
+validator so old measurements remain reproducible as the product advances.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any
+
+import query_schema as frozen
+
+
+QUERY_SCHEMA_VERSION = 9
+GENERATED_PROVENANCE_BASES = ("all-members", "compiled-css-pipeline")
+GENERATED_PROVENANCE_SOURCES = ("caller-path", "nose-inferred")
+QuerySchemaError = frozen.QuerySchemaError
+
+
+@dataclass(frozen=True)
+class DashboardQuery:
+    families: list[dict[str, Any]]
+    reported_families: int
+    shown: int
+
+
+def fail(source: str, path: str, message: str) -> QuerySchemaError:
+    return QuerySchemaError(f"{source}: {path}: {message}")
+
+
+def is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_generated_provenance(
+    family: dict[str, Any], *, source: str, path: str
+) -> None:
+    if family["surface"] != "generated":
+        if "generated_provenance" in family:
+            raise fail(
+                source,
+                f"{path}.generated_provenance",
+                "expected only on a generated family",
+            )
+        return
+
+    provenance = family.get("generated_provenance")
+    provenance_path = f"{path}.generated_provenance"
+    if not isinstance(provenance, dict):
+        raise fail(source, provenance_path, "expected an object for a generated family")
+    if set(provenance) != {"basis", "sources"}:
+        raise fail(source, provenance_path, "expected exactly basis and sources")
+    if provenance["basis"] not in GENERATED_PROVENANCE_BASES:
+        raise fail(
+            source,
+            f"{provenance_path}.basis",
+            f"expected one of {', '.join(GENERATED_PROVENANCE_BASES)}",
+        )
+    sources = provenance["sources"]
+    if (
+        not isinstance(sources, list)
+        or not sources
+        or any(value not in GENERATED_PROVENANCE_SOURCES for value in sources)
+        or sources != sorted(set(sources))
+    ):
+        raise fail(
+            source,
+            f"{provenance_path}.sources",
+            "expected a non-empty sorted unique array of caller-path/nose-inferred",
+        )
+
+
+def validate_family(family: object, *, source: str, index: int) -> dict[str, Any]:
+    frozen._validate_family(family, source=source, index=index)
+    assert isinstance(family, dict)
+    validate_generated_provenance(family, source=source, path=f"families[{index}]")
+    return family
+
+
+def decode_envelope(stdout: str, *, source: str, view: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as error:
+        raise fail(source, "$", f"invalid JSON: {error.msg}") from error
+    if not isinstance(payload, dict):
+        raise fail(source, "$", "expected the query JSON envelope object")
+    if payload.get("schema_version") != QUERY_SCHEMA_VERSION:
+        raise fail(
+            source,
+            "schema_version",
+            f"expected {QUERY_SCHEMA_VERSION}, got {payload.get('schema_version')!r}",
+        )
+    if payload.get("tool") != "nose":
+        raise fail(source, "tool", f"expected 'nose', got {payload.get('tool')!r}")
+    if payload.get("view") != view:
+        raise fail(source, "view", f"expected {view!r}, got {payload.get('view')!r}")
+    return payload
+
+
+def validate_families(
+    families: object, *, source: str, field: str = "families"
+) -> list[dict[str, Any]]:
+    if not isinstance(families, list):
+        raise fail(source, field, "expected an array")
+    return [
+        validate_family(family, source=source, index=index)
+        for index, family in enumerate(families)
+    ]
+
+
+def query_families(stdout: str, *, source: str = "nose query") -> list[dict[str, Any]]:
+    payload = decode_envelope(stdout, source=source, view="list")
+    return validate_families(payload.get("families"), source=source)
+
+
+def family_surface(family: dict[str, Any], *, source: str = "query family") -> str:
+    return validate_family(family, source=source, index=0)["surface"]
+
+
+def dashboard_query(
+    stdout: str, *, source: str = "nose query dashboard"
+) -> DashboardQuery:
+    payload = decode_envelope(stdout, source=source, view="dashboard")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise fail(source, "summary", "expected an object")
+    for field in ("families", "shown"):
+        value = summary.get(field)
+        if not is_int(value) or value < 0:
+            raise fail(source, f"summary.{field}", "expected a non-negative integer")
+    families = validate_families(payload.get("families"), source=source)
+    top_candidates = validate_families(
+        payload.get("top_candidates"),
+        source=f"{source} top_candidates",
+        field="top_candidates",
+    )
+    if [family["id"] for family in families] != [
+        family["id"] for family in top_candidates
+    ]:
+        raise fail(source, "top_candidates", "expected the alias to match families IDs/order")
+    if summary["shown"] != len(families):
+        raise fail(source, "summary.shown", "expected the emitted family count")
+    if summary["families"] < summary["shown"]:
+        raise fail(source, "summary.families", "expected at least summary.shown")
+    return DashboardQuery(families, summary["families"], summary["shown"])
+
+
+def example_family() -> dict[str, Any]:
+    return {
+        "id": "0123456789abcdef",
+        "scope": "prod",
+        "surface": "default",
+        "value": 42.0,
+        "locations": [{"file": "example/a.py", "start": 3, "end": 8}],
+    }
+
+
+def expect_error(payload: object, expected: str, *, dashboard: bool = False) -> None:
+    try:
+        decoder = dashboard_query if dashboard else query_families
+        decoder(json.dumps(payload), source="self-test")
+    except QuerySchemaError as error:
+        assert expected in str(error), (expected, str(error))
+    else:
+        raise AssertionError(f"expected QuerySchemaError containing {expected!r}")
+
+
+def check_live_binary(nose: Path) -> None:
+    source = """\
+def first(items):
+    return sum(item * 2 for item in items if item > 0)
+def second(values):
+    return sum(value * 2 for value in values if value > 0)
+"""
+    with tempfile.TemporaryDirectory(prefix="nose-live-query-schema-") as directory:
+        (Path(directory) / "duplicate.py").write_text(source, encoding="utf-8")
+
+        def run(*selectors: str) -> str:
+            result = subprocess.run(
+                [str(nose), "query", directory, *selectors, "--format", "json"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                raise AssertionError(
+                    f"live query {selectors} failed: {result.stderr.strip()}"
+                )
+            return result.stdout
+
+        all_families = query_families(run("all", "top=0"), source="live all list")
+        default_families = query_families(run("top=0"), source="live default list")
+        dashboard = dashboard_query(run(), source="live bare dashboard")
+        assert all_families, "live query fixture must produce a family"
+        default_ids = [family["id"] for family in default_families]
+        assert default_ids == [
+            family["id"]
+            for family in all_families
+            if family_surface(family, source="live all-list family") == "default"
+        ]
+        assert dashboard.reported_families == len(default_ids)
+        assert [family["id"] for family in dashboard.families] == default_ids[:5]
+
+        generated = query_families(
+            run("all", "top=0", "--generated-path", "duplicate.py"),
+            source="live generated list",
+        )
+        assert generated and all(
+            family["surface"] == "generated"
+            and family["generated_provenance"]
+            == {"basis": "all-members", "sources": ["caller-path"]}
+            for family in generated
+        )
+
+
+def run_self_test(nose: Path | None = None) -> None:
+    family = example_family()
+    listing = {
+        "schema_version": QUERY_SCHEMA_VERSION,
+        "tool": "nose",
+        "view": "list",
+        "families": [family],
+    }
+    assert query_families(json.dumps(listing))[0]["id"] == family["id"]
+    wrong_version = json.loads(json.dumps(listing))
+    wrong_version["schema_version"] = 8
+    expect_error(wrong_version, "expected 9")
+
+    generated = json.loads(json.dumps(listing))
+    generated["families"][0].update(
+        surface="generated",
+        generated_provenance={
+            "basis": "all-members",
+            "sources": ["caller-path", "nose-inferred"],
+        },
+    )
+    query_families(json.dumps(generated), source="self-test generated")
+    missing = json.loads(json.dumps(generated))
+    del missing["families"][0]["generated_provenance"]
+    expect_error(missing, "expected an object for a generated family")
+    unsorted = json.loads(json.dumps(generated))
+    unsorted["families"][0]["generated_provenance"]["sources"].reverse()
+    expect_error(unsorted, "expected a non-empty sorted unique array")
+    unexpected = json.loads(json.dumps(listing))
+    unexpected["families"][0]["generated_provenance"] = None
+    expect_error(unexpected, "expected only on a generated family")
+
+    dashboard = {
+        "schema_version": QUERY_SCHEMA_VERSION,
+        "tool": "nose",
+        "view": "dashboard",
+        "summary": {"families": 1, "shown": 1},
+        "families": [family],
+        "top_candidates": [family],
+    }
+    assert dashboard_query(json.dumps(dashboard)).shown == 1
+    dashboard["top_candidates"] = [{**family, "id": "different"}]
+    expect_error(dashboard, "alias", dashboard=True)
+
+    if nose is not None:
+        check_live_binary(nose.resolve())
+    print("live query schema v9 self-test passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--nose", type=Path, help="also validate a real nose binary")
+    args = parser.parse_args()
+    if not args.self_test:
+        raise SystemExit("--self-test is required")
+    run_self_test(args.nose)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "45acb4491c7a1f033f81c44354d7b0ce3f2621e9",
+  "product_crates_tree": "cba2f10020c44e0f1ce70f0642b1ada7d81349a1",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/docs/dogfooding-history.md
+++ b/docs/dogfooding-history.md
@@ -1309,3 +1309,14 @@ records separate assurance, and adds kernel evidence to the corpus. A common
 base registry would couple those security boundaries for incidental structure.
 The members are kept separate, the stale numeric ID is replaced, and no budget
 increase or new avoidable duplication is accepted.
+
+The post-#872 completion audit raises the reviewed count from 27 to 28. The
+bounded mutation/oracle additions shift self-query fingerprints enough for the
+long-standing `interp/ops.rs::int_bin` / `float_bin` dispatcher family
+`aa2b95cf822a1cd2` to cross value 40 again; neither function was changed by the
+CI-contract repair. The family shares ten dispatch lines, but integer wrapping,
+floor/modulo, and bitwise semantics deliberately differ from float IEEE
+arithmetic and unsupported-operation behavior. Extracting a common numeric
+dispatcher would couple those soundness policies for incidental structure, so
+the already reviewed family is restored to the baseline rather than hidden by
+an abstraction. No new avoidable duplication is accepted.

--- a/docs/incremental-cache-benchmark.md
+++ b/docs/incremental-cache-benchmark.md
@@ -38,8 +38,7 @@ same-binary control before attributing a regression.
 
 ## Checked #872 evidence
 
-The checked
-[`issue-872-v0.19.0-vs-candidate-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-872-v0.19.0-vs-candidate-sympy-paired-2026-07-20.v1.json)
+The checked [`issue-872-v0.19.0-vs-candidate-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-872-v0.19.0-vs-candidate-sympy-paired-2026-07-20.v1.json)
 contains all 180 raw rows from 30 alternating AB/BA replays on the pinned SymPy checkout. The
 official executable came from the verified `aarch64-apple-darwin` v0.19.0 archive at commit
 `0985e696`; the candidate is commit `2ac8b411`. Both roles independently passed exact
@@ -55,8 +54,7 @@ This is the locked baseline, not a claim that the current cache is already insta
 candidate's warm run all 1,584 inputs hit, but the p50 cache stage still takes 48.3 ms, the
 store is 379,910,220 bytes, and total p50 remains 702.69 ms because most global work is repeated.
 
-The checked
-[`issue-872-mutation-matrix-receipt-2026-07-20.v1.json`](../bench/cache/issue-872-mutation-matrix-receipt-2026-07-20.v1.json)
+The checked [`issue-872-mutation-matrix-receipt-2026-07-20.v1.json`](../bench/cache/issue-872-mutation-matrix-receipt-2026-07-20.v1.json)
 seals the complete 2,100-row raw matrix by SHA-256 while retaining every summary and source
 identity in the repository. All 14 executable mutations passed 30 replays. Representative warm
 hit/miss closures are no-op `3/0`, leaf edit `2/1`, provider export edit `1/2`, high fan-out

--- a/docs/query-json.md
+++ b/docs/query-json.md
@@ -13,6 +13,11 @@ divergent-edit gate should also require `query.capabilities.query_base_json_v8`,
 `query.capabilities.query_base_gate_fail_default`, and, for SARIF uploads,
 `query.capabilities.query_base_sarif`.
 
+Validate a binary against the current non-`base` contract with
+`python3 bench/labels/live_query_schema.py --self-test --nose <nose>`. The older
+`query_schema.py` and `default_head_query_schema.py` adapters remain byte-stable inputs to
+the frozen v0.19.0 quality evidence; they are not the current-product compatibility gate.
+
 ## Envelope
 
 Every response is an object with:

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -134,6 +134,7 @@ run_regression_checker_selftests() {
     python3 scripts/check-domain-calibration.py --self-test
     python3 bench/labels/query_schema.py --self-test
     python3 bench/labels/default_head_query_schema.py --self-test
+    python3 bench/labels/live_query_schema.py --self-test
     python3 bench/labels/eval_by_language.py --self-test
     python3 bench/labels/check_default_head_baseline.py --self-test
     python3 bench/labels/check_default_head_baseline.py
@@ -289,8 +290,7 @@ run_missed_worthy_frontier_checks() {
 
 run_product_query_schema_live_check() {
     need_cmd python3
-    python3 bench/labels/query_schema.py --self-test --nose "$1"
-    python3 bench/labels/default_head_query_schema.py --self-test --nose "$1"
+    python3 bench/labels/live_query_schema.py --self-test --nose "$1"
 }
 
 run_shell_script_lint() {

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -268,6 +268,11 @@ set -euo pipefail
 # dispatcher representative with an exact/near registry whole-impl overlap. Those registries
 # intentionally keep receipt-backed exact mutation separate from near-protocol evidence; no shared
 # base registry or budget increase is accepted. See docs/dogfooding-history.md.
+# 27 -> 28 (post-#872 completion audit): the bounded mutation/oracle additions shift self-query
+# fingerprints enough for the long-reviewed `int_bin` / `float_bin` dispatcher family
+# `aa2b95cf822a1cd2` to cross value 40 again; neither member changed. Integer wrapping/floor/bitwise
+# and float IEEE policies remain deliberately separate, so no shared numeric dispatcher is accepted.
+# See docs/dogfooding-history.md.
 BIN="${NOSE_BIN:-./target/release/nose}"
 BASELINE="${NOSE_DUP_BASELINE:-scripts/duplication-baseline.json}"
 

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -12,6 +12,7 @@
     "3fefab5ac16598ec",
     "8d3e36bdd11cf2c0",
     "95e83331abfa623f",
+    "aa2b95cf822a1cd2",
     "2bca2e8582b7d7a7",
     "a679fd9cdbda1be2",
     "b59e5826da2acff8",
@@ -28,7 +29,7 @@
     "f6d422cfc56ae976",
     "f918559454acf9c4"
   ],
-  "budget": 27,
+  "budget": 28,
   "generated_by": "target/release/nose query crates all top=0 --mode near --min-value 40 --format json",
   "min_value": 40,
   "mode": "near",


### PR DESCRIPTION
## Summary

- preserve the byte-frozen query JSON v7 adapters used by historical quality evidence
- add a dedicated live v9 contract gate covering list, dashboard, and generated-path provenance
- refresh the Type-4 product source-tree receipt after #908/#925/#872
- fix two link-only lines rejected by the current docs lint

## Why

The completion audit after #872 reproduced two latent main-branch failures: the live product emitted query schema v9 while CI still exercised the frozen v7 adapter, and the Type-4 receipt still named the pre-optimization Rust source tree. Updating the frozen adapter would invalidate historical measurement hashes, so current-product validation now has an independent boundary.

## Validation

- `./scripts/check-ci-local.sh --fast`
- live schema v9: ordinary list, default list, dashboard parity, and `--generated-path` provenance
- 358/358 focused Type-4 expectations
- Type-4 axis/language gate: 0 false merges, 0 canonicalization violations
- frozen v7 adapter SHA-256 values unchanged
