### PR TITLE
feat(cache): dependency-aware cross-file invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +518,7 @@ dependencies = [
  "anyhow",
  "clap",
  "ignore",
+ "lz4_flex",
  "nose-detect",
  "nose-eval",
  "nose-frontend",
@@ -559,8 +569,10 @@ dependencies = [
  "nose-il",
  "nose-semantics",
  "rayon",
+ "rmp-serde",
  "rustc-hash",
  "serde",
+ "sha2",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-css",
@@ -1068,6 +1080,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ memchr = "2"
 toml = "0.8"
 quick-xml = "0.41"
 rmp-serde = "1"
+lz4_flex = "0.14"
 
 # Centralized lint policy — every crate opts in with `[lints] workspace = true`,
 # so the quality bar is defined once and enforced uniformly. CI runs clippy with

--- a/bench/cache/issue-874-dependency-invalidation-sympy-paired-2026-07-20.v1.json
+++ b/bench/cache/issue-874-dependency-invalidation-sympy-paired-2026-07-20.v1.json
@@ -1,0 +1,10619 @@
+{
+  "environment": {
+    "architecture": "arm64",
+    "logical_cpu_count": 18,
+    "os": "Darwin",
+    "os_release": "25.5.0",
+    "python_version": "3.14.5"
+  },
+  "equivalence": {
+    "candidate": true,
+    "official": true
+  },
+  "measurement": {
+    "cache_stats_required": {
+      "candidate": true,
+      "official": false
+    },
+    "minimum_replays": 30,
+    "order": "alternating-ab-ba",
+    "p95": "nearest-rank",
+    "replays": 30
+  },
+  "provenance": {
+    "candidate": {
+      "binary": "target/issue-874-final/release/nose",
+      "binary_code_sha256": "33ddbc966b19d9b61acb513f4f0297c4ce91111ca45d851993fce7ebf501e1f4",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "e1617924cb33243cf418ec7ffc341eb0fcdde30a",
+      "binary_sha256": "052ab4f1dae9e54c526907e94ff40966ffd29665733385dfb51861083758a5f5"
+    },
+    "harness": "scripts/cache-query-regression.py",
+    "harness_sha256": "969cbbc8ae98ed7e9a586c931799958e12b4b4858ec53019b56d4859bc6d145d",
+    "mutation_manifest": "bench/cache/mutation-manifest.v1.json",
+    "mutation_manifest_sha256": "13597fba09fb7e9b5e8785ba2a998d232bf86fa3b23103035b324b0c128ecdc6",
+    "official": {
+      "binary": "target/issue-839/official-v0.19.0/nose-cli-aarch64-apple-darwin/nose",
+      "binary_code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "release_verification": {
+        "archive": "target/issue-839/official-v0.19.0/nose-cli-aarch64-apple-darwin.tar.xz",
+        "archive_sha256": "097c7e766e9ab756a32cec715897067d1360e145074715168a653962be409981",
+        "target": "aarch64-apple-darwin"
+      }
+    },
+    "official_baseline": "bench/cache/official-v0.19.0-binaries.v1.json",
+    "official_baseline_sha256": "a9e127dea4303378ed57e3274ca8e0d358b5f0ad253912e4316e8c1f0f83639a"
+  },
+  "runs": [
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 979.6849999111146,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 968294400,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 27.1,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 29.2,
+        "groups": 10.1,
+        "import-resolve": 43.0,
+        "lower": 422.8,
+        "normalize+extract": 359.9,
+        "parse+lower": 350.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 79.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1546.9762079883367,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1141293056,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 484.6,
+        "candidates": 19.1,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.7,
+        "import-resolve": 32.7,
+        "lower": 881.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 76.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 726.1458330322057,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 845774848,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 83.0,
+        "candidates": 22.8,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 10.0,
+        "import-resolve": 26.6,
+        "lower": 467.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 76.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1041.841124999337,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 977862656,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.2,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 26.3,
+        "groups": 10.4,
+        "import-resolve": 49.3,
+        "lower": 449.0,
+        "normalize+extract": 397.4,
+        "parse+lower": 373.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.5,
+        "shared_lines": 75.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1032.8287909505889,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099988992,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 17.8,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 25.8,
+        "groups": 9.9,
+        "import-resolve": 49.7,
+        "lower": 405.8,
+        "parse+lower": 330.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 1.9,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 77.1
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 700.4479171009734,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1054113792,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.7,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 25.6,
+        "groups": 10.2,
+        "import-resolve": 48.8,
+        "lower": 456.5,
+        "parse+lower": 382.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 78.3
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1007.6309170108289,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 987987968,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.7,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.7,
+        "groups": 10.7,
+        "import-resolve": 46.9,
+        "lower": 403.5,
+        "normalize+extract": 411.9,
+        "parse+lower": 329.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 76.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1069.552291999571,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1105428480,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.2,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.4,
+        "groups": 11.0,
+        "import-resolve": 46.6,
+        "lower": 405.0,
+        "parse+lower": 331.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.9,
+        "shared_lines": 74.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 631.5774590475485,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1088110592,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.1,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 24.2,
+        "groups": 12.0,
+        "import-resolve": 46.8,
+        "lower": 388.6,
+        "parse+lower": 317.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 81.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1062.5814580125734,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 965771264,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 25.9,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 25.7,
+        "groups": 10.8,
+        "import-resolve": 42.4,
+        "lower": 468.3,
+        "normalize+extract": 400.4,
+        "parse+lower": 400.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 76.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1605.7728750165552,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1221410816,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 462.1,
+        "candidates": 19.0,
+        "cluster": 1.2,
+        "contiguous": 0.8,
+        "groups": 9.5,
+        "import-resolve": 29.3,
+        "lower": 940.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.2,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 0.5,
+        "shared_lines": 88.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 717.4169579520822,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 843956224,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 85.1,
+        "candidates": 22.3,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.7,
+        "import-resolve": 26.0,
+        "lower": 456.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 76.1
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1007.038666983135,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 999178240,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 19.0,
+        "cluster": 1.3,
+        "contiguous": 0.9,
+        "discover": 30.4,
+        "groups": 10.3,
+        "import-resolve": 43.0,
+        "lower": 446.2,
+        "normalize+extract": 360.5,
+        "parse+lower": 372.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.4,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 87.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1589.148125029169,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1181990912,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 532.4,
+        "candidates": 24.3,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "groups": 10.1,
+        "import-resolve": 28.2,
+        "lower": 867.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 761.1587499268353,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 834420736,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 98.7,
+        "candidates": 23.7,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.6,
+        "import-resolve": 28.1,
+        "lower": 485.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.1
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1012.7970419125631,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 991772672,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.9,
+        "groups": 10.8,
+        "import-resolve": 52.2,
+        "lower": 414.1,
+        "normalize+extract": 405.5,
+        "parse+lower": 334.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 79.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1083.4675839869305,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1086078976,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.7,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 26.4,
+        "groups": 10.4,
+        "import-resolve": 51.6,
+        "lower": 440.7,
+        "parse+lower": 362.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 79.1
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 721.7972499784082,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1083801600,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.3,
+        "groups": 10.6,
+        "import-resolve": 53.4,
+        "lower": 475.0,
+        "parse+lower": 395.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 78.6
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1076.9825410097837,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 977829888,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.0,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "discover": 25.9,
+        "groups": 10.3,
+        "import-resolve": 50.8,
+        "lower": 442.2,
+        "normalize+extract": 437.7,
+        "parse+lower": 365.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 79.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1070.856042089872,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1092091904,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.4,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.2,
+        "groups": 10.1,
+        "import-resolve": 54.5,
+        "lower": 432.6,
+        "parse+lower": 351.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 75.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 698.5672910232097,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1096810496,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.3,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 25.7,
+        "groups": 10.9,
+        "import-resolve": 51.9,
+        "lower": 452.3,
+        "parse+lower": 374.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 83.1
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1034.3679579673335,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 995000320,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 26.6,
+        "groups": 10.1,
+        "import-resolve": 49.3,
+        "lower": 438.2,
+        "normalize+extract": 413.9,
+        "parse+lower": 362.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 76.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1663.6530420510098,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1162854400,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 504.9,
+        "candidates": 23.0,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 11.1,
+        "import-resolve": 28.5,
+        "lower": 955.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 84.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 759.0085410047323,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 834191360,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 86.9,
+        "candidates": 25.1,
+        "cluster": 1.4,
+        "contiguous": 1.2,
+        "groups": 11.8,
+        "import-resolve": 26.0,
+        "lower": 471.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 13.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 2.1,
+        "rank_map": 1.3,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 86.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1076.9872500095516,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 983302144,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 27.5,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.7,
+        "groups": 11.4,
+        "import-resolve": 43.1,
+        "lower": 443.6,
+        "normalize+extract": 430.2,
+        "parse+lower": 373.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 81.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1594.2142920102924,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1158316032,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 484.8,
+        "candidates": 20.3,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.7,
+        "import-resolve": 33.6,
+        "lower": 918.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.4,
+        "query_rank_sort": 3.0,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.5,
+        "shared_lines": 79.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 754.2367920977995,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 846315520,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 86.7,
+        "candidates": 23.3,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "groups": 9.8,
+        "import-resolve": 26.7,
+        "lower": 489.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 76.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1102.704583085142,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 999292928,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.2,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 34.2,
+        "groups": 10.5,
+        "import-resolve": 47.5,
+        "lower": 523.6,
+        "normalize+extract": 371.2,
+        "parse+lower": 441.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.2,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 91.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1102.0351669285446,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1100038144,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.5,
+        "cluster": 1.5,
+        "contiguous": 1.0,
+        "discover": 29.6,
+        "groups": 11.8,
+        "import-resolve": 46.9,
+        "lower": 471.3,
+        "parse+lower": 394.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.9,
+        "shared_lines": 85.6
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 686.0813749954104,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1067892736,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.1,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 30.7,
+        "groups": 11.0,
+        "import-resolve": 47.1,
+        "lower": 443.9,
+        "parse+lower": 366.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 80.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1096.8036249978468,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 999751680,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.5,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 30.8,
+        "groups": 10.0,
+        "import-resolve": 50.0,
+        "lower": 505.4,
+        "normalize+extract": 383.0,
+        "parse+lower": 424.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.5,
+        "query_render": 15.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 95.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1135.6432089814916,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1109458944,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.2,
+        "cluster": 2.4,
+        "contiguous": 0.9,
+        "discover": 31.5,
+        "groups": 12.6,
+        "import-resolve": 47.2,
+        "lower": 483.7,
+        "parse+lower": 405.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 14.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 87.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 688.537040958181,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1064353792,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.3,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 29.4,
+        "groups": 11.0,
+        "import-resolve": 47.1,
+        "lower": 449.6,
+        "parse+lower": 373.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 81.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1046.3222499238327,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 996818944,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 32.6,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 31.1,
+        "groups": 11.4,
+        "import-resolve": 43.2,
+        "lower": 426.1,
+        "normalize+extract": 401.6,
+        "parse+lower": 351.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.5,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 84.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1647.2636250546202,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 78,
+          "misses": 1506,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 78,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1178288128,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 493.6,
+        "candidates": 24.5,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "groups": 10.2,
+        "import-resolve": 33.8,
+        "lower": 960.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.5,
+        "shared_lines": 76.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 806.4702079864219,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 832929792,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 87.3,
+        "candidates": 24.8,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "groups": 10.1,
+        "import-resolve": 27.2,
+        "lower": 539.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 76.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1114.8090419592336,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 997097472,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.3,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 27.6,
+        "groups": 10.0,
+        "import-resolve": 43.3,
+        "lower": 540.3,
+        "normalize+extract": 370.1,
+        "parse+lower": 469.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.6,
+        "query_render": 14.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 90.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1668.2244580006227,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1137786880,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 537.8,
+        "candidates": 20.4,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "groups": 9.8,
+        "import-resolve": 28.2,
+        "lower": 947.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.4,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 0.5,
+        "shared_lines": 75.3
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 766.6451249970123,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 841007104,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 105.1,
+        "candidates": 21.1,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.9,
+        "import-resolve": 29.5,
+        "lower": 487.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.4,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 74.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1080.0687919836491,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 977600512,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.4,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.2,
+        "groups": 10.3,
+        "import-resolve": 53.8,
+        "lower": 466.4,
+        "normalize+extract": 425.4,
+        "parse+lower": 385.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 75.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1095.932791940868,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099579392,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.4,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.2,
+        "groups": 10.3,
+        "import-resolve": 54.7,
+        "lower": 464.0,
+        "parse+lower": 382.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 75.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 761.6713331080973,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065320448,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.9,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 24.3,
+        "groups": 10.6,
+        "import-resolve": 50.5,
+        "lower": 519.3,
+        "parse+lower": 444.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 85.1
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1062.8234170144424,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 999096320,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.1,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 28.0,
+        "groups": 9.9,
+        "import-resolve": 55.1,
+        "lower": 477.7,
+        "normalize+extract": 402.1,
+        "parse+lower": 394.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 0.6,
+        "shared_lines": 76.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1146.924415952526,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1092157440,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.5,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 25.3,
+        "groups": 10.2,
+        "import-resolve": 53.3,
+        "lower": 491.1,
+        "parse+lower": 412.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 75.6
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 749.5923329843208,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1066385408,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.9,
+        "groups": 10.7,
+        "import-resolve": 48.2,
+        "lower": 511.2,
+        "parse+lower": 436.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 82.9
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1114.2664169892669,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 982827008,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.2,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.0,
+        "groups": 10.5,
+        "import-resolve": 54.0,
+        "lower": 535.1,
+        "normalize+extract": 385.3,
+        "parse+lower": 455.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 78.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1735.990625107661,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1182121984,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 584.9,
+        "candidates": 26.1,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 10.1,
+        "import-resolve": 28.4,
+        "lower": 954.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 74.1
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 799.0671670995653,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 839958528,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 90.5,
+        "candidates": 23.9,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "groups": 10.1,
+        "import-resolve": 27.3,
+        "lower": 524.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 0.8,
+        "shared_lines": 79.5
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1055.70845794864,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 986841088,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.2,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.7,
+        "groups": 10.4,
+        "import-resolve": 49.8,
+        "lower": 508.8,
+        "normalize+extract": 363.3,
+        "parse+lower": 432.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 75.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1700.427083997056,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1196752896,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 560.4,
+        "candidates": 24.0,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 9.5,
+        "import-resolve": 29.1,
+        "lower": 951.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.5,
+        "shared_lines": 74.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 779.9828751012683,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 837287936,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 107.6,
+        "candidates": 26.2,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 11.0,
+        "import-resolve": 30.8,
+        "lower": 487.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 77.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1071.1540420306846,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 983220224,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.5,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 26.2,
+        "groups": 10.1,
+        "import-resolve": 48.7,
+        "lower": 435.5,
+        "normalize+extract": 446.0,
+        "parse+lower": 360.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1118.6539169866592,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1097089024,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.7,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.5,
+        "groups": 10.7,
+        "import-resolve": 56.0,
+        "lower": 446.9,
+        "parse+lower": 363.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 716.3777910172939,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1078198272,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.9,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 26.2,
+        "groups": 10.9,
+        "import-resolve": 54.4,
+        "lower": 461.6,
+        "parse+lower": 381.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.8,
+        "shared_lines": 82.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1102.5707919616252,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 987742208,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.9,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 32.6,
+        "groups": 10.4,
+        "import-resolve": 50.2,
+        "lower": 466.8,
+        "normalize+extract": 451.9,
+        "parse+lower": 384.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.2,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 75.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1103.4309170208871,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1100611584,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.6,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 24.8,
+        "groups": 10.2,
+        "import-resolve": 54.7,
+        "lower": 435.3,
+        "parse+lower": 355.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 76.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 722.9042090475559,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070350336,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.0,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 27.1,
+        "groups": 11.8,
+        "import-resolve": 55.4,
+        "lower": 471.8,
+        "parse+lower": 389.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 80.5
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1064.1133750323206,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 980811776,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.1,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "discover": 27.4,
+        "groups": 12.1,
+        "import-resolve": 50.6,
+        "lower": 453.6,
+        "normalize+extract": 416.0,
+        "parse+lower": 375.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 0.6,
+        "shared_lines": 87.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1726.5344999032095,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1133576192,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 550.3,
+        "candidates": 24.6,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "groups": 11.4,
+        "import-resolve": 28.5,
+        "lower": 980.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.3,
+        "shared_lines": 77.4
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 775.7515000412241,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 836501504,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 107.0,
+        "candidates": 26.1,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 11.0,
+        "import-resolve": 31.9,
+        "lower": 471.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 84.6
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1061.3630840089172,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 961839104,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.4,
+        "cluster": 1.9,
+        "contiguous": 0.8,
+        "discover": 25.6,
+        "groups": 10.6,
+        "import-resolve": 48.4,
+        "lower": 423.6,
+        "normalize+extract": 446.8,
+        "parse+lower": 349.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 74.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1710.6308341026306,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1130119168,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 535.9,
+        "candidates": 28.4,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "groups": 11.5,
+        "import-resolve": 29.2,
+        "lower": 958.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 87.4
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 777.9150839196518,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 842006528,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 88.5,
+        "candidates": 26.3,
+        "cluster": 1.8,
+        "contiguous": 1.0,
+        "groups": 12.5,
+        "import-resolve": 26.7,
+        "lower": 486.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.3,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.5,
+        "shared_lines": 86.1
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1104.7120000002906,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1001455616,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.1,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 27.7,
+        "groups": 13.5,
+        "import-resolve": 53.0,
+        "lower": 456.3,
+        "normalize+extract": 407.7,
+        "parse+lower": 375.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.8,
+        "query_render": 17.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 101.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1299.3205829989165,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085325312,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 2.8,
+        "contiguous": 0.9,
+        "discover": 31.5,
+        "groups": 15.2,
+        "import-resolve": 64.1,
+        "lower": 497.3,
+        "parse+lower": 401.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.5,
+        "query_render": 16.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 98.5
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 737.4822079436854,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1081065472,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.3,
+        "cluster": 1.7,
+        "contiguous": 1.0,
+        "discover": 29.9,
+        "groups": 12.8,
+        "import-resolve": 63.3,
+        "lower": 463.5,
+        "parse+lower": 370.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.8,
+        "shared_lines": 89.0
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1143.8803750788793,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 979451904,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.9,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 25.7,
+        "groups": 13.6,
+        "import-resolve": 53.9,
+        "lower": 438.5,
+        "normalize+extract": 466.4,
+        "parse+lower": 358.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 93.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1224.020375055261,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1086767104,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.9,
+        "cluster": 1.8,
+        "contiguous": 0.9,
+        "discover": 28.4,
+        "groups": 14.1,
+        "import-resolve": 64.2,
+        "lower": 486.9,
+        "parse+lower": 394.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.7,
+        "query_render": 16.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 99.3
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 812.0343339396641,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090207744,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.0,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 29.2,
+        "groups": 12.6,
+        "import-resolve": 65.3,
+        "lower": 556.2,
+        "parse+lower": 461.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.2,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 86.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1159.7792078973725,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1000652800,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 25.7,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 28.2,
+        "groups": 13.3,
+        "import-resolve": 53.0,
+        "lower": 542.3,
+        "normalize+extract": 396.1,
+        "parse+lower": 461.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.6,
+        "query_rank_sort": 2.7,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 93.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1776.2971670599654,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1148583936,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 528.8,
+        "candidates": 30.4,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "groups": 13.5,
+        "import-resolve": 35.9,
+        "lower": 1018.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 90.5
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 812.1337920892984,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 838696960,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 97.4,
+        "candidates": 23.2,
+        "cluster": 1.8,
+        "contiguous": 0.7,
+        "groups": 11.5,
+        "import-resolve": 26.2,
+        "lower": 534.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.0,
+        "shared_lines": 75.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1139.2081249505281,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 968802304,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.2,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 31.6,
+        "groups": 12.5,
+        "import-resolve": 51.1,
+        "lower": 513.6,
+        "normalize+extract": 399.0,
+        "parse+lower": 430.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.6,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 93.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1778.4417079528794,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 77,
+          "misses": 1507,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 77,
+          "misses": 1506,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1163968512,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 534.8,
+        "candidates": 31.7,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "groups": 13.5,
+        "import-resolve": 36.5,
+        "lower": 1014.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 14.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 89.5
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 793.8161659985781,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 840794112,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 87.9,
+        "candidates": 24.1,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "groups": 10.0,
+        "import-resolve": 26.6,
+        "lower": 524.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.7,
+        "shared_lines": 78.5
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1146.5001249453053,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1013334016,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.1,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 25.8,
+        "groups": 14.0,
+        "import-resolve": 61.9,
+        "lower": 496.0,
+        "normalize+extract": 417.2,
+        "parse+lower": 408.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.8,
+        "query_render": 16.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 92.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1290.8424580236897,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1098612736,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.3,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 29.8,
+        "groups": 14.1,
+        "import-resolve": 67.0,
+        "lower": 537.2,
+        "parse+lower": 440.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 17.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 103.4
+      },
+      "store": {
+        "bytes": 380153031,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 755.1427910802886,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090748416,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.2,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 31.8,
+        "groups": 13.4,
+        "import-resolve": 66.9,
+        "lower": 478.5,
+        "parse+lower": 379.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.5,
+        "query_render": 15.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.3,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 98.1
+      },
+      "store": {
+        "bytes": 380153031,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1217.9365420015529,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 979533824,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.7,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 29.4,
+        "groups": 13.7,
+        "import-resolve": 66.9,
+        "lower": 506.6,
+        "normalize+extract": 452.4,
+        "parse+lower": 410.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.1,
+        "query_render": 20.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 105.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1333.7649590102956,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1117093888,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.3,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 34.2,
+        "groups": 15.2,
+        "import-resolve": 67.1,
+        "lower": 482.5,
+        "parse+lower": 381.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.1,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 104.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 825.8308749645948,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1076379648,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.3,
+        "cluster": 1.8,
+        "contiguous": 1.0,
+        "discover": 33.7,
+        "groups": 13.4,
+        "import-resolve": 66.8,
+        "lower": 531.6,
+        "parse+lower": 431.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.6,
+        "query_render": 16.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 99.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1153.889041976072,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 982401024,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.8,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 27.1,
+        "groups": 13.7,
+        "import-resolve": 61.3,
+        "lower": 479.3,
+        "normalize+extract": 437.8,
+        "parse+lower": 390.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.9,
+        "query_render": 15.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 100.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1961.5330420201644,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1203765248,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 574.9,
+        "candidates": 26.0,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "groups": 13.3,
+        "import-resolve": 32.3,
+        "lower": 1147.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.6,
+        "query_render": 15.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 95.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 820.2262920094654,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 842760192,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 89.3,
+        "candidates": 23.0,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 10.0,
+        "import-resolve": 26.2,
+        "lower": 552.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 77.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1173.2930829748511,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 991363072,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 25.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 30.3,
+        "groups": 14.2,
+        "import-resolve": 58.5,
+        "lower": 510.9,
+        "normalize+extract": 412.6,
+        "parse+lower": 422.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.2,
+        "query_render": 16.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 0.7,
+        "shared_lines": 105.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 1861.5172499557957,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1179172864,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 528.1,
+        "candidates": 31.6,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "groups": 14.0,
+        "import-resolve": 42.2,
+        "lower": 1077.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 17.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.6,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 108.3
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 806.004749960266,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 850673664,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 87.7,
+        "candidates": 24.3,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "groups": 10.0,
+        "import-resolve": 27.0,
+        "lower": 541.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 74.3
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1220.974208903499,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 992608256,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.1,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 30.1,
+        "groups": 15.2,
+        "import-resolve": 66.7,
+        "lower": 546.2,
+        "normalize+extract": 413.1,
+        "parse+lower": 449.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 105.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1332.752124988474,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070989312,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.0,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 36.5,
+        "groups": 15.3,
+        "import-resolve": 69.4,
+        "lower": 516.2,
+        "parse+lower": 410.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 108.5
+      },
+      "store": {
+        "bytes": 380153030,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 852.9339589877054,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1041465344,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.9,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "discover": 36.5,
+        "groups": 13.6,
+        "import-resolve": 69.5,
+        "lower": 537.0,
+        "parse+lower": 430.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 105.2
+      },
+      "store": {
+        "bytes": 380153030,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1228.591207996942,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 987791360,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.9,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 31.2,
+        "groups": 14.7,
+        "import-resolve": 68.7,
+        "lower": 458.0,
+        "normalize+extract": 513.9,
+        "parse+lower": 358.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 105.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1327.3637909442186,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1056325632,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.6,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 35.9,
+        "groups": 14.6,
+        "import-resolve": 67.1,
+        "lower": 546.2,
+        "parse+lower": 443.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 113.8
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 834.6981659997255,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1061027840,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.8,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 37.5,
+        "groups": 13.4,
+        "import-resolve": 70.4,
+        "lower": 544.9,
+        "parse+lower": 437.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 18.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 101.2
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1168.6560830567032,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 974356480,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.1,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 30.8,
+        "groups": 14.7,
+        "import-resolve": 62.0,
+        "lower": 458.6,
+        "normalize+extract": 449.2,
+        "parse+lower": 365.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.2,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.7,
+        "rank_map": 1.6,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 104.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2007.4056249577552,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1174388736,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 589.4,
+        "candidates": 27.3,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "groups": 13.5,
+        "import-resolve": 42.8,
+        "lower": 1158.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 16.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 105.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 866.9717089505866,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 847806464,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 106.1,
+        "candidates": 27.2,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 11.4,
+        "import-resolve": 31.4,
+        "lower": 554.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 87.2
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1205.3897080477327,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 996802560,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.6,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 25.3,
+        "groups": 15.3,
+        "import-resolve": 62.5,
+        "lower": 458.8,
+        "normalize+extract": 482.7,
+        "parse+lower": 371.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 19.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 106.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2102.230125106871,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1137541120,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 639.9,
+        "candidates": 28.0,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "groups": 13.5,
+        "import-resolve": 40.9,
+        "lower": 1214.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 102.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 857.8404589788988,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 833323008,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 87.5,
+        "candidates": 24.1,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 29.5,
+        "lower": 586.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 77.4
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1243.6334589729086,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 984285184,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.8,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 31.4,
+        "groups": 15.4,
+        "import-resolve": 66.3,
+        "lower": 555.8,
+        "normalize+extract": 426.4,
+        "parse+lower": 458.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.7,
+        "shared_lines": 109.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1397.2987089073285,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1095139328,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.7,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 38.1,
+        "groups": 15.4,
+        "import-resolve": 73.9,
+        "lower": 549.4,
+        "parse+lower": 437.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 115.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 866.2041670177132,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1055834112,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.8,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 34.6,
+        "groups": 14.9,
+        "import-resolve": 73.9,
+        "lower": 524.5,
+        "parse+lower": 415.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 119.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1261.1097079934552,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1023737856,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.7,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 32.1,
+        "groups": 14.9,
+        "import-resolve": 68.4,
+        "lower": 483.9,
+        "normalize+extract": 506.9,
+        "parse+lower": 383.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 116.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1465.2159999823198,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1084391424,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.0,
+        "cluster": 2.8,
+        "contiguous": 1.0,
+        "discover": 36.9,
+        "groups": 16.5,
+        "import-resolve": 75.6,
+        "lower": 625.2,
+        "parse+lower": 512.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.9,
+        "shared_lines": 125.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 873.5090420814231,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065549824,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.9,
+        "cluster": 2.4,
+        "contiguous": 1.2,
+        "discover": 37.3,
+        "groups": 15.9,
+        "import-resolve": 73.6,
+        "lower": 551.9,
+        "parse+lower": 440.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 107.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1211.6742089856416,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 971505664,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 35.3,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 29.7,
+        "groups": 14.7,
+        "import-resolve": 61.1,
+        "lower": 439.9,
+        "normalize+extract": 505.6,
+        "parse+lower": 349.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.2,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 0.9,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 108.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2138.8194169849157,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1181286400,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 629.7,
+        "candidates": 34.8,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "groups": 14.8,
+        "import-resolve": 41.9,
+        "lower": 1247.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 104.1
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 923.5994999762625,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 845152256,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 99.9,
+        "candidates": 25.8,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "groups": 11.3,
+        "import-resolve": 31.4,
+        "lower": 625.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 83.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1232.7943339478225,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 967999488,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 40.6,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 30.2,
+        "groups": 15.3,
+        "import-resolve": 61.5,
+        "lower": 515.2,
+        "normalize+extract": 438.9,
+        "parse+lower": 423.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.3,
+        "query_render": 18.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 112.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2140.466457931325,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1190674432,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 659.6,
+        "candidates": 37.3,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "groups": 14.8,
+        "import-resolve": 47.0,
+        "lower": 1201.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 112.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 922.0986249856651,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 853409792,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 114.1,
+        "candidates": 30.1,
+        "cluster": 1.8,
+        "contiguous": 0.9,
+        "groups": 12.5,
+        "import-resolve": 32.6,
+        "lower": 585.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 15.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 93.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1266.5770000312477,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 963821568,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 25.9,
+        "groups": 14.9,
+        "import-resolve": 67.9,
+        "lower": 492.6,
+        "normalize+extract": 506.6,
+        "parse+lower": 398.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 111.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1422.0102910185233,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090420736,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.1,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 36.7,
+        "groups": 16.7,
+        "import-resolve": 74.1,
+        "lower": 585.2,
+        "parse+lower": 474.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 115.3
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 895.9363749017939,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1043283968,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.3,
+        "cluster": 2.0,
+        "contiguous": 1.1,
+        "discover": 39.2,
+        "groups": 15.7,
+        "import-resolve": 73.6,
+        "lower": 566.2,
+        "parse+lower": 453.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 113.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1294.6512500056997,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1030389760,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.5,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 36.5,
+        "groups": 15.4,
+        "import-resolve": 74.1,
+        "lower": 498.1,
+        "normalize+extract": 524.3,
+        "parse+lower": 387.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.0,
+        "shared_lines": 112.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1430.6388329714537,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099333632,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 37.2,
+        "groups": 15.8,
+        "import-resolve": 74.2,
+        "lower": 565.9,
+        "parse+lower": 454.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.8,
+        "query_opp": 1.4,
+        "query_rank_sort": 3.4,
+        "query_render": 22.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 113.6
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 920.1409579254687,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1081245696,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.4,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 37.4,
+        "groups": 15.0,
+        "import-resolve": 74.0,
+        "lower": 605.9,
+        "parse+lower": 494.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 105.5
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1269.3295000353828,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1023295488,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 33.7,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 34.0,
+        "groups": 15.1,
+        "import-resolve": 61.9,
+        "lower": 482.2,
+        "normalize+extract": 516.6,
+        "parse+lower": 386.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 113.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2205.2036250242963,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1149894656,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 659.9,
+        "candidates": 28.2,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "groups": 14.5,
+        "import-resolve": 45.6,
+        "lower": 1284.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 110.4
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 942.522625089623,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 845594624,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 98.5,
+        "candidates": 29.5,
+        "cluster": 1.8,
+        "contiguous": 0.9,
+        "groups": 12.2,
+        "import-resolve": 33.8,
+        "lower": 636.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 87.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1243.9585000975057,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 974274560,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 35.3,
+        "cluster": 2.4,
+        "contiguous": 1.4,
+        "discover": 29.9,
+        "groups": 19.1,
+        "import-resolve": 61.2,
+        "lower": 527.9,
+        "normalize+extract": 433.1,
+        "parse+lower": 436.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 0.9,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 113.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2251.227583969012,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1184350208,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 641.3,
+        "candidates": 29.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "groups": 17.4,
+        "import-resolve": 46.8,
+        "lower": 1324.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 114.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 946.7612080043182,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 834666496,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 121.8,
+        "candidates": 32.5,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "groups": 13.4,
+        "import-resolve": 34.8,
+        "lower": 603.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 2.3,
+        "shared_lines": 91.3
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1259.7646659705788,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 988299264,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 27.3,
+        "groups": 15.1,
+        "import-resolve": 70.6,
+        "lower": 460.8,
+        "normalize+extract": 531.2,
+        "parse+lower": 362.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 113.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1562.9759579896927,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1107099648,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.8,
+        "cluster": 2.4,
+        "contiguous": 1.2,
+        "discover": 36.9,
+        "groups": 16.7,
+        "import-resolve": 73.6,
+        "lower": 665.7,
+        "parse+lower": 555.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 114.6
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 906.3104169908911,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1072906240,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.3,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 39.9,
+        "groups": 15.0,
+        "import-resolve": 77.5,
+        "lower": 562.9,
+        "parse+lower": 445.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 114.8
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1354.8696249490604,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 999882752,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 36.7,
+        "groups": 15.3,
+        "import-resolve": 76.2,
+        "lower": 523.4,
+        "normalize+extract": 557.1,
+        "parse+lower": 410.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 118.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1522.4615830229595,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099497472,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 37.9,
+        "groups": 16.4,
+        "import-resolve": 74.6,
+        "lower": 636.8,
+        "parse+lower": 524.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 123.9
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 930.3594999946654,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1059012608,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.3,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 41.1,
+        "groups": 15.1,
+        "import-resolve": 75.2,
+        "lower": 583.0,
+        "parse+lower": 466.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 113.6
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1294.140417012386,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 962838528,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 33.4,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 33.4,
+        "groups": 15.6,
+        "import-resolve": 68.1,
+        "lower": 505.0,
+        "normalize+extract": 514.4,
+        "parse+lower": 403.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 112.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2181.4729999750853,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1155940352,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 622.4,
+        "candidates": 28.3,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "groups": 14.5,
+        "import-resolve": 47.2,
+        "lower": 1277.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 120.2
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1003.3271668944508,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 843218944,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 100.2,
+        "candidates": 30.4,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "groups": 15.9,
+        "import-resolve": 37.7,
+        "lower": 666.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.8,
+        "query_render": 16.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 98.2
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1292.2467909520492,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 982532096,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.9,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 28.1,
+        "groups": 14.8,
+        "import-resolve": 63.0,
+        "lower": 507.6,
+        "normalize+extract": 521.2,
+        "parse+lower": 416.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 111.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2262.9399999277666,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1164918784,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 648.5,
+        "candidates": 29.4,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "groups": 14.3,
+        "import-resolve": 47.7,
+        "lower": 1344.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.7,
+        "query_render": 19.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 112.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 988.4895830182359,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 840122368,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 100.3,
+        "candidates": 29.6,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "groups": 13.0,
+        "import-resolve": 37.4,
+        "lower": 662.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.6,
+        "query_render": 15.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 100.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1334.088125033304,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 981876736,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.1,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 30.9,
+        "groups": 15.2,
+        "import-resolve": 73.0,
+        "lower": 531.4,
+        "normalize+extract": 526.1,
+        "parse+lower": 427.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 116.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1514.0778330387548,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085423616,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 40.3,
+        "groups": 16.7,
+        "import-resolve": 77.0,
+        "lower": 577.1,
+        "parse+lower": 459.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 22.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.6,
+        "rank_families": 3.0,
+        "rank_map": 1.7,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 119.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 975.7589169312268,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065648128,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.0,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 40.6,
+        "groups": 15.0,
+        "import-resolve": 76.8,
+        "lower": 641.2,
+        "parse+lower": 523.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 22.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 115.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1472.4994580028579,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 986152960,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.3,
+        "cluster": 2.7,
+        "contiguous": 1.1,
+        "discover": 38.3,
+        "groups": 17.1,
+        "import-resolve": 73.8,
+        "lower": 596.6,
+        "normalize+extract": 580.1,
+        "parse+lower": 484.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 119.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1498.2659160159528,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1093599232,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.7,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 41.0,
+        "groups": 16.5,
+        "import-resolve": 74.5,
+        "lower": 587.6,
+        "parse+lower": 472.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.7,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.5,
+        "shared_lines": 124.5
+      },
+      "store": {
+        "bytes": 380153030,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 963.5733750183135,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1056505856,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.6,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 40.9,
+        "groups": 14.5,
+        "import-resolve": 74.2,
+        "lower": 633.6,
+        "parse+lower": 518.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.5,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.6,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 119.3
+      },
+      "store": {
+        "bytes": 380153030,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1361.63337493781,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 969719808,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 36.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 37.5,
+        "groups": 15.1,
+        "import-resolve": 68.0,
+        "lower": 526.7,
+        "normalize+extract": 556.0,
+        "parse+lower": 421.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 114.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2261.4521250361577,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1200848896,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 654.9,
+        "candidates": 35.1,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "groups": 15.5,
+        "import-resolve": 46.5,
+        "lower": 1333.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.2,
+        "query_render": 17.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 114.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 986.60045908764,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 837615616,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 97.8,
+        "candidates": 29.8,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "groups": 13.4,
+        "import-resolve": 37.6,
+        "lower": 657.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.8,
+        "query_render": 16.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 102.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1288.764041964896,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 989544448,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.7,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 28.7,
+        "groups": 14.9,
+        "import-resolve": 61.7,
+        "lower": 491.6,
+        "normalize+extract": 524.2,
+        "parse+lower": 401.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.2,
+        "shared_lines": 114.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2407.5559170451015,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1138638848,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 672.1,
+        "candidates": 28.2,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "groups": 14.0,
+        "import-resolve": 49.1,
+        "lower": 1451.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.7,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 121.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1020.0290830107406,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 844726272,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 99.1,
+        "candidates": 33.8,
+        "cluster": 1.8,
+        "contiguous": 1.1,
+        "groups": 15.9,
+        "import-resolve": 37.1,
+        "lower": 679.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.9,
+        "query_render": 17.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 100.7
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1321.6928750043735,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1025949696,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.9,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 32.4,
+        "groups": 17.0,
+        "import-resolve": 73.8,
+        "lower": 496.9,
+        "normalize+extract": 544.5,
+        "parse+lower": 390.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.6,
+        "rank_families": 3.1,
+        "rank_map": 1.5,
+        "rank_sort": 1.0,
+        "score": 1.3,
+        "shared_lines": 115.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1554.5952499378473,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085079552,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.1,
+        "cluster": 2.7,
+        "contiguous": 1.2,
+        "discover": 40.5,
+        "groups": 17.4,
+        "import-resolve": 79.4,
+        "lower": 618.2,
+        "parse+lower": 498.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 121.3
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 968.9402090152726,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1062092800,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.3,
+        "cluster": 2.1,
+        "contiguous": 1.2,
+        "discover": 40.9,
+        "groups": 16.1,
+        "import-resolve": 80.7,
+        "lower": 626.3,
+        "parse+lower": 504.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.9,
+        "shared_lines": 115.1
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1495.820750016719,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 967655424,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 41.3,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 41.1,
+        "groups": 15.6,
+        "import-resolve": 73.6,
+        "lower": 590.5,
+        "normalize+extract": 618.2,
+        "parse+lower": 475.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 115.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1526.7714579822496,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1089060864,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.5,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 38.7,
+        "groups": 18.9,
+        "import-resolve": 74.5,
+        "lower": 627.4,
+        "parse+lower": 514.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 4.0,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 128.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 985.5043750721961,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1066647552,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.6,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 40.8,
+        "groups": 15.4,
+        "import-resolve": 84.5,
+        "lower": 637.5,
+        "parse+lower": 512.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 116.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1367.3829169711098,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 972423168,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.2,
+        "cluster": 2.5,
+        "contiguous": 1.0,
+        "discover": 37.3,
+        "groups": 16.0,
+        "import-resolve": 67.4,
+        "lower": 562.5,
+        "normalize+extract": 528.6,
+        "parse+lower": 457.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 0.9,
+        "shared_lines": 114.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2265.7691669883206,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1141227520,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 630.1,
+        "candidates": 33.0,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "groups": 14.6,
+        "import-resolve": 46.3,
+        "lower": 1359.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 2.1,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1011.9328749133274,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 845463552,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 122.7,
+        "candidates": 32.2,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "groups": 13.6,
+        "import-resolve": 38.4,
+        "lower": 644.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 103.6
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1308.7775419699028,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1000603648,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.6,
+        "cluster": 2.6,
+        "contiguous": 1.0,
+        "discover": 29.0,
+        "groups": 15.2,
+        "import-resolve": 65.1,
+        "lower": 547.0,
+        "normalize+extract": 490.1,
+        "parse+lower": 452.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 113.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2346.449958975427,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1163378688,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 664.2,
+        "candidates": 39.9,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "groups": 16.1,
+        "import-resolve": 47.5,
+        "lower": 1397.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 113.8
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1031.9782079895958,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 844595200,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 120.1,
+        "candidates": 32.5,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "groups": 13.8,
+        "import-resolve": 38.0,
+        "lower": 662.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 104.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1327.0482079824433,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 989429760,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 40.9,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 32.4,
+        "groups": 17.0,
+        "import-resolve": 75.9,
+        "lower": 467.7,
+        "normalize+extract": 565.9,
+        "parse+lower": 359.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 2.2,
+        "shared_lines": 115.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1641.6473749559373,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1087979520,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.9,
+        "cluster": 2.4,
+        "contiguous": 1.2,
+        "discover": 41.2,
+        "groups": 16.6,
+        "import-resolve": 82.7,
+        "lower": 684.0,
+        "parse+lower": 560.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.6,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 127.8
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 947.6361250272021,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1072676864,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.4,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 38.0,
+        "groups": 16.4,
+        "import-resolve": 83.0,
+        "lower": 598.5,
+        "parse+lower": 477.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 116.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1456.1830830061808,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 978239488,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.5,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 37.9,
+        "groups": 16.6,
+        "import-resolve": 73.9,
+        "lower": 614.6,
+        "normalize+extract": 539.1,
+        "parse+lower": 502.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 130.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1578.470499953255,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1088700416,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.9,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 40.2,
+        "groups": 16.7,
+        "import-resolve": 83.1,
+        "lower": 623.7,
+        "parse+lower": 500.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 122.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1027.7570829493925,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1054703616,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.3,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 40.0,
+        "groups": 14.8,
+        "import-resolve": 76.0,
+        "lower": 683.7,
+        "parse+lower": 567.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 116.4
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1429.6809170627967,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 990314496,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 41.4,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 38.0,
+        "groups": 17.4,
+        "import-resolve": 68.2,
+        "lower": 595.4,
+        "normalize+extract": 540.9,
+        "parse+lower": 489.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.0,
+        "rank_sort": 0.8,
+        "score": 1.7,
+        "shared_lines": 116.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2364.590625045821,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1161707520,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 706.1,
+        "candidates": 34.9,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "groups": 15.1,
+        "import-resolve": 45.8,
+        "lower": 1379.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.0,
+        "shared_lines": 113.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1030.5427910061553,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 836124672,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 97.6,
+        "candidates": 29.1,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "groups": 13.3,
+        "import-resolve": 37.2,
+        "lower": 704.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.8,
+        "query_render": 16.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 99.5
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1325.586957973428,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 983695360,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 32.4,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 31.0,
+        "groups": 16.3,
+        "import-resolve": 66.8,
+        "lower": 521.4,
+        "normalize+extract": 521.4,
+        "parse+lower": 423.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 20.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 0.9,
+        "shared_lines": 117.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2382.1475830627605,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1183350784,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 698.0,
+        "candidates": 38.4,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "groups": 16.5,
+        "import-resolve": 46.1,
+        "lower": 1401.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 111.0
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1045.6284590763971,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 844120064,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 99.0,
+        "candidates": 29.1,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "groups": 13.4,
+        "import-resolve": 36.7,
+        "lower": 706.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 16.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.6,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 108.4
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1346.7544158920646,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1024376832,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.0,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 33.5,
+        "groups": 16.5,
+        "import-resolve": 73.6,
+        "lower": 504.0,
+        "normalize+extract": 549.7,
+        "parse+lower": 396.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.4,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.0,
+        "shared_lines": 124.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1628.7686669966206,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1091649536,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.5,
+        "cluster": 2.5,
+        "contiguous": 1.2,
+        "discover": 39.4,
+        "groups": 17.9,
+        "import-resolve": 82.4,
+        "lower": 666.2,
+        "parse+lower": 544.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.6,
+        "rank_families": 2.9,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 125.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 976.1142920469865,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068924928,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.8,
+        "cluster": 2.1,
+        "contiguous": 1.2,
+        "discover": 41.0,
+        "groups": 15.9,
+        "import-resolve": 82.0,
+        "lower": 632.9,
+        "parse+lower": 509.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 2.2,
+        "shared_lines": 114.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1455.2815828938037,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 992444416,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.8,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 40.2,
+        "groups": 16.8,
+        "import-resolve": 74.9,
+        "lower": 568.0,
+        "normalize+extract": 599.9,
+        "parse+lower": 452.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.6,
+        "rank_families": 2.3,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 115.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1562.810166971758,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1098579968,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 39.9,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 39.8,
+        "groups": 16.6,
+        "import-resolve": 82.5,
+        "lower": 641.7,
+        "parse+lower": 519.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 126.7
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 946.6237078886479,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1067073536,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.1,
+        "cluster": 2.3,
+        "contiguous": 1.2,
+        "discover": 40.5,
+        "groups": 16.5,
+        "import-resolve": 85.2,
+        "lower": 593.0,
+        "parse+lower": 467.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 116.7
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1343.1232499424368,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 997244928,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.5,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 37.7,
+        "groups": 16.7,
+        "import-resolve": 68.6,
+        "lower": 546.9,
+        "normalize+extract": 513.8,
+        "parse+lower": 440.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.8,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 116.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2344.8535830248147,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1142849536,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 618.0,
+        "candidates": 42.2,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "groups": 16.5,
+        "import-resolve": 47.5,
+        "lower": 1435.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.4,
+        "query_render": 20.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.3,
+        "shared_lines": 112.9
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1018.9516670070589,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 837697536,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 126.6,
+        "candidates": 31.2,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "groups": 13.4,
+        "import-resolve": 38.5,
+        "lower": 649.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 104.6
+      },
+      "store": {
+        "bytes": 333945915,
+        "files": 4586
+      },
+      "workload_id": "sympy"
+    }
+  ],
+  "schema": "nose.cache_query_comparison/v1",
+  "source_identity": "a8e6f459bb51308c817df086021e29239a398ac2e4cd82c7057a53128d1ccd3e",
+  "status": "passed",
+  "summary": {
+    "candidate": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1170.9745830157772,
+            "p95": 1367.3829169711098
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 983064576.0,
+            "p95": 1000652800
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 29.75,
+              "p95": 40.6
+            },
+            "cluster": {
+              "p50": 2.1500000000000004,
+              "p95": 2.6
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.1
+            },
+            "discover": {
+              "p50": 29.45,
+              "p95": 37.7
+            },
+            "groups": {
+              "p50": 14.45,
+              "p95": 17.4
+            },
+            "import-resolve": {
+              "p50": 61.150000000000006,
+              "p95": 68.2
+            },
+            "lower": {
+              "p50": 506.3,
+              "p95": 562.5
+            },
+            "normalize+extract": {
+              "p50": 438.35,
+              "p95": 540.9
+            },
+            "parse+lower": {
+              "p50": 409.8,
+              "p95": 469.4
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.8500000000000001,
+              "p95": 1.0
+            },
+            "query_opp": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "query_rank_sort": {
+              "p50": 3.1500000000000004,
+              "p95": 3.5
+            },
+            "query_render": {
+              "p50": 17.35,
+              "p95": 20.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.65,
+              "p95": 8.3
+            },
+            "rank_dedup": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "rank_families": {
+              "p50": 2.2,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.0,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.8
+            },
+            "score": {
+              "p50": 0.9,
+              "p95": 1.7
+            },
+            "shared_lines": {
+              "p50": 105.15,
+              "p95": 116.6
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 80.0,
+              "p95": 80
+            },
+            "misses": {
+              "p50": 1504.0,
+              "p95": 1504
+            },
+            "read_bytes": {
+              "p50": 11120.0,
+              "p95": 11120
+            },
+            "written_bytes": {
+              "p50": 190665950.0,
+              "p95": 190665950
+            }
+          },
+          "elapsed_ms": {
+            "p50": 1984.4693334889598,
+            "p95": 2382.1475830627605
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1163673600.0,
+            "p95": 1203765248
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 587.15,
+              "p95": 698.0
+            },
+            "candidates": {
+              "p50": 28.25,
+              "p95": 39.9
+            },
+            "cluster": {
+              "p50": 2.0,
+              "p95": 2.5
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.1
+            },
+            "groups": {
+              "p50": 13.5,
+              "p95": 16.5
+            },
+            "import-resolve": {
+              "p50": 41.4,
+              "p95": 47.7
+            },
+            "lower": {
+              "p50": 1152.9499999999998,
+              "p95": 1435.0
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.8,
+              "p95": 1.0
+            },
+            "query_opp": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "query_rank_sort": {
+              "p50": 3.0,
+              "p95": 3.5
+            },
+            "query_render": {
+              "p50": 17.0,
+              "p95": 20.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.4,
+              "p95": 8.0
+            },
+            "rank_dedup": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "rank_families": {
+              "p50": 2.2,
+              "p95": 2.5
+            },
+            "rank_map": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.0,
+              "p95": 1.5
+            },
+            "shared_lines": {
+              "p50": 103.4,
+              "p95": 120.2
+            }
+          },
+          "store_bytes": {
+            "p50": 333945915.0,
+            "p95": 333945915
+          }
+        },
+        "history-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "misses": {
+              "p50": 0.0,
+              "p95": 0
+            },
+            "read_bytes": {
+              "p50": 190677070.0,
+              "p95": 190677070
+            },
+            "written_bytes": {
+              "p50": 0.0,
+              "p95": 0
+            }
+          },
+          "elapsed_ms": {
+            "p50": 839.0333754941821,
+            "p95": 1031.9782079895958
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 841506816.0,
+            "p95": 850673664
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 98.6,
+              "p95": 122.7
+            },
+            "candidates": {
+              "p50": 26.15,
+              "p95": 32.5
+            },
+            "cluster": {
+              "p50": 1.5,
+              "p95": 2.1
+            },
+            "contiguous": {
+              "p50": 0.8,
+              "p95": 1.1
+            },
+            "groups": {
+              "p50": 11.45,
+              "p95": 15.9
+            },
+            "import-resolve": {
+              "p50": 31.1,
+              "p95": 38.4
+            },
+            "lower": {
+              "p50": 553.5,
+              "p95": 704.5
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.6,
+              "p95": 0.9
+            },
+            "query_opp": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "query_rank_sort": {
+              "p50": 2.3,
+              "p95": 3.1
+            },
+            "query_render": {
+              "p50": 13.55,
+              "p95": 18.4
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 5.9,
+              "p95": 7.0
+            },
+            "rank_dedup": {
+              "p50": 0.3,
+              "p95": 0.4
+            },
+            "rank_families": {
+              "p50": 1.8,
+              "p95": 2.1
+            },
+            "rank_map": {
+              "p50": 0.95,
+              "p95": 1.1
+            },
+            "rank_sort": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "score": {
+              "p50": 1.0,
+              "p95": 1.7
+            },
+            "shared_lines": {
+              "p50": 85.3,
+              "p95": 104.9
+            }
+          },
+          "store_bytes": {
+            "p50": 333945915.0,
+            "p95": 333945915
+          }
+        }
+      }
+    },
+    "official": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1224.7827084502205,
+            "p95": 1472.4994580028579
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 988143616.0,
+            "p95": 1025949696
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 27.450000000000003,
+              "p95": 40.9
+            },
+            "cluster": {
+              "p50": 2.05,
+              "p95": 2.6
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.1
+            },
+            "discover": {
+              "p50": 30.85,
+              "p95": 40.2
+            },
+            "groups": {
+              "p50": 14.8,
+              "p95": 17.0
+            },
+            "import-resolve": {
+              "p50": 66.80000000000001,
+              "p95": 75.9
+            },
+            "lower": {
+              "p50": 494.3,
+              "p95": 596.6
+            },
+            "normalize+extract": {
+              "p50": 459.4,
+              "p95": 599.9
+            },
+            "parse+lower": {
+              "p50": 392.6,
+              "p95": 484.4
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.6
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.05,
+              "p95": 3.6
+            },
+            "query_render": {
+              "p50": 19.45,
+              "p95": 21.7
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.45,
+              "p95": 8.4
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.3,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.15,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.8
+            },
+            "score": {
+              "p50": 1.0,
+              "p95": 1.5
+            },
+            "shared_lines": {
+              "p50": 105.75,
+              "p95": 124.7
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1333.2585419993848,
+            "p95": 1628.7686669966206
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1092878336.0,
+            "p95": 1109458944
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 29.950000000000003,
+              "p95": 38.1
+            },
+            "cluster": {
+              "p50": 2.2,
+              "p95": 2.8
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 36.2,
+              "p95": 41.0
+            },
+            "groups": {
+              "p50": 15.25,
+              "p95": 17.9
+            },
+            "import-resolve": {
+              "p50": 68.25,
+              "p95": 82.7
+            },
+            "lower": {
+              "p50": 541.7,
+              "p95": 666.2
+            },
+            "parse+lower": {
+              "p50": 438.85,
+              "p95": 555.1
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 1.15,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.1500000000000004,
+              "p95": 3.7
+            },
+            "query_render": {
+              "p50": 19.25,
+              "p95": 22.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 7.05,
+              "p95": 8.5
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.4,
+              "p95": 2.9
+            },
+            "rank_map": {
+              "p50": 1.15,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.3,
+              "p95": 1.9
+            },
+            "shared_lines": {
+              "p50": 111.05,
+              "p95": 127.8
+            }
+          },
+          "store_bytes": {
+            "p50": 380153028.0,
+            "p95": 380153036
+          }
+        },
+        "history-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 843.8160624937154,
+            "p95": 985.5043750721961
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1066860544.0,
+            "p95": 1090748416
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 27.35,
+              "p95": 34.3
+            },
+            "cluster": {
+              "p50": 1.9,
+              "p95": 2.3
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 35.55,
+              "p95": 41.0
+            },
+            "groups": {
+              "p50": 13.5,
+              "p95": 16.4
+            },
+            "import-resolve": {
+              "p50": 69.95,
+              "p95": 84.5
+            },
+            "lower": {
+              "p50": 540.95,
+              "p95": 641.2
+            },
+            "parse+lower": {
+              "p50": 438.95,
+              "p95": 523.8
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.6
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.2
+            },
+            "query_rank_sort": {
+              "p50": 3.0,
+              "p95": 3.5
+            },
+            "query_render": {
+              "p50": 18.85,
+              "p95": 21.6
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.5,
+              "p95": 7.6
+            },
+            "rank_dedup": {
+              "p50": 0.45,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.3,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.2,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.25,
+              "p95": 1.9
+            },
+            "shared_lines": {
+              "p50": 103.2,
+              "p95": 119.3
+            }
+          },
+          "store_bytes": {
+            "p50": 380153028.0,
+            "p95": 380153036
+          }
+        }
+      }
+    }
+  },
+  "workload": {
+    "commit": "da4a5fa52418ae593a941d4ba585cfef87a31870",
+    "id": "sympy",
+    "kind": "real",
+    "path": "bench/repos/sympy"
+  }
+}

--- a/bench/cache/issue-874-mutation-matrix-receipt-2026-07-20.v1.json
+++ b/bench/cache/issue-874-mutation-matrix-receipt-2026-07-20.v1.json
@@ -1,0 +1,8733 @@
+{
+  "environment": {
+    "architecture": "arm64",
+    "logical_cpu_count": 18,
+    "os": "Darwin",
+    "os_release": "25.5.0",
+    "python_version": "3.14.5"
+  },
+  "equivalence": {
+    "after_clean_equals_empty_store": true,
+    "after_clean_equals_history_store": true,
+    "seed_clean_equals_empty_store": true
+  },
+  "measurement": {
+    "cache_stats_required": true,
+    "characterization_only": false,
+    "minimum_replays": 30,
+    "p95": "nearest-rank",
+    "replays": 30
+  },
+  "provenance": {
+    "binary": "target/issue-874-final/release/nose",
+    "binary_code_sha256": "33ddbc966b19d9b61acb513f4f0297c4ce91111ca45d851993fce7ebf501e1f4",
+    "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+    "binary_revision": "e1617924cb33243cf418ec7ffc341eb0fcdde30a",
+    "binary_sha256": "052ab4f1dae9e54c526907e94ff40966ffd29665733385dfb51861083758a5f5",
+    "harness": "scripts/cache-query-regression.py",
+    "harness_sha256": "969cbbc8ae98ed7e9a586c931799958e12b4b4858ec53019b56d4859bc6d145d",
+    "mutation_manifest": "bench/cache/mutation-manifest.v1.json",
+    "mutation_manifest_sha256": "13597fba09fb7e9b5e8785ba2a998d232bf86fa3b23103035b324b0c128ecdc6",
+    "official_baseline": "bench/cache/official-v0.19.0-binaries.v1.json",
+    "official_baseline_sha256": "a9e127dea4303378ed57e3274ca8e0d358b5f0ad253912e4316e8c1f0f83639a",
+    "official_release_verification": null
+  },
+  "raw_report": {
+    "bytes": 4356455,
+    "retention": "local-target; regenerate with the checked harness",
+    "rows": 2100,
+    "sha256": "976ae1e4ccf640b29893437483549dbad0541b15efe302bcef5c96845894f176"
+  },
+  "report_schema": "nose.cache_query_regression/v1",
+  "schema": "nose.cache_query_regression_receipt/v1",
+  "source_identity": {
+    "add-delete-rename": {
+      "after": "52a47a66165b6566941c3db50ff5abf73b5fec8c7d7e0d18400e9b811dca57ac",
+      "before": "968465d49737b6d2cbcb57f67fb3fb1f15b220d88af227b9f4c654b28fe4e97b"
+    },
+    "analysis-config-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "baseline-ignore-change": {
+      "after": "5eea0d0faf8b6f50256473834941b6683dc750747f553c52004f780acc2fe5f5",
+      "before": "55d8de6f0a69fc30a1ff12624e54c0197b7d3323fa3e3d9829f4858734cb0b47"
+    },
+    "embedded-region-edit": {
+      "after": "74975e07007ac2f36afa3425834a318fdd3cf88004d46c3e1851224485dca974",
+      "before": "07e494dcb00deaca4419b75c0025859628c410d6fee77ba7214d486fc5d89338"
+    },
+    "high-fanout-provider-edit": {
+      "after": "015bdc8c320474e7fc544ac494e17a4d3eb8cd5f79519ed84dfdd6ae54a56604",
+      "before": "42bba0ac8356e34dfc0a59ca2288ac8bee7a3edca57f232d6f85e0ebe83dc346"
+    },
+    "ignore-exclude-root-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "leaf-edit": {
+      "after": "89c3cf821f9993da9a29a27b8d8403d9ff441557899ad15832ffcb3c6239c0a5",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "no-op": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "provider-export-edit": {
+      "after": "931a3cf2a72de39266bc16149bbe7fd15a8d58b228020ca76e5993f14e005b0d",
+      "before": "c3a783fb0ebda0efb3eecea0accaa9abab840fea8921d1f2874ee95fbbf7875a"
+    },
+    "provider-non-export-edit": {
+      "after": "efa68310dadac0f376e2b0c37ed4fca78df5eeffee59bd81f30342e1084ae63e",
+      "before": "af1b200a589585c3c329e3d33d46ece7eb7601302943c22832a7db091e9bcd2d"
+    },
+    "same-size-restored-mtime-edit": {
+      "after": "ac78dd39579a9e902beb77175a06dcb109c11d5c8d8a9361ccffd5b7802def61",
+      "before": "62fc4e2ff7c705a5b2de0d0ac9707963fbbdb95eb9efc8c11f2a6968af2878e2"
+    },
+    "semantic-pack-change": {
+      "after": "ce8006cc0073f8970370aa42101fd6fbc1b0dee25f037dfe460b1c4efd512843",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "swift-global-barrier-change": {
+      "after": "ca7643190cff5be5c7e2f2c93bb7cda3016343a2d3371c79d8fb986747e80f86",
+      "before": "f0dbf99c52ea44f1b0fb997ebbefe5c86b01c3c3b227e30414ff8e396e7858d0"
+    },
+    "view-config-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    }
+  },
+  "status": "passed",
+  "summary": {
+    "add-delete-rename": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.18512495001778,
+          "p95": 16.322916955687106
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10264576.0,
+          "p95": 10387456
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.6
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 6.8
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 6.5
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.988312450237572,
+          "p95": 15.907665947452188
+        },
+        "output_sha256": [
+          "c2c065ade64cf0807ce7f90e4543de3e4f0e4e3ae7cbe2257e7904950bdb50e5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10272768.0,
+          "p95": 10436608
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 11811.0,
+            "p95": 11811
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.98968752846122,
+          "p95": 48.37333399336785
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11780096.0,
+          "p95": 11894784
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.8
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.6,
+            "p95": 36.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.55,
+            "p95": 5.1
+          }
+        },
+        "store_bytes": {
+          "p50": 21722.0,
+          "p95": 21722
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 11811.0,
+            "p95": 11811
+          }
+        },
+        "elapsed_ms": {
+          "p50": 43.785541492979974,
+          "p95": 47.86275001242757
+        },
+        "output_sha256": [
+          "c2c065ade64cf0807ce7f90e4543de3e4f0e4e3ae7cbe2257e7904950bdb50e5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11804672.0,
+          "p95": 11960320
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.8
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.849999999999994,
+            "p95": 37.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 21710.0,
+          "p95": 21710
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 2953.0,
+            "p95": 2953
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.214457945898175,
+          "p95": 50.23479100782424
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12255232.0,
+          "p95": 12402688
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.7,
+            "p95": 38.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 27578.0,
+          "p95": 27578
+        }
+      }
+    },
+    "analysis-config-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.78891698550433,
+          "p95": 15.512124984525144
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10305536
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.15000000000000002,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.321916514541954,
+          "p95": 15.907792025245726
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10190848.0,
+          "p95": 10289152
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 6986.0,
+            "p95": 6986
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.82162502547726,
+          "p95": 50.504415994510055
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11599872.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.65,
+            "p95": 40.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 14569.0,
+          "p95": 14569
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.05397900659591,
+          "p95": 48.31924999598414
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11616256.0,
+          "p95": 11714560
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.35,
+            "p95": 37.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 6986.0,
+            "p95": 6986
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.12124949460849,
+          "p95": 48.4838749980554
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11239424.0,
+          "p95": 11403264
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.1,
+            "p95": 36.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 23427.0,
+          "p95": 23427
+        }
+      }
+    },
+    "baseline-ignore-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.043478993698955,
+          "p95": 15.711165964603424
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10141696.0,
+          "p95": 10223616
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 4.25,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 4.5,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.194666990078986,
+          "p95": 17.09737500641495
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10190848.0,
+          "p95": 10354688
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.75,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 6.4
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.8842289946042,
+          "p95": 47.86737507674843
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11567104.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.55,
+            "p95": 37.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.09422902204096,
+          "p95": 50.52041704766452
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11640832.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.55,
+            "p95": 40.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.68949994305149,
+          "p95": 47.074667061679065
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10493952.0,
+          "p95": 10616832
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 30.6,
+            "p95": 37.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      }
+    },
+    "embedded-region-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.14581248536706,
+          "p95": 15.91566693969071
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10428416.0,
+          "p95": 10518528
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 6.8
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.529646025039256,
+          "p95": 16.273958957754076
+        },
+        "output_sha256": [
+          "ef19b55e0c71174494cdfeb7e362c856ef0e7f0c2d7810fa50600112ce3283ee"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10436608.0,
+          "p95": 10518528
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.4
+          },
+          "normalize+extract": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.45,
+            "p95": 6.4
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 19452.0,
+            "p95": 19452
+          }
+        },
+        "elapsed_ms": {
+          "p50": 43.19377097999677,
+          "p95": 54.43220806773752
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11894784.0,
+          "p95": 12025856
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.7,
+            "p95": 0.9
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.4,
+            "p95": 41.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 24251.0,
+          "p95": 24251
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 19299.0,
+            "p95": 19299
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.26583300624043,
+          "p95": 48.502666992135346
+        },
+        "output_sha256": [
+          "ef19b55e0c71174494cdfeb7e362c856ef0e7f0c2d7810fa50600112ce3283ee"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11960320
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.7,
+            "p95": 1.0
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.7,
+            "p95": 37.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 24098.0,
+          "p95": 24098
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 5.0,
+            "p95": 5
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 16332.0,
+            "p95": 16332
+          },
+          "written_bytes": {
+            "p50": 3120.0,
+            "p95": 3120
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.16197901405394,
+          "p95": 47.468458069488406
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12288000.0,
+          "p95": 12386304
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.05,
+            "p95": 37.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 31307.0,
+          "p95": 31307
+        }
+      }
+    },
+    "high-fanout-provider-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 18.94408295629546,
+          "p95": 22.269541979767382
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12460032.0,
+          "p95": 12550144
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.9,
+            "p95": 6.9
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 4.8,
+            "p95": 7.7
+          },
+          "normalize+extract": {
+            "p50": 1.9,
+            "p95": 2.1
+          },
+          "parse+lower": {
+            "p50": 0.7,
+            "p95": 0.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 5.0,
+            "p95": 7.2
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 18.425229471176863,
+          "p95": 21.175083005800843
+        },
+        "output_sha256": [
+          "d8e98b36da38d3222e3834aada1a5f9715f97175159b459b2c93e745f1f0424a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12509184.0,
+          "p95": 12648448
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.8499999999999996,
+            "p95": 5.7
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 4.7,
+            "p95": 6.4
+          },
+          "normalize+extract": {
+            "p50": 1.8,
+            "p95": 2.1
+          },
+          "parse+lower": {
+            "p50": 0.7,
+            "p95": 0.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 4.2,
+            "p95": 5.7
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 132033.0,
+            "p95": 132033
+          }
+        },
+        "elapsed_ms": {
+          "p50": 60.170645476318896,
+          "p95": 69.65520896483213
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 14213120.0,
+          "p95": 14499840
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.2,
+            "p95": 4.8
+          },
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 44.7,
+            "p95": 52.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 4.1,
+            "p95": 5.7
+          }
+        },
+        "store_bytes": {
+          "p50": 269026.0,
+          "p95": 269026
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 132033.0,
+            "p95": 132033
+          }
+        },
+        "elapsed_ms": {
+          "p50": 60.75979152228683,
+          "p95": 67.22291698679328
+        },
+        "output_sha256": [
+          "d8e98b36da38d3222e3834aada1a5f9715f97175159b459b2c93e745f1f0424a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 14163968.0,
+          "p95": 14483456
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.3,
+            "p95": 5.0
+          },
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 45.1,
+            "p95": 50.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 4.1,
+            "p95": 5.7
+          }
+        },
+        "store_bytes": {
+          "p50": 269004.0,
+          "p95": 269004
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "misses": {
+            "p50": 33.0,
+            "p95": 33
+          },
+          "read_bytes": {
+            "p50": 3956.0,
+            "p95": 3956
+          },
+          "written_bytes": {
+            "p50": 128077.0,
+            "p95": 128077
+          }
+        },
+        "elapsed_ms": {
+          "p50": 55.549771001096815,
+          "p95": 61.47879094351083
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 14270464.0,
+          "p95": 14467072
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.0,
+            "p95": 4.5
+          },
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.8
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 39.95,
+            "p95": 45.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 4.1,
+            "p95": 5.8
+          }
+        },
+        "store_bytes": {
+          "p50": 465145.0,
+          "p95": 465145
+        }
+      }
+    },
+    "ignore-exclude-root-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.834624958690256,
+          "p95": 15.654250048100948
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10289152
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.604020467028022,
+          "p95": 16.16054098121822
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10305536
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.56224994221702,
+          "p95": 50.49183405935764
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11567104.0,
+          "p95": 11698176
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.6,
+            "p95": 38.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 4.9,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 11189.0,
+          "p95": 11189
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.160833545494825,
+          "p95": 50.26070796884596
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11657216.0,
+          "p95": 11845632
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.3,
+            "p95": 39.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 40.08370853262022,
+          "p95": 45.86104105692357
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10600448.0,
+          "p95": 10715136
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 30.65,
+            "p95": 34.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16802.0,
+          "p95": 16802
+        }
+      }
+    },
+    "leaf-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.284396030940115,
+          "p95": 15.841334010474384
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10223616.0,
+          "p95": 10321920
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.447333534713835,
+          "p95": 16.46591699682176
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10272768
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.3499999999999996,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8912.0,
+            "p95": 8912
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.545625066850334,
+          "p95": 47.652500099502504
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11632640.0,
+          "p95": 11730944
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.05,
+            "p95": 37.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16495.0,
+          "p95": 16495
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.6173335397616,
+          "p95": 52.10054200142622
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11640832.0,
+          "p95": 11812864
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.15,
+            "p95": 40.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          },
+          "written_bytes": {
+            "p50": 3008.0,
+            "p95": 3008
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.18847899371758,
+          "p95": 50.127374939620495
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12124160.0,
+          "p95": 12222464
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.5,
+            "p95": 38.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 22108.0,
+          "p95": 22108
+        }
+      }
+    },
+    "no-op": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.6997289955616,
+          "p95": 16.145083936862648
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10289152
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 6.7
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.02954146033153,
+          "p95": 15.971750020980835
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10190848.0,
+          "p95": 10272768
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.75,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.32504148967564,
+          "p95": 48.79258293658495
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11567104.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.2,
+            "p95": 38.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.53845855034888,
+          "p95": 48.79529192112386
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11616256.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.7,
+            "p95": 38.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 40.659062447957695,
+          "p95": 50.71462504565716
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10592256.0,
+          "p95": 10715136
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 30.55,
+            "p95": 39.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 6.5
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      }
+    },
+    "provider-export-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 9.774146019481122,
+          "p95": 10.691542061977088
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 9977856.0,
+          "p95": 10043392
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.093916455749422,
+          "p95": 15.939917066134512
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10567680.0,
+          "p95": 10633216
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8197.0,
+            "p95": 8197
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.88416658062488,
+          "p95": 45.758499996736646
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11673600.0,
+          "p95": 11763712
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.25,
+            "p95": 39.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": {
+          "p50": 18128.0,
+          "p95": 18128
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8197.0,
+            "p95": 8197
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.8720209854655,
+          "p95": 50.379958003759384
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12058624.0,
+          "p95": 12173312
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.55,
+            "p95": 39.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 18128.0,
+          "p95": 18128
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 3956.0,
+            "p95": 3956
+          },
+          "written_bytes": {
+            "p50": 4241.0,
+            "p95": 4241
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.85100003005937,
+          "p95": 43.24137500952929
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11960320.0,
+          "p95": 12091392
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.9,
+            "p95": 35.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": {
+          "p50": 27301.0,
+          "p95": 27301
+        }
+      }
+    },
+    "provider-non-export-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.688396022189409,
+          "p95": 15.6326669966802
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10600448.0,
+          "p95": 10682368
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.733208470512182,
+          "p95": 15.703957993537188
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10584064.0,
+          "p95": 10665984
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.3,
+            "p95": 6.3
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 9915.0,
+            "p95": 9915
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.47183300321922,
+          "p95": 52.168959053233266
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12107776.0,
+          "p95": 12222464
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 33.05,
+            "p95": 41.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 20457.0,
+          "p95": 20457
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 9915.0,
+            "p95": 9915
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.9960829205811,
+          "p95": 48.494708025828004
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12083200.0,
+          "p95": 12304384
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 32.75,
+            "p95": 36.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 4.1,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 20451.0,
+          "p95": 20451
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 7950.0,
+            "p95": 7950
+          },
+          "written_bytes": {
+            "p50": 1965.0,
+            "p95": 1965
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.73731245100498,
+          "p95": 52.806457970291376
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12107776.0,
+          "p95": 12238848
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.700000000000003,
+            "p95": 41.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 6.3
+          }
+        },
+        "store_bytes": {
+          "p50": 26272.0,
+          "p95": 26272
+        }
+      }
+    },
+    "same-size-restored-mtime-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.027104480192065,
+          "p95": 16.230582958087325
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10240000.0,
+          "p95": 10338304
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.15000000000000002,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.041645976249129,
+          "p95": 16.71358395833522
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10256384.0,
+          "p95": 10354688
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 12319.0,
+            "p95": 12319
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.570562509354204,
+          "p95": 47.41004097741097
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11640832.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.35,
+            "p95": 36.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 21526.0,
+          "p95": 21526
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 12319.0,
+            "p95": 12319
+          }
+        },
+        "elapsed_ms": {
+          "p50": 43.033396010287106,
+          "p95": 48.038584063760936
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11665408.0,
+          "p95": 11763712
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.4,
+            "p95": 37.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 21526.0,
+          "p95": 21526
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 3461.0,
+            "p95": 3461
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.65120847756043,
+          "p95": 50.928084063343704
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11878400.0,
+          "p95": 12025856
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.15,
+            "p95": 39.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.5,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 27214.0,
+          "p95": 27214
+        }
+      }
+    },
+    "semantic-pack-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 12.990645947866142,
+          "p95": 16.23254199512303
+        },
+        "output_sha256": [
+          "7a8faf6bd1382bfb3ff1f538110d2345a958a153076e0e5ea1c68b74d6e49ea5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10567680.0,
+          "p95": 10665984
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 6.7
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.099479536525905,
+          "p95": 15.77808300498873
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10240000.0,
+          "p95": 10371072
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.6,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.9,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.935082979965955,
+          "p95": 47.90916701313108
+        },
+        "output_sha256": [
+          "7a8faf6bd1382bfb3ff1f538110d2345a958a153076e0e5ea1c68b74d6e49ea5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12009472.0,
+          "p95": 12107776
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 36.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.868916993029416,
+          "p95": 49.56237506121397
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11616256.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 38.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.45,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.195728990715,
+          "p95": 49.392250017262995
+        },
+        "output_sha256": [
+          "7a8faf6bd1382bfb3ff1f538110d2345a958a153076e0e5ea1c68b74d6e49ea5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10985472.0,
+          "p95": 11108352
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.299999999999997,
+            "p95": 39.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      }
+    },
+    "swift-global-barrier-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.148520480375737,
+          "p95": 15.957999974489212
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11354112.0,
+          "p95": 11501568
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.6,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 4.0,
+            "p95": 6.7
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.15000000000000002,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.3499999999999996,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.798999949358404,
+          "p95": 16.12600008957088
+        },
+        "output_sha256": [
+          "db53413c2e47123509eb1d8e09990f485a0ae28a3037d73bb1d7173cdb6cf05b"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11206656.0,
+          "p95": 11288576
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.3,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 10812.0,
+            "p95": 10812
+          }
+        },
+        "elapsed_ms": {
+          "p50": 43.48929150728509,
+          "p95": 53.85074997320771
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12812288.0,
+          "p95": 13025280
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.8,
+            "p95": 42.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.45,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 21412.0,
+          "p95": 21412
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 7526.0,
+            "p95": 7526
+          }
+        },
+        "elapsed_ms": {
+          "p50": 41.89274989767,
+          "p95": 47.09687491413206
+        },
+        "output_sha256": [
+          "db53413c2e47123509eb1d8e09990f485a0ae28a3037d73bb1d7173cdb6cf05b"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12599296.0,
+          "p95": 12746752
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.349999999999994,
+            "p95": 37.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 12879.0,
+          "p95": 12879
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 10812.0,
+            "p95": 10812
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.389520502183586,
+          "p95": 46.91124998498708
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12910592.0,
+          "p95": 13025280
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.25,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 35.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 29857.0,
+          "p95": 29857
+        }
+      }
+    },
+    "view-config-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.051208039745688,
+          "p95": 15.913499984890223
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10067968.0,
+          "p95": 10174464
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.965854013804346,
+          "p95": 15.815124963410199
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10199040.0,
+          "p95": 10321920
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.490624997299165,
+          "p95": 48.93116606399417
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11567104.0,
+          "p95": 11747328
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 38.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 42.57016652263701,
+          "p95": 48.69179101660848
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11624448.0,
+          "p95": 11796480
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 37.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 40.58458347572014,
+          "p95": 48.90862503089011
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10551296.0,
+          "p95": 10747904
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 30.9,
+            "p95": 39.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.05,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": {
+          "p50": 16441.0,
+          "p95": 16441
+        }
+      }
+    }
+  },
+  "workload": {
+    "ids": [
+      "add-delete-rename",
+      "analysis-config-change",
+      "baseline-ignore-change",
+      "embedded-region-edit",
+      "high-fanout-provider-edit",
+      "ignore-exclude-root-change",
+      "leaf-edit",
+      "no-op",
+      "provider-export-edit",
+      "provider-non-export-edit",
+      "same-size-restored-mtime-edit",
+      "semantic-pack-change",
+      "swift-global-barrier-change",
+      "view-config-change"
+    ],
+    "kind": "fixture-matrix"
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "94ead8282a6b0e92ebb408709622bbeb654e257a",
+  "product_crates_tree": "c14ec504c4a8bc8a24c5bdc46f6d68267757ece4",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "c14ec504c4a8bc8a24c5bdc46f6d68267757ece4",
+  "product_crates_tree": "9c8770b24f8055611533d23fc9e35f70403f3cf3",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/Cargo.toml
+++ b/crates/nose-cli/Cargo.toml
@@ -30,6 +30,7 @@ ignore = { workspace = true }
 rustc-hash = { workspace = true }
 sha2 = { workspace = true }
 rmp-serde = { workspace = true }
+lz4_flex = { workspace = true }
 
 [dev-dependencies]
 nose-il = { workspace = true }

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -1,25 +1,25 @@
-//! Optional layered content-addressed cache. The currently active product layer
-//! stores per-file detection units keyed by the **resolved IL and reporting
-//! metadata** SHA-256 digest. Re-running nose on a project where
-//! most files are unchanged then skips the dominant cost (normalize + extract)
-//! for those files and deserializes their units instead.
+//! Optional dependency-aware layered content-addressed cache. Clean Git-tracked
+//! sources use blob identities; dirty, untracked, and non-Git sources use exact
+//! SHA-256 content identities. Raw IL, consumer-visible export/dependency summaries,
+//! affected resolved IL, and detection units are separate stages.
 //!
-//! The corpus is lowered AND cross-file-resolved every run
-//! (`lower_corpus_filtered` — parse + lower + `resolve_imported_immutable_bindings`,
-//! the smaller half of the work per experiments §BQ); only the dominant
-//! normalize+extract step is cached. The key is a content hash of each file's
-//! *post-resolve* IL, so a file whose imported-immutable-literal context changed
-//! (its provider edited) gets a different key and recomputes — fixing #275, where
-//! the old source-content key skipped resolution entirely and the cached analysis
-//! under-merged cross-file imported-literal convergence. A [`UnitFeat`]'s features
-//! are interner-independent content hashes, so a hit needs no interner. The key
-//! covers nodes, edges, spans, facets, symbol strings, suppression, and complete
-//! semantic evidence plus stage/schema/options identity. Paths and process-local
-//! ids stay outside the key and are rebound on a hit. A checksummed envelope makes
-//! corrupt, truncated, or misplaced entries clean misses rather than silent reuse.
+//! A resolved key contains the raw IL identity plus only facts that can affect that
+//! region: imported literal/namespace export surfaces, Rust/Java/Go module outcomes,
+//! unresolved-dependency catalogs, and Swift corpus-global sentinels. Provider
+//! implementation edits therefore leave importer keys stable when the export
+//! surface is unchanged, while export edits still invalidate #275 consumers.
+//! Paths and process-local ids stay outside portable keys and are rebound on a hit,
+//! so checkout moves and sorted `FileId` shifts do not fan out invalidation.
+//!
+//! Every stage uses the checksummed CAS envelope. Corrupt, truncated, or misplaced
+//! entries are misses; the mutable workspace state is diagnostics-only and never a
+//! correctness input. `NOSE_CACHE_STATS` also emits a machine-readable
+//! `nose.invalidation/v1` closure with exact reasons and explicit over-invalidation.
 
 mod digest;
 mod portable_il;
+mod resolved;
+mod source;
 mod store;
 
 use nose_detect::{DetectOptions, Stream, UnitFeat};
@@ -29,7 +29,41 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use self::digest::ContentDigest;
+pub(crate) use self::resolved::CachedCorpus;
 use self::store::{ArtifactKey, ArtifactStage, LayeredCas};
+
+pub(crate) fn build_corpus_cached(
+    roots: &[&Path],
+    exclude: &[String],
+    dir: &Path,
+    semantic_packs: &nose_semantics::SemanticPackSet,
+) -> CachedCorpus {
+    let raw = source::build_raw_corpus_cached(roots, exclude, dir);
+    resolved::build_resolved_corpus_cached(raw, dir, semantic_pack_digest(semantic_packs))
+}
+
+pub(crate) fn invalidation_report_json(report: &resolved::InvalidationReport) -> String {
+    serde_json::to_string(report).expect("invalidation report is always JSON serializable")
+}
+
+fn semantic_pack_digest(packs: &nose_semantics::SemanticPackSet) -> ContentDigest {
+    let mut rows = packs
+        .packs()
+        .iter()
+        .map(|pack| {
+            format!(
+                "{}\0{}\0{}\0{}",
+                pack.id,
+                pack.version,
+                pack.hash_hex(),
+                pack.semantic_digest.as_deref().unwrap_or("")
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    let rows = rows.iter().map(String::as_bytes).collect::<Vec<_>>();
+    ContentDigest::derive(b"nose.semantic-pack-influence.v1", &rows)
+}
 
 /// Bump when unit/stream serialization, extraction, or feature hashing changes.
 const UNITS_SYNTAX_SCHEMA: u32 = 2;
@@ -57,7 +91,27 @@ pub(crate) struct CacheStats {
 /// cache keys on that *post-resolve* IL (fixing #275) and only the dominant
 /// normalize+extract step is cached. A cache hit needs no interner (features are
 /// content-derived); a miss recomputes and writes back.
-pub(crate) fn build_units_cached(corpus: &Corpus, opts: &DetectOptions, dir: &Path) -> CachedUnits {
+#[cfg(test)]
+fn build_units_cached(corpus: &Corpus, opts: &DetectOptions, dir: &Path) -> CachedUnits {
+    build_units_cached_inner(corpus, opts, dir, None)
+}
+
+pub(crate) fn build_units_cached_with_context(
+    corpus: &Corpus,
+    opts: &DetectOptions,
+    dir: &Path,
+    resolution_contexts: &[[u8; 32]],
+) -> CachedUnits {
+    assert_eq!(corpus.files.len(), resolution_contexts.len());
+    build_units_cached_inner(corpus, opts, dir, Some(resolution_contexts))
+}
+
+fn build_units_cached_inner(
+    corpus: &Corpus,
+    opts: &DetectOptions,
+    dir: &Path,
+    resolution_contexts: Option<&[[u8; 32]]>,
+) -> CachedUnits {
     let cas = LayeredCas::new(dir);
     let options = options_digest(opts);
     let hits = AtomicUsize::new(0);
@@ -68,14 +122,23 @@ pub(crate) fn build_units_cached(corpus: &Corpus, opts: &DetectOptions, dir: &Pa
     let per_file: Vec<(Vec<UnitFeat>, Stream)> = corpus
         .files
         .par_iter()
-        .map(|il| {
+        .enumerate()
+        .map(|(index, il)| {
             let path = il.meta.path.clone();
             let resolved = portable_il::semantic_digest(il, &corpus.interner);
-            let key = ArtifactKey::derive(
-                ArtifactStage::UnitsSyntax,
-                UNITS_SYNTAX_SCHEMA,
-                &[resolved.as_bytes(), options.as_bytes()],
-            );
+            let context = resolution_contexts.map(|contexts| contexts[index].as_slice());
+            let key = match context {
+                Some(context) => ArtifactKey::derive(
+                    ArtifactStage::UnitsSyntax,
+                    UNITS_SYNTAX_SCHEMA,
+                    &[resolved.as_bytes(), options.as_bytes(), context],
+                ),
+                None => ArtifactKey::derive(
+                    ArtifactStage::UnitsSyntax,
+                    UNITS_SYNTAX_SCHEMA,
+                    &[resolved.as_bytes(), options.as_bytes()],
+                ),
+            };
 
             if let Some(entry) = cas.load(key) {
                 read_bytes.fetch_add(entry.stored_bytes, Ordering::Relaxed);

--- a/crates/nose-cli/src/cache/portable_il.rs
+++ b/crates/nose-cli/src/cache/portable_il.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 
-const PORTABLE_IL_SCHEMA: u32 = 1;
+const PORTABLE_IL_SCHEMA: u32 = 3;
+const MAX_PORTABLE_IL_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Serialize, Deserialize)]
 struct PortableIl {
@@ -99,14 +100,29 @@ pub(super) fn encode(il: &Il, interner: &Interner) -> Result<Vec<u8>> {
         symbols,
         il: canonical,
     };
-    serde_json::to_vec(&portable).context("serialize portable IL")
+    let bytes = rmp_serde::to_vec_named(&portable).context("serialize portable IL")?;
+    if bytes.len() > MAX_PORTABLE_IL_BYTES {
+        bail!("portable IL exceeds the per-region cache safety limit");
+    }
+    Ok(lz4_flex::compress_prepend_size(&bytes))
 }
 
 /// Restore an artifact into the caller's shared interner and current checkout.
 /// Invalid symbol ids, schema drift, or region corruption fail closed.
 pub(super) fn decode(bytes: &[u8], interner: &Interner, file: FileId, path: String) -> Result<Il> {
+    let declared = bytes
+        .get(..4)
+        .and_then(|size| size.try_into().ok())
+        .map(u32::from_le_bytes)
+        .map(|size| size as usize)
+        .context("portable IL lacks an LZ4 size prefix")?;
+    if declared > MAX_PORTABLE_IL_BYTES {
+        bail!("portable IL expands beyond the per-region safety limit");
+    }
+    let decompressed =
+        lz4_flex::decompress_size_prepended(bytes).context("decompress portable IL")?;
     let mut portable: PortableIl =
-        serde_json::from_slice(bytes).context("deserialize portable IL")?;
+        rmp_serde::from_slice(&decompressed).context("deserialize portable IL")?;
     if portable.schema != PORTABLE_IL_SCHEMA {
         bail!(
             "portable IL schema {} is not supported (expected {})",

--- a/crates/nose-cli/src/cache/resolved.rs
+++ b/crates/nose-cli/src/cache/resolved.rs
@@ -1,0 +1,552 @@
+use super::digest::ContentDigest;
+use super::portable_il;
+use super::source::{RawCorpus, SourceIdentityKind};
+use super::store::{ArtifactKey, ArtifactStage, LayeredCas};
+use nose_frontend::ResolutionDependency;
+use nose_il::Corpus;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const EXPORT_DEPENDENCY_SCHEMA: u32 = 1;
+const RESOLVED_IL_SCHEMA: u32 = 3;
+static STATE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) struct CachedCorpus {
+    pub(crate) corpus: Corpus,
+    pub(crate) report: InvalidationReport,
+    pub(crate) unit_contexts: Vec<[u8; 32]>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct InvalidationReport {
+    schema: &'static str,
+    discovery_membership_digest: String,
+    corpus_global_line_statistics_digest: String,
+    semantic_pack_digest: String,
+    swift_global_digest: String,
+    global_invalidations: Vec<&'static str>,
+    source_identities: SourceIdentityCounts,
+    source_snapshots: LayerStats,
+    raw_il: LayerStats,
+    resolved_il: LayerStats,
+    invalidated: Vec<InvalidatedRegion>,
+    over_invalidated: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LayerStats {
+    hits: usize,
+    misses: usize,
+    passthrough: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceIdentityCounts {
+    git_blob: usize,
+    content_sha256: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct InvalidatedRegion {
+    path: String,
+    language: String,
+    reasons: Vec<&'static str>,
+    dependency_providers: Vec<String>,
+    source_identity: Option<SourceIdentityKind>,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+struct WorkspaceState {
+    schema: u32,
+    discovery_membership_digest: String,
+    corpus_global_line_statistics_digest: String,
+    semantic_pack_digest: String,
+    swift_global_digest: String,
+    regions: BTreeMap<String, RegionState>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct RegionState {
+    path: String,
+    language: String,
+    raw_digest: String,
+    export_digest: String,
+    resolution_digest: String,
+    over_invalidated: bool,
+}
+
+#[derive(Serialize)]
+struct StoredDependencySummary<'a> {
+    schema: u32,
+    discovery_membership_digest: String,
+    swift_global_digest: String,
+    swift_global_active: bool,
+    files: Vec<StoredFileSummary<'a>>,
+}
+
+#[derive(Serialize)]
+struct StoredFileSummary<'a> {
+    path: &'a str,
+    export_digest: String,
+    resolution_digest: String,
+    dependencies: &'a [ResolutionDependency],
+    over_invalidated: bool,
+    requires_resolution: bool,
+}
+
+enum ResolvedReuse {
+    Passthrough,
+    Hit(Box<CorpusFile>),
+    Miss,
+}
+
+type CorpusFile = nose_il::Il;
+
+pub(super) fn build_resolved_corpus_cached(
+    mut raw: RawCorpus,
+    dir: &Path,
+    semantic_pack_digest: ContentDigest,
+) -> CachedCorpus {
+    let cas = LayeredCas::new(dir);
+    let summary =
+        nose_frontend::resolution_dependency_summary(&raw.corpus.files, &raw.corpus.interner);
+    debug_assert_eq!(raw.corpus.files.len(), raw.regions.len());
+    debug_assert_eq!(summary.files.len(), raw.regions.len());
+    let state_path = state_path(dir, raw.workspace_digest);
+    let previous_state = load_state(&state_path);
+    let current_state = workspace_state(&raw, &summary, semantic_pack_digest);
+    store_dependency_summary(&cas, &raw, &summary);
+    let resolved_keys = resolved_artifact_keys(&raw, &summary.files);
+    let resolved_reuse = load_resolved_reuse(&cas, &raw, &summary.files, &resolved_keys);
+    let affected = resolved_reuse
+        .iter()
+        .map(|reuse| matches!(reuse, ResolvedReuse::Miss))
+        .collect::<Vec<_>>();
+    nose_frontend::resolve_corpus_affected(&mut raw.corpus, &affected);
+    apply_resolved_reuse(&cas, &mut raw, &resolved_keys, resolved_reuse);
+    let report = build_invalidation_report(
+        &raw,
+        &summary,
+        &affected,
+        previous_state.as_ref(),
+        &current_state,
+        semantic_pack_digest,
+    );
+    store_state(&state_path, &current_state);
+    CachedCorpus {
+        unit_contexts: summary
+            .files
+            .iter()
+            .map(|file| file.resolution_digest)
+            .collect(),
+        report,
+        corpus: raw.corpus,
+    }
+}
+
+fn store_dependency_summary(
+    cas: &LayeredCas,
+    raw: &RawCorpus,
+    summary: &nose_frontend::ResolutionDependencySummary,
+) {
+    let key = ArtifactKey::derive(
+        ArtifactStage::ExportDependencySummary,
+        EXPORT_DEPENDENCY_SCHEMA,
+        &[
+            raw.discovery_digest.as_bytes(),
+            raw.global_line_statistics_digest.as_bytes(),
+        ],
+    );
+    if cas.load(key).is_some() {
+        return;
+    }
+    let stored = StoredDependencySummary {
+        schema: EXPORT_DEPENDENCY_SCHEMA,
+        discovery_membership_digest: raw.discovery_digest.hex(),
+        swift_global_digest: hex(summary.swift_global_digest),
+        swift_global_active: summary.swift_global_active,
+        files: summary
+            .files
+            .iter()
+            .zip(&raw.regions)
+            .map(|(file, region)| StoredFileSummary {
+                path: &region.logical_path,
+                export_digest: hex(file.export_digest),
+                resolution_digest: hex(file.resolution_digest),
+                dependencies: &file.dependencies,
+                over_invalidated: file.over_invalidated,
+                requires_resolution: file.requires_resolution,
+            })
+            .collect(),
+    };
+    if let Ok(payload) = rmp_serde::to_vec_named(&stored) {
+        let _ = cas.store(key, &payload);
+    }
+}
+
+fn resolved_artifact_keys(
+    raw: &RawCorpus,
+    summaries: &[nose_frontend::FileResolutionDependencySummary],
+) -> Vec<ArtifactKey> {
+    raw.regions
+        .iter()
+        .zip(summaries)
+        .map(|(region, file)| {
+            ArtifactKey::derive(
+                ArtifactStage::ResolvedIl,
+                RESOLVED_IL_SCHEMA,
+                &[region.raw_digest.as_bytes(), &file.resolution_digest],
+            )
+        })
+        .collect()
+}
+
+fn load_resolved_reuse(
+    cas: &LayeredCas,
+    raw: &RawCorpus,
+    summaries: &[nose_frontend::FileResolutionDependencySummary],
+    keys: &[ArtifactKey],
+) -> Vec<ResolvedReuse> {
+    keys.par_iter()
+        .enumerate()
+        .map(|(index, &key)| {
+            if !summaries[index].requires_resolution {
+                return ResolvedReuse::Passthrough;
+            }
+            let Some(entry) = cas.load(key) else {
+                return ResolvedReuse::Miss;
+            };
+            portable_il::decode(
+                &entry.payload,
+                &raw.corpus.interner,
+                raw.corpus.files[index].file,
+                raw.corpus.files[index].meta.path.clone(),
+            )
+            .map_or(ResolvedReuse::Miss, |il| ResolvedReuse::Hit(Box::new(il)))
+        })
+        .collect()
+}
+
+fn apply_resolved_reuse(
+    cas: &LayeredCas,
+    raw: &mut RawCorpus,
+    keys: &[ArtifactKey],
+    reuse: Vec<ResolvedReuse>,
+) {
+    for (index, reuse) in reuse.into_iter().enumerate() {
+        match reuse {
+            ResolvedReuse::Passthrough => continue,
+            ResolvedReuse::Hit(cached) => {
+                raw.corpus.files[index] = *cached;
+                continue;
+            }
+            ResolvedReuse::Miss => {}
+        }
+        if let Ok(payload) = portable_il::encode(&raw.corpus.files[index], &raw.corpus.interner) {
+            let _ = cas.store(keys[index], &payload);
+        }
+    }
+}
+
+fn build_invalidation_report(
+    raw: &RawCorpus,
+    summary: &nose_frontend::ResolutionDependencySummary,
+    affected: &[bool],
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+    semantic_pack_digest: ContentDigest,
+) -> InvalidationReport {
+    let (invalidated, over_invalidated) =
+        invalidated_regions(raw, summary, affected, previous, current);
+    let raw_hits = raw.regions.iter().filter(|region| region.raw_hit).count();
+    let resolved_misses = affected.iter().filter(|affected| **affected).count();
+    let resolved_passthrough = summary
+        .files
+        .iter()
+        .filter(|file| !file.requires_resolution)
+        .count();
+    InvalidationReport {
+        schema: "nose.invalidation/v1",
+        discovery_membership_digest: raw.discovery_digest.hex(),
+        corpus_global_line_statistics_digest: raw.global_line_statistics_digest.hex(),
+        semantic_pack_digest: semantic_pack_digest.hex(),
+        swift_global_digest: hex(summary.swift_global_digest),
+        global_invalidations: global_invalidations(previous, current),
+        source_identities: SourceIdentityCounts {
+            git_blob: raw
+                .regions
+                .iter()
+                .filter(|region| region.source_kind == SourceIdentityKind::GitBlob)
+                .count(),
+            content_sha256: raw
+                .regions
+                .iter()
+                .filter(|region| region.source_kind == SourceIdentityKind::ContentSha256)
+                .count(),
+        },
+        source_snapshots: LayerStats {
+            hits: raw.source_hits,
+            misses: raw.source_misses,
+            passthrough: 0,
+        },
+        raw_il: LayerStats {
+            hits: raw_hits,
+            misses: raw.regions.len() - raw_hits,
+            passthrough: 0,
+        },
+        resolved_il: LayerStats {
+            hits: affected.len() - resolved_misses,
+            misses: resolved_misses,
+            passthrough: resolved_passthrough,
+        },
+        invalidated,
+        over_invalidated,
+    }
+}
+
+fn invalidated_regions(
+    raw: &RawCorpus,
+    summary: &nose_frontend::ResolutionDependencySummary,
+    affected: &[bool],
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+) -> (Vec<InvalidatedRegion>, Vec<String>) {
+    if previous.is_none() {
+        return (Vec::new(), Vec::new());
+    }
+    let indexes = affected
+        .iter()
+        .enumerate()
+        .filter_map(|(index, affected)| {
+            (*affected || region_state_changed(index, raw, previous, current)).then_some(index)
+        })
+        .collect::<BTreeSet<_>>();
+    let mut invalidated = indexes
+        .iter()
+        .map(|&index| {
+            invalidated_region(
+                index,
+                raw,
+                &summary.files[index].dependencies,
+                previous,
+                current,
+            )
+        })
+        .collect::<Vec<_>>();
+    append_deleted_regions(&mut invalidated, previous, current);
+    invalidated.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.language.cmp(&right.language))
+    });
+    let over_invalidated = indexes
+        .iter()
+        .filter(|&&index| summary.files[index].over_invalidated)
+        .map(|&index| raw.regions[index].logical_path.clone())
+        .collect();
+    (invalidated, over_invalidated)
+}
+
+fn append_deleted_regions(
+    invalidated: &mut Vec<InvalidatedRegion>,
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+) {
+    let Some(previous) = previous else { return };
+    let current_keys = current.regions.keys().collect::<BTreeSet<_>>();
+    invalidated.extend(
+        previous
+            .regions
+            .iter()
+            .filter(|(key, _)| !current_keys.contains(key))
+            .map(|(_, region)| InvalidatedRegion {
+                path: region.path.clone(),
+                language: region.language.clone(),
+                reasons: vec!["deleted-source"],
+                dependency_providers: Vec::new(),
+                source_identity: None,
+            }),
+    );
+}
+
+fn region_state_changed(
+    index: usize,
+    raw: &RawCorpus,
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+) -> bool {
+    let Some(previous) = previous else {
+        return true;
+    };
+    let key = region_key(raw, index);
+    let Some(before) = previous.regions.get(&key) else {
+        return true;
+    };
+    let after = &current.regions[&key];
+    before.raw_digest != after.raw_digest || before.resolution_digest != after.resolution_digest
+}
+
+fn invalidated_region(
+    index: usize,
+    raw: &RawCorpus,
+    dependencies: &[ResolutionDependency],
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+) -> InvalidatedRegion {
+    let region = &raw.regions[index];
+    let mut reasons = Vec::new();
+    let key = region_key(raw, index);
+    let current_region = &current.regions[&key];
+    let previous_region = previous.and_then(|state| state.regions.get(&key));
+    match (previous, previous_region) {
+        (None, _) => reasons.push("cold-start"),
+        (Some(_), None) => reasons.push("added-source"),
+        (Some(previous), Some(before)) if before.raw_digest != current_region.raw_digest => {
+            reasons.push(match region.source_kind {
+                SourceIdentityKind::GitBlob | SourceIdentityKind::ContentSha256 => "source-content",
+            });
+            if before.export_digest != current_region.export_digest {
+                reasons.push("export-surface");
+            }
+            if previous.discovery_membership_digest != current.discovery_membership_digest {
+                reasons.push("discovery-membership");
+            }
+        }
+        (Some(previous), Some(before))
+            if before.resolution_digest != current_region.resolution_digest =>
+        {
+            if raw.corpus.files[index].meta.lang == nose_il::Lang::Swift
+                && previous.swift_global_digest != current.swift_global_digest
+            {
+                reasons.push("swift-global-sentinel");
+            } else if current_region.over_invalidated {
+                reasons.push("unknown-dependency-over-invalidation");
+            } else {
+                reasons.push("dependency-export");
+            }
+        }
+        _ => reasons.push("artifact-miss-or-corruption"),
+    }
+    let mut dependency_providers = dependencies
+        .iter()
+        .filter_map(|dependency| dependency.provider_file)
+        .filter_map(|provider| raw.regions.get(provider))
+        .map(|provider| provider.logical_path.clone())
+        .collect::<Vec<_>>();
+    dependency_providers.sort();
+    dependency_providers.dedup();
+    InvalidatedRegion {
+        path: region.logical_path.clone(),
+        language: raw.corpus.files[index].meta.lang.name().to_owned(),
+        reasons,
+        dependency_providers,
+        source_identity: Some(region.source_kind),
+    }
+}
+
+fn workspace_state(
+    raw: &RawCorpus,
+    summary: &nose_frontend::ResolutionDependencySummary,
+    semantic_pack_digest: ContentDigest,
+) -> WorkspaceState {
+    let regions = raw
+        .regions
+        .iter()
+        .zip(&raw.corpus.files)
+        .zip(&summary.files)
+        .enumerate()
+        .map(|(index, ((region, il), summary))| {
+            (
+                region_key(raw, index),
+                RegionState {
+                    path: region.logical_path.clone(),
+                    language: il.meta.lang.name().to_owned(),
+                    raw_digest: region.raw_digest.hex(),
+                    export_digest: hex(summary.export_digest),
+                    resolution_digest: hex(summary.resolution_digest),
+                    over_invalidated: summary.over_invalidated,
+                },
+            )
+        })
+        .collect();
+    WorkspaceState {
+        schema: 1,
+        discovery_membership_digest: raw.discovery_digest.hex(),
+        corpus_global_line_statistics_digest: raw.global_line_statistics_digest.hex(),
+        semantic_pack_digest: semantic_pack_digest.hex(),
+        swift_global_digest: hex(summary.swift_global_digest),
+        regions,
+    }
+}
+
+fn region_key(raw: &RawCorpus, index: usize) -> String {
+    let region = &raw.regions[index];
+    format!(
+        "{}\0{}\0{}",
+        region.logical_path,
+        raw.corpus.files[index].meta.lang.name(),
+        region.region_id
+    )
+}
+
+fn global_invalidations(
+    previous: Option<&WorkspaceState>,
+    current: &WorkspaceState,
+) -> Vec<&'static str> {
+    let Some(previous) = previous else {
+        return vec!["cold-start"];
+    };
+    let mut out = Vec::new();
+    if previous.discovery_membership_digest != current.discovery_membership_digest {
+        out.push("discovery-membership");
+    }
+    if previous.corpus_global_line_statistics_digest != current.corpus_global_line_statistics_digest
+    {
+        out.push("corpus-global-line-statistics");
+    }
+    if previous.semantic_pack_digest != current.semantic_pack_digest {
+        out.push("semantic-pack-influence");
+    }
+    out
+}
+
+fn state_path(dir: &Path, workspace: ContentDigest) -> PathBuf {
+    dir.join("state-v1")
+        .join(format!("{}.json", workspace.hex()))
+}
+
+fn load_state(path: &Path) -> Option<WorkspaceState> {
+    let bytes = std::fs::read(path).ok()?;
+    let state = serde_json::from_slice::<WorkspaceState>(&bytes).ok()?;
+    (state.schema == 1).then_some(state)
+}
+
+fn store_state(path: &Path, state: &WorkspaceState) {
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(bytes) = serde_json::to_vec(state) else {
+        return;
+    };
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        STATE_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+fn hex(bytes: [u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}

--- a/crates/nose-cli/src/cache/source.rs
+++ b/crates/nose-cli/src/cache/source.rs
@@ -1,0 +1,434 @@
+use super::digest::ContentDigest;
+use super::portable_il;
+use super::store::{ArtifactKey, ArtifactStage, LayeredCas};
+use nose_il::{Corpus, FileId, Il, Interner, Lang};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SOURCE_SNAPSHOT_SCHEMA: u32 = 1;
+const RAW_IL_SCHEMA: u32 = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum SourceIdentityKind {
+    GitBlob,
+    ContentSha256,
+}
+
+pub(super) struct RawRegion {
+    pub(super) il: Il,
+    pub(super) raw_digest: ContentDigest,
+    pub(super) raw_hit: bool,
+    pub(super) source_kind: SourceIdentityKind,
+    pub(super) logical_path: String,
+}
+
+pub(super) struct RawCorpus {
+    pub(super) corpus: Corpus,
+    pub(super) regions: Vec<RawRegionMetadata>,
+    pub(super) discovery_digest: ContentDigest,
+    pub(super) global_line_statistics_digest: ContentDigest,
+    pub(super) workspace_digest: ContentDigest,
+    pub(super) source_hits: usize,
+    pub(super) source_misses: usize,
+}
+
+pub(super) struct RawRegionMetadata {
+    pub(super) raw_digest: ContentDigest,
+    pub(super) raw_hit: bool,
+    pub(super) source_kind: SourceIdentityKind,
+    pub(super) logical_path: String,
+    pub(super) region_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PortableRawBundle {
+    schema: u32,
+    regions: Vec<Vec<u8>>,
+}
+
+struct SourceResult {
+    regions: Vec<RawRegion>,
+    source_digest: Option<ContentDigest>,
+    logical_path: String,
+    lang: Lang,
+    snapshot_hit: bool,
+}
+
+pub(super) fn build_raw_corpus_cached(
+    roots: &[&Path],
+    exclude: &[String],
+    dir: &Path,
+) -> RawCorpus {
+    let paths = nose_frontend::discover_unique_paths(roots, exclude);
+    let git = GitCatalog::new(roots);
+    let cas = LayeredCas::new(dir);
+    let interner = Interner::new();
+    let results = paths
+        .par_iter()
+        .enumerate()
+        .map(|(index, (path, lang))| {
+            load_source(
+                index,
+                path,
+                *lang,
+                logical_path(roots, Path::new(path)),
+                &git,
+                &cas,
+                &interner,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let source_hits = results.iter().filter(|result| result.snapshot_hit).count();
+    let source_misses = results.len() - source_hits;
+    let mut discovery_rows = Vec::new();
+    let mut line_rows = Vec::new();
+    let mut files = Vec::new();
+    let mut regions = Vec::new();
+    for result in results {
+        if let Some(digest) = result.source_digest {
+            discovery_rows.push(framed(&[
+                result.logical_path.as_bytes(),
+                result.lang.name().as_bytes(),
+            ]));
+            line_rows.push(framed(&[result.logical_path.as_bytes(), digest.as_bytes()]));
+        }
+        for region in result.regions {
+            regions.push(RawRegionMetadata {
+                raw_digest: region.raw_digest,
+                raw_hit: region.raw_hit,
+                source_kind: region.source_kind,
+                logical_path: region.logical_path,
+                region_id: portable_il::region_identity(&region.il).hex(),
+            });
+            files.push(region.il);
+        }
+    }
+    discovery_rows.sort();
+    line_rows.sort();
+    let discovery_refs = discovery_rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let line_refs = line_rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    RawCorpus {
+        corpus: Corpus::new(interner, files),
+        regions,
+        discovery_digest: ContentDigest::derive(b"nose.discovery-membership.v1", &discovery_refs),
+        global_line_statistics_digest: ContentDigest::derive(
+            b"nose.corpus-global-line-statistics.v1",
+            &line_refs,
+        ),
+        workspace_digest: workspace_digest(roots),
+        source_hits,
+        source_misses,
+    }
+}
+
+fn workspace_digest(roots: &[&Path]) -> ContentDigest {
+    let rows = roots
+        .iter()
+        .map(|root| {
+            std::fs::canonicalize(root)
+                .unwrap_or_else(|_| root.to_path_buf())
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    let rows = rows.iter().map(String::as_bytes).collect::<Vec<_>>();
+    ContentDigest::derive(b"nose.workspace-state.v1", &rows)
+}
+
+// Keep the hit and miss paths together: both must construct exactly the same
+// region metadata before the parallel results are flattened into one corpus.
+#[allow(clippy::too_many_lines)]
+fn load_source(
+    index: usize,
+    path: &str,
+    lang: Lang,
+    logical_path: String,
+    git: &GitCatalog,
+    cas: &LayeredCas,
+    interner: &Interner,
+) -> SourceResult {
+    let clean_blob = git.clean_blob(Path::new(path));
+    let (source_digest, source_kind, source) = match clean_blob {
+        Some(blob) if std::fs::metadata(path).is_ok() => (
+            ContentDigest::derive(
+                b"nose.source-snapshot.git-blob.v1",
+                &[lang.name().as_bytes(), blob.as_bytes()],
+            ),
+            SourceIdentityKind::GitBlob,
+            None,
+        ),
+        _ => match std::fs::read(path) {
+            Ok(source) => (
+                portable_il::source_digest(lang, &source),
+                SourceIdentityKind::ContentSha256,
+                Some(source),
+            ),
+            Err(_) => {
+                return SourceResult {
+                    regions: Vec::new(),
+                    source_digest: None,
+                    logical_path,
+                    lang,
+                    snapshot_hit: false,
+                };
+            }
+        },
+    };
+    let snapshot_key = ArtifactKey::derive(
+        ArtifactStage::SourceSnapshot,
+        SOURCE_SNAPSHOT_SCHEMA,
+        &[source_digest.as_bytes()],
+    );
+    let snapshot_hit = cas.load(snapshot_key).is_some();
+    let raw_key = ArtifactKey::derive(
+        ArtifactStage::RawIl,
+        RAW_IL_SCHEMA,
+        &[source_digest.as_bytes()],
+    );
+    if let Some(entry) = cas.load(raw_key) {
+        if let Ok(bundle) = rmp_serde::from_slice::<PortableRawBundle>(&entry.payload) {
+            if bundle.schema == RAW_IL_SCHEMA {
+                let decoded = bundle
+                    .regions
+                    .iter()
+                    .map(|bytes| {
+                        portable_il::decode(bytes, interner, FileId(index as u32), path.to_owned())
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>();
+                if let Ok(decoded) = decoded {
+                    return SourceResult {
+                        regions: decoded
+                            .into_iter()
+                            .map(|il| RawRegion {
+                                raw_digest: portable_il::semantic_digest(&il, interner),
+                                il,
+                                raw_hit: true,
+                                source_kind,
+                                logical_path: logical_path.clone(),
+                            })
+                            .collect(),
+                        source_digest: Some(source_digest),
+                        logical_path,
+                        lang,
+                        snapshot_hit,
+                    };
+                }
+            }
+        }
+    }
+
+    let source = match source {
+        Some(source) => source,
+        None => match std::fs::read(path) {
+            Ok(source) => source,
+            Err(_) => {
+                return SourceResult {
+                    regions: Vec::new(),
+                    source_digest: None,
+                    logical_path,
+                    lang,
+                    snapshot_hit,
+                };
+            }
+        },
+    };
+    let lowered = if nose_frontend::source_is_analyzable(Path::new(path), lang, &source) {
+        nose_frontend::lower_source_regions(FileId(index as u32), path, &source, lang, interner)
+    } else {
+        Vec::new()
+    };
+    let bundle = PortableRawBundle {
+        schema: RAW_IL_SCHEMA,
+        regions: lowered
+            .iter()
+            .filter_map(|il| portable_il::encode(il, interner).ok())
+            .collect(),
+    };
+    if bundle.regions.len() == lowered.len() {
+        if let Ok(payload) = rmp_serde::to_vec(&bundle) {
+            let _ = cas.store(raw_key, &payload);
+            let _ = cas.store(snapshot_key, b"nose-source-snapshot-v1");
+        }
+    }
+    SourceResult {
+        regions: lowered
+            .into_iter()
+            .map(|il| RawRegion {
+                raw_digest: portable_il::semantic_digest(&il, interner),
+                il,
+                raw_hit: false,
+                source_kind,
+                logical_path: logical_path.clone(),
+            })
+            .collect(),
+        source_digest: Some(source_digest),
+        logical_path,
+        lang,
+        snapshot_hit,
+    }
+}
+
+fn logical_path(roots: &[&Path], path: &Path) -> String {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    for (index, root) in roots.iter().enumerate() {
+        let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+        let base = if canonical_root.is_file() {
+            canonical_root.parent().unwrap_or(&canonical_root)
+        } else {
+            &canonical_root
+        };
+        if let Ok(relative) = canonical.strip_prefix(base) {
+            return format!("{index}:{}", relative.to_string_lossy());
+        }
+    }
+    canonical.to_string_lossy().to_string()
+}
+
+fn framed(components: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for component in components {
+        out.extend_from_slice(&(component.len() as u64).to_be_bytes());
+        out.extend_from_slice(component);
+    }
+    out
+}
+
+struct GitInventory {
+    root: PathBuf,
+    tracked: BTreeMap<PathBuf, String>,
+    dirty: BTreeSet<PathBuf>,
+}
+
+struct GitCatalog(Vec<GitInventory>);
+
+impl GitCatalog {
+    fn new(roots: &[&Path]) -> Self {
+        let mut git_roots = BTreeSet::new();
+        for root in roots {
+            let base = if root.is_file() {
+                root.parent().unwrap_or(root)
+            } else {
+                root
+            };
+            let output = Command::new("git")
+                .args([
+                    "-C",
+                    &base.to_string_lossy(),
+                    "rev-parse",
+                    "--show-toplevel",
+                ])
+                .output();
+            if let Ok(output) = output {
+                if output.status.success() {
+                    let root = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+                    git_roots.insert(PathBuf::from(root));
+                }
+            }
+        }
+        Self(
+            git_roots
+                .into_iter()
+                .filter_map(GitInventory::load)
+                .collect(),
+        )
+    }
+
+    fn clean_blob(&self, path: &Path) -> Option<&str> {
+        let canonical = std::fs::canonicalize(path).ok()?;
+        self.0.iter().find_map(|git| {
+            let relative = canonical.strip_prefix(&git.root).ok()?;
+            (!git.dirty.contains(relative))
+                .then(|| git.tracked.get(relative).map(String::as_str))
+                .flatten()
+        })
+    }
+}
+
+impl GitInventory {
+    fn load(root: PathBuf) -> Option<Self> {
+        let root = std::fs::canonicalize(root).ok()?;
+        let listed = Command::new("git")
+            .args(["-C", &root.to_string_lossy(), "ls-files", "--stage", "-z"])
+            .output()
+            .ok()?;
+        let status = Command::new("git")
+            .args([
+                "-C",
+                &root.to_string_lossy(),
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=no",
+            ])
+            .output()
+            .ok()?;
+        if !listed.status.success() || !status.status.success() {
+            return None;
+        }
+        let mut tracked = BTreeMap::new();
+        for record in listed
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|row| !row.is_empty())
+        {
+            let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+                continue;
+            };
+            let header = String::from_utf8_lossy(&record[..tab]);
+            let mut fields = header.split_whitespace();
+            let _mode = fields.next();
+            let Some(oid) = fields.next() else { continue };
+            if fields.next() != Some("0") {
+                continue;
+            }
+            tracked.insert(
+                PathBuf::from(String::from_utf8_lossy(&record[tab + 1..]).as_ref()),
+                oid.to_owned(),
+            );
+        }
+        let mut dirty = BTreeSet::new();
+        let records = status
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|row| !row.is_empty())
+            .collect::<Vec<_>>();
+        let mut index = 0;
+        while index < records.len() {
+            let record = records[index];
+            if record.len() >= 4 {
+                dirty.insert(PathBuf::from(
+                    String::from_utf8_lossy(&record[3..]).as_ref(),
+                ));
+                if matches!(record[0], b'R' | b'C') || matches!(record[1], b'R' | b'C') {
+                    index += 1;
+                    if let Some(old) = records.get(index) {
+                        dirty.insert(PathBuf::from(String::from_utf8_lossy(old).as_ref()));
+                    }
+                }
+            }
+            index += 1;
+        }
+        Some(Self {
+            root,
+            tracked,
+            dirty,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_size_and_mtime_never_override_content_identity() {
+        let first = portable_il::source_digest(Lang::Python, b"return x + 1\n");
+        let second = portable_il::source_digest(Lang::Python, b"return x - 1\n");
+        assert_ne!(first, second);
+    }
+}

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -248,9 +248,28 @@ fn query_detect_report(
     nose_semantics::SemanticPackNearRegistry,
     nose_semantics::SemanticPackExternalExactRegistry,
 ) {
-    // Lower AND cross-file-resolve every run. The cache skips only the dominant
-    // normalize/extract step and therefore stays identical to the uncached path.
-    let mut corpus = time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude));
+    let (mut corpus, invalidation_report, unit_contexts) = if let Some(dir) = &args.cache_dir {
+        let cached = time_lower(|| cache::build_corpus_cached(refs, exclude, dir, semantic_packs));
+        (
+            cached.corpus,
+            Some(cached.report),
+            Some(cached.unit_contexts),
+        )
+    } else {
+        (
+            time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude)),
+            None,
+            None,
+        )
+    };
+    if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+        if let Some(report) = &invalidation_report {
+            eprintln!(
+                "  [invalidation] {}",
+                cache::invalidation_report_json(report)
+            );
+        }
+    }
     let scope = QueryScope::from_corpus(&corpus);
     let semantic_pack_evidence =
         nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
@@ -271,7 +290,16 @@ fn query_detect_report(
             streams,
             files,
             stats,
-        } = time_stage("cache", || cache::build_units_cached(&corpus, opts, dir));
+        } = time_stage("cache", || {
+            cache::build_units_cached_with_context(
+                &corpus,
+                opts,
+                dir,
+                unit_contexts
+                    .as_deref()
+                    .expect("cached corpus includes unit contexts"),
+            )
+        });
         if std::env::var_os("NOSE_CACHE_STATS").is_some() {
             eprintln!(
                 "  [cache] files={} hits={} misses={} read_bytes={} written_bytes={}",

--- a/crates/nose-cli/tests/cli/cache.rs
+++ b/crates/nose-cli/tests/cli/cache.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::Deserialize;
 use std::process::Output;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -6,6 +7,36 @@ struct CacheStats {
     files: usize,
     hits: usize,
     misses: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct InvalidationReport {
+    schema: String,
+    global_invalidations: Vec<String>,
+    source_snapshots: LayerStats,
+    raw_il: LayerStats,
+    resolved_il: LayerStats,
+    invalidated: Vec<InvalidatedRegion>,
+    over_invalidated: Vec<String>,
+    source_identities: SourceIdentityCounts,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceIdentityCounts {
+    git_blob: usize,
+    content_sha256: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayerStats {
+    hits: usize,
+    misses: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct InvalidatedRegion {
+    path: String,
+    reasons: Vec<String>,
 }
 
 fn query(project: &Path, cache: Option<&Path>) -> Output {
@@ -57,6 +88,19 @@ fn cache_stats(output: &Output) -> CacheStats {
     }
 }
 
+fn invalidation_report(output: &Output) -> InvalidationReport {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|line| line.trim_start().starts_with("[invalidation]"))
+        .unwrap_or_else(|| panic!("missing invalidation report in stderr: {stderr}"));
+    let json = line
+        .trim_start()
+        .strip_prefix("[invalidation] ")
+        .expect("invalidation report prefix");
+    serde_json::from_str(json).expect("valid invalidation JSON")
+}
+
 #[test]
 fn clone_shaped_files_keep_their_own_names_on_a_warm_hit() {
     let project = TempProject::new("cache_reporting_identity");
@@ -76,6 +120,16 @@ fn clone_shaped_files_keep_their_own_names_on_a_warm_hit() {
 
     assert_eq!(cold.stdout, clean.stdout);
     assert_eq!(warm.stdout, clean.stdout);
+    let warm_invalidation = invalidation_report(&warm);
+    assert_eq!(
+        (
+            warm_invalidation.resolved_il.hits,
+            warm_invalidation.resolved_il.misses
+        ),
+        (3, 0)
+    );
+    assert!(warm_invalidation.invalidated.is_empty());
+    assert!(warm_invalidation.global_invalidations.is_empty());
     assert_eq!(
         cache_stats(&warm),
         CacheStats {
@@ -153,6 +207,229 @@ fn provider_edit_keeps_issue_275_output_equal_and_invalidates_the_importer() {
             files: 3,
             hits: 3,
             misses: 0
+        }
+    );
+}
+
+#[test]
+fn provider_internal_edit_does_not_invalidate_importers() {
+    let project = TempProject::new("cache_export_surface");
+    project.write(
+        "tables.py",
+        "LOOKUP = {\"red\": 1}\n\ndef helper():\n    return 1\n",
+    );
+    project.write(
+        "imported.py",
+        "from tables import LOOKUP\n\ndef lookup(key):\n    return LOOKUP.get(key, 0)\n",
+    );
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write(
+        "tables.py",
+        "def helper():\n    return 9\n\nLOOKUP = {\"red\": 1}\n",
+    );
+    let output = query(project.path(), Some(&cache));
+    let report = invalidation_report(&output);
+    assert_eq!(report.schema, "nose.invalidation/v1");
+    assert_eq!((report.raw_il.hits, report.raw_il.misses), (1, 1));
+    assert_eq!((report.resolved_il.hits, report.resolved_il.misses), (1, 1));
+    assert_eq!(report.invalidated.len(), 1);
+    assert!(report.invalidated[0].path.ends_with("tables.py"));
+    assert_eq!(report.invalidated[0].reasons, ["source-content"]);
+}
+
+#[test]
+fn adding_an_earlier_path_does_not_invalidate_shifted_file_ids() {
+    let project = TempProject::new("cache_file_id_shift");
+    project.write("b.py", "VALUE = {\"answer\": 1}\n");
+    project.write(
+        "c.py",
+        "from b import VALUE\n\ndef c():\n    return VALUE.get(\"answer\", 0)\n",
+    );
+    project.write("d.py", "def d(x):\n    return x + 3\n");
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write("a.py", "def a(x):\n    return x + 4\n");
+    let output = query(project.path(), Some(&cache));
+    let report = invalidation_report(&output);
+    assert_eq!(
+        (report.source_snapshots.hits, report.source_snapshots.misses),
+        (3, 1)
+    );
+    assert_eq!((report.raw_il.hits, report.raw_il.misses), (3, 1));
+    assert_eq!((report.resolved_il.hits, report.resolved_il.misses), (4, 0));
+    assert_eq!(report.invalidated.len(), 1);
+    assert!(report.invalidated[0].path.ends_with("a.py"));
+    assert!(report
+        .global_invalidations
+        .iter()
+        .any(|reason| reason == "discovery-membership"));
+}
+
+#[test]
+fn swift_global_barrier_invalidates_every_swift_consumer() {
+    let project = TempProject::new("cache_swift_barrier");
+    project.write(
+        "User.swift",
+        "func positive(_ values: [Int]) -> Bool {\n  values.allSatisfy { $0 >= 0 }\n}\n",
+    );
+    project.write(
+        "Twin.swift",
+        "func alsoPositive(_ values: [Int]) -> Bool {\n  values.allSatisfy { $0 >= 0 }\n}\n",
+    );
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write(
+        "Overload.swift",
+        "extension Array where Element == Int {\n  func allSatisfy(_ predicate: (Int) -> Bool) -> Bool { false }\n}\n",
+    );
+    let output = query(project.path(), Some(&cache));
+    let report = invalidation_report(&output);
+    assert_eq!((report.raw_il.hits, report.raw_il.misses), (2, 1));
+    assert_eq!((report.resolved_il.hits, report.resolved_il.misses), (0, 3));
+    assert_eq!(report.invalidated.len(), 3);
+    assert!(report.invalidated.iter().any(|region| region
+        .reasons
+        .iter()
+        .any(|reason| reason == "swift-global-sentinel")));
+}
+
+#[test]
+fn unknown_imports_fail_safe_and_report_over_invalidation() {
+    let project = TempProject::new("cache_unknown_dependency");
+    project.write(
+        "consumer.py",
+        "from absent import VALUE\n\ndef value():\n    return VALUE\n",
+    );
+    project.write("other.py", "EXPORTED = 1\n");
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write("other.py", "EXPORTED = 2\n");
+    let output = query(project.path(), Some(&cache));
+    let report = invalidation_report(&output);
+    assert_eq!((report.raw_il.hits, report.raw_il.misses), (1, 1));
+    assert_eq!((report.resolved_il.hits, report.resolved_il.misses), (1, 1));
+    assert_eq!(
+        cache_stats(&output),
+        CacheStats {
+            files: 2,
+            hits: 0,
+            misses: 2,
+        }
+    );
+    assert!(report
+        .over_invalidated
+        .iter()
+        .any(|path| path.ends_with("consumer.py")));
+    assert!(report.invalidated.iter().any(|region| {
+        region.path.ends_with("consumer.py")
+            && region
+                .reasons
+                .iter()
+                .any(|reason| reason == "unknown-dependency-over-invalidation")
+    }));
+}
+
+#[test]
+fn clean_tracked_sources_use_git_blob_identity_but_dirty_sources_use_content() {
+    let project = TempProject::new("cache_git_identity");
+    project.write("tracked.py", "def value(x):\n    return x + 1\n");
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "cache@example.invalid"][..],
+        &["config", "user.name", "Cache Test"][..],
+        &["add", "tracked.py"][..],
+        &["commit", "-qm", "fixture"][..],
+    ] {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(project.path())
+            .args(args)
+            .status()
+            .expect("run git fixture command");
+        assert!(status.success());
+    }
+    let cache = project.path().join(".cache");
+    let clean = query(project.path(), Some(&cache));
+    let clean_report = invalidation_report(&clean);
+    assert_eq!(clean_report.source_identities.git_blob, 1);
+    assert_eq!(clean_report.source_identities.content_sha256, 0);
+
+    project.write("tracked.py", "def value(x):\n    return x - 1\n");
+    let dirty = query(project.path(), Some(&cache));
+    let dirty_report = invalidation_report(&dirty);
+    assert_eq!(dirty_report.source_identities.git_blob, 0);
+    assert_eq!(dirty_report.source_identities.content_sha256, 1);
+}
+
+#[test]
+fn a_new_ambiguous_provider_invalidates_the_import_consumer_fail_safe() {
+    let project = TempProject::new("cache_provider_ambiguity");
+    project.write("tables.py", "VALUE = {\"answer\": 1}\n");
+    project.write(
+        "consumer.py",
+        "from tables import VALUE\n\ndef answer():\n    return VALUE.get(\"answer\", 0)\n",
+    );
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write("duplicate/tables.py", "VALUE = {\"answer\": 1}\n");
+    let clean = query(project.path(), None);
+    let cached = query(project.path(), Some(&cache));
+    assert_eq!(cached.stdout, clean.stdout);
+    let report = invalidation_report(&cached);
+    assert!(report.invalidated.iter().any(|region| {
+        region.path.ends_with("consumer.py")
+            && region
+                .reasons
+                .iter()
+                .any(|reason| reason == "unknown-dependency-over-invalidation")
+    }));
+    assert!(report
+        .over_invalidated
+        .iter()
+        .any(|path| path.ends_with("consumer.py")));
+}
+
+#[test]
+fn a_new_go_namespace_export_invalidates_a_partially_resolved_consumer() {
+    let project = TempProject::new("cache_go_partial_namespace");
+    project.write(
+        "tables.go",
+        "package tables\nvar Lookup = map[string]int{\"red\": 1}\n",
+    );
+    project.write(
+        "consumer.go",
+        "package consumer\nimport \"tables\"\nfunc value(key string) int { return tables.Lookup[key] + tables.Missing[key] }\n",
+    );
+    let cache = project.path().join(".cache");
+    query(project.path(), Some(&cache));
+
+    project.write(
+        "tables.go",
+        "package tables\nvar Lookup = map[string]int{\"red\": 1}\nvar Missing = map[string]int{\"red\": 2}\n",
+    );
+    let clean = query(project.path(), None);
+    let cached = query(project.path(), Some(&cache));
+    assert_eq!(cached.stdout, clean.stdout);
+    let report = invalidation_report(&cached);
+    assert!(report.invalidated.iter().any(|region| {
+        region.path.ends_with("consumer.go")
+            && region
+                .reasons
+                .iter()
+                .any(|reason| reason == "dependency-export")
+    }));
+    assert_eq!(
+        cache_stats(&cached),
+        CacheStats {
+            files: 2,
+            hits: 0,
+            misses: 2,
         }
     );
 }

--- a/crates/nose-frontend/Cargo.toml
+++ b/crates/nose-frontend/Cargo.toml
@@ -14,6 +14,8 @@ ignore = { workspace = true }
 memchr = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
+sha2 = { workspace = true }
+rmp-serde = { workspace = true }
 
 # Core 0.25 accepts grammar ABI 14 AND 15, so the ABI-15 grammars below (python/
 # javascript 0.25, c 0.24, go 0.25, rust 0.24) load alongside the ABI-14 grammars

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -30,7 +30,11 @@ mod semantic_pack_evidence_tests;
 pub use coverage::{coverage, raw_node_surface, CoverageReport, RawSurface};
 pub use declaration_facts::{declaration_facts, DeclarationFacts};
 pub use discover::{discover_paths, discover_unique_paths};
-pub use module_imports::{imported_immutable_snapshot_census, ImportSnapshotCensus};
+pub use module_imports::{
+    imported_immutable_snapshot_census, resolution_dependency_summary,
+    FileResolutionDependencySummary, ImportSnapshotCensus, ResolutionDependency,
+    ResolutionDependencyKind, ResolutionDependencySummary,
+};
 
 use nose_il::{Corpus, FileId, Il, Interner, Lang};
 use rayon::prelude::*;
@@ -137,6 +141,13 @@ pub fn is_intentional_raw_boundary_tag(tag: &str) -> bool {
     lower::is_intentional_raw_boundary_tag(tag)
 }
 
+/// Whether a discovered source buffer should enter the analysis corpus. Cache
+/// loaders use the same generated/binary artifact gate as the uncached path so
+/// an artifact never becomes analyzable merely because it was cached.
+pub fn source_is_analyzable(path: &Path, lang: Lang, source: &[u8]) -> bool {
+    source_artifacts::skip_reason(path, lang, source).is_none()
+}
+
 /// Lower every analyzable region of a file into separate [`Il`]s. For most languages
 /// this is one `Il` (delegating to [`lower_source`]); for `<script>`/`<style>`-bearing
 /// containers (Vue/Svelte/HTML) it is one per embedded region (JS/TS for `<script>`, CSS
@@ -233,10 +244,28 @@ pub fn lower_corpus_raw_filtered(roots: &[&Path], exclude: &[String]) -> Corpus 
 /// this boundary explicit lets raw and resolved artifacts round-trip separately
 /// without changing the clean-scan pipeline.
 pub fn resolve_corpus(corpus: &mut Corpus) {
+    let targets = vec![true; corpus.files.len()];
+    resolve_corpus_affected(corpus, &targets);
+}
+
+/// Resolve only the selected raw IL regions while reading dependency facts from
+/// the complete raw corpus. Callers can then replace unselected regions with
+/// previously resolved portable artifacts without making dependency discovery
+/// depend on stale resolved evidence.
+pub fn resolve_corpus_affected(corpus: &mut Corpus, targets: &[bool]) {
+    assert_eq!(corpus.files.len(), targets.len());
     let timing = std::env::var_os("NOSE_TIME").is_some();
     let started = std::time::Instant::now();
-    module_imports::resolve_imported_immutable_bindings(&mut corpus.files, &corpus.interner);
-    swift_cross_file_shadows::close_shadowed_stdlib_apis(&mut corpus.files, &corpus.interner);
+    module_imports::resolve_imported_immutable_bindings_affected(
+        &mut corpus.files,
+        &corpus.interner,
+        targets,
+    );
+    swift_cross_file_shadows::close_shadowed_stdlib_apis_affected(
+        &mut corpus.files,
+        &corpus.interner,
+        targets,
+    );
     if timing {
         eprintln!(
             "  [time] {:<12} {:>7.1}ms  (corpus import facts)",

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -40,7 +40,6 @@ use snapshot::{
 struct ExportedBinding {
     file_idx: usize,
     deps: Vec<SubtreeSnapshot>,
-    dependency_keys: Vec<(u64, u64)>,
     rhs: NodeId,
 }
 

--- a/crates/nose-frontend/src/module_imports.rs
+++ b/crates/nose-frontend/src/module_imports.rs
@@ -8,6 +8,7 @@
 //! module-binding seed can reuse its mutation and canonicalization logic.
 
 mod bindings;
+mod dependency;
 mod diagnostics;
 mod exports;
 mod modules;
@@ -17,12 +18,16 @@ mod snapshot;
 use bindings::{
     assignment_name, collect_top_level_statements, import_binding_proof, BindingUseIndex,
 };
+pub use dependency::{
+    resolution_dependency_summary, FileResolutionDependencySummary, ResolutionDependency,
+    ResolutionDependencyKind, ResolutionDependencySummary,
+};
 pub use diagnostics::{imported_immutable_snapshot_census, ImportSnapshotCensus};
 use exports::collect_literal_exports;
 use modules::{
     file_module_hashes, rust_importable_module_hashes, rust_module_identity, RustModuleIdentity,
 };
-use namespace_members::{collect_namespace_member_replacements, NamespaceMemberReplacement};
+use namespace_members::{collect_namespace_member_analyses, NamespaceMemberReplacement};
 use nose_il::{EvidenceId, Il, Interner, NodeId};
 use nose_semantics::semantics;
 use snapshot::{
@@ -35,6 +40,7 @@ use snapshot::{
 struct ExportedBinding {
     file_idx: usize,
     deps: Vec<SubtreeSnapshot>,
+    dependency_keys: Vec<(u64, u64)>,
     rhs: NodeId,
 }
 
@@ -48,7 +54,12 @@ struct ImportReplacement {
     rhs_snapshot: SubtreeSnapshot,
 }
 
-pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &Interner) {
+pub(crate) fn resolve_imported_immutable_bindings_affected(
+    files: &mut [Il],
+    interner: &Interner,
+    targets: &[bool],
+) {
+    debug_assert_eq!(files.len(), targets.len());
     let contexts: Vec<FileImportContext> = files
         .iter()
         .map(|il| FileImportContext::new(il, interner))
@@ -58,6 +69,9 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         return;
     }
     for (&(module_hash, exported_hash), export) in exports.iter_keyed() {
+        if !targets[export.file_idx] {
+            continue;
+        }
         record_immutable_literal_export_evidence(
             &mut files[export.file_idx],
             export.rhs,
@@ -71,6 +85,9 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         .iter()
         .enumerate()
         .map(|(file_idx, il)| {
+            if !targets[file_idx] {
+                return Vec::new();
+            }
             let context = &contexts[file_idx];
             let Some(top_level) = context.top_level.as_deref() else {
                 return Vec::new();
@@ -108,14 +125,30 @@ pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &I
         })
         .collect();
     let namespace_replacements =
-        collect_namespace_member_replacements(files, interner, &contexts, &exports);
+        collect_namespace_member_analyses(files, interner, &contexts, &exports)
+            .into_iter()
+            .map(|analysis| analysis.replacements)
+            .collect();
 
-    apply_import_replacements(files, replacements);
-    apply_namespace_member_replacements(files, namespace_replacements);
+    apply_import_replacements(files, replacements, targets);
+    apply_namespace_member_replacements(files, namespace_replacements, targets);
 }
 
-fn apply_import_replacements(files: &mut [Il], replacements: Vec<Vec<ImportReplacement>>) {
+#[cfg(test)]
+pub(crate) fn resolve_imported_immutable_bindings(files: &mut [Il], interner: &Interner) {
+    let targets = vec![true; files.len()];
+    resolve_imported_immutable_bindings_affected(files, interner, &targets);
+}
+
+fn apply_import_replacements(
+    files: &mut [Il],
+    replacements: Vec<Vec<ImportReplacement>>,
+    targets: &[bool],
+) {
     for (file_idx, file_replacements) in replacements.into_iter().enumerate() {
+        if !targets[file_idx] {
+            continue;
+        }
         for replacement in file_replacements {
             let (rhs, snapshot_evidence) = append_replacement_snapshot(
                 &mut files[file_idx],
@@ -138,8 +171,12 @@ fn apply_import_replacements(files: &mut [Il], replacements: Vec<Vec<ImportRepla
 fn apply_namespace_member_replacements(
     files: &mut [Il],
     replacements: Vec<Vec<NamespaceMemberReplacement>>,
+    targets: &[bool],
 ) {
     for (file_idx, file_replacements) in replacements.into_iter().enumerate() {
+        if !targets[file_idx] {
+            continue;
+        }
         for replacement in file_replacements {
             let (rhs, snapshot_evidence) = append_replacement_snapshot(
                 &mut files[file_idx],

--- a/crates/nose-frontend/src/module_imports/bindings.rs
+++ b/crates/nose-frontend/src/module_imports/bindings.rs
@@ -34,6 +34,21 @@ pub(super) fn import_dependency_snapshots(
         .collect()
 }
 
+pub(super) fn import_dependency_keys(
+    il: &Il,
+    rhs: NodeId,
+    top_level: &[NodeId],
+) -> Vec<(u64, u64)> {
+    top_level
+        .iter()
+        .copied()
+        .filter(|&stmt| {
+            assignment_name(il, stmt).is_some_and(|name| node_contains_symbol(il, rhs, name))
+        })
+        .filter_map(|stmt| import_binding_key(il, stmt))
+        .collect()
+}
+
 pub(super) fn collect_top_level_statements(il: &Il) -> Vec<NodeId> {
     let class_roots: FxHashSet<NodeId> = il
         .units

--- a/crates/nose-frontend/src/module_imports/dependency.rs
+++ b/crates/nose-frontend/src/module_imports/dependency.rs
@@ -1,0 +1,486 @@
+use super::bindings::{assignment_name, import_binding_proof};
+use super::exports::{collect_literal_exports, LiteralExports};
+use super::namespace_members::collect_namespace_member_analyses;
+use super::snapshot::{snapshot_subtree, surface_fingerprint};
+use super::{ExportedBinding, FileImportContext};
+use nose_il::{Il, Interner, Lang};
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ResolutionDependencyKind {
+    ImportedBinding,
+    ImportedNamespaceMember,
+    UnknownBinding,
+    UnknownNamespace,
+    SwiftGlobalSentinel,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ResolutionDependency {
+    pub kind: ResolutionDependencyKind,
+    pub provider_file: Option<usize>,
+    pub module_hash: Option<u64>,
+    pub exported_hash: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FileResolutionDependencySummary {
+    pub export_digest: [u8; 32],
+    pub resolution_digest: [u8; 32],
+    pub dependencies: Vec<ResolutionDependency>,
+    pub over_invalidated: bool,
+    pub requires_resolution: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolutionDependencySummary {
+    pub files: Vec<FileResolutionDependencySummary>,
+    pub swift_global_digest: [u8; 32],
+    pub swift_global_active: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct BindingKey {
+    file: usize,
+    root: u32,
+}
+
+impl BindingKey {
+    fn of(binding: &ExportedBinding) -> Self {
+        Self {
+            file: binding.file_idx,
+            root: binding.rhs.0,
+        }
+    }
+}
+
+struct BindingNode {
+    base: [u8; 32],
+    edges: Vec<BindingEdge>,
+}
+
+#[derive(Clone, Copy)]
+struct BindingEdge {
+    module_hash: u64,
+    exported_hash: u64,
+    target: usize,
+}
+
+/// Describe exactly which corpus facts can change each resolved IL. Export
+/// fingerprints contain only consumer-visible literal snapshots; dependency
+/// cycles are collapsed before hashing, so traversal order cannot affect keys.
+pub fn resolution_dependency_summary(
+    files: &[Il],
+    interner: &Interner,
+) -> ResolutionDependencySummary {
+    let contexts = files
+        .iter()
+        .map(|il| FileImportContext::new(il, interner))
+        .collect::<Vec<_>>();
+    let exports = collect_literal_exports(files, interner, &contexts);
+    let (nodes, binding_indexes) = binding_graph(files, interner, &contexts, &exports);
+    let binding_digests = binding_digests(&nodes);
+    let (file_export_digests, file_has_exports) =
+        file_export_digests(files.len(), &exports, &binding_indexes, &binding_digests);
+    let language_catalogs = language_catalogs(files, &file_export_digests);
+    let (swift_global_digest, swift_global_active) =
+        crate::swift_cross_file_shadows::swift_global_dependency_state(files, interner);
+    let namespace_analyses =
+        collect_namespace_member_analyses(files, interner, &contexts, &exports);
+
+    let summaries = files
+        .iter()
+        .enumerate()
+        .map(|(file_idx, il)| {
+            summarize_file(
+                file_idx,
+                il,
+                files,
+                interner,
+                &contexts,
+                &exports,
+                &binding_indexes,
+                &binding_digests,
+                &file_export_digests,
+                file_has_exports[file_idx],
+                language_catalogs[&il.meta.lang],
+                swift_global_digest,
+                swift_global_active,
+                &namespace_analyses[file_idx],
+            )
+        })
+        .collect();
+    ResolutionDependencySummary {
+        files: summaries,
+        swift_global_digest,
+        swift_global_active,
+    }
+}
+
+fn binding_graph(
+    files: &[Il],
+    interner: &Interner,
+    contexts: &[FileImportContext],
+    exports: &LiteralExports,
+) -> (Vec<BindingNode>, BTreeMap<BindingKey, usize>) {
+    let mut bindings = BTreeMap::new();
+    for record in exports.records() {
+        bindings.insert(BindingKey::of(&record.binding), record.binding.clone());
+    }
+    let indexes = bindings
+        .keys()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<BTreeMap<_, _>>();
+    let nodes = bindings
+        .into_values()
+        .map(|binding| {
+            let rhs = snapshot_subtree(&files[binding.file_idx], binding.rhs);
+            let mut components = vec![surface_fingerprint(&rhs, interner).to_vec()];
+            components.extend(
+                binding
+                    .deps
+                    .iter()
+                    .map(|snapshot| surface_fingerprint(snapshot, interner).to_vec()),
+            );
+            let refs = components.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            let base = derive(b"nose.export-surface.base.v1", &refs);
+            let mut edges = binding
+                .dependency_keys
+                .iter()
+                .filter_map(|&(module_hash, exported_hash)| {
+                    let target =
+                        exports.get(contexts, binding.file_idx, module_hash, exported_hash)?;
+                    let target = indexes.get(&BindingKey::of(target)).copied()?;
+                    Some(BindingEdge {
+                        module_hash,
+                        exported_hash,
+                        target,
+                    })
+                })
+                .collect::<Vec<_>>();
+            edges.sort_by_key(|edge| (edge.module_hash, edge.exported_hash, edge.target));
+            BindingNode { base, edges }
+        })
+        .collect();
+    (nodes, indexes)
+}
+
+fn binding_digests(nodes: &[BindingNode]) -> Vec<[u8; 32]> {
+    let components = strongly_connected_components(nodes);
+    let mut component_of = vec![0; nodes.len()];
+    for (component, members) in components.iter().enumerate() {
+        for &member in members {
+            component_of[member] = component;
+        }
+    }
+    let mut memo = vec![None; components.len()];
+    fn component_digest(
+        component: usize,
+        components: &[Vec<usize>],
+        component_of: &[usize],
+        nodes: &[BindingNode],
+        memo: &mut [Option<[u8; 32]>],
+    ) -> [u8; 32] {
+        if let Some(digest) = memo[component] {
+            return digest;
+        }
+        let mut rows = Vec::new();
+        for &member in &components[component] {
+            rows.push(framed(&[nodes[member].base.as_slice()]));
+            for edge in &nodes[member].edges {
+                let target_component = component_of[edge.target];
+                let target = if target_component == component {
+                    nodes[edge.target].base
+                } else {
+                    component_digest(target_component, components, component_of, nodes, memo)
+                };
+                rows.push(framed(&[
+                    nodes[member].base.as_slice(),
+                    &edge.module_hash.to_be_bytes(),
+                    &edge.exported_hash.to_be_bytes(),
+                    target.as_slice(),
+                ]));
+            }
+        }
+        rows.sort();
+        let refs = rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let digest = derive(b"nose.export-surface.scc.v1", &refs);
+        memo[component] = Some(digest);
+        digest
+    }
+
+    let mut out = vec![[0; 32]; nodes.len()];
+    for index in 0..nodes.len() {
+        let component = component_of[index];
+        let aggregate = component_digest(component, &components, &component_of, nodes, &mut memo);
+        out[index] = derive(
+            b"nose.export-surface.member.v1",
+            &[nodes[index].base.as_slice(), aggregate.as_slice()],
+        );
+    }
+    out
+}
+
+fn strongly_connected_components(nodes: &[BindingNode]) -> Vec<Vec<usize>> {
+    struct Tarjan<'a> {
+        nodes: &'a [BindingNode],
+        next: usize,
+        indexes: Vec<Option<usize>>,
+        low: Vec<usize>,
+        stack: Vec<usize>,
+        on_stack: Vec<bool>,
+        out: Vec<Vec<usize>>,
+    }
+    impl Tarjan<'_> {
+        fn visit(&mut self, node: usize) {
+            let index = self.next;
+            self.next += 1;
+            self.indexes[node] = Some(index);
+            self.low[node] = index;
+            self.stack.push(node);
+            self.on_stack[node] = true;
+            for edge in &self.nodes[node].edges {
+                if self.indexes[edge.target].is_none() {
+                    self.visit(edge.target);
+                    self.low[node] = self.low[node].min(self.low[edge.target]);
+                } else if self.on_stack[edge.target] {
+                    self.low[node] = self.low[node].min(self.indexes[edge.target].unwrap());
+                }
+            }
+            if self.low[node] != index {
+                return;
+            }
+            let mut component = Vec::new();
+            loop {
+                let member = self.stack.pop().expect("SCC root must be on the stack");
+                self.on_stack[member] = false;
+                component.push(member);
+                if member == node {
+                    break;
+                }
+            }
+            component.sort_unstable();
+            self.out.push(component);
+        }
+    }
+    let mut state = Tarjan {
+        nodes,
+        next: 0,
+        indexes: vec![None; nodes.len()],
+        low: vec![0; nodes.len()],
+        stack: Vec::new(),
+        on_stack: vec![false; nodes.len()],
+        out: Vec::new(),
+    };
+    for node in 0..nodes.len() {
+        if state.indexes[node].is_none() {
+            state.visit(node);
+        }
+    }
+    state.out
+}
+
+fn file_export_digests(
+    file_count: usize,
+    exports: &LiteralExports,
+    indexes: &BTreeMap<BindingKey, usize>,
+    binding_digests: &[[u8; 32]],
+) -> (Vec<[u8; 32]>, Vec<bool>) {
+    let mut rows = vec![Vec::new(); file_count];
+    for (&(module_hash, exported_hash), binding) in exports.iter_keyed() {
+        let digest = binding_digests[indexes[&BindingKey::of(binding)]];
+        rows[binding.file_idx].push(framed(&[
+            &module_hash.to_be_bytes(),
+            &exported_hash.to_be_bytes(),
+            digest.as_slice(),
+        ]));
+    }
+    for reexport in exports.reexports() {
+        rows[reexport.file_idx].push(framed(&[
+            &reexport.local_exported_hash.to_be_bytes(),
+            &reexport.target_module_hash.to_be_bytes(),
+            &reexport.target_exported_hash.to_be_bytes(),
+        ]));
+    }
+    let has_exports = rows.iter().map(|rows| !rows.is_empty()).collect();
+    let digests = rows
+        .into_iter()
+        .map(|mut rows| {
+            rows.sort();
+            let refs = rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            derive(b"nose.file-export-surface.v1", &refs)
+        })
+        .collect();
+    (digests, has_exports)
+}
+
+fn language_catalogs(files: &[Il], exports: &[[u8; 32]]) -> FxHashMap<Lang, [u8; 32]> {
+    let mut rows: FxHashMap<Lang, Vec<Vec<u8>>> = FxHashMap::default();
+    for (il, digest) in files.iter().zip(exports) {
+        rows.entry(il.meta.lang).or_default().push(digest.to_vec());
+    }
+    rows.into_iter()
+        .map(|(lang, mut rows)| {
+            rows.sort();
+            let refs = rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            (lang, derive(b"nose.language-export-catalog.v1", &refs))
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn summarize_file(
+    file_idx: usize,
+    il: &Il,
+    files: &[Il],
+    interner: &Interner,
+    contexts: &[FileImportContext],
+    exports: &LiteralExports,
+    indexes: &BTreeMap<BindingKey, usize>,
+    binding_digests: &[[u8; 32]],
+    file_exports: &[[u8; 32]],
+    has_exports: bool,
+    catalog: [u8; 32],
+    swift_digest: [u8; 32],
+    swift_active: bool,
+    namespace_analysis: &super::namespace_members::NamespaceMemberAnalysis,
+) -> FileResolutionDependencySummary {
+    let top_level = contexts[file_idx].top_level.as_deref().unwrap_or_default();
+    let mut dependencies = Vec::new();
+    let mut hash_rows = Vec::new();
+    for &stmt in top_level {
+        if let Some(proof) = import_binding_proof(il, stmt) {
+            let Some(local) = assignment_name(il, stmt) else {
+                continue;
+            };
+            if contexts[file_idx]
+                .binding_uses(il, interner)
+                .binding_mutated(il, local, stmt)
+            {
+                continue;
+            }
+            let export = exports.get(contexts, file_idx, proof.module_hash, proof.exported_hash);
+            if let Some(export) = export.filter(|export| {
+                export.file_idx != file_idx && files[export.file_idx].meta.lang == il.meta.lang
+            }) {
+                let digest = binding_digests[indexes[&BindingKey::of(export)]];
+                dependencies.push(ResolutionDependency {
+                    kind: ResolutionDependencyKind::ImportedBinding,
+                    provider_file: Some(export.file_idx),
+                    module_hash: Some(proof.module_hash),
+                    exported_hash: Some(proof.exported_hash),
+                });
+                hash_rows.push(framed(&[
+                    b"binding",
+                    &proof.module_hash.to_be_bytes(),
+                    &proof.exported_hash.to_be_bytes(),
+                    digest.as_slice(),
+                ]));
+            } else {
+                dependencies.push(ResolutionDependency {
+                    kind: ResolutionDependencyKind::UnknownBinding,
+                    provider_file: None,
+                    module_hash: Some(proof.module_hash),
+                    exported_hash: Some(proof.exported_hash),
+                });
+                hash_rows.push(framed(&[
+                    b"unknown-binding",
+                    &proof.module_hash.to_be_bytes(),
+                    &proof.exported_hash.to_be_bytes(),
+                    catalog.as_slice(),
+                ]));
+            }
+        }
+    }
+    for replacement in &namespace_analysis.replacements {
+        let Some(export) = exports.get_exact(replacement.module_hash, replacement.exported_hash)
+        else {
+            continue;
+        };
+        let digest = binding_digests[indexes[&BindingKey::of(export)]];
+        dependencies.push(ResolutionDependency {
+            kind: ResolutionDependencyKind::ImportedNamespaceMember,
+            provider_file: Some(replacement.provider_file_idx),
+            module_hash: Some(replacement.module_hash),
+            exported_hash: Some(replacement.exported_hash),
+        });
+        hash_rows.push(framed(&[
+            b"namespace-member",
+            &replacement.module_hash.to_be_bytes(),
+            &replacement.exported_hash.to_be_bytes(),
+            digest.as_slice(),
+        ]));
+    }
+    for &(module_hash, exported_hash) in &namespace_analysis.unresolved {
+        dependencies.push(ResolutionDependency {
+            kind: ResolutionDependencyKind::UnknownNamespace,
+            provider_file: None,
+            module_hash: Some(module_hash),
+            exported_hash: Some(exported_hash),
+        });
+        hash_rows.push(framed(&[
+            b"unknown-namespace",
+            &module_hash.to_be_bytes(),
+            &exported_hash.to_be_bytes(),
+            catalog.as_slice(),
+        ]));
+    }
+    if il.meta.lang == Lang::Swift {
+        dependencies.push(ResolutionDependency {
+            kind: ResolutionDependencyKind::SwiftGlobalSentinel,
+            provider_file: None,
+            module_hash: None,
+            exported_hash: None,
+        });
+        hash_rows.push(framed(&[b"swift-global", swift_digest.as_slice()]));
+    }
+    dependencies.sort();
+    dependencies.dedup();
+    hash_rows.push(file_exports[file_idx].to_vec());
+    hash_rows.sort();
+    let refs = hash_rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let requires_resolution = has_exports
+        || dependencies.iter().any(|dependency| {
+            matches!(
+                dependency.kind,
+                ResolutionDependencyKind::ImportedBinding
+                    | ResolutionDependencyKind::ImportedNamespaceMember
+            )
+        })
+        || il.meta.lang == Lang::Swift && swift_active;
+    FileResolutionDependencySummary {
+        export_digest: file_exports[file_idx],
+        resolution_digest: derive(b"nose.file-resolution-context.v1", &refs),
+        over_invalidated: dependencies.iter().any(|dependency| {
+            matches!(
+                dependency.kind,
+                ResolutionDependencyKind::UnknownBinding
+                    | ResolutionDependencyKind::UnknownNamespace
+            )
+        }),
+        requires_resolution,
+        dependencies,
+    }
+}
+
+fn framed(components: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for component in components {
+        out.extend_from_slice(&(component.len() as u64).to_be_bytes());
+        out.extend_from_slice(component);
+    }
+    out
+}
+
+fn derive(domain: &[u8], components: &[&[u8]]) -> [u8; 32] {
+    let mut hash = Sha256::new();
+    hash.update((domain.len() as u64).to_be_bytes());
+    hash.update(domain);
+    hash.update(framed(components));
+    hash.finalize().into()
+}

--- a/crates/nose-frontend/src/module_imports/dependency.rs
+++ b/crates/nose-frontend/src/module_imports/dependency.rs
@@ -1,4 +1,4 @@
-use super::bindings::{assignment_name, import_binding_proof};
+use super::bindings::{assignment_name, import_binding_proof, import_dependency_keys};
 use super::exports::{collect_literal_exports, LiteralExports};
 use super::namespace_members::collect_namespace_member_analyses;
 use super::snapshot::{snapshot_subtree, surface_fingerprint};
@@ -149,8 +149,14 @@ fn binding_graph(
             );
             let refs = components.iter().map(Vec::as_slice).collect::<Vec<_>>();
             let base = derive(b"nose.export-surface.base.v1", &refs);
-            let mut edges = binding
-                .dependency_keys
+            let dependency_keys = contexts[binding.file_idx]
+                .top_level
+                .as_deref()
+                .map(|top_level| {
+                    import_dependency_keys(&files[binding.file_idx], binding.rhs, top_level)
+                })
+                .unwrap_or_default();
+            let mut edges = dependency_keys
                 .iter()
                 .filter_map(|&(module_hash, exported_hash)| {
                     let target =

--- a/crates/nose-frontend/src/module_imports/exports.rs
+++ b/crates/nose-frontend/src/module_imports/exports.rs
@@ -1,6 +1,6 @@
 use super::bindings::{
-    assignment_name, assignment_rhs, collect_statements_for_root, import_dependency_keys,
-    import_dependency_snapshots, BindingUseIndex,
+    assignment_name, assignment_rhs, collect_statements_for_root, import_dependency_snapshots,
+    BindingUseIndex,
 };
 use super::modules::java_class_module_hashes;
 use super::{ExportedBinding, FileImportContext};
@@ -329,13 +329,11 @@ fn collect_statement_exports(
         }
         let exported = stable_symbol_hash(interner.resolve(name));
         let deps = import_dependency_snapshots(il, rhs, scope.top_level);
-        let dependency_keys = import_dependency_keys(il, rhs, scope.top_level);
         out.records.push(LiteralExportRecord {
             exported_hash: exported,
             binding: ExportedBinding {
                 file_idx: scope.file_idx,
                 deps: deps.clone(),
-                dependency_keys: dependency_keys.clone(),
                 rhs,
             },
         });
@@ -348,7 +346,6 @@ fn collect_statement_exports(
                     ExportedBinding {
                         file_idx: scope.file_idx,
                         deps: deps.clone(),
-                        dependency_keys: dependency_keys.clone(),
                         rhs,
                     },
                 )

--- a/crates/nose-frontend/src/module_imports/exports.rs
+++ b/crates/nose-frontend/src/module_imports/exports.rs
@@ -1,6 +1,6 @@
 use super::bindings::{
-    assignment_name, assignment_rhs, collect_statements_for_root, import_dependency_snapshots,
-    BindingUseIndex,
+    assignment_name, assignment_rhs, collect_statements_for_root, import_dependency_keys,
+    import_dependency_snapshots, BindingUseIndex,
 };
 use super::modules::java_class_module_hashes;
 use super::{ExportedBinding, FileImportContext};
@@ -17,9 +17,9 @@ pub(super) struct LiteralExports {
     reexports: Vec<ReExportRecord>,
 }
 
-struct LiteralExportRecord {
-    exported_hash: u64,
-    binding: ExportedBinding,
+pub(super) struct LiteralExportRecord {
+    pub(super) exported_hash: u64,
+    pub(super) binding: ExportedBinding,
 }
 
 pub(super) struct ReExportRecord {
@@ -37,6 +37,14 @@ impl LiteralExports {
 
     pub(super) fn iter_keyed(&self) -> impl Iterator<Item = (&(u64, u64), &ExportedBinding)> {
         self.by_key.iter()
+    }
+
+    pub(super) fn records(&self) -> &[LiteralExportRecord] {
+        &self.records
+    }
+
+    pub(super) fn reexports(&self) -> &[ReExportRecord] {
+        &self.reexports
     }
 
     pub(super) fn get(
@@ -321,11 +329,13 @@ fn collect_statement_exports(
         }
         let exported = stable_symbol_hash(interner.resolve(name));
         let deps = import_dependency_snapshots(il, rhs, scope.top_level);
+        let dependency_keys = import_dependency_keys(il, rhs, scope.top_level);
         out.records.push(LiteralExportRecord {
             exported_hash: exported,
             binding: ExportedBinding {
                 file_idx: scope.file_idx,
                 deps: deps.clone(),
+                dependency_keys: dependency_keys.clone(),
                 rhs,
             },
         });
@@ -338,6 +348,7 @@ fn collect_statement_exports(
                     ExportedBinding {
                         file_idx: scope.file_idx,
                         deps: deps.clone(),
+                        dependency_keys: dependency_keys.clone(),
                         rhs,
                     },
                 )

--- a/crates/nose-frontend/src/module_imports/namespace_members.rs
+++ b/crates/nose-frontend/src/module_imports/namespace_members.rs
@@ -9,6 +9,7 @@ use nose_semantics::{
 use rustc_hash::FxHashSet;
 
 pub(super) struct NamespaceMemberReplacement {
+    pub(super) provider_file_idx: usize,
     pub(super) node: NodeId,
     pub(super) import_evidence: nose_il::EvidenceId,
     pub(super) module_hash: u64,
@@ -17,12 +18,18 @@ pub(super) struct NamespaceMemberReplacement {
     pub(super) rhs_snapshot: SubtreeSnapshot,
 }
 
-pub(super) fn collect_namespace_member_replacements(
+#[derive(Default)]
+pub(super) struct NamespaceMemberAnalysis {
+    pub(super) replacements: Vec<NamespaceMemberReplacement>,
+    pub(super) unresolved: Vec<(u64, u64)>,
+}
+
+pub(super) fn collect_namespace_member_analyses(
     files: &[Il],
     interner: &Interner,
     contexts: &[FileImportContext],
     exports: &LiteralExports,
-) -> Vec<Vec<NamespaceMemberReplacement>> {
+) -> Vec<NamespaceMemberAnalysis> {
     files
         .iter()
         .enumerate()
@@ -31,20 +38,20 @@ pub(super) fn collect_namespace_member_replacements(
                 .modules()
                 .go_import_namespace_facts()
             {
-                return Vec::new();
+                return NamespaceMemberAnalysis::default();
             }
             let context = &contexts[file_idx];
             let Some(top_level) = context.top_level.as_deref() else {
-                return Vec::new();
+                return NamespaceMemberAnalysis::default();
             };
-            collect_file_namespace_replacements(
+            collect_file_namespace_analysis(
                 files, interner, file_idx, il, top_level, context, exports,
             )
         })
         .collect()
 }
 
-fn collect_file_namespace_replacements(
+fn collect_file_namespace_analysis(
     files: &[Il],
     interner: &Interner,
     file_idx: usize,
@@ -52,7 +59,7 @@ fn collect_file_namespace_replacements(
     top_level: &[NodeId],
     context: &FileImportContext,
     exports: &LiteralExports,
-) -> Vec<NamespaceMemberReplacement> {
+) -> NamespaceMemberAnalysis {
     let namespace_imports: Vec<NamespaceImport> = top_level
         .iter()
         .copied()
@@ -68,7 +75,7 @@ fn collect_file_namespace_replacements(
         })
         .collect();
     if namespace_imports.is_empty() {
-        return Vec::new();
+        return NamespaceMemberAnalysis::default();
     }
     let binding_uses = context.binding_uses(il, interner);
     let imported_namespaces: FxHashSet<Symbol> = namespace_imports
@@ -79,7 +86,7 @@ fn collect_file_namespace_replacements(
     let unsafe_exports = unsafe_namespace_member_exports(il, interner, &imported_namespaces);
     let member_fields = namespace_member_fields(il, &imported_namespaces);
 
-    let mut out = Vec::new();
+    let mut out = NamespaceMemberAnalysis::default();
     for import in namespace_imports {
         if binding_uses.binding_mutated(il, import.namespace, import.stmt)
             || shadowed_namespaces.contains(&import.namespace)
@@ -95,12 +102,15 @@ fn collect_file_namespace_replacements(
             }
             let exported_hash = stable_symbol_hash(interner.resolve(exported));
             let Some(export) = exports.get_exact(import.module_hash, exported_hash) else {
+                out.unresolved.push((import.module_hash, exported_hash));
                 continue;
             };
             if export.file_idx == file_idx || files[export.file_idx].meta.lang != il.meta.lang {
+                out.unresolved.push((import.module_hash, exported_hash));
                 continue;
             }
-            out.push(NamespaceMemberReplacement {
+            out.replacements.push(NamespaceMemberReplacement {
+                provider_file_idx: export.file_idx,
                 node: field,
                 import_evidence: import.evidence,
                 module_hash: import.module_hash,
@@ -110,6 +120,8 @@ fn collect_file_namespace_replacements(
             });
         }
     }
+    out.unresolved.sort_unstable();
+    out.unresolved.dedup();
     out
 }
 

--- a/crates/nose-frontend/src/module_imports/snapshot.rs
+++ b/crates/nose-frontend/src/module_imports/snapshot.rs
@@ -1,10 +1,12 @@
 use nose_il::{
-    stable_symbol_hash, EvidenceAnchor, EvidenceEmitter, EvidenceId, EvidenceKind,
-    EvidenceProvenance, EvidenceRecord, EvidenceStatus, Il, ImportEvidenceKind, Node, NodeId,
-    NodeKind, Payload, Span,
+    stable_symbol_hash, CallTargetEvidenceKind, EvidenceAnchor, EvidenceEmitter, EvidenceId,
+    EvidenceKind, EvidenceProvenance, EvidenceRecord, EvidenceStatus, FileId, GuardEvidenceKind,
+    Il, ImportEvidenceKind, Node, NodeId, NodeKind, Payload, PromiseSettledValueEvidenceKind, Span,
 };
 use nose_semantics::language_core_evidence_provenance;
 use rustc_hash::{FxHashMap, FxHashSet};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
 
 #[derive(Clone)]
 pub(super) struct SnapshotNode {
@@ -34,6 +36,112 @@ pub(super) struct SnapshotEvidence {
 pub(super) struct AppendedSnapshot {
     pub(super) root: NodeId,
     pub(super) evidence: Vec<EvidenceId>,
+}
+
+#[derive(Serialize)]
+enum SurfacePayload<'a> {
+    Name(&'a str),
+    Value(Payload),
+}
+
+#[derive(Serialize)]
+struct SurfaceNode<'a> {
+    kind: NodeKind,
+    payload: SurfacePayload<'a>,
+    children: &'a [usize],
+}
+
+#[derive(Serialize)]
+struct SurfaceEvidence {
+    kind: EvidenceKind,
+    provenance: EvidenceProvenance,
+    dependencies: Vec<usize>,
+    status: EvidenceStatus,
+}
+
+/// Collision-resistant semantic identity of a copied export subtree. Source
+/// coordinates and process-local evidence ids are deliberately excluded: a
+/// provider may move an unchanged literal without changing what consumers see.
+pub(super) fn surface_fingerprint(
+    snapshot: &SubtreeSnapshot,
+    interner: &nose_il::Interner,
+) -> [u8; 32] {
+    let nodes = snapshot
+        .nodes
+        .iter()
+        .map(|node| SurfaceNode {
+            kind: node.kind,
+            payload: match node.payload {
+                Payload::Name(symbol) => SurfacePayload::Name(interner.resolve(symbol)),
+                payload => SurfacePayload::Value(payload),
+            },
+            children: &node.children,
+        })
+        .collect::<Vec<_>>();
+    let evidence_indexes = snapshot
+        .evidence
+        .iter()
+        .enumerate()
+        .map(|(index, evidence)| (evidence.source_id, index))
+        .collect::<FxHashMap<_, _>>();
+    let evidence = snapshot
+        .evidence
+        .iter()
+        .map(|record| SurfaceEvidence {
+            kind: surface_evidence_kind(record.kind),
+            provenance: record.provenance,
+            dependencies: record
+                .dependencies
+                .iter()
+                .filter_map(|dependency| evidence_indexes.get(dependency).copied())
+                .collect(),
+            status: record.status,
+        })
+        .collect::<Vec<_>>();
+    let payload = rmp_serde::to_vec(&(snapshot.root, nodes, evidence))
+        .expect("export surface is always MessagePack serializable");
+    Sha256::digest(payload).into()
+}
+
+fn surface_evidence_kind(kind: EvidenceKind) -> EvidenceKind {
+    let canonical = |_span: Span| Span::synthetic(FileId(0));
+    match kind {
+        EvidenceKind::Guard(GuardEvidenceKind::BoundOrder {
+            lower_span,
+            upper_span,
+            activation,
+        }) => EvidenceKind::Guard(GuardEvidenceKind::BoundOrder {
+            lower_span: canonical(lower_span),
+            upper_span: canonical(upper_span),
+            activation,
+        }),
+        EvidenceKind::CallTarget(CallTargetEvidenceKind::DirectFunction {
+            target_span,
+            name_hash,
+        }) => EvidenceKind::CallTarget(CallTargetEvidenceKind::DirectFunction {
+            target_span: canonical(target_span),
+            name_hash,
+        }),
+        EvidenceKind::CallTarget(CallTargetEvidenceKind::DirectMethod {
+            target_span,
+            receiver_type_hash,
+            method_hash,
+        }) => EvidenceKind::CallTarget(CallTargetEvidenceKind::DirectMethod {
+            target_span: canonical(target_span),
+            receiver_type_hash,
+            method_hash,
+        }),
+        EvidenceKind::PromiseSettledValue(PromiseSettledValueEvidenceKind {
+            channel,
+            payload_span,
+            payload_kind,
+        }) => EvidenceKind::PromiseSettledValue(PromiseSettledValueEvidenceKind {
+            channel,
+            payload_span: canonical(payload_span),
+            payload_kind,
+        }),
+        other => other,
+    }
 }
 
 pub(super) fn snapshot_subtree(il: &Il, root: NodeId) -> SubtreeSnapshot {

--- a/crates/nose-frontend/src/module_imports/tests/go_namespace.rs
+++ b/crates/nose-frontend/src/module_imports/tests/go_namespace.rs
@@ -112,3 +112,23 @@ fn go_namespace_import_without_member_use_does_not_snapshot_export() {
         "the namespace import assignment should remain as an import proof anchor"
     );
 }
+
+#[test]
+fn go_namespace_dependency_summary_keeps_mixed_unresolved_members_fail_safe() {
+    let interner = Interner::new();
+    let provider_src = "package tables\nvar Lookup = map[string]int{\"red\": 1}\n";
+    let importer_src = "package consumer\nimport \"tables\"\nfunc value(key string) int { return tables.Lookup[key] + tables.Missing[key] }\n";
+    let (provider, importer) = go_provider_and_importer(provider_src, importer_src, &interner);
+
+    let summary = super::super::resolution_dependency_summary(&[provider, importer], &interner);
+    let importer = &summary.files[1];
+    assert!(importer.dependencies.iter().any(|dependency| {
+        dependency.kind == super::super::ResolutionDependencyKind::ImportedNamespaceMember
+            && dependency.exported_hash == Some(stable_symbol_hash("Lookup"))
+    }));
+    assert!(importer.dependencies.iter().any(|dependency| {
+        dependency.kind == super::super::ResolutionDependencyKind::UnknownNamespace
+            && dependency.exported_hash == Some(stable_symbol_hash("Missing"))
+    }));
+    assert!(importer.over_invalidated);
+}

--- a/crates/nose-frontend/src/swift_cross_file_shadows.rs
+++ b/crates/nose-frontend/src/swift_cross_file_shadows.rs
@@ -11,6 +11,8 @@ use nose_semantics::{
     SWIFT_NIL_LITERAL_CONFORMANCE_MARKER, SWIFT_NIL_LITERAL_PROOF_BARRIER_MARKER,
 };
 use rustc_hash::FxHashSet;
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
 
 const SWIFT_STDLIB_SHADOW_NAMES: &[&str] = &["Array", "Set", "Dictionary", "String", "Swift"];
 
@@ -36,7 +38,29 @@ pub(crate) fn close_local_dictionary_default_subscript(il: &mut Il, interner: &I
     close_shadowed_swift_string_parameters(il, string_shadowed, swift_shadowed);
 }
 
-pub(crate) fn close_shadowed_stdlib_apis(files: &mut [Il], interner: &Interner) {
+#[derive(Serialize)]
+struct SwiftGlobalFacts {
+    shadowed: Vec<u64>,
+    unproven_collection_parameter: bool,
+    compact_map_dispatch_ambiguous: bool,
+    flat_map_dispatch_ambiguous: bool,
+    all_satisfy_dispatch_ambiguous: bool,
+    nil_literal_conformance: bool,
+    dictionary_default_subscript_ambiguous: bool,
+}
+
+impl SwiftGlobalFacts {
+    fn is_active(&self) -> bool {
+        !self.shadowed.is_empty()
+            || self.compact_map_dispatch_ambiguous
+            || self.flat_map_dispatch_ambiguous
+            || self.all_satisfy_dispatch_ambiguous
+            || self.nil_literal_conformance
+            || self.dictionary_default_subscript_ambiguous
+    }
+}
+
+fn swift_global_facts(files: &[Il], interner: &Interner) -> SwiftGlobalFacts {
     let shadowed = shadowed_swift_stdlib_factory_name_hashes(files, interner);
     let unproven_collection_parameter = swift_unproven_collection_parameter_declared(files);
     let compact_map_dispatch_ambiguous =
@@ -49,40 +73,64 @@ pub(crate) fn close_shadowed_stdlib_apis(files: &mut [Il], interner: &Interner) 
     let nil_literal_conformance = swift_nil_literal_conformance_declared(files, interner);
     let dictionary_default_subscript_ambiguous =
         swift_dictionary_default_subscript_barrier_declared(files, interner);
+    let mut shadowed = shadowed.into_iter().collect::<Vec<_>>();
+    shadowed.sort_unstable();
+    SwiftGlobalFacts {
+        shadowed,
+        unproven_collection_parameter,
+        compact_map_dispatch_ambiguous,
+        flat_map_dispatch_ambiguous,
+        all_satisfy_dispatch_ambiguous,
+        nil_literal_conformance,
+        dictionary_default_subscript_ambiguous,
+    }
+}
+
+pub(crate) fn swift_global_dependency_state(files: &[Il], interner: &Interner) -> ([u8; 32], bool) {
+    let facts = swift_global_facts(files, interner);
+    let payload = rmp_serde::to_vec(&facts).expect("Swift global facts are serializable");
+    (Sha256::digest(payload).into(), facts.is_active())
+}
+
+pub(crate) fn close_shadowed_stdlib_apis_affected(
+    files: &mut [Il],
+    interner: &Interner,
+    targets: &[bool],
+) {
+    debug_assert_eq!(files.len(), targets.len());
+    let facts = swift_global_facts(files, interner);
+    if !facts.is_active() {
+        return;
+    }
+    let shadowed = facts.shadowed.into_iter().collect::<FxHashSet<_>>();
     let dictionary_name_shadowed = shadowed.contains(&stable_symbol_hash("Dictionary"));
     let string_name_shadowed = shadowed.contains(&stable_symbol_hash("String"));
     let swift_namespace_shadowed = shadowed.contains(&stable_symbol_hash("Swift"));
-    if shadowed.is_empty()
-        && !compact_map_dispatch_ambiguous
-        && !flat_map_dispatch_ambiguous
-        && !all_satisfy_dispatch_ambiguous
-        && !nil_literal_conformance
-        && !dictionary_default_subscript_ambiguous
-    {
-        return;
-    }
-    for il in files.iter_mut().filter(|il| il.meta.lang == Lang::Swift) {
+    for (index, il) in files.iter_mut().enumerate() {
+        if !targets[index] || il.meta.lang != Lang::Swift {
+            continue;
+        }
         close_shadowed_unshadowed_globals(il, &shadowed);
         if dictionary_name_shadowed
             || swift_namespace_shadowed
-            || dictionary_default_subscript_ambiguous
+            || facts.dictionary_default_subscript_ambiguous
         {
             close_shadowed_swift_dictionary_parameters(
                 il,
                 dictionary_name_shadowed,
                 swift_namespace_shadowed,
-                dictionary_default_subscript_ambiguous,
+                facts.dictionary_default_subscript_ambiguous,
             );
         }
         close_shadowed_swift_string_bindings(il, string_name_shadowed, swift_namespace_shadowed);
         close_shadowed_swift_string_parameters(il, string_name_shadowed, swift_namespace_shadowed);
-        if compact_map_dispatch_ambiguous || nil_literal_conformance {
+        if facts.compact_map_dispatch_ambiguous || facts.nil_literal_conformance {
             close_shadowed_compact_map(il);
         }
-        if flat_map_dispatch_ambiguous {
+        if facts.flat_map_dispatch_ambiguous {
             close_shadowed_flat_map(il);
         }
-        if all_satisfy_dispatch_ambiguous {
+        if facts.all_satisfy_dispatch_ambiguous {
             close_shadowed_swift_method(il, "allSatisfy", 1);
         }
     }

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -319,21 +319,31 @@ for the recorded artifact and disposition shape.
 
 `--cache-dir <dir>` caches each file's analysis in the
 [portable layered CAS](portable-cache-artifacts.md), keyed by a SHA-256 digest of its complete
-post-resolution IL/reporting identity and unit-affecting options. Entries have stage/schema
-identity plus an independent payload checksum; corrupt or truncated bytes recompute. Unchanged
-files reuse [normalization](normalization.md), feature extraction, and syntax streams on the next
-run, including when the same relative source is checked out below another absolute root.
+source, consumer-visible dependency context, post-resolution IL/reporting identity, and
+unit-affecting options. Clean tracked files use Git blob ids without rereading source bytes for
+lowering;
+dirty, untracked, and non-Git files use exact content SHA-256. Unchanged files reuse raw lowering,
+resolved cross-file facts, [normalization](normalization.md), feature extraction, and syntax
+streams, including across checkout paths and after unrelated additions shift `FileId` indexes.
 
-The active cache layer still rediscovers, reads, parses, and lowers the whole selected corpus,
-resolves cross-file facts, and repeats global detection and presentation. Raw/resolved portable
-formats are ready for dependency-aware activation in #874, but #873 does not claim those stages
-are skipped. Point the directory at storage your CI preserves between runs; see the
+Importers are invalidated only when a provider's exported literal surface changes. Swift global
+shadow/overload/conformance barriers invalidate Swift dependents, and unresolved dependencies
+fail safe by over-invalidating their language export catalog. Global detection, line-frequency
+ranking reads, and presentation still run on every query; #875 owns the next reuse boundary. Point
+the directory at storage your
+CI preserves between runs; see the
 [incremental cache benchmark](incremental-cache-benchmark.md) for the exact performance and
 clean-scan-equivalence contract.
 
 ```sh
 nose query src --cache-dir .nose-cache --fail-on any
 ```
+
+Set `NOSE_CACHE_STATS=1` to retain the existing `[cache]` unit hit/miss line and add one
+`[invalidation]` JSON object (`nose.invalidation/v1`). It reports source/raw/resolved layer counts,
+the affected path closure and reasons, deleted sources, Git-blob versus content identities,
+explicit fail-safe over-invalidation, and digests/invalidation markers for discovery membership,
+semantic-pack influence, Swift global sentinels, and corpus-global line statistics.
 
 ---
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -203,9 +203,8 @@ fundamentals; the rest is grouped by area.
 - [etcd Go frontend attribution](runtime-performance-issue-907-2026-07-19.md) — #907's frozen-r40 source, executable, machine-code, and profile evidence attributing the residual to build provenance plus control subtraction.
 - [normalize-and-extract closeout](runtime-performance-issue-908-2026-07-19.md) — #908's output-identical MinHash hot-loop optimization and frozen Guava/MinIO r40 closeout against official v0.19.0.
 - [incremental cache benchmark](incremental-cache-benchmark.md) — the #872 official-v0.19.0 binary pin, clean/cold/warm equivalence rule, mutation closure inventory, and real/synthetic workload contract for the Instant Monorepo engine.
-- [portable cache artifacts](portable-cache-artifacts.md) — the #873 SHA-256 layered CAS,
-  checksummed envelope, path/interner-independent raw and resolved IL format, and active-stage
-  boundary.
+- [portable cache artifacts](portable-cache-artifacts.md) — the #873 SHA-256 layered CAS and #874
+  dependency-aware source/raw/resolved reuse, exact invalidation closure, and fail-safe reporting.
 - [experiments](experiments.md) — the measured log of what was tried and what happened.
 
 ### Field evidence & audits

--- a/docs/incremental-cache-benchmark.md
+++ b/docs/incremental-cache-benchmark.md
@@ -83,6 +83,38 @@ named-MessagePack store is 190,665,950 bytes, 49.8% smaller than the official 38
 store, while warm p50 RSS is 6.5% lower. Those numbers price the #873 trust boundary before later
 issues remove repeated pipeline stages.
 
+## Checked #874 evidence
+
+The checked [`issue-874-dependency-invalidation-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-874-dependency-invalidation-sympy-paired-2026-07-20.v1.json)
+contains 30 alternating AB/BA replays of implementation commit `e1617924` against the
+checksum-verified published v0.19.0 `aarch64-apple-darwin` binary. Both roles independently passed
+exact clean/empty/history output equivalence across all 180 rows.
+
+| Phase | Official p50 / p95 | #874 p50 / p95 | #874 delta p50 / p95 |
+| --- | ---: | ---: | ---: |
+| Clean | 1224.78 / 1472.50 ms | 1170.97 / 1367.38 ms | -4.39% / -7.14% |
+| Empty store | 1333.26 / 1628.77 ms | 1984.47 / 2382.15 ms | +48.84% / +46.25% |
+| Warm store | 843.82 / 985.50 ms | 839.03 / 1031.98 ms | -0.57% / +4.72% |
+
+The clean path remains inside the epic's 5% gate and is faster in this paired run. The empty-store
+cost is intentionally reported as a regression: #874 now writes source, raw-IL, dependency,
+resolved-IL, and units artifacts instead of only the published release's units cache. On a no-op
+warm run all 1,584 raw, resolved, and unit regions hit; 1,510 resolved regions are raw
+pass-throughs, so they do not duplicate payloads. Total warm p50 is effectively neutral while
+p95 is 4.72% higher because global detection and source-line ranking still repeat. #875 owns that
+remaining latency boundary.
+
+The added layers do not recreate the earlier uncompressed expansion: the #874 store is
+333,945,915 bytes versus the official 380,153,028 bytes (-12.15%). Warm p50/p95 peak RSS is
+841,506,816 / 850,673,664 bytes versus 1,066,860,544 / 1,090,748,416 bytes (-21.12% / -22.01%).
+
+The checked [`issue-874-mutation-matrix-receipt-2026-07-20.v1.json`](../bench/cache/issue-874-mutation-matrix-receipt-2026-07-20.v1.json)
+seals a 4,356,455-byte, 2,100-row raw report. All 14 mutations passed 30 replays with exact
+clean/empty/history equality. Representative history-bearing unit hit/miss closures are no-op
+`3/0`, leaf edit `2/1`, provider-private edit `2/1`, provider export edit `1/2`, high fan-out
+`1/33`, add/delete/rename `3/1`, embedded-region edit `5/1`, restored-mtime edit `3/1`, and Swift
+global barrier `0/3`.
+
 ## What the current cache actually reuses
 
 The published v0.19.0 cache is schema v11 and the locked #872 candidate is schema v14. #873 moved

--- a/docs/incremental-cache-benchmark.md
+++ b/docs/incremental-cache-benchmark.md
@@ -85,19 +85,23 @@ issues remove repeated pipeline stages.
 
 ## What the current cache actually reuses
 
-The published v0.19.0 cache is schema v11 and the locked #872 candidate is schema v14. The current
-0.20 development tree migrates that same active units/syntax boundary to the #873 layered CAS v1.
-All three still rediscover, read, parse, and lower every selected source, rebuild corpus import
-facts, and repeat global detection, family construction/ranking, and presentation. In particular,
-a warm hit does **not** skip parsing.
+The published v0.19.0 cache is schema v11 and the locked #872 candidate is schema v14. #873 moved
+the 0.20 development tree to layered CAS v1 while keeping only units/syntax active. #874 now reuses
+source snapshots, raw lowering, dependency-aware resolved IL, and units/syntax. A warm clean-Git
+hit avoids source reads for lowering and skips parsing; the still-global line-frequency/ranking
+stage may read source later. Dirty, untracked, and non-Git inputs are read so their exact bytes,
+rather than mtime/size, establish identity.
 
 CAS v1 replaces the u64 entry name with a stage/schema-separated SHA-256 address over the complete
 post-resolution semantic/reporting identity and unit-affecting options. An independent payload
 SHA-256, exact length, and envelope identity make corrupt or misplaced bytes clean misses. Paths,
 `FileId`s, and interner ids are portable and rebound; names, spans, suppression, facets, and full
-evidence records remain identity-bearing. The raw/resolved portable codec is complete, but those
-layers are intentionally not written until #874 can invalidate them by affected closure instead
-of duplicating unused data. See [portable cache artifacts](portable-cache-artifacts.md).
+evidence records remain identity-bearing. Resolved entries add a deterministic
+consumer-visible export/dependency context, so provider-private changes leave importers hot while
+export, ambiguity, deletion/rename, and Swift-global changes reach their consumers. Global
+detection, source-line frequency reads, family construction/ranking, and presentation still
+repeat; #875 owns that boundary.
+See [portable cache artifacts](portable-cache-artifacts.md).
 
 #275 is the required cross-file regression. A provider literal and importer that converge with
 an inline literal must remain converged on an empty store, warm store, and after the provider
@@ -115,7 +119,10 @@ Each mutation replay has two revisions and five subprocesses:
 5. history-bearing scan using the store seeded in step 2, compared with both step-4 scans.
 
 `NOSE_TIME=1` supplies stage timings. Cache instrumentation reports files, hits, misses, bytes
-read, and bytes written; the harness also measures recursive regular-file store bytes and peak
+read, and bytes written. #874 additionally emits a `nose.invalidation/v1` JSON closure with
+source/raw/resolved counts, exact reasons, global dependency markers, and explicit fail-safe
+over-invalidation. The harness retains that object on cached candidate rows and also measures
+recursive regular-file store bytes and peak
 RSS for each subprocess. Report summaries use the ordinary median and nearest-rank p95
 (`ceil(0.95 * n)`, one-indexed) over at least 30 successful replays. Raw rows remain in the
 artifact; p50/p95 never replace them. A checked receipt may seal a large local raw report while

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -134,5 +134,7 @@ equivalence across all 180 raw rows.
 The clean result remains within the epic's 5% gate. The warm delta prices full checksum validation
 instead of trusting file presence, while named MessagePack limits that cost: the store falls from
 380,153,028 to 190,665,950 bytes (-49.8%), and warm p50 RSS falls from 1,066,008,576 to 996,851,712
-bytes (-6.5%). This remains the before-#874 foundation measurement; the #874 comparison below owns
-the activated parse/resolve result, while #875 owns repeated global work.
+bytes (-6.5%). This remains the before-#874 foundation measurement; the #874 comparison owns the
+activated parse/resolve result in the
+[incremental cache benchmark](incremental-cache-benchmark.md#checked-874-evidence), while #875
+owns repeated global work.

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -1,8 +1,8 @@
 # Portable cache artifacts
 
 The 0.20 Instant Monorepo cache uses one layered content-addressed store (CAS) contract for every
-analysis stage. This page defines the #873 boundary: what is portable now, what is actively reused,
-and what later dependency-aware issues may activate without changing the storage trust model.
+analysis stage. #873 defined the portable trust boundary; #874 activates dependency-aware source,
+raw-IL, export-summary, and resolved-IL reuse without changing that storage model.
 
 ## Layer contract
 
@@ -10,22 +10,54 @@ Every address is a SHA-256 digest over a domain separator, the stage id, that st
 length-framed semantic inputs. A stage cannot read another stage's entry, and a schema change lands
 at a different address. The six stable stage identities are:
 
-| Stage | #873 state | Next consumer |
+| Stage | 0.20 development state | Identity / consumer |
 | --- | --- | --- |
-| source snapshot | address space defined | #874 discovery/source inventory |
-| raw lowered IL | portable codec and round-trip gate complete | #874 parse/lower reuse |
-| export/dependency summary | address space defined | #874 dependency graph |
-| resolved IL | portable codec and round-trip gate complete | #874 affected-closure resolution |
-| units and syntax streams | actively read and written by `--cache-dir` | current query pipeline |
+| source snapshot | actively read and written | clean Git blob id or exact content SHA-256 |
+| raw lowered IL | actively read and written | source snapshot; current path/`FileId` rebound |
+| export/dependency summary | actively written and checksummed | deterministic export graph and SCC closure |
+| resolved IL | actively read and written | raw IL plus the region's dependency context |
+| units and syntax streams | actively read and written | resolved IL plus unit-affecting options |
 | global detection indexes | address space defined | #875 incremental detection |
 
-Defining a stage is not a claim that queries already skip it. At #873 only units and syntax streams
-are active, encoded as named MessagePack so serde-compatible schema evolution remains possible
-without JSON's repeated decimal expansion of feature hashes. Discovery, source reads, parsing,
-lowering, corpus resolution, global detection, and
-presentation still run as described by the [incremental benchmark](incremental-cache-benchmark.md).
-Raw/resolved payloads are not duplicated into the store before #874 can invalidate them precisely;
-that avoids knowingly worsening the cache-size ratio merely to populate unused artifacts.
+Raw and resolved IL use named MessagePack wrapped in fast LZ4 blocks; the decoder rejects a claimed
+region expansion above 512 MiB before allocation. The units layer stays named MessagePack without
+compression because those payloads are already compact feature hashes and dominate warm reads.
+Discovery still walks the selected roots so additions and deletions are visible, but a clean
+tracked raw hit needs no source read or parse in the lowering stage. Dependency summaries scan raw
+IL, compute consumer-visible literal surfaces, collapse cycles deterministically, and resolve
+imports against current module/package facts. Only resolved misses run corpus mutation; hits are
+rebound afterward. Global detection, source-line frequency reads, family construction/ranking,
+and presentation remain per-query work for #875.
+
+## Dependency-aware invalidation
+
+Each region's resolved address combines its path-independent raw semantic digest with a dependency
+context digest. That context contains its own export coordinates, resolved imported-binding and
+namespace-member surfaces, Rust module/re-export outcomes, Java/Go package facts, unresolved
+language catalogs, and the Swift global shadow/overload/conformance sentinel when applicable.
+Export surfaces hash copied literal structure and evidence but omit source coordinates and local
+evidence ids. Therefore changing private provider implementation does not invalidate importers;
+changing an exported literal does, including the #275 provider/importer case.
+
+The export graph incorporates imports used by exported values. Strongly connected components are
+collapsed before hashing, then the component DAG is resolved dependency-first. This gives cycles
+and re-exports a deterministic fixed point without depending on traversal order. Cache identities
+never include sorted corpus indexes, so adding or deleting an earlier path does not invalidate
+unrelated artifacts merely because `FileId`s moved.
+
+Unknown static dependencies include the language's export catalog in their key. This can invalidate
+more than necessary when an unrelated export changes, but it cannot reuse a stale unresolved fact;
+the path is listed under `over_invalidated`. Discovery membership, semantic-pack influence, and
+corpus-global line-statistics digests are carried in diagnostics now even though their downstream
+global stages remain #875 work.
+
+The mutable `state-v1` workspace record exists only to explain changes and deleted paths. It is not
+a cache-key or reuse input: deleting or corrupting it loses reason history, never correctness.
+Under `NOSE_CACHE_STATS=1`, stderr includes one `nose.invalidation/v1` JSON closure alongside the
+backward-compatible `[cache]` units line. Cold start is summarized globally instead of listing
+every file; history-bearing runs list the exact changed/deleted closure. Resolved `passthrough`
+counts identify regions whose raw IL is already the correct resolved form, so no duplicate payload
+is stored.
 
 ## Envelope and failure behavior
 
@@ -80,7 +112,9 @@ Focused tests prove:
 - script, style, and markup regions have stable distinct subidentities; and
 - corruption and truncation fail closed.
 
-The existing #275 provider/importer integration test remains the cross-file safety gate, and the
+The #275 provider/importer integration test remains the cross-file safety gate. Focused gates also
+cover unchanged export surfaces, shifted `FileId`s with an active import edge, Swift global
+barriers, unresolved-dependency over-invalidation, and Git-blob/content identity selection. The
 benchmark's clean/empty/history equality remains the product-output authority. See
 [continuous integration](continuous-integration.md) for current user-facing cache behavior.
 
@@ -100,5 +134,5 @@ equivalence across all 180 raw rows.
 The clean result remains within the epic's 5% gate. The warm delta prices full checksum validation
 instead of trusting file presence, while named MessagePack limits that cost: the store falls from
 380,153,028 to 190,665,950 bytes (-49.8%), and warm p50 RSS falls from 1,066,008,576 to 996,851,712
-bytes (-6.5%). This is foundation evidence, not an instant-cache claim; #874 and #875 own removal
-of repeated parse/resolve and global work.
+bytes (-6.5%). This remains the before-#874 foundation measurement; the #874 comparison below owns
+the activated parse/resolve result, while #875 owns repeated global work.

--- a/scripts/cache-query-regression.py
+++ b/scripts/cache-query-regression.py
@@ -36,6 +36,7 @@ CACHE_RE = re.compile(
     r"\[cache\]\s+files=(\d+)\s+hits=(\d+)\s+misses=(\d+)\s+"
     r"read_bytes=(\d+)\s+written_bytes=(\d+)"
 )
+INVALIDATION_PREFIX = "[invalidation] "
 DARWIN_RSS_RE = re.compile(r"^\s*(\d+)\s+maximum resident set size\s*$", re.MULTILINE)
 LINUX_RSS_RE = re.compile(
     r"^\s*Maximum resident set size \(kbytes\):\s*(\d+)\s*$", re.MULTILINE
@@ -317,6 +318,21 @@ def parse_cache_stats(stderr: str) -> dict[str, int] | None:
     return dict(zip(("files", "hits", "misses", "read_bytes", "written_bytes"), map(int, match.groups())))
 
 
+def parse_invalidation(stderr: str) -> dict[str, Any] | None:
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(INVALIDATION_PREFIX):
+            continue
+        try:
+            value = json.loads(stripped.removeprefix(INVALIDATION_PREFIX))
+        except json.JSONDecodeError as error:
+            raise SystemExit(f"invalid cache invalidation JSON: {error}") from error
+        if not isinstance(value, dict) or value.get("schema") != "nose.invalidation/v1":
+            raise SystemExit("cache invalidation evidence has an unsupported schema")
+        return value
+    return None
+
+
 def parse_rss(stderr: str) -> int:
     if sys.platform == "darwin":
         match = DARWIN_RSS_RE.search(stderr)
@@ -393,6 +409,9 @@ def run_query(
     cache_stats = parse_cache_stats(stderr)
     if cache is not None and require_cache_stats and cache_stats is None:
         raise SystemExit(f"{phase} replay {replay}: binary omitted NOSE_CACHE_STATS evidence")
+    invalidation = parse_invalidation(stderr)
+    if cache is not None and require_cache_stats and invalidation is None:
+        raise SystemExit(f"{phase} replay {replay}: binary omitted invalidation evidence")
     row = {
         "phase": phase,
         "replay": replay,
@@ -404,6 +423,7 @@ def run_query(
         "schema_version": payload.get("schema_version"),
         "stages_ms": parse_stages(stderr),
         "cache": cache_stats,
+        "invalidation": invalidation,
         "store": store_usage(cache) if cache is not None else None,
     }
     return row, result.stdout


### PR DESCRIPTION
## Summary

- activate clean-Git/content-addressed source snapshots and compressed portable raw/resolved IL reuse
- derive deterministic consumer-visible export and dependency contexts, including SCCs, Rust/Java/Go module facts, namespace members, unknown-dependency fail-safe catalogs, and Swift global sentinels
- resolve only cache misses, keep raw-equivalent regions as pass-throughs, and preserve unit reuse across checkout/FileId movement
- emit `nose.invalidation/v1` reasons, closures, global markers, source identities, and explicit over-invalidation
- document the active boundary and check in the published-v0.19.0 comparison plus 30-replay mutation receipt

## Correctness evidence

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `scripts/check-docs.sh`
- `python3 scripts/cache-query-regression.py --self-test`
- 14 mutation fixtures × 30 replays = 2,100 rows; exact clean/empty/history output equality passed
- focused coverage for #275 export edits, provider-private edits, Go partial namespace resolution, Swift barriers, ambiguity, same-size/restored-mtime edits, Git blob/content identity, and shifted FileIds

## Published v0.19.0 comparison

30 alternating AB/BA SymPy replays against the checksum-verified published arm64 binary:

| Phase | v0.19.0 p50 / p95 | Candidate p50 / p95 | Delta |
| --- | ---: | ---: | ---: |
| Clean | 1224.78 / 1472.50 ms | 1170.97 / 1367.38 ms | -4.39% / -7.14% |
| Empty store | 1333.26 / 1628.77 ms | 1984.47 / 2382.15 ms | +48.84% / +46.25% |
| Warm store | 843.82 / 985.50 ms | 839.03 / 1031.98 ms | -0.57% / +4.72% |

The cold regression is the cost of populating the additional source/raw/dependency/resolved layers. Warm p50 is neutral, store size falls 12.15%, and warm p50/p95 RSS falls 21.12%/22.01%. #875 owns the still-global detection and line-ranking latency.

Closes #874
