### PR TITLE
Incrementally update global detection state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,8 +545,10 @@ dependencies = [
  "nose-normalize",
  "nose-semantics",
  "rayon",
+ "rmp-serde",
  "rustc-hash",
  "serde",
+ "sha2",
 ]
 
 [[package]]

--- a/bench/cache/issue-875-incremental-global-sympy-paired-2026-07-20.v1.json
+++ b/bench/cache/issue-875-incremental-global-sympy-paired-2026-07-20.v1.json
@@ -1,0 +1,10619 @@
+{
+  "environment": {
+    "architecture": "arm64",
+    "logical_cpu_count": 18,
+    "os": "Darwin",
+    "os_release": "25.5.0",
+    "python_version": "3.14.5"
+  },
+  "equivalence": {
+    "candidate": true,
+    "official": true
+  },
+  "measurement": {
+    "cache_stats_required": {
+      "candidate": true,
+      "official": false
+    },
+    "minimum_replays": 30,
+    "order": "alternating-ab-ba",
+    "p95": "nearest-rank",
+    "replays": 30
+  },
+  "provenance": {
+    "candidate": {
+      "binary": "target/release/nose",
+      "binary_code_sha256": "615e70d11a916cab96dada7d68e7441dfd7d3457c807146aada52984c7e379c0",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "e93bdc0526aaf00af32416ecad1d0ef6272f267c",
+      "binary_sha256": "9d5e8952eb5475dfa92d0242cf4e36caa849e7f77607b30c6d24e43d4767f09a"
+    },
+    "harness": "scripts/cache-query-regression.py",
+    "harness_sha256": "969cbbc8ae98ed7e9a586c931799958e12b4b4858ec53019b56d4859bc6d145d",
+    "mutation_manifest": "bench/cache/mutation-manifest.v1.json",
+    "mutation_manifest_sha256": "13597fba09fb7e9b5e8785ba2a998d232bf86fa3b23103035b324b0c128ecdc6",
+    "official": {
+      "binary": "target/issue-875-baseline/nose-cli-aarch64-apple-darwin/nose",
+      "binary_code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "release_verification": {
+        "archive": "target/issue-875-baseline/nose-cli-aarch64-apple-darwin.tar.xz",
+        "archive_sha256": "097c7e766e9ab756a32cec715897067d1360e145074715168a653962be409981",
+        "target": "aarch64-apple-darwin"
+      }
+    },
+    "official_baseline": "bench/cache/official-v0.19.0-binaries.v1.json",
+    "official_baseline_sha256": "a9e127dea4303378ed57e3274ca8e0d358b5f0ad253912e4316e8c1f0f83639a"
+  },
+  "runs": [
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1035.853708977811,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1014939648,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.3,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 27.0,
+        "groups": 10.3,
+        "import-resolve": 43.7,
+        "lower": 418.6,
+        "normalize+extract": 429.4,
+        "parse+lower": 347.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.3,
+        "shared_lines": 74.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2610.6840410502627,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1721614336,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 464.1,
+        "candidates": 570.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.9,
+        "import-resolve": 29.1,
+        "lower": 910.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 4.7,
+        "shared_lines": 427.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 858.8757080724463,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 855572480,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 103.0,
+        "candidates": 30.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.0,
+        "import-resolve": 25.5,
+        "lower": 457.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.4,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 11.2,
+        "shared_lines": 23.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1023.5465409932658,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1002307584,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 18.6,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 28.6,
+        "groups": 10.0,
+        "import-resolve": 47.1,
+        "lower": 455.3,
+        "normalize+extract": 367.2,
+        "parse+lower": 379.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 86.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1070.5536250025034,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1080770560,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.3,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 27.5,
+        "groups": 11.5,
+        "import-resolve": 46.4,
+        "lower": 449.2,
+        "parse+lower": 375.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.9,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 1.5,
+        "shared_lines": 81.6
+      },
+      "store": {
+        "bytes": 380153027,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 634.9112919997424,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1048920064,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.0,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 28.9,
+        "groups": 9.8,
+        "import-resolve": 46.3,
+        "lower": 406.8,
+        "parse+lower": 331.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 75.5
+      },
+      "store": {
+        "bytes": 380153027,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1038.0649999715388,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 997048320,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.2,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 28.6,
+        "groups": 10.0,
+        "import-resolve": 47.1,
+        "lower": 487.5,
+        "normalize+extract": 359.0,
+        "parse+lower": 411.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 88.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1074.577708961442,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085554688,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.8,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 27.9,
+        "groups": 10.2,
+        "import-resolve": 47.0,
+        "lower": 483.7,
+        "parse+lower": 408.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 78.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 700.3675830783322,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1072250880,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.8,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 32.8,
+        "groups": 9.7,
+        "import-resolve": 47.1,
+        "lower": 468.8,
+        "parse+lower": 388.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.2,
+        "shared_lines": 77.4
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1074.0012500900775,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 999981056,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 19.2,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 28.2,
+        "groups": 11.4,
+        "import-resolve": 43.3,
+        "lower": 524.2,
+        "normalize+extract": 353.9,
+        "parse+lower": 452.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.4,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.5,
+        "shared_lines": 81.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2588.525000028312,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1689583616,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 557.2,
+        "candidates": 468.6,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.3,
+        "import-resolve": 27.6,
+        "lower": 914.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.4,
+        "shared_lines": 400.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 881.2302089063451,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 871710720,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 125.7,
+        "candidates": 31.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.2,
+        "import-resolve": 27.6,
+        "lower": 456.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 11.1,
+        "shared_lines": 21.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1039.0222920104861,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 980762624,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.5,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 27.3,
+        "groups": 10.1,
+        "import-resolve": 45.8,
+        "lower": 470.9,
+        "normalize+extract": 378.6,
+        "parse+lower": 397.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2746.7606250429526,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1702805504,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 559.3,
+        "candidates": 524.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.6,
+        "import-resolve": 28.3,
+        "lower": 989.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.4,
+        "rank_sort": 0.4,
+        "score": 4.0,
+        "shared_lines": 422.5
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 870.0859999516979,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 860717056,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 116.7,
+        "candidates": 31.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 28.7,
+        "lower": 450.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 10.7,
+        "shared_lines": 21.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1046.3810830842704,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1019478016,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 18.6,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 25.4,
+        "groups": 10.4,
+        "import-resolve": 52.0,
+        "lower": 408.5,
+        "normalize+extract": 455.8,
+        "parse+lower": 331.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 74.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1060.6576250866055,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1108705280,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.7,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 26.1,
+        "groups": 10.2,
+        "import-resolve": 54.3,
+        "lower": 414.1,
+        "parse+lower": 333.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 76.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 683.7032911134884,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1067941888,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.4,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 24.8,
+        "groups": 10.9,
+        "import-resolve": 52.3,
+        "lower": 429.3,
+        "parse+lower": 352.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 83.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1027.8727089753374,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1012006912,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.7,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 25.5,
+        "groups": 11.8,
+        "import-resolve": 46.7,
+        "lower": 405.7,
+        "normalize+extract": 422.3,
+        "parse+lower": 333.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 82.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1127.7735829353333,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068072960,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.1,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 25.4,
+        "groups": 10.1,
+        "import-resolve": 46.4,
+        "lower": 435.3,
+        "parse+lower": 363.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 78.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 725.3675829852,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1073381376,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.9,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 26.3,
+        "groups": 11.3,
+        "import-resolve": 53.0,
+        "lower": 471.6,
+        "parse+lower": 392.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 78.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1079.5244579203427,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 978223104,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.4,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 25.7,
+        "groups": 10.2,
+        "import-resolve": 44.2,
+        "lower": 425.5,
+        "normalize+extract": 462.5,
+        "parse+lower": 355.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.4,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 79,
+        "misses": 1505,
+        "read_bytes": 10981,
+        "written_bytes": 190666089
+      },
+      "elapsed_ms": 2677.5749169755727,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1735770112,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 520.5,
+        "candidates": 495.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 28.2,
+        "lower": 978.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.5,
+        "shared_lines": 445.4
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 898.2150410301983,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 860176384,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 107.4,
+        "candidates": 34.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.1,
+        "import-resolve": 25.9,
+        "lower": 469.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 12.1,
+        "shared_lines": 24.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1067.5707909977064,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 993951744,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 27.5,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 25.6,
+        "groups": 13.2,
+        "import-resolve": 42.7,
+        "lower": 435.2,
+        "normalize+extract": 427.2,
+        "parse+lower": 366.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.4,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 79.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2679.9129580613226,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1707737088,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 537.5,
+        "candidates": 495.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.2,
+        "import-resolve": 29.0,
+        "lower": 980.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 4.1,
+        "shared_lines": 429.4
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 900.4708749707788,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 854343680,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 108.0,
+        "candidates": 35.1,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.0,
+        "import-resolve": 26.8,
+        "lower": 472.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 11.8,
+        "shared_lines": 23.1
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1018.5345419449732,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1015087104,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.2,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 28.0,
+        "groups": 11.7,
+        "import-resolve": 47.4,
+        "lower": 409.5,
+        "normalize+extract": 404.3,
+        "parse+lower": 334.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.5,
+        "shared_lines": 83.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1096.8677909113467,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1101824000,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.2,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 25.3,
+        "groups": 11.2,
+        "import-resolve": 47.0,
+        "lower": 419.9,
+        "parse+lower": 347.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 82.6
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 711.386707960628,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1053343744,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.4,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 25.8,
+        "groups": 12.1,
+        "import-resolve": 46.3,
+        "lower": 449.9,
+        "parse+lower": 377.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.3,
+        "query_render": 15.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 87.4
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1072.5235840072855,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1017528320,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.1,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 28.8,
+        "groups": 11.9,
+        "import-resolve": 46.5,
+        "lower": 445.7,
+        "normalize+extract": 411.2,
+        "parse+lower": 370.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.8,
+        "shared_lines": 86.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1133.0353750381619,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1081278464,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.9,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 27.2,
+        "groups": 12.5,
+        "import-resolve": 46.7,
+        "lower": 444.5,
+        "parse+lower": 370.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 83.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 737.9927500151098,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065598976,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.2,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 29.2,
+        "groups": 12.5,
+        "import-resolve": 47.0,
+        "lower": 473.3,
+        "parse+lower": 397.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 86.1
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1062.2555000009015,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1053982720,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 24.1,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 25.6,
+        "groups": 13.1,
+        "import-resolve": 43.7,
+        "lower": 438.0,
+        "normalize+extract": 424.7,
+        "parse+lower": 368.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 78.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2808.658791007474,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1700462592,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 511.3,
+        "candidates": 596.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.6,
+        "import-resolve": 30.7,
+        "lower": 998.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.3,
+        "score": 4.4,
+        "shared_lines": 463.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 913.1849160185084,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 852230144,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 112.5,
+        "candidates": 36.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.7,
+        "import-resolve": 26.2,
+        "lower": 463.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 12.5,
+        "shared_lines": 23.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1074.2384169716388,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 985464832,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.7,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 27.4,
+        "groups": 11.0,
+        "import-resolve": 48.3,
+        "lower": 438.4,
+        "normalize+extract": 443.9,
+        "parse+lower": 362.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.4,
+        "rank_map": 0.7,
+        "rank_sort": 0.4,
+        "score": 1.3,
+        "shared_lines": 78.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2691.3057909114286,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1694531584,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 540.0,
+        "candidates": 495.4,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.6,
+        "import-resolve": 28.4,
+        "lower": 967.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.1,
+        "shared_lines": 452.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 922.8653749451041,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 853786624,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 110.0,
+        "candidates": 34.6,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.6,
+        "import-resolve": 26.4,
+        "lower": 476.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 12.1,
+        "shared_lines": 22.3
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1094.7790830396116,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 987348992,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.9,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 27.1,
+        "groups": 10.5,
+        "import-resolve": 46.5,
+        "lower": 444.8,
+        "normalize+extract": 446.0,
+        "parse+lower": 371.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.2,
+        "shared_lines": 78.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1144.2321250215173,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1109803008,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.7,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.2,
+        "groups": 11.0,
+        "import-resolve": 46.5,
+        "lower": 435.0,
+        "parse+lower": 362.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.2,
+        "query_render": 13.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 78.8
+      },
+      "store": {
+        "bytes": 380153032,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 714.5963750081137,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1057931264,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.8,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 24.9,
+        "groups": 11.6,
+        "import-resolve": 52.9,
+        "lower": 450.4,
+        "parse+lower": 372.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.4,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.3,
+        "rank_families": 2.1,
+        "rank_map": 1.3,
+        "rank_sort": 0.5,
+        "score": 1.7,
+        "shared_lines": 86.0
+      },
+      "store": {
+        "bytes": 380153032,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1089.5972090074793,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 993263616,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.3,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 27.0,
+        "groups": 11.5,
+        "import-resolve": 48.6,
+        "lower": 448.4,
+        "normalize+extract": 439.3,
+        "parse+lower": 372.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.2,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.8,
+        "shared_lines": 79.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1147.2979999380186,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1101676544,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.4,
+        "cluster": 1.2,
+        "contiguous": 0.7,
+        "discover": 27.6,
+        "groups": 10.0,
+        "import-resolve": 53.1,
+        "lower": 459.8,
+        "parse+lower": 379.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 77.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 739.0847499482334,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1077510144,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.6,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 27.1,
+        "groups": 11.8,
+        "import-resolve": 57.2,
+        "lower": 483.0,
+        "parse+lower": 398.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.3,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 78.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1073.0719580315053,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1001963520,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.4,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "discover": 25.7,
+        "groups": 10.3,
+        "import-resolve": 56.1,
+        "lower": 457.9,
+        "normalize+extract": 425.3,
+        "parse+lower": 376.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 75.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2753.762000007555,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1703215104,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 568.0,
+        "candidates": 490.0,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.6,
+        "import-resolve": 28.4,
+        "lower": 982.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.2,
+        "shared_lines": 456.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 922.9024170199409,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 842547200,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 137.6,
+        "candidates": 36.5,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.4,
+        "import-resolve": 26.1,
+        "lower": 458.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 11.2,
+        "shared_lines": 21.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1080.224083038047,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1004830720,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 26.8,
+        "groups": 9.7,
+        "import-resolve": 49.5,
+        "lower": 463.3,
+        "normalize+extract": 420.8,
+        "parse+lower": 386.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 77.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2753.6758340429515,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1741176832,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 558.9,
+        "candidates": 516.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.7,
+        "import-resolve": 29.1,
+        "lower": 995.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 3.9,
+        "shared_lines": 436.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 902.5215409928933,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 852885504,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 128.6,
+        "candidates": 30.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.4,
+        "import-resolve": 31.3,
+        "lower": 461.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 1.9,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 11.2,
+        "shared_lines": 21.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1088.66220805794,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 974241792,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.9,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 28.4,
+        "groups": 10.0,
+        "import-resolve": 55.2,
+        "lower": 447.8,
+        "normalize+extract": 447.9,
+        "parse+lower": 364.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 78.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1140.3250829316676,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1080999936,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.3,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 25.8,
+        "groups": 10.0,
+        "import-resolve": 55.3,
+        "lower": 479.9,
+        "parse+lower": 398.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 75.8
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 725.5452499957755,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070940160,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.3,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 27.1,
+        "groups": 9.8,
+        "import-resolve": 56.8,
+        "lower": 487.2,
+        "parse+lower": 403.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 76.8
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1117.1950419666246,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 964149248,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.3,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 25.3,
+        "groups": 12.7,
+        "import-resolve": 57.7,
+        "lower": 481.2,
+        "normalize+extract": 435.0,
+        "parse+lower": 398.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 79.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1150.444042054005,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1079296000,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.3,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 24.6,
+        "groups": 11.0,
+        "import-resolve": 56.6,
+        "lower": 483.6,
+        "parse+lower": 402.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 83.5
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 769.1208339529112,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1059176448,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.3,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 25.8,
+        "groups": 10.5,
+        "import-resolve": 48.4,
+        "lower": 527.2,
+        "parse+lower": 452.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 0.8,
+        "shared_lines": 82.1
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1099.5946249458939,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 996868096,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 27.5,
+        "groups": 10.5,
+        "import-resolve": 44.4,
+        "lower": 528.4,
+        "normalize+extract": 381.1,
+        "parse+lower": 456.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 77.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2711.7571668932214,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1717469184,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 591.1,
+        "candidates": 492.4,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.7,
+        "import-resolve": 28.1,
+        "lower": 961.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.2,
+        "shared_lines": 401.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 917.2125830082223,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 862388224,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 113.9,
+        "candidates": 32.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 30.5,
+        "lower": 505.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 11.2,
+        "shared_lines": 21.1
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1087.3409999767318,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 997556224,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 24.4,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 28.5,
+        "groups": 10.3,
+        "import-resolve": 43.5,
+        "lower": 514.2,
+        "normalize+extract": 377.0,
+        "parse+lower": 442.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 14.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 75.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2791.01520893164,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1701199872,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 620.6,
+        "candidates": 542.7,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.1,
+        "import-resolve": 29.6,
+        "lower": 969.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 5.0,
+        "shared_lines": 404.1
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 970.7573330961168,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 860454912,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 110.1,
+        "candidates": 33.4,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.5,
+        "import-resolve": 26.6,
+        "lower": 547.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.1,
+        "rank_sort": 0.3,
+        "score": 11.4,
+        "shared_lines": 21.5
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1058.8767500594258,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 999358464,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.8,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 25.6,
+        "groups": 10.7,
+        "import-resolve": 53.1,
+        "lower": 488.0,
+        "normalize+extract": 379.7,
+        "parse+lower": 409.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 78.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1174.8245420167223,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1107509248,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.3,
+        "cluster": 1.2,
+        "contiguous": 0.8,
+        "discover": 28.9,
+        "groups": 12.2,
+        "import-resolve": 47.4,
+        "lower": 509.7,
+        "parse+lower": 433.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 15.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 90.4
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 704.8393340082839,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070415872,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 33.2,
+        "groups": 10.2,
+        "import-resolve": 48.3,
+        "lower": 468.6,
+        "parse+lower": 387.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.0,
+        "shared_lines": 76.6
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1114.466292085126,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 974864384,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 18.9,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 28.3,
+        "groups": 10.1,
+        "import-resolve": 48.5,
+        "lower": 518.6,
+        "normalize+extract": 388.0,
+        "parse+lower": 441.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.3,
+        "query_render": 14.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 83.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1183.59191599302,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099563008,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.3,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 30.0,
+        "groups": 12.4,
+        "import-resolve": 49.2,
+        "lower": 500.4,
+        "parse+lower": 421.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.3,
+        "query_render": 14.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.8,
+        "shared_lines": 87.5
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 693.9664169913158,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068580864,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.0,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 28.8,
+        "groups": 10.9,
+        "import-resolve": 54.8,
+        "lower": 454.9,
+        "parse+lower": 371.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 80.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1153.528208960779,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 999505920,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 29.6,
+        "groups": 12.8,
+        "import-resolve": 50.7,
+        "lower": 488.0,
+        "normalize+extract": 433.5,
+        "parse+lower": 407.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.6,
+        "query_render": 15.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 93.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2772.808333975263,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1689452544,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 528.4,
+        "candidates": 536.8,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.8,
+        "import-resolve": 34.1,
+        "lower": 1039.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 4.0,
+        "shared_lines": 428.6
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 917.0603749807924,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 858161152,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 108.6,
+        "candidates": 34.6,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.9,
+        "import-resolve": 25.9,
+        "lower": 485.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 13.9,
+        "shared_lines": 24.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1062.5520829344168,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1017348096,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.9,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 25.7,
+        "groups": 10.9,
+        "import-resolve": 44.5,
+        "lower": 439.6,
+        "normalize+extract": 418.5,
+        "parse+lower": 369.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 84.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2715.0813749758527,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1654915072,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 508.9,
+        "candidates": 536.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.5,
+        "import-resolve": 28.9,
+        "lower": 1001.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.2,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.3,
+        "score": 4.0,
+        "shared_lines": 430.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 890.5622080201283,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 876019712,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 108.8,
+        "candidates": 35.2,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.2,
+        "import-resolve": 25.6,
+        "lower": 463.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 13.9,
+        "shared_lines": 24.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1043.5412499355152,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1036337152,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.7,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 30.6,
+        "groups": 11.2,
+        "import-resolve": 47.2,
+        "lower": 432.6,
+        "normalize+extract": 396.1,
+        "parse+lower": 354.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.5,
+        "query_render": 15.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.7,
+        "shared_lines": 87.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1190.4038329375908,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090732032,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.9,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 29.7,
+        "groups": 12.9,
+        "import-resolve": 54.3,
+        "lower": 468.1,
+        "parse+lower": 384.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 15.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 86.9
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 702.553707989864,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1075118080,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.3,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 27.5,
+        "groups": 12.3,
+        "import-resolve": 55.0,
+        "lower": 441.0,
+        "parse+lower": 358.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.3,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.5,
+        "shared_lines": 84.9
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1140.8901660470292,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1006321664,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.7,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 30.2,
+        "groups": 13.8,
+        "import-resolve": 56.4,
+        "lower": 449.8,
+        "normalize+extract": 436.5,
+        "parse+lower": 363.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 106.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1315.8371669705957,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1083342848,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.5,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 31.5,
+        "groups": 15.2,
+        "import-resolve": 66.6,
+        "lower": 485.2,
+        "parse+lower": 387.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 19.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 1.5,
+        "shared_lines": 105.6
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 832.9963330179453,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1072480256,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.5,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "discover": 33.2,
+        "groups": 13.7,
+        "import-resolve": 67.2,
+        "lower": 520.1,
+        "parse+lower": 419.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.4,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 102.5
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1209.276375011541,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1013006336,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.1,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 26.0,
+        "groups": 13.2,
+        "import-resolve": 57.4,
+        "lower": 552.1,
+        "normalize+extract": 412.0,
+        "parse+lower": 468.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 17.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 100.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3010.593582992442,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1669840896,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 596.3,
+        "candidates": 604.5,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.5,
+        "import-resolve": 42.5,
+        "lower": 1158.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.4,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 4.5,
+        "shared_lines": 412.1
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 953.744416940026,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 859947008,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 126.1,
+        "candidates": 31.0,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.6,
+        "import-resolve": 27.5,
+        "lower": 511.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.4,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 10.7,
+        "shared_lines": 31.2
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1135.8056670287624,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 977551360,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 33.4,
+        "cluster": 1.9,
+        "contiguous": 1.0,
+        "discover": 26.4,
+        "groups": 14.0,
+        "import-resolve": 47.9,
+        "lower": 460.7,
+        "normalize+extract": 438.2,
+        "parse+lower": 386.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 0.9,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 92.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 2915.19387497101,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1694613504,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 604.1,
+        "candidates": 558.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 41.2,
+        "lower": 1071.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.5,
+        "shared_lines": 444.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 890.2444170089439,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 867172352,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 112.3,
+        "candidates": 34.6,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.1,
+        "import-resolve": 26.0,
+        "lower": 452.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 12.3,
+        "shared_lines": 22.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1185.2499999804422,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 969588736,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.2,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 27.3,
+        "groups": 13.9,
+        "import-resolve": 55.3,
+        "lower": 462.9,
+        "normalize+extract": 466.6,
+        "parse+lower": 380.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 1.1,
+        "query_rank_sort": 2.9,
+        "query_render": 16.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.5,
+        "shared_lines": 104.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1294.5591249736026,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1097678848,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.3,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 31.8,
+        "groups": 14.9,
+        "import-resolve": 67.8,
+        "lower": 489.4,
+        "parse+lower": 389.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 102.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 887.1347919339314,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070710784,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.9,
+        "cluster": 1.8,
+        "contiguous": 0.9,
+        "discover": 37.6,
+        "groups": 13.6,
+        "import-resolve": 71.4,
+        "lower": 588.5,
+        "parse+lower": 479.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.4,
+        "rank_families": 3.1,
+        "rank_map": 1.6,
+        "rank_sort": 1.0,
+        "score": 1.2,
+        "shared_lines": 103.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1282.0567089365795,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 993132544,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.0,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 30.4,
+        "groups": 15.7,
+        "import-resolve": 66.7,
+        "lower": 545.1,
+        "normalize+extract": 455.3,
+        "parse+lower": 448.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.8,
+        "shared_lines": 116.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1427.2425420349464,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1098301440,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 37.6,
+        "groups": 15.7,
+        "import-resolve": 73.9,
+        "lower": 564.2,
+        "parse+lower": 452.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.9,
+        "shared_lines": 114.3
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 887.0974580058828,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068564480,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.2,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 36.8,
+        "groups": 14.4,
+        "import-resolve": 74.5,
+        "lower": 578.2,
+        "parse+lower": 466.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 105.8
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1232.8813329804689,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1026277376,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 27.7,
+        "groups": 14.7,
+        "import-resolve": 60.9,
+        "lower": 547.4,
+        "normalize+extract": 429.9,
+        "parse+lower": 458.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.8,
+        "query_rank_sort": 3.5,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 103.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3150.9652079548687,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1656520704,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 651.1,
+        "candidates": 635.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.9,
+        "import-resolve": 42.4,
+        "lower": 1201.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.5,
+        "shared_lines": 426.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 883.0811249790713,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 844251136,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 105.7,
+        "candidates": 34.1,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 13.4,
+        "import-resolve": 26.0,
+        "lower": 466.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 13.7,
+        "shared_lines": 23.5
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1197.292957920581,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1036877824,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.7,
+        "cluster": 2.5,
+        "contiguous": 1.0,
+        "discover": 28.9,
+        "groups": 14.2,
+        "import-resolve": 59.9,
+        "lower": 458.0,
+        "normalize+extract": 486.6,
+        "parse+lower": 369.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 18.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 103.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3206.2002909369767,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1714077696,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 680.0,
+        "candidates": 646.8,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.6,
+        "import-resolve": 40.9,
+        "lower": 1237.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 4.6,
+        "shared_lines": 399.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 912.7704579150304,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 855359488,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 107.3,
+        "candidates": 31.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 26.4,
+        "lower": 510.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.1,
+        "rank_sort": 0.3,
+        "score": 10.7,
+        "shared_lines": 20.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1203.5683749709278,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 985808896,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.6,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 26.9,
+        "groups": 15.2,
+        "import-resolve": 67.1,
+        "lower": 516.9,
+        "normalize+extract": 422.5,
+        "parse+lower": 422.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 1.0,
+        "query_rank_sort": 3.1,
+        "query_render": 18.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 108.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1404.713416006416,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1107574784,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 36.7,
+        "groups": 15.1,
+        "import-resolve": 74.5,
+        "lower": 563.2,
+        "parse+lower": 451.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 114.3
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 900.4762499826029,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1086816256,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.1,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 40.0,
+        "groups": 15.1,
+        "import-resolve": 76.5,
+        "lower": 552.7,
+        "parse+lower": 436.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 114.6
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1325.788832968101,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 994246656,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.2,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 37.6,
+        "groups": 14.4,
+        "import-resolve": 76.2,
+        "lower": 510.8,
+        "normalize+extract": 544.1,
+        "parse+lower": 397.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 0.9,
+        "shared_lines": 113.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1392.005915986374,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1104707584,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.7,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 36.3,
+        "groups": 16.1,
+        "import-resolve": 74.3,
+        "lower": 590.2,
+        "parse+lower": 479.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.7,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 941.9077499769628,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1064714240,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.0,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 41.2,
+        "groups": 15.5,
+        "import-resolve": 73.9,
+        "lower": 608.0,
+        "parse+lower": 492.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 114.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1336.015542037785,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 978796544,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 35.1,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 34.3,
+        "groups": 14.8,
+        "import-resolve": 63.5,
+        "lower": 533.3,
+        "normalize+extract": 529.4,
+        "parse+lower": 435.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 112.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3222.310374956578,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1685340160,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 647.3,
+        "candidates": 652.8,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.5,
+        "import-resolve": 41.4,
+        "lower": 1271.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.2,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 4.4,
+        "shared_lines": 402.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 909.6580829937011,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 853196800,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 105.3,
+        "candidates": 31.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.8,
+        "import-resolve": 25.9,
+        "lower": 508.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 11.1,
+        "shared_lines": 21.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1189.5434589823708,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 997294080,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 32.3,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 26.6,
+        "groups": 14.9,
+        "import-resolve": 60.7,
+        "lower": 461.8,
+        "normalize+extract": 452.7,
+        "parse+lower": 374.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 3.4,
+        "query_render": 20.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.2,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 113.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3314.329541986808,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1750138880,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 713.8,
+        "candidates": 663.5,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.7,
+        "import-resolve": 46.0,
+        "lower": 1270.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.4,
+        "shared_lines": 401.4
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 910.3331670630723,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 855916544,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 114.5,
+        "candidates": 31.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.6,
+        "import-resolve": 29.5,
+        "lower": 491.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.3,
+        "score": 10.7,
+        "shared_lines": 20.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1252.4535419652238,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 963084288,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.6,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 25.3,
+        "groups": 15.5,
+        "import-resolve": 66.9,
+        "lower": 517.6,
+        "normalize+extract": 454.0,
+        "parse+lower": 425.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 119.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1503.8120410172269,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1094762496,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 37.6,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 39.0,
+        "groups": 16.9,
+        "import-resolve": 74.1,
+        "lower": 583.0,
+        "parse+lower": 469.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.7,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 907.5684580020607,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1060208640,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.2,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 38.9,
+        "groups": 15.1,
+        "import-resolve": 75.0,
+        "lower": 558.2,
+        "parse+lower": 444.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 115.6
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1364.142999984324,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1009303552,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.9,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 37.3,
+        "groups": 15.1,
+        "import-resolve": 74.4,
+        "lower": 544.4,
+        "normalize+extract": 544.5,
+        "parse+lower": 432.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.7,
+        "query_render": 21.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.8,
+        "shared_lines": 115.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1496.5971660567448,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1105969152,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.0,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 41.4,
+        "groups": 16.5,
+        "import-resolve": 74.1,
+        "lower": 626.9,
+        "parse+lower": 511.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.4,
+        "shared_lines": 114.6
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 907.3341659968719,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068761088,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 39.5,
+        "groups": 14.8,
+        "import-resolve": 75.0,
+        "lower": 565.9,
+        "parse+lower": 451.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 115.8
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1346.2308339076117,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1019297792,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 28.4,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 35.6,
+        "groups": 14.4,
+        "import-resolve": 67.2,
+        "lower": 591.8,
+        "normalize+extract": 481.0,
+        "parse+lower": 488.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.7,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 116.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3287.197166006081,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1690550272,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 661.8,
+        "candidates": 660.1,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.6,
+        "import-resolve": 46.9,
+        "lower": 1293.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 4.9,
+        "shared_lines": 426.5
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 908.6636659922078,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 850231296,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 114.4,
+        "candidates": 33.9,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.1,
+        "import-resolve": 25.6,
+        "lower": 463.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 12.1,
+        "shared_lines": 22.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1283.576124929823,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 979894272,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 27.2,
+        "groups": 14.5,
+        "import-resolve": 62.2,
+        "lower": 483.6,
+        "normalize+extract": 528.9,
+        "parse+lower": 394.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 114.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3534.4562500249594,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1694679040,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 660.6,
+        "candidates": 769.4,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.0,
+        "import-resolve": 47.0,
+        "lower": 1406.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 5.1,
+        "shared_lines": 446.3
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 923.818250070326,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 855048192,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 115.3,
+        "candidates": 35.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.2,
+        "import-resolve": 26.0,
+        "lower": 477.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 12.8,
+        "shared_lines": 23.3
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1273.719791090116,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 985006080,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.7,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 25.8,
+        "groups": 16.3,
+        "import-resolve": 67.3,
+        "lower": 430.5,
+        "normalize+extract": 547.1,
+        "parse+lower": 337.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 120.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1598.534458084032,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090224128,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.4,
+        "cluster": 2.3,
+        "contiguous": 1.2,
+        "discover": 40.1,
+        "groups": 17.1,
+        "import-resolve": 81.6,
+        "lower": 689.7,
+        "parse+lower": 567.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.4,
+        "query_rank_sort": 3.9,
+        "query_render": 22.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 126.6
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 985.6067079817876,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1070301184,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.5,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 40.3,
+        "groups": 15.0,
+        "import-resolve": 82.9,
+        "lower": 629.9,
+        "parse+lower": 506.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1429.3381249299273,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 977240064,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.3,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 36.3,
+        "groups": 16.4,
+        "import-resolve": 76.3,
+        "lower": 568.6,
+        "normalize+extract": 582.7,
+        "parse+lower": 456.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 114.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1501.5907499473542,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1101496320,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.6,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 38.9,
+        "groups": 16.5,
+        "import-resolve": 74.5,
+        "lower": 636.2,
+        "parse+lower": 522.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 958.7791659869254,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1060110336,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.4,
+        "cluster": 2.4,
+        "contiguous": 1.0,
+        "discover": 38.7,
+        "groups": 14.8,
+        "import-resolve": 77.7,
+        "lower": 601.9,
+        "parse+lower": 485.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.6,
+        "query_render": 22.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 119.3
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1407.8861660091206,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 978796544,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.3,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 37.3,
+        "groups": 16.0,
+        "import-resolve": 67.0,
+        "lower": 574.0,
+        "normalize+extract": 545.3,
+        "parse+lower": 469.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 17.6,
+        "rank_map": 16.4,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 119.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3351.658875006251,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1717927936,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 670.0,
+        "candidates": 670.0,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.1,
+        "import-resolve": 47.3,
+        "lower": 1329.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 420.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 917.1766249928623,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 841269248,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 125.6,
+        "candidates": 35.4,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.4,
+        "import-resolve": 28.7,
+        "lower": 463.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 11.9,
+        "shared_lines": 22.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1252.0455000922084,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1000439808,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.8,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 26.8,
+        "groups": 15.8,
+        "import-resolve": 60.9,
+        "lower": 482.0,
+        "normalize+extract": 494.1,
+        "parse+lower": 394.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.6,
+        "query_render": 20.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.9,
+        "shared_lines": 112.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3556.609332910739,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1696710656,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 707.4,
+        "candidates": 692.0,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.2,
+        "import-resolve": 47.3,
+        "lower": 1446.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 5.3,
+        "shared_lines": 441.1
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 951.9859999418259,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 850853888,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 138.0,
+        "candidates": 36.6,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.1,
+        "import-resolve": 29.3,
+        "lower": 478.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.1,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 11.9,
+        "shared_lines": 22.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1309.9545830627903,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1004191744,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.4,
+        "cluster": 3.2,
+        "contiguous": 1.1,
+        "discover": 25.5,
+        "groups": 18.0,
+        "import-resolve": 68.8,
+        "lower": 480.0,
+        "normalize+extract": 538.6,
+        "parse+lower": 385.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.9,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 118.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1667.4770839745179,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1100087296,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.2,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 40.6,
+        "groups": 17.1,
+        "import-resolve": 83.8,
+        "lower": 681.1,
+        "parse+lower": 556.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.4,
+        "query_rank_sort": 3.9,
+        "query_render": 23.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.8,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 127.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 964.1707909759134,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1083588608,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.3,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 41.0,
+        "groups": 16.1,
+        "import-resolve": 82.9,
+        "lower": 599.7,
+        "parse+lower": 475.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.4,
+        "rank_sort": 0.8,
+        "score": 2.1,
+        "shared_lines": 119.1
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1430.7342499960214,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 976535552,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.3,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 40.2,
+        "groups": 16.6,
+        "import-resolve": 74.5,
+        "lower": 599.6,
+        "normalize+extract": 535.0,
+        "parse+lower": 484.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 119.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1639.337957953103,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1081884672,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 39.8,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 40.6,
+        "groups": 16.9,
+        "import-resolve": 77.2,
+        "lower": 652.3,
+        "parse+lower": 534.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 113.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 972.2395830322057,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068974080,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.6,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 39.6,
+        "groups": 14.6,
+        "import-resolve": 75.1,
+        "lower": 632.6,
+        "parse+lower": 517.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 114.8
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1445.3139160759747,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 980123648,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 40.5,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 34.4,
+        "groups": 16.7,
+        "import-resolve": 67.6,
+        "lower": 601.2,
+        "normalize+extract": 547.4,
+        "parse+lower": 499.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.7,
+        "query_render": 20.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.4,
+        "rank_sort": 0.8,
+        "score": 1.3,
+        "shared_lines": 116.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3441.621999954805,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1738424320,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 742.0,
+        "candidates": 687.2,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 13.2,
+        "import-resolve": 46.1,
+        "lower": 1344.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 5.0,
+        "shared_lines": 403.6
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 948.2429170748219,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 846086144,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 118.6,
+        "candidates": 30.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 29.4,
+        "lower": 526.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 10.5,
+        "shared_lines": 21.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1280.315374955535,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 983252992,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 34.4,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 28.4,
+        "groups": 16.2,
+        "import-resolve": 60.7,
+        "lower": 507.0,
+        "normalize+extract": 493.1,
+        "parse+lower": 417.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 20.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 112.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 79,
+        "misses": 1505,
+        "read_bytes": 10981,
+        "written_bytes": 190666089
+      },
+      "elapsed_ms": 3612.146583967842,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1747517440,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 807.0,
+        "candidates": 700.6,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.8,
+        "import-resolve": 45.5,
+        "lower": 1412.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 2.1,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 421.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 941.9173749629408,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 862339072,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 112.1,
+        "candidates": 33.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 14.8,
+        "import-resolve": 28.6,
+        "lower": 505.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 12.1,
+        "shared_lines": 22.6
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1327.839458012022,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 995606528,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.1,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 30.4,
+        "groups": 16.8,
+        "import-resolve": 72.0,
+        "lower": 509.2,
+        "normalize+extract": 522.9,
+        "parse+lower": 406.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.8,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.2,
+        "shared_lines": 125.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1648.2021249830723,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1095073792,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.8,
+        "cluster": 2.5,
+        "contiguous": 1.2,
+        "discover": 39.5,
+        "groups": 17.2,
+        "import-resolve": 83.2,
+        "lower": 656.5,
+        "parse+lower": 533.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.8,
+        "query_opp": 1.4,
+        "query_rank_sort": 4.1,
+        "query_render": 24.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.4,
+        "rank_sort": 0.8,
+        "score": 1.2,
+        "shared_lines": 130.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 991.3320420309901,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1077231616,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.4,
+        "cluster": 2.4,
+        "contiguous": 1.2,
+        "discover": 40.9,
+        "groups": 16.8,
+        "import-resolve": 83.0,
+        "lower": 634.0,
+        "parse+lower": 510.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.8,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 117.7
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1460.0571669870988,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 984793088,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 39.4,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 41.1,
+        "groups": 16.7,
+        "import-resolve": 75.7,
+        "lower": 570.3,
+        "normalize+extract": 587.4,
+        "parse+lower": 453.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 118.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1582.1517499862239,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1098809344,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 40.8,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 39.8,
+        "groups": 18.2,
+        "import-resolve": 80.0,
+        "lower": 660.5,
+        "parse+lower": 540.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 122.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 910.6485419906676,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1066090496,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 40.9,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 39.8,
+        "groups": 15.8,
+        "import-resolve": 82.2,
+        "lower": 558.2,
+        "parse+lower": 436.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 2.1,
+        "shared_lines": 116.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1405.98704200238,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 997146624,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.9,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 36.9,
+        "groups": 15.8,
+        "import-resolve": 67.7,
+        "lower": 599.4,
+        "normalize+extract": 523.9,
+        "parse+lower": 494.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 3.5,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 113.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3379.6137500321493,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1713766400,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 676.2,
+        "candidates": 682.6,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.8,
+        "import-resolve": 46.5,
+        "lower": 1325.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.0,
+        "shared_lines": 427.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 936.3441669847816,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 843776000,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 122.4,
+        "candidates": 35.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.2,
+        "import-resolve": 26.5,
+        "lower": 480.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 12.0,
+        "shared_lines": 22.7
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1331.7867079749703,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 985382912,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 37.3,
+        "cluster": 2.4,
+        "contiguous": 1.3,
+        "discover": 26.8,
+        "groups": 17.0,
+        "import-resolve": 61.7,
+        "lower": 511.2,
+        "normalize+extract": 530.8,
+        "parse+lower": 422.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 2.0,
+        "shared_lines": 115.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3572.1727500203997,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1658241024,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 723.8,
+        "candidates": 703.3,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.9,
+        "import-resolve": 52.6,
+        "lower": 1413.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 457.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 936.6541670169681,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 848625664,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 128.1,
+        "candidates": 35.2,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.6,
+        "import-resolve": 28.6,
+        "lower": 466.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 11.9,
+        "shared_lines": 22.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1279.6078330138698,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 990429184,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 37.0,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 26.8,
+        "groups": 17.1,
+        "import-resolve": 67.5,
+        "lower": 453.5,
+        "normalize+extract": 534.3,
+        "parse+lower": 359.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 118.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1703.595209051855,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1088749568,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.8,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 42.7,
+        "groups": 16.4,
+        "import-resolve": 83.7,
+        "lower": 708.6,
+        "parse+lower": 582.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.8,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 9.0,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.2,
+        "shared_lines": 130.1
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 978.6589159630239,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1055670272,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.7,
+        "cluster": 2.3,
+        "contiguous": 1.2,
+        "discover": 39.3,
+        "groups": 16.4,
+        "import-resolve": 82.4,
+        "lower": 620.7,
+        "parse+lower": 498.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 22.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 115.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1451.4422079082578,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 966590464,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.3,
+        "cluster": 2.4,
+        "contiguous": 1.0,
+        "discover": 41.4,
+        "groups": 16.6,
+        "import-resolve": 73.2,
+        "lower": 592.7,
+        "normalize+extract": 561.0,
+        "parse+lower": 478.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 122.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1549.782000016421,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1096105984,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.5,
+        "cluster": 2.4,
+        "contiguous": 1.2,
+        "discover": 39.1,
+        "groups": 17.0,
+        "import-resolve": 76.4,
+        "lower": 602.5,
+        "parse+lower": 487.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 114.9
+      },
+      "store": {
+        "bytes": 380153025,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 969.4184169638902,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1057718272,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.5,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 39.6,
+        "groups": 14.4,
+        "import-resolve": 78.1,
+        "lower": 631.0,
+        "parse+lower": 513.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 113.1
+      },
+      "store": {
+        "bytes": 380153025,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1376.7185419565067,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 990035968,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 39.9,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 33.3,
+        "groups": 16.7,
+        "import-resolve": 67.4,
+        "lower": 601.5,
+        "normalize+extract": 484.6,
+        "parse+lower": 500.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 3.4,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.9,
+        "shared_lines": 114.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3464.806125033647,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1719943168,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 750.0,
+        "candidates": 664.9,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.5,
+        "import-resolve": 45.7,
+        "lower": 1388.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 397.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 943.7260830309242,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 862404608,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 113.1,
+        "candidates": 31.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 28.4,
+        "lower": 524.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 10.8,
+        "shared_lines": 20.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1281.4325829967856,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1017479168,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.7,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 28.3,
+        "groups": 16.3,
+        "import-resolve": 60.6,
+        "lower": 505.9,
+        "normalize+extract": 498.9,
+        "parse+lower": 416.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.8,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 114.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11120,
+        "written_bytes": 190665950
+      },
+      "elapsed_ms": 3535.8385830186307,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1718140928,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 745.1,
+        "candidates": 691.7,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 13.3,
+        "import-resolve": 46.4,
+        "lower": 1396.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 5.5,
+        "shared_lines": 416.8
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1012.0868330122903,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 850919424,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 126.9,
+        "candidates": 32.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.8,
+        "import-resolve": 29.4,
+        "lower": 557.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.1,
+        "query_render": 15.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 11.3,
+        "shared_lines": 25.3
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1313.208750099875,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 983351296,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.6,
+        "cluster": 2.9,
+        "contiguous": 1.1,
+        "discover": 28.1,
+        "groups": 17.1,
+        "import-resolve": 73.9,
+        "lower": 498.5,
+        "normalize+extract": 511.5,
+        "parse+lower": 396.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.6,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 118.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1626.8449580529705,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1103478784,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.7,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 39.5,
+        "groups": 16.2,
+        "import-resolve": 87.3,
+        "lower": 594.1,
+        "parse+lower": 467.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 22.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 122.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 991.2362500326708,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1044807680,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 40.0,
+        "groups": 14.9,
+        "import-resolve": 81.8,
+        "lower": 647.1,
+        "parse+lower": 525.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 120.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1391.1826249677688,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 989528064,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 39.8,
+        "cluster": 2.5,
+        "contiguous": 1.2,
+        "discover": 37.1,
+        "groups": 17.0,
+        "import-resolve": 74.4,
+        "lower": 544.6,
+        "normalize+extract": 551.7,
+        "parse+lower": 433.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 2.2,
+        "shared_lines": 115.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1528.3154170028865,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090338816,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.8,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 40.8,
+        "groups": 17.5,
+        "import-resolve": 78.4,
+        "lower": 579.0,
+        "parse+lower": 459.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.2,
+        "shared_lines": 125.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 968.7854169169441,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1075134464,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.4,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 40.8,
+        "groups": 14.8,
+        "import-resolve": 73.5,
+        "lower": 631.0,
+        "parse+lower": 516.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.9,
+        "rank_map": 1.6,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 119.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1428.1263339798898,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1003585536,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.5,
+        "cluster": 2.4,
+        "contiguous": 1.0,
+        "discover": 37.5,
+        "groups": 14.6,
+        "import-resolve": 68.9,
+        "lower": 582.3,
+        "normalize+extract": 575.5,
+        "parse+lower": 475.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.4,
+        "query_render": 20.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 110.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 79,
+        "misses": 1505,
+        "read_bytes": 10981,
+        "written_bytes": 190666089
+      },
+      "elapsed_ms": 3390.2034170459956,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1741963264,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 665.8,
+        "candidates": 701.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.9,
+        "import-resolve": 47.3,
+        "lower": 1339.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.3,
+        "score": 5.1,
+        "shared_lines": 423.0
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 190677070,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 917.0288749737665,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 857341952,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 107.1,
+        "candidates": 34.5,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.0,
+        "import-resolve": 26.8,
+        "lower": 481.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.4,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 11.6,
+        "shared_lines": 22.9
+      },
+      "store": {
+        "bytes": 448315564,
+        "files": 4590
+      },
+      "workload_id": "sympy"
+    }
+  ],
+  "schema": "nose.cache_query_comparison/v1",
+  "source_identity": "a8e6f459bb51308c817df086021e29239a398ac2e4cd82c7057a53128d1ccd3e",
+  "status": "passed",
+  "summary": {
+    "candidate": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1193.418208451476,
+            "p95": 1428.1263339798898
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 997425152.0,
+            "p95": 1036877824
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 28.1,
+              "p95": 39.9
+            },
+            "cluster": {
+              "p50": 2.0,
+              "p95": 2.5
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.1
+            },
+            "discover": {
+              "p50": 27.45,
+              "p95": 37.3
+            },
+            "groups": {
+              "p50": 14.1,
+              "p95": 16.7
+            },
+            "import-resolve": {
+              "p50": 58.65,
+              "p95": 67.7
+            },
+            "lower": {
+              "p50": 496.95,
+              "p95": 601.2
+            },
+            "normalize+extract": {
+              "p50": 448.29999999999995,
+              "p95": 547.4
+            },
+            "parse+lower": {
+              "p50": 412.29999999999995,
+              "p95": 499.1
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.8,
+              "p95": 1.0
+            },
+            "query_opp": {
+              "p50": 0.5,
+              "p95": 0.7
+            },
+            "query_rank_sort": {
+              "p50": 3.0,
+              "p95": 3.7
+            },
+            "query_render": {
+              "p50": 18.0,
+              "p95": 20.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.5,
+              "p95": 8.0
+            },
+            "rank_dedup": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "rank_families": {
+              "p50": 2.25,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.1,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.2,
+              "p95": 1.9
+            },
+            "shared_lines": {
+              "p50": 102.1,
+              "p95": 116.7
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 80.0,
+              "p95": 80
+            },
+            "misses": {
+              "p50": 1504.0,
+              "p95": 1505
+            },
+            "read_bytes": {
+              "p50": 11120.0,
+              "p95": 11120
+            },
+            "written_bytes": {
+              "p50": 190665950.0,
+              "p95": 190666089
+            }
+          },
+          "elapsed_ms": {
+            "p50": 3080.7793954736553,
+            "p95": 3572.1727500203997
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1703010304.0,
+            "p95": 1747517440
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 633.95,
+              "p95": 750.0
+            },
+            "candidates": {
+              "p50": 619.9,
+              "p95": 703.3
+            },
+            "cluster": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "contiguous": {
+              "p50": 0.8,
+              "p95": 0.9
+            },
+            "groups": {
+              "p50": 11.6,
+              "p95": 13.2
+            },
+            "import-resolve": {
+              "p50": 41.3,
+              "p95": 47.3
+            },
+            "lower": {
+              "p50": 1179.65,
+              "p95": 1413.5
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "query_opp": {
+              "p50": 0.3,
+              "p95": 0.5
+            },
+            "query_rank_sort": {
+              "p50": 2.1,
+              "p95": 2.3
+            },
+            "query_render": {
+              "p50": 12.45,
+              "p95": 14.0
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 5.9,
+              "p95": 6.0
+            },
+            "rank_dedup": {
+              "p50": 0.3,
+              "p95": 0.4
+            },
+            "rank_families": {
+              "p50": 1.7,
+              "p95": 2.1
+            },
+            "rank_map": {
+              "p50": 1.0,
+              "p95": 1.3
+            },
+            "rank_sort": {
+              "p50": 0.4,
+              "p95": 0.4
+            },
+            "score": {
+              "p50": 4.5,
+              "p95": 5.3
+            },
+            "shared_lines": {
+              "p50": 426.25,
+              "p95": 457.0
+            }
+          },
+          "store_bytes": {
+            "p50": 448315564.0,
+            "p95": 448315564
+          }
+        },
+        "history-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "misses": {
+              "p50": 0.0,
+              "p95": 0
+            },
+            "read_bytes": {
+              "p50": 190677070.0,
+              "p95": 190677070
+            },
+            "written_bytes": {
+              "p50": 0.0,
+              "p95": 0
+            }
+          },
+          "elapsed_ms": {
+            "p50": 917.0446249772795,
+            "p95": 970.7573330961168
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 855203840.0,
+            "p95": 871710720
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 113.5,
+              "p95": 137.6
+            },
+            "candidates": {
+              "p50": 34.0,
+              "p95": 36.5
+            },
+            "cluster": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "contiguous": {
+              "p50": 0.8,
+              "p95": 0.9
+            },
+            "groups": {
+              "p50": 11.75,
+              "p95": 13.4
+            },
+            "import-resolve": {
+              "p50": 26.700000000000003,
+              "p95": 30.5
+            },
+            "lower": {
+              "p50": 477.29999999999995,
+              "p95": 547.5
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "query_opp": {
+              "p50": 0.3,
+              "p95": 0.5
+            },
+            "query_rank_sort": {
+              "p50": 2.1,
+              "p95": 2.3
+            },
+            "query_render": {
+              "p50": 13.0,
+              "p95": 14.6
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 5.8,
+              "p95": 6.2
+            },
+            "rank_dedup": {
+              "p50": 0.3,
+              "p95": 0.3
+            },
+            "rank_families": {
+              "p50": 1.7,
+              "p95": 1.9
+            },
+            "rank_map": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "rank_sort": {
+              "p50": 0.4,
+              "p95": 0.4
+            },
+            "score": {
+              "p50": 11.7,
+              "p95": 13.9
+            },
+            "shared_lines": {
+              "p50": 22.7,
+              "p95": 25.3
+            }
+          },
+          "store_bytes": {
+            "p50": 448315564.0,
+            "p95": 448315564
+          }
+        }
+      }
+    },
+    "official": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1194.409187475685,
+            "p95": 1451.4422079082578
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 991780864.0,
+            "p95": 1019478016
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 29.1,
+              "p95": 39.4
+            },
+            "cluster": {
+              "p50": 2.05,
+              "p95": 2.9
+            },
+            "contiguous": {
+              "p50": 0.95,
+              "p95": 1.1
+            },
+            "discover": {
+              "p50": 28.35,
+              "p95": 41.1
+            },
+            "groups": {
+              "p50": 14.15,
+              "p95": 17.1
+            },
+            "import-resolve": {
+              "p50": 62.2,
+              "p95": 76.2
+            },
+            "lower": {
+              "p50": 484.35,
+              "p95": 592.7
+            },
+            "normalize+extract": {
+              "p50": 454.65,
+              "p95": 582.7
+            },
+            "parse+lower": {
+              "p50": 396.75,
+              "p95": 478.0
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.1500000000000004,
+              "p95": 3.6
+            },
+            "query_render": {
+              "p50": 19.2,
+              "p95": 21.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.9,
+              "p95": 8.5
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.25,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.1,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.15,
+              "p95": 1.8
+            },
+            "shared_lines": {
+              "p50": 107.35,
+              "p95": 122.3
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1353.9215414784849,
+            "p95": 1667.4770839745179
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1096892416.0,
+            "p95": 1108705280
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 31.8,
+              "p95": 39.8
+            },
+            "cluster": {
+              "p50": 2.2,
+              "p95": 2.5
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 34.05,
+              "p95": 41.4
+            },
+            "groups": {
+              "p50": 15.149999999999999,
+              "p95": 17.5
+            },
+            "import-resolve": {
+              "p50": 70.85,
+              "p95": 83.8
+            },
+            "lower": {
+              "p50": 536.45,
+              "p95": 689.7
+            },
+            "parse+lower": {
+              "p50": 442.6,
+              "p95": 567.9
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.4
+            },
+            "query_rank_sort": {
+              "p50": 3.1500000000000004,
+              "p95": 3.9
+            },
+            "query_render": {
+              "p50": 19.25,
+              "p95": 23.9
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 7.05,
+              "p95": 8.8
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.3499999999999996,
+              "p95": 2.8
+            },
+            "rank_map": {
+              "p50": 1.2,
+              "p95": 1.4
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.8
+            },
+            "score": {
+              "p50": 1.2,
+              "p95": 1.8
+            },
+            "shared_lines": {
+              "p50": 109.55,
+              "p95": 130.1
+            }
+          },
+          "store_bytes": {
+            "p50": 380153026.0,
+            "p95": 380153032
+          }
+        },
+        "history-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 887.1161249699071,
+            "p95": 991.2362500326708
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1068670976.0,
+            "p95": 1083588608
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 28.15,
+              "p95": 36.3
+            },
+            "cluster": {
+              "p50": 1.95,
+              "p95": 2.4
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 37.2,
+              "p95": 41.0
+            },
+            "groups": {
+              "p50": 14.05,
+              "p95": 16.4
+            },
+            "import-resolve": {
+              "p50": 72.45,
+              "p95": 82.9
+            },
+            "lower": {
+              "p50": 555.45,
+              "p95": 634.0
+            },
+            "parse+lower": {
+              "p50": 440.15,
+              "p95": 517.8
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.6
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.0,
+              "p95": 3.5
+            },
+            "query_render": {
+              "p50": 19.4,
+              "p95": 22.2
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.699999999999999,
+              "p95": 8.3
+            },
+            "rank_dedup": {
+              "p50": 0.4,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.3499999999999996,
+              "p95": 2.9
+            },
+            "rank_map": {
+              "p50": 1.2,
+              "p95": 1.6
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.8
+            },
+            "score": {
+              "p50": 1.3,
+              "p95": 2.1
+            },
+            "shared_lines": {
+              "p50": 104.69999999999999,
+              "p95": 119.3
+            }
+          },
+          "store_bytes": {
+            "p50": 380153026.0,
+            "p95": 380153032
+          }
+        }
+      }
+    }
+  },
+  "workload": {
+    "commit": "da4a5fa52418ae593a941d4ba585cfef87a31870",
+    "id": "sympy",
+    "kind": "real",
+    "path": "bench/repos/sympy"
+  }
+}

--- a/bench/cache/issue-875-mutation-matrix-receipt-2026-07-20.v1.json
+++ b/bench/cache/issue-875-mutation-matrix-receipt-2026-07-20.v1.json
@@ -1,0 +1,8733 @@
+{
+  "environment": {
+    "architecture": "arm64",
+    "logical_cpu_count": 18,
+    "os": "Darwin",
+    "os_release": "25.5.0",
+    "python_version": "3.14.5"
+  },
+  "equivalence": {
+    "after_clean_equals_empty_store": true,
+    "after_clean_equals_history_store": true,
+    "seed_clean_equals_empty_store": true
+  },
+  "measurement": {
+    "cache_stats_required": true,
+    "characterization_only": false,
+    "minimum_replays": 30,
+    "p95": "nearest-rank",
+    "replays": 30
+  },
+  "provenance": {
+    "binary": "target/release/nose",
+    "binary_code_sha256": "615e70d11a916cab96dada7d68e7441dfd7d3457c807146aada52984c7e379c0",
+    "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+    "binary_revision": "e93bdc0526aaf00af32416ecad1d0ef6272f267c",
+    "binary_sha256": "9d5e8952eb5475dfa92d0242cf4e36caa849e7f77607b30c6d24e43d4767f09a",
+    "harness": "scripts/cache-query-regression.py",
+    "harness_sha256": "969cbbc8ae98ed7e9a586c931799958e12b4b4858ec53019b56d4859bc6d145d",
+    "mutation_manifest": "bench/cache/mutation-manifest.v1.json",
+    "mutation_manifest_sha256": "13597fba09fb7e9b5e8785ba2a998d232bf86fa3b23103035b324b0c128ecdc6",
+    "official_baseline": "bench/cache/official-v0.19.0-binaries.v1.json",
+    "official_baseline_sha256": "a9e127dea4303378ed57e3274ca8e0d358b5f0ad253912e4316e8c1f0f83639a",
+    "official_release_verification": null
+  },
+  "raw_report": {
+    "bytes": 4356466,
+    "retention": "local-target; regenerate with the checked harness",
+    "rows": 2100,
+    "sha256": "e66a61fa014fa1dc831e4b71e9a95146332a07c468233a163a6149857c4b35c8"
+  },
+  "report_schema": "nose.cache_query_regression/v1",
+  "schema": "nose.cache_query_regression_receipt/v1",
+  "source_identity": {
+    "add-delete-rename": {
+      "after": "52a47a66165b6566941c3db50ff5abf73b5fec8c7d7e0d18400e9b811dca57ac",
+      "before": "968465d49737b6d2cbcb57f67fb3fb1f15b220d88af227b9f4c654b28fe4e97b"
+    },
+    "analysis-config-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "baseline-ignore-change": {
+      "after": "5eea0d0faf8b6f50256473834941b6683dc750747f553c52004f780acc2fe5f5",
+      "before": "55d8de6f0a69fc30a1ff12624e54c0197b7d3323fa3e3d9829f4858734cb0b47"
+    },
+    "embedded-region-edit": {
+      "after": "74975e07007ac2f36afa3425834a318fdd3cf88004d46c3e1851224485dca974",
+      "before": "07e494dcb00deaca4419b75c0025859628c410d6fee77ba7214d486fc5d89338"
+    },
+    "high-fanout-provider-edit": {
+      "after": "015bdc8c320474e7fc544ac494e17a4d3eb8cd5f79519ed84dfdd6ae54a56604",
+      "before": "42bba0ac8356e34dfc0a59ca2288ac8bee7a3edca57f232d6f85e0ebe83dc346"
+    },
+    "ignore-exclude-root-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "leaf-edit": {
+      "after": "89c3cf821f9993da9a29a27b8d8403d9ff441557899ad15832ffcb3c6239c0a5",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "no-op": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "provider-export-edit": {
+      "after": "931a3cf2a72de39266bc16149bbe7fd15a8d58b228020ca76e5993f14e005b0d",
+      "before": "c3a783fb0ebda0efb3eecea0accaa9abab840fea8921d1f2874ee95fbbf7875a"
+    },
+    "provider-non-export-edit": {
+      "after": "efa68310dadac0f376e2b0c37ed4fca78df5eeffee59bd81f30342e1084ae63e",
+      "before": "af1b200a589585c3c329e3d33d46ece7eb7601302943c22832a7db091e9bcd2d"
+    },
+    "same-size-restored-mtime-edit": {
+      "after": "ac78dd39579a9e902beb77175a06dcb109c11d5c8d8a9361ccffd5b7802def61",
+      "before": "62fc4e2ff7c705a5b2de0d0ac9707963fbbdb95eb9efc8c11f2a6968af2878e2"
+    },
+    "semantic-pack-change": {
+      "after": "ce8006cc0073f8970370aa42101fd6fbc1b0dee25f037dfe460b1c4efd512843",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    },
+    "swift-global-barrier-change": {
+      "after": "ca7643190cff5be5c7e2f2c93bb7cda3016343a2d3371c79d8fb986747e80f86",
+      "before": "f0dbf99c52ea44f1b0fb997ebbefe5c86b01c3c3b227e30414ff8e396e7858d0"
+    },
+    "view-config-change": {
+      "after": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2",
+      "before": "dcf365061cd4e4a8e1eaedf9915682099fbd8d2cbf34e8ddaea6f4b2239bedc2"
+    }
+  },
+  "status": "passed",
+  "summary": {
+    "add-delete-rename": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.886104454286397,
+          "p95": 15.558290993794799
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10297344.0,
+          "p95": 10436608
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.310666534584016,
+          "p95": 16.181958024390042
+        },
+        "output_sha256": [
+          "c2c065ade64cf0807ce7f90e4543de3e4f0e4e3ae7cbe2257e7904950bdb50e5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10256384.0,
+          "p95": 10371072
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 11811.0,
+            "p95": 11811
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.25441647879779,
+          "p95": 49.587792018428445
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12025856.0,
+          "p95": 12107776
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.7,
+            "p95": 0.9
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.7,
+            "p95": 41.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.7,
+            "p95": 0.8
+          }
+        },
+        "store_bytes": {
+          "p50": 32425.0,
+          "p95": 32425
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 11811.0,
+            "p95": 11811
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.438104489818215,
+          "p95": 47.488790936768055
+        },
+        "output_sha256": [
+          "c2c065ade64cf0807ce7f90e4543de3e4f0e4e3ae7cbe2257e7904950bdb50e5"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12009472.0,
+          "p95": 12107776
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.8
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.849999999999994,
+            "p95": 39.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 32253.0,
+          "p95": 32253
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 2953.0,
+            "p95": 2953
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.62245806865394,
+          "p95": 49.01462502311915
+        },
+        "output_sha256": [
+          "da8a41b372234829b87d3c8040a631a2035342cc6c54c80942a634cbcab8089a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12664832.0,
+          "p95": 12730368
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.1,
+            "p95": 40.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.6,
+            "p95": 0.8
+          }
+        },
+        "store_bytes": {
+          "p50": 38281.0,
+          "p95": 38281
+        }
+      }
+    },
+    "analysis-config-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.970291940495372,
+          "p95": 15.762458904646337
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10338304
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 6.7
+          },
+          "normalize+extract": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 6.4
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.802479486912489,
+          "p95": 15.747624915093184
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10354688
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.55,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 6986.0,
+            "p95": 6986
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.26697898330167,
+          "p95": 44.8053750442341
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11812864.0,
+          "p95": 11894784
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.85,
+            "p95": 37.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 22717.0,
+          "p95": 22717
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.58285444928333,
+          "p95": 45.55137502029538
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11927552
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.4,
+            "p95": 38.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.7,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 6986.0,
+            "p95": 6986
+          }
+        },
+        "elapsed_ms": {
+          "p50": 35.72197904577479,
+          "p95": 45.23829196114093
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11517952.0,
+          "p95": 11616256
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 29.85,
+            "p95": 37.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.1,
+            "p95": 0.2
+          }
+        },
+        "store_bytes": {
+          "p50": 38035.0,
+          "p95": 38035
+        }
+      }
+    },
+    "baseline-ignore-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.955229020211846,
+          "p95": 15.251041040755808
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10117120.0,
+          "p95": 10272768
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.4,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.182479004375637,
+          "p95": 15.966249979101121
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10215424.0,
+          "p95": 10321920
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.886145513970405,
+          "p95": 44.45308307185769
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11812864.0,
+          "p95": 11943936
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.6,
+            "p95": 37.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.924042019061744,
+          "p95": 48.33812499418855
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11911168
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 40.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.8
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 36.91912553040311,
+          "p95": 46.093833982013166
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10682368.0,
+          "p95": 10780672
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.35,
+            "p95": 39.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.1,
+            "p95": 0.1
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      }
+    },
+    "embedded-region-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.000645955093205,
+          "p95": 16.01374999154359
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10338304.0,
+          "p95": 10452992
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.4
+          },
+          "normalize+extract": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.915208051912487,
+          "p95": 16.98745903559029
+        },
+        "output_sha256": [
+          "ef19b55e0c71174494cdfeb7e362c856ef0e7f0c2d7810fa50600112ce3283ee"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10321920.0,
+          "p95": 10452992
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.4
+          },
+          "normalize+extract": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 19452.0,
+            "p95": 19452
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.77439547795802,
+          "p95": 47.01991705223918
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11984896.0,
+          "p95": 12189696
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.7,
+            "p95": 0.9
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.2,
+            "p95": 38.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.15000000000000002,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.55,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 43745.0,
+          "p95": 43745
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 19299.0,
+            "p95": 19299
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.16662494884804,
+          "p95": 45.82808411214501
+        },
+        "output_sha256": [
+          "ef19b55e0c71174494cdfeb7e362c856ef0e7f0c2d7810fa50600112ce3283ee"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11952128.0,
+          "p95": 12025856
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.7,
+            "p95": 0.9
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.2,
+            "p95": 38.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 45352.0,
+          "p95": 45352
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 6.0,
+            "p95": 6
+          },
+          "hits": {
+            "p50": 5.0,
+            "p95": 5
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 16332.0,
+            "p95": 16332
+          },
+          "written_bytes": {
+            "p50": 3120.0,
+            "p95": 3120
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.892771419137716,
+          "p95": 48.21662500035018
+        },
+        "output_sha256": [
+          "64b51ccb53514f8631c389cbfd7a538b0f0f418b0c7e64af0e83f0191c0fa166"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12771328.0,
+          "p95": 12943360
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.200000000000003,
+            "p95": 40.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 50801.0,
+          "p95": 50801
+        }
+      }
+    },
+    "high-fanout-provider-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 19.048770947847515,
+          "p95": 21.465249941684306
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12468224.0,
+          "p95": 12550144
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.9,
+            "p95": 5.4
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 4.7,
+            "p95": 6.3
+          },
+          "normalize+extract": {
+            "p50": 1.9,
+            "p95": 2.1
+          },
+          "parse+lower": {
+            "p50": 0.6,
+            "p95": 0.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.45,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 4.2,
+            "p95": 5.8
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 18.70091655291617,
+          "p95": 20.798666984774172
+        },
+        "output_sha256": [
+          "d8e98b36da38d3222e3834aada1a5f9715f97175159b459b2c93e745f1f0424a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12525568.0,
+          "p95": 12632064
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.9,
+            "p95": 5.4
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 4.7,
+            "p95": 6.3
+          },
+          "normalize+extract": {
+            "p50": 1.95,
+            "p95": 2.1
+          },
+          "parse+lower": {
+            "p50": 0.6,
+            "p95": 0.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 4.1,
+            "p95": 5.7
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 132033.0,
+            "p95": 132033
+          }
+        },
+        "elapsed_ms": {
+          "p50": 58.01345850341022,
+          "p95": 65.4540000250563
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 14581760.0,
+          "p95": 14991360
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.3,
+            "p95": 4.7
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 45.15,
+            "p95": 52.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.45,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 1.7,
+            "p95": 1.9
+          }
+        },
+        "store_bytes": {
+          "p50": 413856.0,
+          "p95": 413856
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 132033.0,
+            "p95": 132033
+          }
+        },
+        "elapsed_ms": {
+          "p50": 57.03749996609986,
+          "p95": 62.812749994918704
+        },
+        "output_sha256": [
+          "d8e98b36da38d3222e3834aada1a5f9715f97175159b459b2c93e745f1f0424a"
+        ],
+        "peak_rss_bytes": {
+          "p50": 14712832.0,
+          "p95": 15204352
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.25,
+            "p95": 5.0
+          },
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 43.9,
+            "p95": 48.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 1.8,
+            "p95": 3.0
+          }
+        },
+        "store_bytes": {
+          "p50": 414411.0,
+          "p95": 414411
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 34.0,
+            "p95": 34
+          },
+          "hits": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "misses": {
+            "p50": 33.0,
+            "p95": 33
+          },
+          "read_bytes": {
+            "p50": 3956.0,
+            "p95": 3956
+          },
+          "written_bytes": {
+            "p50": 128077.0,
+            "p95": 128077
+          }
+        },
+        "elapsed_ms": {
+          "p50": 53.15618752501905,
+          "p95": 58.1878749653697
+        },
+        "output_sha256": [
+          "acfeae42bfcd902744d5f9d38be764b1cff09c11cea5095875c6e06cdcf2ac1d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 15081472.0,
+          "p95": 15368192
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 4.05,
+            "p95": 4.5
+          },
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 39.75,
+            "p95": 44.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.5,
+            "p95": 0.5
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "shared_lines": {
+            "p50": 1.5,
+            "p95": 2.5
+          }
+        },
+        "store_bytes": {
+          "p50": 609975.0,
+          "p95": 609975
+        }
+      }
+    },
+    "ignore-exclude-root-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.053312537726015,
+          "p95": 16.937749926000834
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10354688
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 3.3,
+            "p95": 6.4
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.731729006394744,
+          "p95": 14.569792081601918
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10215424.0,
+          "p95": 10371072
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.72052096994594,
+          "p95": 43.94795896951109
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11714560.0,
+          "p95": 11812864
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.5,
+            "p95": 36.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.6,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 16957.0,
+          "p95": 16957
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.67758350679651,
+          "p95": 47.27841692510992
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11927552
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.25,
+            "p95": 39.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.47656202176586,
+          "p95": 46.486916951835155
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10895360.0,
+          "p95": 10993664
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.299999999999997,
+            "p95": 38.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.5
+          }
+        },
+        "store_bytes": {
+          "p50": 22570.0,
+          "p95": 22570
+        }
+      }
+    },
+    "leaf-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.750791491474956,
+          "p95": 15.251583070494235
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10289152
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.149707974866033,
+          "p95": 16.18945796508342
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10223616.0,
+          "p95": 10289152
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 6.5
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.75,
+            "p95": 6.7
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8912.0,
+            "p95": 8912
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.80606248276308,
+          "p95": 48.281915951520205
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11821056.0,
+          "p95": 11894784
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.55,
+            "p95": 39.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 23153.0,
+          "p95": 23153
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.99960400303826,
+          "p95": 46.28920799586922
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11812864.0,
+          "p95": 11911168
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.349999999999994,
+            "p95": 37.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.6499999999999999,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 5904.0,
+            "p95": 5904
+          },
+          "written_bytes": {
+            "p50": 3008.0,
+            "p95": 3008
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.96297905500978,
+          "p95": 44.500374933704734
+        },
+        "output_sha256": [
+          "d19a959726c2147a8e192abd225891ba3c64458703e0de5aa9411dd835a4fe6c"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12541952.0,
+          "p95": 12632064
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.6,
+            "p95": 37.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.6,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 28766.0,
+          "p95": 28766
+        }
+      }
+    },
+    "no-op": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.075937564484775,
+          "p95": 15.632417052984238
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10215424.0,
+          "p95": 10338304
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.9064165414311,
+          "p95": 15.983708086423576
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10223616.0,
+          "p95": 10305536
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.660583493765444,
+          "p95": 47.14537493418902
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11796480.0,
+          "p95": 11878400
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.3,
+            "p95": 40.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.52422897377983,
+          "p95": 50.266332924366
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11804672.0,
+          "p95": 11894784
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.25,
+            "p95": 42.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 36.55110450927168,
+          "p95": 43.691958067938685
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10698752.0,
+          "p95": 10813440
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.1,
+            "p95": 36.7
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.1,
+            "p95": 0.1
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      }
+    },
+    "provider-export-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 10.071541997604072,
+          "p95": 11.152708088047802
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 9928704.0,
+          "p95": 10027008
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.29668755736202,
+          "p95": 15.81991696730256
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10477568.0,
+          "p95": 10633216
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8197.0,
+            "p95": 8197
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.18041644990444,
+          "p95": 46.78912507370114
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11886592.0,
+          "p95": 12042240
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.1
+          },
+          "lower": {
+            "p50": 32.55,
+            "p95": 40.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": {
+          "p50": 26822.0,
+          "p95": 26822
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8197.0,
+            "p95": 8197
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.28685397841036,
+          "p95": 45.95412500202656
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12156928.0,
+          "p95": 12238848
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.75,
+            "p95": 38.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 27539.0,
+          "p95": 27539
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 3956.0,
+            "p95": 3956
+          },
+          "written_bytes": {
+            "p50": 4241.0,
+            "p95": 4241
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.76754153659567,
+          "p95": 47.75116604287177
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12550144.0,
+          "p95": 12664832
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.85,
+            "p95": 40.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.0,
+            "p95": 0.0
+          }
+        },
+        "store_bytes": {
+          "p50": 37303.0,
+          "p95": 37303
+        }
+      }
+    },
+    "provider-non-export-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.222666504792869,
+          "p95": 16.26716705504805
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10485760.0,
+          "p95": 10600448
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.019312046002597,
+          "p95": 15.351583017036319
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10452992.0,
+          "p95": 10551296
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 9915.0,
+            "p95": 9915
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.74908306170255,
+          "p95": 45.32158398069441
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12181504.0,
+          "p95": 12288000
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.5,
+            "p95": 37.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.6,
+            "p95": 1.0
+          }
+        },
+        "store_bytes": {
+          "p50": 30020.0,
+          "p95": 30020
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 9915.0,
+            "p95": 9915
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.890583033207804,
+          "p95": 45.95708299893886
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12173312.0,
+          "p95": 12271616
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.8,
+            "p95": 38.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 30018.0,
+          "p95": 30018
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 7950.0,
+            "p95": 7950
+          },
+          "written_bytes": {
+            "p50": 1965.0,
+            "p95": 1965
+          }
+        },
+        "elapsed_ms": {
+          "p50": 37.892437481787056,
+          "p95": 48.56929101515561
+        },
+        "output_sha256": [
+          "f152de389d7f29a867208e802d0bfe651a4da36d4044b29f4f307d107ca3cdb4"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12484608.0,
+          "p95": 12582912
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.549999999999997,
+            "p95": 40.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.4,
+            "p95": 0.4
+          }
+        },
+        "store_bytes": {
+          "p50": 35835.0,
+          "p95": 35835
+        }
+      }
+    },
+    "same-size-restored-mtime-edit": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.833666569553316,
+          "p95": 16.07925002463162
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10256384.0,
+          "p95": 10420224
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 5.0
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.205875457264483,
+          "p95": 15.967166982591152
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10256384.0,
+          "p95": 10354688
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.45,
+            "p95": 6.4
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 12319.0,
+            "p95": 12319
+          }
+        },
+        "elapsed_ms": {
+          "p50": 39.05714605934918,
+          "p95": 48.26279194094241
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11894784.0,
+          "p95": 11960320
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.45,
+            "p95": 40.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.7,
+            "p95": 0.8
+          }
+        },
+        "store_bytes": {
+          "p50": 34421.0,
+          "p95": 34421
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 12319.0,
+            "p95": 12319
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.86783350026235,
+          "p95": 49.88837498240173
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11870208.0,
+          "p95": 11960320
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.6,
+            "p95": 42.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 34205.0,
+          "p95": 34205
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 4.0,
+            "p95": 4
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 1.0,
+            "p95": 1
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 3461.0,
+            "p95": 3461
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.234145496971905,
+          "p95": 45.25987501256168
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12255232.0,
+          "p95": 12353536
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.75,
+            "p95": 37.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.4,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 40109.0,
+          "p95": 40109
+        }
+      }
+    },
+    "semantic-pack-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.078021467663348,
+          "p95": 15.76075004413724
+        },
+        "output_sha256": [
+          "a627b49d5f58503a14f3737831f11e15b86019ece5927f87948d6ba799dfbe7f"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10559488.0,
+          "p95": 10682368
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.199708472006023,
+          "p95": 16.040666960179806
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10321920
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.5
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.4
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.61785453045741,
+          "p95": 47.208125004544854
+        },
+        "output_sha256": [
+          "a627b49d5f58503a14f3737831f11e15b86019ece5927f87948d6ba799dfbe7f"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12189696.0,
+          "p95": 12304384
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.3,
+            "p95": 39.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.84485404705629,
+          "p95": 47.3412920255214
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11927552
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.6
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.349999999999994,
+            "p95": 39.5
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 36.94174997508526,
+          "p95": 42.900290922261775
+        },
+        "output_sha256": [
+          "a627b49d5f58503a14f3737831f11e15b86019ece5927f87948d6ba799dfbe7f"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11173888.0,
+          "p95": 11255808
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.2,
+            "p95": 36.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.1,
+            "p95": 0.1
+          }
+        },
+        "store_bytes": {
+          "p50": 30954.0,
+          "p95": 30954
+        }
+      }
+    },
+    "swift-global-barrier-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.765582989435643,
+          "p95": 16.69887499883771
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11272192.0,
+          "p95": 11436032
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.75,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.817625062074512,
+          "p95": 15.936583979055285
+        },
+        "output_sha256": [
+          "db53413c2e47123509eb1d8e09990f485a0ae28a3037d73bb1d7173cdb6cf05b"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11157504.0,
+          "p95": 11288576
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.3
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 3.3,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 10812.0,
+            "p95": 10812
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.7538755312562,
+          "p95": 48.28474996611476
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12877824.0,
+          "p95": 12976128
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.6,
+            "p95": 41.0
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.6
+          }
+        },
+        "store_bytes": {
+          "p50": 35796.0,
+          "p95": 35796
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 2.0,
+            "p95": 2
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 7526.0,
+            "p95": 7526
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.69518748251721,
+          "p95": 50.939375068992376
+        },
+        "output_sha256": [
+          "db53413c2e47123509eb1d8e09990f485a0ae28a3037d73bb1d7173cdb6cf05b"
+        ],
+        "peak_rss_bytes": {
+          "p50": 12738560.0,
+          "p95": 12861440
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.6,
+            "p95": 0.8
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.099999999999994,
+            "p95": 42.9
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 0.4,
+            "p95": 0.9
+          }
+        },
+        "store_bytes": {
+          "p50": 22359.0,
+          "p95": 22359
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 10812.0,
+            "p95": 10812
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.31999999238178,
+          "p95": 45.22587498649955
+        },
+        "output_sha256": [
+          "992b97dcae5a1cc23bc509ac36b1890c77aef86db4fdae97831ddd4755e4d566"
+        ],
+        "peak_rss_bytes": {
+          "p50": 13287424.0,
+          "p95": 13369344
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.4,
+            "p95": 0.5
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 31.9,
+            "p95": 37.8
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.5
+          }
+        },
+        "store_bytes": {
+          "p50": 44241.0,
+          "p95": 44241
+        }
+      }
+    },
+    "view-config-change": {
+      "clean-after": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 13.785687508061528,
+          "p95": 15.91099996585399
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10125312.0,
+          "p95": 10223616
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.3,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.7,
+            "p95": 5.2
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "clean-seed": {
+        "cache": null,
+        "elapsed_ms": {
+          "p50": 14.153374475426972,
+          "p95": 15.87908307556063
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10207232.0,
+          "p95": 10338304
+        },
+        "stages_ms": {
+          "candidates": {
+            "p50": 0.2,
+            "p95": 0.4
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "discover": {
+            "p50": 3.5,
+            "p95": 5.1
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 3.8,
+            "p95": 5.3
+          },
+          "normalize+extract": {
+            "p50": 0.2,
+            "p95": 0.3
+          },
+          "parse+lower": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "shared_lines": {
+            "p50": 3.4,
+            "p95": 4.9
+          }
+        },
+        "store_bytes": null
+      },
+      "empty-store-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.447208469733596,
+          "p95": 45.85354099981487
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11730944.0,
+          "p95": 11927552
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.1,
+            "p95": 38.2
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "empty-store-seed": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "misses": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "read_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "written_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          }
+        },
+        "elapsed_ms": {
+          "p50": 38.227583456318825,
+          "p95": 45.92804191634059
+        },
+        "output_sha256": [
+          "b4b792ea5bbfa3dc8ed2c6a053b6bfb068c16d049ebb60907493687206726db2"
+        ],
+        "peak_rss_bytes": {
+          "p50": 11829248.0,
+          "p95": 11960320
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.5,
+            "p95": 0.7
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 32.0,
+            "p95": 38.1
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.2,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.5,
+            "p95": 0.7
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      },
+      "history-after": {
+        "cache": {
+          "files": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "hits": {
+            "p50": 3.0,
+            "p95": 3
+          },
+          "misses": {
+            "p50": 0.0,
+            "p95": 0
+          },
+          "read_bytes": {
+            "p50": 8858.0,
+            "p95": 8858
+          },
+          "written_bytes": {
+            "p50": 0.0,
+            "p95": 0
+          }
+        },
+        "elapsed_ms": {
+          "p50": 36.469333979766816,
+          "p95": 42.93200001120567
+        },
+        "output_sha256": [
+          "69ce0b4a71e58dfb1f7e217525236ed2ab15de8048c5bf3bfe74d9e9b2583b0d"
+        ],
+        "peak_rss_bytes": {
+          "p50": 10641408.0,
+          "p95": 10747904
+        },
+        "stages_ms": {
+          "cache": {
+            "p50": 0.1,
+            "p95": 0.2
+          },
+          "candidates": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "cluster": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "contiguous": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "groups": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "import-resolve": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "lower": {
+            "p50": 30.8,
+            "p95": 36.6
+          },
+          "query_activate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_filter": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_gate": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_opp": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_render": {
+            "p50": 0.15000000000000002,
+            "p95": 0.2
+          },
+          "query_since": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "query_surface": {
+            "p50": 0.1,
+            "p95": 0.1
+          },
+          "rank_dedup": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_families": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_map": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "rank_sort": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "score": {
+            "p50": 0.0,
+            "p95": 0.0
+          },
+          "shared_lines": {
+            "p50": 0.1,
+            "p95": 0.1
+          }
+        },
+        "store_bytes": {
+          "p50": 24494.0,
+          "p95": 24494
+        }
+      }
+    }
+  },
+  "workload": {
+    "ids": [
+      "add-delete-rename",
+      "analysis-config-change",
+      "baseline-ignore-change",
+      "embedded-region-edit",
+      "high-fanout-provider-edit",
+      "ignore-exclude-root-change",
+      "leaf-edit",
+      "no-op",
+      "provider-export-edit",
+      "provider-non-export-edit",
+      "same-size-restored-mtime-edit",
+      "semantic-pack-change",
+      "swift-global-barrier-change",
+      "view-config-change"
+    ],
+    "kind": "fixture-matrix"
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "dd2f5fa048953a11325f6e78bdcbfe485dfafb48",
+  "product_crates_tree": "11d89b35b7a0831568f4aec531e828a9ab54ad26",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -98,6 +98,7 @@ const UNITS_SYNTAX_SCHEMA: u32 = 2;
 
 pub(crate) struct CachedUnits {
     pub units: Vec<UnitFeat>,
+    pub unit_keys: Vec<[u8; 32]>,
     pub streams: Vec<Stream>,
     pub files: usize,
     pub stats: CacheStats,
@@ -147,7 +148,7 @@ fn build_units_cached_inner(
     let read_bytes = AtomicU64::new(0);
     let written_bytes = AtomicU64::new(0);
 
-    let per_file: Vec<(Vec<UnitFeat>, Stream)> = corpus
+    let per_file: Vec<(Vec<UnitFeat>, Stream, ContentDigest, String)> = corpus
         .files
         .par_iter()
         .enumerate()
@@ -175,7 +176,7 @@ fn build_units_cached_inner(
                 {
                     hits.fetch_add(1, Ordering::Relaxed);
                     retarget(&mut units, &mut stream, &path);
-                    return (units, stream);
+                    return (units, stream, key.digest, path);
                 }
             }
 
@@ -194,19 +195,31 @@ fn build_units_cached_inner(
                     written_bytes.fetch_add(bytes, Ordering::Relaxed);
                 }
             }
-            (units, stream)
+            (units, stream, key.digest, path)
         })
         .collect();
 
     let files = per_file.len();
     let mut all_units = Vec::new();
+    let mut unit_keys = Vec::new();
     let mut all_streams = Vec::new();
-    for (u, s) in per_file {
+    for (u, s, artifact, path) in per_file {
+        for index in 0..u.len() {
+            let ordinal = (index as u64).to_be_bytes();
+            unit_keys.push(
+                *ContentDigest::derive(
+                    b"nose.cached-unit-identity.v1",
+                    &[artifact.as_bytes(), path.as_bytes(), &ordinal],
+                )
+                .as_bytes(),
+            );
+        }
         all_units.extend(u);
         all_streams.push(s);
     }
     CachedUnits {
         units: all_units,
+        unit_keys,
         streams: all_streams,
         files,
         stats: CacheStats {

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -16,7 +16,9 @@
 //! correctness input. `NOSE_CACHE_STATS` also emits a machine-readable
 //! `nose.invalidation/v1` closure with exact reasons and explicit over-invalidation.
 
+mod detection;
 mod digest;
+mod lines;
 mod portable_il;
 mod resolved;
 mod source;
@@ -28,9 +30,25 @@ use rayon::prelude::*;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
+pub(crate) use self::detection::{
+    load_detection_state, store_detection_state, DetectionCacheIdentity,
+};
 use self::digest::ContentDigest;
+pub(crate) use self::lines::{build_line_index, LineIndexStats};
 pub(crate) use self::resolved::CachedCorpus;
 use self::store::{ArtifactKey, ArtifactStage, LayeredCas};
+
+#[derive(Clone)]
+pub(crate) struct CachedSourceFile {
+    pub(crate) path: String,
+    pub(crate) digest: [u8; 32],
+}
+
+pub(crate) struct CachedLineContext {
+    pub(crate) cache_dir: std::path::PathBuf,
+    pub(crate) workspace_digest: [u8; 32],
+    pub(crate) source_files: Vec<CachedSourceFile>,
+}
 
 pub(crate) fn build_corpus_cached(
     roots: &[&Path],
@@ -44,6 +62,16 @@ pub(crate) fn build_corpus_cached(
 
 pub(crate) fn invalidation_report_json(report: &resolved::InvalidationReport) -> String {
     serde_json::to_string(report).expect("invalidation report is always JSON serializable")
+}
+
+pub(crate) fn incremental_detection_stats_json(
+    stats: &nose_detect::IncrementalDetectionStats,
+) -> String {
+    serde_json::to_string(stats).expect("incremental detection stats are JSON serializable")
+}
+
+pub(crate) fn line_index_stats_json(stats: &LineIndexStats) -> String {
+    serde_json::to_string(stats).expect("line index stats are JSON serializable")
 }
 
 fn semantic_pack_digest(packs: &nose_semantics::SemanticPackSet) -> ContentDigest {

--- a/crates/nose-cli/src/cache/detection.rs
+++ b/crates/nose-cli/src/cache/detection.rs
@@ -1,0 +1,139 @@
+//! Process-boundary persistence for `nose-detect`'s opaque incremental state.
+
+use super::digest::ContentDigest;
+use nose_detect::{DetectOptions, IncrementalDetectionState};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) struct DetectionCacheIdentity {
+    workspace: [u8; 32],
+    query: ContentDigest,
+}
+
+impl DetectionCacheIdentity {
+    pub(crate) fn new(
+        workspace: [u8; 32],
+        semantic_packs: [u8; 32],
+        opts: &DetectOptions,
+        detector: &dyn nose_detect::Detector,
+    ) -> Self {
+        let options = options_bytes(opts);
+        let environment = influential_environment();
+        Self {
+            workspace,
+            query: ContentDigest::derive(
+                b"nose.incremental-detection-query.v1",
+                &[
+                    &semantic_packs,
+                    detector.name().as_bytes(),
+                    &options,
+                    &environment,
+                ],
+            ),
+        }
+    }
+}
+
+pub(crate) fn load_detection_state(
+    root: &Path,
+    identity: &DetectionCacheIdentity,
+) -> Option<IncrementalDetectionState> {
+    let bytes = std::fs::read(state_path(root, identity)).ok()?;
+    rmp_serde::from_slice(&bytes).ok()
+}
+
+pub(crate) fn store_detection_state(
+    root: &Path,
+    identity: &DetectionCacheIdentity,
+    state: &IncrementalDetectionState,
+) {
+    let path = state_path(root, identity);
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(bytes) = rmp_serde::to_vec_named(state) else {
+        return;
+    };
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, &path).is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+fn state_path(root: &Path, identity: &DetectionCacheIdentity) -> PathBuf {
+    root.join("detection-state-v1")
+        .join(hex(&identity.workspace))
+        .join(format!("{}.msgpack", identity.query.hex()))
+}
+
+fn options_bytes(opts: &DetectOptions) -> Vec<u8> {
+    let values = [
+        opts.min_lines as u64,
+        opts.min_tokens as u64,
+        opts.threshold.to_bits(),
+        opts.minhash_k as u64,
+        opts.bands as u64,
+        opts.cfg_norm as u64,
+        opts.dce as u64,
+        opts.jaccard_weight.to_bits(),
+        opts.block_units as u64,
+        opts.contiguous_min_tokens as u64,
+        opts.contiguous_min_lines as u64,
+        opts.contiguous as u64,
+        opts.structural as u64,
+        opts.value_candidates as u64,
+        opts.shape_candidates as u64,
+        opts.shape_features as u64,
+        opts.connected_witnesses as u64,
+        opts.abstraction_witnesses as u64,
+        opts.emit_pairs as u64,
+    ];
+    values.into_iter().flat_map(u64::to_be_bytes).collect()
+}
+
+fn influential_environment() -> Vec<u8> {
+    let mut rows = std::env::vars_os()
+        .filter_map(|(name, value)| {
+            let name = name.to_string_lossy();
+            name.starts_with("NOSE_").then(|| {
+                let mut row = name.as_bytes().to_vec();
+                row.push(0);
+                row.extend_from_slice(value.to_string_lossy().as_bytes());
+                row
+            })
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    rows.into_iter().flatten().collect()
+}
+
+fn hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thresholds_and_modes_separate_detection_state() {
+        let mut first = DetectOptions::default();
+        let detector = nose_detect::StructuralDetector::strict(first.jaccard_weight);
+        let a = DetectionCacheIdentity::new([1; 32], [2; 32], &first, &detector);
+        first.threshold = 0.7;
+        let b = DetectionCacheIdentity::new([1; 32], [2; 32], &first, &detector);
+        assert_ne!(a.query, b.query);
+    }
+}

--- a/crates/nose-cli/src/cache/detection.rs
+++ b/crates/nose-cli/src/cache/detection.rs
@@ -54,7 +54,7 @@ pub(crate) fn store_detection_state(
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
-    let Ok(bytes) = rmp_serde::to_vec_named(state) else {
+    let Ok(bytes) = rmp_serde::to_vec(state) else {
         return;
     };
     let temp = parent.join(format!(

--- a/crates/nose-cli/src/cache/lines.rs
+++ b/crates/nose-cli/src/cache/lines.rs
@@ -1,0 +1,211 @@
+use super::CachedSourceFile;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const STATE_SCHEMA: u32 = 1;
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Default, Deserialize, Serialize)]
+struct LineIndexState {
+    schema: u32,
+    files: BTreeMap<String, StoredFileLines>,
+    document_frequency: BTreeMap<String, u32>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredFileLines {
+    digest: [u8; 32],
+    lines: Vec<String>,
+    unique_substantive: Vec<String>,
+}
+
+pub(crate) struct CachedLineIndex {
+    pub(crate) document_frequency: FxHashMap<String, u32>,
+    pub(crate) files: FxHashMap<String, Option<Vec<String>>>,
+    pub(crate) changed_lines: FxHashSet<String>,
+    pub(crate) file_count: usize,
+}
+
+#[derive(Default, serde::Serialize)]
+pub(crate) struct LineIndexStats {
+    schema: &'static str,
+    files_reused: usize,
+    files_rebuilt: usize,
+    files_removed: usize,
+    changed_document_frequencies: usize,
+}
+
+pub(crate) fn build_line_index(
+    cache_dir: &Path,
+    workspace: [u8; 32],
+    source_files: &[CachedSourceFile],
+) -> (CachedLineIndex, LineIndexStats) {
+    let path = state_path(cache_dir, workspace);
+    let previous = load_state(&path);
+    let mut document_frequency = previous.document_frequency.clone();
+    let current_paths = source_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut changed_lines = FxHashSet::default();
+    let mut stats = LineIndexStats {
+        schema: "nose.line-index/v1",
+        ..LineIndexStats::default()
+    };
+    for (path, file) in &previous.files {
+        if !current_paths.contains(path.as_str()) {
+            apply_frequency_delta(
+                &mut document_frequency,
+                &file.unique_substantive,
+                false,
+                &mut changed_lines,
+            );
+            stats.files_removed += 1;
+        }
+    }
+
+    let mut files = BTreeMap::new();
+    for source in source_files {
+        if let Some(previous_file) = previous
+            .files
+            .get(&source.path)
+            .filter(|file| file.digest == source.digest)
+        {
+            stats.files_reused += 1;
+            files.insert(
+                source.path.clone(),
+                StoredFileLines {
+                    digest: previous_file.digest,
+                    lines: previous_file.lines.clone(),
+                    unique_substantive: previous_file.unique_substantive.clone(),
+                },
+            );
+            continue;
+        }
+        if let Some(previous_file) = previous.files.get(&source.path) {
+            apply_frequency_delta(
+                &mut document_frequency,
+                &previous_file.unique_substantive,
+                false,
+                &mut changed_lines,
+            );
+        }
+        let Some(text) = std::fs::read_to_string(&source.path).ok() else {
+            continue;
+        };
+        let lines = text.lines().map(str::to_string).collect::<Vec<_>>();
+        let unique_substantive = unique_substantive_lines(&lines);
+        apply_frequency_delta(
+            &mut document_frequency,
+            &unique_substantive,
+            true,
+            &mut changed_lines,
+        );
+        stats.files_rebuilt += 1;
+        files.insert(
+            source.path.clone(),
+            StoredFileLines {
+                digest: source.digest,
+                lines,
+                unique_substantive,
+            },
+        );
+    }
+    document_frequency.retain(|_, count| *count > 0);
+    stats.changed_document_frequencies = changed_lines.len();
+    let state = LineIndexState {
+        schema: STATE_SCHEMA,
+        files,
+        document_frequency,
+    };
+    store_state(&path, &state);
+    let index = CachedLineIndex {
+        document_frequency: state
+            .document_frequency
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect(),
+        files: state
+            .files
+            .iter()
+            .map(|(path, file)| (path.clone(), Some(file.lines.clone())))
+            .collect(),
+        changed_lines,
+        file_count: state.files.len(),
+    };
+    (index, stats)
+}
+
+fn unique_substantive_lines(lines: &[String]) -> Vec<String> {
+    let mut unique = lines
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !crate::source_lines::is_trivial_line(line))
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    unique.shrink_to_fit();
+    unique
+}
+
+fn apply_frequency_delta(
+    frequencies: &mut BTreeMap<String, u32>,
+    lines: &[String],
+    add: bool,
+    changed: &mut FxHashSet<String>,
+) {
+    for line in lines {
+        let value = frequencies.entry(line.clone()).or_default();
+        if add {
+            *value += 1;
+        } else {
+            *value = value.saturating_sub(1);
+        }
+        changed.insert(line.clone());
+    }
+}
+
+fn state_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
+    cache_dir
+        .join("line-index-state-v1")
+        .join(format!("{}.msgpack", hex(&workspace)))
+}
+
+fn load_state(path: &Path) -> LineIndexState {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| rmp_serde::from_slice::<LineIndexState>(&bytes).ok())
+        .filter(|state| state.schema == STATE_SCHEMA)
+        .unwrap_or_default()
+}
+
+fn store_state(path: &Path, state: &LineIndexState) {
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(bytes) = rmp_serde::to_vec_named(state) else {
+        return;
+    };
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+fn hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}

--- a/crates/nose-cli/src/cache/lines.rs
+++ b/crates/nose-cli/src/cache/lines.rs
@@ -22,11 +22,18 @@ struct StoredFileLines {
     unique_substantive: Vec<String>,
 }
 
+#[derive(Eq, PartialEq, Deserialize, Serialize)]
+struct LineIndexManifest {
+    schema: u32,
+    files: BTreeMap<String, [u8; 32]>,
+}
+
 pub(crate) struct CachedLineIndex {
     pub(crate) document_frequency: FxHashMap<String, u32>,
     pub(crate) files: FxHashMap<String, Option<Vec<String>>>,
     pub(crate) changed_lines: FxHashSet<String>,
     pub(crate) file_count: usize,
+    pub(crate) complete: bool,
 }
 
 #[derive(Default, serde::Serialize)]
@@ -42,9 +49,19 @@ pub(crate) fn build_line_index(
     cache_dir: &Path,
     workspace: [u8; 32],
     source_files: &[CachedSourceFile],
+    force_full: bool,
 ) -> (CachedLineIndex, LineIndexStats) {
     let path = state_path(cache_dir, workspace);
-    let previous = load_state(&path);
+    let manifest_path = manifest_path(cache_dir, workspace);
+    let manifest = current_manifest(source_files);
+    if !force_full {
+        if let Some(reused) = reuse_unchanged_index(&manifest_path, &manifest) {
+            return reused;
+        }
+    }
+    let loaded = load_state(&path);
+    let state_hit = loaded.is_some();
+    let previous = loaded.unwrap_or_default();
     let mut document_frequency = previous.document_frequency.clone();
     let current_paths = source_files
         .iter()
@@ -121,7 +138,30 @@ pub(crate) fn build_line_index(
         files,
         document_frequency,
     };
-    store_state(&path, &state);
+    finish_index(
+        &path,
+        &manifest_path,
+        &manifest,
+        state,
+        state_hit,
+        stats,
+        changed_lines,
+    )
+}
+
+fn finish_index(
+    path: &Path,
+    manifest_path: &Path,
+    manifest: &LineIndexManifest,
+    state: LineIndexState,
+    state_hit: bool,
+    stats: LineIndexStats,
+    changed_lines: FxHashSet<String>,
+) -> (CachedLineIndex, LineIndexStats) {
+    if !state_hit || stats.files_rebuilt > 0 || stats.files_removed > 0 {
+        store_state(path, &state);
+    }
+    store_manifest(manifest_path, manifest);
     let index = CachedLineIndex {
         document_frequency: state
             .document_frequency
@@ -135,8 +175,41 @@ pub(crate) fn build_line_index(
             .collect(),
         changed_lines,
         file_count: state.files.len(),
+        complete: true,
     };
     (index, stats)
+}
+
+fn current_manifest(source_files: &[CachedSourceFile]) -> LineIndexManifest {
+    LineIndexManifest {
+        schema: STATE_SCHEMA,
+        files: source_files
+            .iter()
+            .map(|file| (file.path.clone(), file.digest))
+            .collect(),
+    }
+}
+
+fn reuse_unchanged_index(
+    path: &Path,
+    current: &LineIndexManifest,
+) -> Option<(CachedLineIndex, LineIndexStats)> {
+    (load_manifest(path).as_ref() == Some(current)).then(|| {
+        (
+            CachedLineIndex {
+                document_frequency: FxHashMap::default(),
+                files: FxHashMap::default(),
+                changed_lines: FxHashSet::default(),
+                file_count: current.files.len(),
+                complete: false,
+            },
+            LineIndexStats {
+                schema: "nose.line-index/v1",
+                files_reused: current.files.len(),
+                ..LineIndexStats::default()
+            },
+        )
+    })
 }
 
 fn unique_substantive_lines(lines: &[String]) -> Vec<String> {
@@ -175,22 +248,40 @@ fn state_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
         .join(format!("{}.msgpack", hex(&workspace)))
 }
 
-fn load_state(path: &Path) -> LineIndexState {
+fn manifest_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
+    cache_dir
+        .join("line-index-manifest-v1")
+        .join(format!("{}.msgpack", hex(&workspace)))
+}
+
+fn load_state(path: &Path) -> Option<LineIndexState> {
     std::fs::read(path)
         .ok()
         .and_then(|bytes| rmp_serde::from_slice::<LineIndexState>(&bytes).ok())
         .filter(|state| state.schema == STATE_SCHEMA)
-        .unwrap_or_default()
+}
+
+fn load_manifest(path: &Path) -> Option<LineIndexManifest> {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| rmp_serde::from_slice(&bytes).ok())
+        .filter(|manifest: &LineIndexManifest| manifest.schema == STATE_SCHEMA)
+}
+
+fn store_manifest(path: &Path, manifest: &LineIndexManifest) {
+    store_bytes(path, rmp_serde::to_vec(manifest));
 }
 
 fn store_state(path: &Path, state: &LineIndexState) {
+    store_bytes(path, rmp_serde::to_vec(state));
+}
+
+fn store_bytes(path: &Path, bytes: Result<Vec<u8>, rmp_serde::encode::Error>) {
     let Some(parent) = path.parent() else { return };
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
-    let Ok(bytes) = rmp_serde::to_vec_named(state) else {
-        return;
-    };
+    let Ok(bytes) = bytes else { return };
     let temp = parent.join(format!(
         ".{}.{}.tmp",
         std::process::id(),

--- a/crates/nose-cli/src/cache/resolved.rs
+++ b/crates/nose-cli/src/cache/resolved.rs
@@ -18,6 +18,9 @@ pub(crate) struct CachedCorpus {
     pub(crate) corpus: Corpus,
     pub(crate) report: InvalidationReport,
     pub(crate) unit_contexts: Vec<[u8; 32]>,
+    pub(crate) workspace_digest: [u8; 32],
+    pub(crate) semantic_pack_digest: [u8; 32],
+    pub(crate) source_files: Vec<super::CachedSourceFile>,
 }
 
 #[derive(Debug, Serialize)]
@@ -110,6 +113,8 @@ pub(super) fn build_resolved_corpus_cached(
     dir: &Path,
     semantic_pack_digest: ContentDigest,
 ) -> CachedCorpus {
+    let workspace_digest = *raw.workspace_digest.as_bytes();
+    let source_files = raw.source_files.clone();
     let cas = LayeredCas::new(dir);
     let summary =
         nose_frontend::resolution_dependency_summary(&raw.corpus.files, &raw.corpus.interner);
@@ -144,6 +149,9 @@ pub(super) fn build_resolved_corpus_cached(
             .collect(),
         report,
         corpus: raw.corpus,
+        workspace_digest,
+        semantic_pack_digest: *semantic_pack_digest.as_bytes(),
+        source_files,
     }
 }
 

--- a/crates/nose-cli/src/cache/source.rs
+++ b/crates/nose-cli/src/cache/source.rs
@@ -1,6 +1,7 @@
 use super::digest::ContentDigest;
 use super::portable_il;
 use super::store::{ArtifactKey, ArtifactStage, LayeredCas};
+use super::CachedSourceFile;
 use nose_il::{Corpus, FileId, Il, Interner, Lang};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,7 @@ pub(super) struct RawCorpus {
     pub(super) workspace_digest: ContentDigest,
     pub(super) source_hits: usize,
     pub(super) source_misses: usize,
+    pub(super) source_files: Vec<CachedSourceFile>,
 }
 
 pub(super) struct RawRegionMetadata {
@@ -85,6 +87,16 @@ pub(super) fn build_raw_corpus_cached(
 
     let source_hits = results.iter().filter(|result| result.snapshot_hit).count();
     let source_misses = results.len() - source_hits;
+    let source_files = paths
+        .iter()
+        .zip(&results)
+        .filter_map(|((path, _), result)| {
+            result.source_digest.map(|digest| CachedSourceFile {
+                path: path.clone(),
+                digest: *digest.as_bytes(),
+            })
+        })
+        .collect();
     let mut discovery_rows = Vec::new();
     let mut line_rows = Vec::new();
     let mut files = Vec::new();
@@ -123,6 +135,7 @@ pub(super) fn build_raw_corpus_cached(
         workspace_digest: workspace_digest(roots),
         source_hits,
         source_misses,
+        source_files,
     }
 }
 

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -302,9 +302,10 @@ fn query_detect_report(
         &corpus,
     );
     semantic_pack_external_exact.apply(&mut corpus);
-    let (mut units, streams, files) = if let Some(dir) = &args.cache_dir {
+    let (mut units, unit_keys, streams, files) = if let Some(dir) = &args.cache_dir {
         let cache::CachedUnits {
             units,
+            unit_keys,
             streams,
             files,
             stats,
@@ -324,12 +325,12 @@ fn query_detect_report(
                 stats.files, stats.hits, stats.misses, stats.read_bytes, stats.written_bytes
             );
         }
-        (units, streams, files)
+        (units, Some(unit_keys), streams, files)
     } else {
         let features = time_stage("normalize+extract", || {
             nose_detect::corpus_features(&corpus, opts)
         });
-        (features.units, features.streams, features.files)
+        (features.units, None, features.streams, features.files)
     };
     if opts.shape_candidates && semantic_pack_near.is_active() {
         for unit in &mut units {
@@ -340,7 +341,7 @@ fn query_detect_report(
     let report = detect_cached_or_clean(
         args,
         cache_identity_parts,
-        units,
+        (units, unit_keys.as_deref()),
         files,
         &streams,
         opts,
@@ -358,12 +359,13 @@ fn query_detect_report(
 fn detect_cached_or_clean(
     args: &QueryArgs,
     cache_identity_parts: Option<([u8; 32], [u8; 32])>,
-    units: Vec<nose_detect::UnitFeat>,
+    detection_units: (Vec<nose_detect::UnitFeat>, Option<&[[u8; 32]]>),
     files: usize,
     streams: &[nose_detect::Stream],
     opts: &nose_detect::DetectOptions,
     detector: &dyn nose_detect::Detector,
 ) -> nose_detect::Report {
+    let (units, unit_keys) = detection_units;
     let (Some(dir), Some((workspace, pack_digest))) = (&args.cache_dir, cache_identity_parts)
     else {
         return nose_detect::detect_from_units_with_accepted_coverage(
@@ -375,9 +377,18 @@ fn detect_cached_or_clean(
     let previous = cache::load_detection_state(dir, &identity);
     let (report, _dump, state, stats) =
         nose_detect::detect_from_units_incremental_with_accepted_coverage(
-            units, files, streams, opts, detector, previous,
+            units, files, streams, opts, detector, previous, unit_keys,
         );
-    cache::store_detection_state(dir, &identity, &state);
+    if !stats.state_hit
+        || stats.units_added > 0
+        || stats.units_removed > 0
+        || stats.buckets_rebuilt > 0
+        || stats.scores_evaluated > 0
+        || stats.connected_evaluations_evaluated > 0
+        || stats.contiguous_streams_rebuilt > 0
+    {
+        cache::store_detection_state(dir, &identity, &state);
+    }
     if std::env::var_os("NOSE_CACHE_STATS").is_some() {
         eprintln!(
             "  [detection] {}",
@@ -479,19 +490,37 @@ fn weight_shared_lines(
     }
     let mut lines = FileLineCache::default();
     if let Some(context) = cached {
-        let (idf, stats, changed_lines, file_count) = cached_line_idf(context, &mut lines);
-        if std::env::var_os("NOSE_CACHE_STATS").is_some() {
-            eprintln!("  [line-index] {}", cache::line_index_stats_json(&stats));
-        }
-        let family_stats = apply_cached_family_lines(
+        let (mut idf, mut stats, mut changed_lines, mut file_count, complete) =
+            cached_line_idf(context, &mut lines, false);
+        let mut family_stats = apply_cached_family_lines(
             families,
             &idf,
             &mut lines,
             context,
             &changed_lines,
             file_count,
+            complete,
         );
+        if family_stats.is_none() {
+            lines = FileLineCache::default();
+            let full = cached_line_idf(context, &mut lines, true);
+            idf = full.0;
+            stats = full.1;
+            changed_lines = full.2;
+            file_count = full.3;
+            family_stats = apply_cached_family_lines(
+                families,
+                &idf,
+                &mut lines,
+                context,
+                &changed_lines,
+                file_count,
+                true,
+            );
+        }
+        let family_stats = family_stats.expect("full line index covers every family");
         if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+            eprintln!("  [line-index] {}", cache::line_index_stats_json(&stats));
             eprintln!(
                 "  [family-lines] {}",
                 serde_json::to_string(&family_stats)

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -7,8 +7,8 @@ use crate::query_options::{
     validate_min_value, DetectionChannels, QueryScope, SortKey, QUERY_DEFAULT_MODES,
 };
 use crate::source_lines::{
-    corpus_line_idf, family_anchor, is_trivial_line, shared_lines_of, varying_spots_of,
-    FileLineCache,
+    apply_cached_family_lines, cached_line_idf, corpus_line_idf, family_anchor, is_trivial_line,
+    shared_lines_of, varying_spots_of, FileLineCache,
 };
 use crate::surfaces::GeneratedPathAssertions;
 use crate::timing::{time_lower, time_stage};
@@ -37,14 +37,15 @@ pub(super) fn build_query_dataset(
     let (settings, semantic_packs) = resolve_query_settings(args)?;
     let opts = detection_options(settings.channels, settings.min_tokens, settings.min_lines);
     let detector = detection_engine(settings.channels, &opts);
-    let (mut report, scope, semantic_pack_near, semantic_pack_external_exact) = query_detect_report(
-        args,
-        refs,
-        &settings.exclude,
-        &opts,
-        detector.as_ref(),
-        &semantic_packs,
-    );
+    let (mut report, scope, semantic_pack_near, semantic_pack_external_exact, line_context) =
+        query_detect_report(
+            args,
+            refs,
+            &settings.exclude,
+            &opts,
+            detector.as_ref(),
+            &semantic_packs,
+        );
 
     let mut families = time_stage("rank_families", || nose_detect::rank_families(&report));
     annotate_semantic_pack_near(&mut families, &semantic_pack_near);
@@ -89,7 +90,12 @@ pub(super) fn build_query_dataset(
         }
     }
     time_stage("shared_lines", || {
-        weight_shared_lines(&mut families, refs, &settings.exclude)
+        weight_shared_lines(
+            &mut families,
+            refs,
+            &settings.exclude,
+            line_context.as_ref(),
+        )
     });
     let sort = settings.sort;
     time_stage("query_rank_sort", || {
@@ -247,21 +253,33 @@ fn query_detect_report(
     QueryScope,
     nose_semantics::SemanticPackNearRegistry,
     nose_semantics::SemanticPackExternalExactRegistry,
+    Option<cache::CachedLineContext>,
 ) {
-    let (mut corpus, invalidation_report, unit_contexts) = if let Some(dir) = &args.cache_dir {
-        let cached = time_lower(|| cache::build_corpus_cached(refs, exclude, dir, semantic_packs));
-        (
-            cached.corpus,
-            Some(cached.report),
-            Some(cached.unit_contexts),
-        )
-    } else {
-        (
-            time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude)),
-            None,
-            None,
-        )
-    };
+    let (mut corpus, invalidation_report, unit_contexts, cache_identity_parts, line_context) =
+        if let Some(dir) = &args.cache_dir {
+            let cached =
+                time_lower(|| cache::build_corpus_cached(refs, exclude, dir, semantic_packs));
+            let line_context = cache::CachedLineContext {
+                cache_dir: dir.clone(),
+                workspace_digest: cached.workspace_digest,
+                source_files: cached.source_files,
+            };
+            (
+                cached.corpus,
+                Some(cached.report),
+                Some(cached.unit_contexts),
+                Some((cached.workspace_digest, cached.semantic_pack_digest)),
+                Some(line_context),
+            )
+        } else {
+            (
+                time_lower(|| nose_frontend::lower_corpus_filtered(refs, exclude)),
+                None,
+                None,
+                None,
+                None,
+            )
+        };
     if std::env::var_os("NOSE_CACHE_STATS").is_some() {
         if let Some(report) = &invalidation_report {
             eprintln!(
@@ -319,16 +337,54 @@ fn query_detect_report(
                 semantic_pack_near.protocols_for_unit(&unit.path, unit.start_line, unit.end_line);
         }
     }
-    let report = nose_detect::detect_from_units_with_accepted_coverage(
-        units, files, &streams, opts, detector,
-    )
-    .0;
+    let report = detect_cached_or_clean(
+        args,
+        cache_identity_parts,
+        units,
+        files,
+        &streams,
+        opts,
+        detector,
+    );
     (
         report,
         scope,
         semantic_pack_near,
         semantic_pack_external_exact,
+        line_context,
     )
+}
+
+fn detect_cached_or_clean(
+    args: &QueryArgs,
+    cache_identity_parts: Option<([u8; 32], [u8; 32])>,
+    units: Vec<nose_detect::UnitFeat>,
+    files: usize,
+    streams: &[nose_detect::Stream],
+    opts: &nose_detect::DetectOptions,
+    detector: &dyn nose_detect::Detector,
+) -> nose_detect::Report {
+    let (Some(dir), Some((workspace, pack_digest))) = (&args.cache_dir, cache_identity_parts)
+    else {
+        return nose_detect::detect_from_units_with_accepted_coverage(
+            units, files, streams, opts, detector,
+        )
+        .0;
+    };
+    let identity = cache::DetectionCacheIdentity::new(workspace, pack_digest, opts, detector);
+    let previous = cache::load_detection_state(dir, &identity);
+    let (report, _dump, state, stats) =
+        nose_detect::detect_from_units_incremental_with_accepted_coverage(
+            units, files, streams, opts, detector, previous,
+        );
+    cache::store_detection_state(dir, &identity, &state);
+    if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+        eprintln!(
+            "  [detection] {}",
+            cache::incremental_detection_stats_json(&stats)
+        );
+    }
+    report
 }
 
 fn annotate_semantic_pack_near(
@@ -415,12 +471,35 @@ fn weight_shared_lines(
     families: &mut [nose_detect::RefactorFamily],
     refs: &[&std::path::Path],
     exclude: &[String],
+    cached: Option<&cache::CachedLineContext>,
 ) {
     let needs_shared = |f: &nose_detect::RefactorFamily| f.languages == 1 && f.locations.len() >= 2;
     if !families.iter().any(needs_shared) {
         return;
     }
     let mut lines = FileLineCache::default();
+    if let Some(context) = cached {
+        let (idf, stats, changed_lines, file_count) = cached_line_idf(context, &mut lines);
+        if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+            eprintln!("  [line-index] {}", cache::line_index_stats_json(&stats));
+        }
+        let family_stats = apply_cached_family_lines(
+            families,
+            &idf,
+            &mut lines,
+            context,
+            &changed_lines,
+            file_count,
+        );
+        if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+            eprintln!(
+                "  [family-lines] {}",
+                serde_json::to_string(&family_stats)
+                    .expect("family line stats are JSON serializable")
+            );
+        }
+        return;
+    }
     let idf = corpus_line_idf(refs, exclude, &mut lines);
     for f in families.iter_mut().filter(|f| needs_shared(f)) {
         // Difference evidence comes from the same first readable representative

--- a/crates/nose-cli/src/source_lines.rs
+++ b/crates/nose-cli/src/source_lines.rs
@@ -1,6 +1,9 @@
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+mod incremental;
+pub(crate) use incremental::apply_cached_family_lines;
+
 /// Anti-unify N line-blocks at line granularity. Anchored on the first (largest) copy,
 /// a line *survives* into the shared body only if it is matched in *every* other copy
 /// (each copy votes via a pairwise `line_diff` against the anchor); any maximal run of
@@ -113,6 +116,7 @@ pub(crate) fn classify_param(lines: &[&str]) -> &'static str {
 /// *ranking* weight, the *displayed* invariant-line count, and the parameter
 /// count — kept as three values because the display count and the ranking set
 /// answer different questions (coevo S4-C2).
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub(crate) struct SharedLines {
     /// Majority-voted invariant lines (deduped, sorted) — the robust signal the
     /// ranking weights by IDF. Robustness is the point: a 6-copy family isn't
@@ -421,6 +425,45 @@ pub(crate) fn corpus_line_idf(
         df,
         n_files: n_files.max(1) as f64,
     }
+}
+
+pub(crate) fn cached_line_idf(
+    context: &crate::cache::CachedLineContext,
+    cache: &mut FileLineCache,
+) -> (
+    LineIdf,
+    crate::cache::LineIndexStats,
+    FxHashSet<String>,
+    usize,
+) {
+    let (index, stats) = crate::cache::build_line_index(
+        &context.cache_dir,
+        context.workspace_digest,
+        &context.source_files,
+    );
+    let mut files = index.files;
+    let aliases = files
+        .iter()
+        .flat_map(|(path, lines)| {
+            let mut aliases = Vec::new();
+            if let Ok(canonical) = std::fs::canonicalize(path) {
+                aliases.push((canonical.to_string_lossy().into_owned(), lines.clone()));
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                aliases.push((crate::path_utils::relativize(path, &cwd), lines.clone()));
+            }
+            aliases
+        })
+        .collect::<Vec<_>>();
+    files.extend(aliases);
+    cache.0 = files;
+    let file_count = index.file_count;
+    let changed_lines = index.changed_lines;
+    let idf = LineIdf {
+        df: index.document_frequency,
+        n_files: file_count.max(1) as f64,
+    };
+    (idf, stats, changed_lines, file_count)
 }
 
 /// Deterministic ranking tie-break: a family's first site `(file, start line)`.

--- a/crates/nose-cli/src/source_lines.rs
+++ b/crates/nose-cli/src/source_lines.rs
@@ -430,16 +430,19 @@ pub(crate) fn corpus_line_idf(
 pub(crate) fn cached_line_idf(
     context: &crate::cache::CachedLineContext,
     cache: &mut FileLineCache,
+    force_full: bool,
 ) -> (
     LineIdf,
     crate::cache::LineIndexStats,
     FxHashSet<String>,
     usize,
+    bool,
 ) {
     let (index, stats) = crate::cache::build_line_index(
         &context.cache_dir,
         context.workspace_digest,
         &context.source_files,
+        force_full,
     );
     let mut files = index.files;
     let aliases = files
@@ -458,12 +461,13 @@ pub(crate) fn cached_line_idf(
     files.extend(aliases);
     cache.0 = files;
     let file_count = index.file_count;
+    let complete = index.complete;
     let changed_lines = index.changed_lines;
     let idf = LineIdf {
         df: index.document_frequency,
         n_files: file_count.max(1) as f64,
     };
-    (idf, stats, changed_lines, file_count)
+    (idf, stats, changed_lines, file_count, complete)
 }
 
 /// Deterministic ranking tie-break: a family's first site `(file, start line)`.

--- a/crates/nose-cli/src/source_lines/incremental.rs
+++ b/crates/nose-cli/src/source_lines/incremental.rs
@@ -41,10 +41,24 @@ pub(crate) fn apply_cached_family_lines(
     context: &CachedLineContext,
     changed_lines: &FxHashSet<String>,
     file_count: usize,
-) -> FamilyLineStats {
+    line_index_complete: bool,
+) -> Option<FamilyLineStats> {
     let path = state_path(&context.cache_dir, context.workspace_digest);
     let previous = load_state(&path);
     let digests = source_digests(context);
+    if !line_index_complete
+        && families
+            .iter()
+            .filter(|family| family.languages == 1 && family.locations.len() >= 2)
+            .any(|family| {
+                previous
+                    .families
+                    .get(&family_key(family, &digests))
+                    .is_none_or(|stored| stored.file_count != file_count)
+            })
+    {
+        return None;
+    }
     let mut current = BTreeMap::new();
     let mut stats = FamilyLineStats {
         schema: "nose.family-line-state/v1",
@@ -82,14 +96,19 @@ pub(crate) fn apply_cached_family_lines(
         apply_analysis(family, &analysis);
         current.insert(key, analysis);
     }
-    store_state(
-        &path,
-        &FamilyLineState {
-            schema: STATE_SCHEMA,
-            families: current,
-        },
-    );
-    stats
+    if stats.families_reweighted > 0
+        || stats.families_rebuilt > 0
+        || current.len() != previous.families.len()
+    {
+        store_state(
+            &path,
+            &FamilyLineState {
+                schema: STATE_SCHEMA,
+                families: current,
+            },
+        );
+    }
+    Some(stats)
 }
 
 fn analyze_family(
@@ -208,6 +227,8 @@ fn store_state(path: &Path, state: &FamilyLineState) {
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
+    // `VaryingSpot` omits empty optional fields, which requires a named map: compact
+    // tuple encoding would shift the remaining fields and fail closed on reload.
     let Ok(bytes) = rmp_serde::to_vec_named(state) else {
         return;
     };
@@ -228,4 +249,38 @@ fn hex(bytes: &[u8; 32]) -> String {
         write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omitted_empty_varying_spot_fields_round_trip() {
+        let state = FamilyLineState {
+            schema: STATE_SCHEMA,
+            families: BTreeMap::from([(
+                [7; 32],
+                StoredFamilyLines {
+                    shared: None,
+                    varying_spots: vec![nose_detect::VaryingSpot {
+                        param: 1,
+                        a_lines: None,
+                        b_lines: None,
+                        a_text: String::new(),
+                        b_text: String::new(),
+                    }],
+                    shared_weight: 0.0,
+                    file_count: 2,
+                },
+            )]),
+        };
+        let bytes = rmp_serde::to_vec_named(&state).expect("serialize family line state");
+        let restored: FamilyLineState =
+            rmp_serde::from_slice(&bytes).expect("deserialize family line state");
+        let spot = &restored.families[&[7; 32]].varying_spots[0];
+        assert_eq!(spot.param, 1);
+        assert!(spot.a_lines.is_none());
+        assert!(spot.a_text.is_empty());
+    }
 }

--- a/crates/nose-cli/src/source_lines/incremental.rs
+++ b/crates/nose-cli/src/source_lines/incremental.rs
@@ -1,0 +1,231 @@
+use super::{
+    is_trivial_line, shared_lines_of, varying_spots_of, FileLineCache, LineIdf, SharedLines,
+};
+use crate::cache::CachedLineContext;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const STATE_SCHEMA: u32 = 1;
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Default, Deserialize, Serialize)]
+struct FamilyLineState {
+    schema: u32,
+    families: BTreeMap<[u8; 32], StoredFamilyLines>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct StoredFamilyLines {
+    shared: Option<SharedLines>,
+    varying_spots: Vec<nose_detect::VaryingSpot>,
+    shared_weight: f64,
+    file_count: usize,
+}
+
+#[derive(Default, Serialize)]
+pub(crate) struct FamilyLineStats {
+    schema: &'static str,
+    families_reused: usize,
+    families_reweighted: usize,
+    families_rebuilt: usize,
+}
+
+pub(crate) fn apply_cached_family_lines(
+    families: &mut [nose_detect::RefactorFamily],
+    idf: &LineIdf,
+    lines: &mut FileLineCache,
+    context: &CachedLineContext,
+    changed_lines: &FxHashSet<String>,
+    file_count: usize,
+) -> FamilyLineStats {
+    let path = state_path(&context.cache_dir, context.workspace_digest);
+    let previous = load_state(&path);
+    let digests = source_digests(context);
+    let mut current = BTreeMap::new();
+    let mut stats = FamilyLineStats {
+        schema: "nose.family-line-state/v1",
+        ..FamilyLineStats::default()
+    };
+    for family in families
+        .iter_mut()
+        .filter(|family| family.languages == 1 && family.locations.len() >= 2)
+    {
+        let key = family_key(family, &digests);
+        let analysis = if let Some(stored) = previous.families.get(&key) {
+            let needs_reweight = stored.file_count != file_count
+                || stored.shared.as_ref().is_some_and(|shared| {
+                    shared
+                        .rank_lines
+                        .iter()
+                        .any(|line| changed_lines.contains(line))
+                });
+            let mut stored = stored.clone();
+            if needs_reweight {
+                stored.shared_weight = stored
+                    .shared
+                    .as_ref()
+                    .map_or(0.0, |shared| shared_weight(shared, idf));
+                stored.file_count = file_count;
+                stats.families_reweighted += 1;
+            } else {
+                stats.families_reused += 1;
+            }
+            stored
+        } else {
+            stats.families_rebuilt += 1;
+            analyze_family(family, idf, lines, file_count)
+        };
+        apply_analysis(family, &analysis);
+        current.insert(key, analysis);
+    }
+    store_state(
+        &path,
+        &FamilyLineState {
+            schema: STATE_SCHEMA,
+            families: current,
+        },
+    );
+    stats
+}
+
+fn analyze_family(
+    family: &nose_detect::RefactorFamily,
+    idf: &LineIdf,
+    lines: &mut FileLineCache,
+    file_count: usize,
+) -> StoredFamilyLines {
+    let varying_spots = family.locations[1..]
+        .iter()
+        .find_map(|other| varying_spots_of(&family.locations[0], other, lines))
+        .unwrap_or_default();
+    let shared = shared_lines_of(&family.locations, lines);
+    let shared_weight = shared
+        .as_ref()
+        .map_or(0.0, |shared| shared_weight(shared, idf));
+    StoredFamilyLines {
+        shared,
+        varying_spots,
+        shared_weight,
+        file_count,
+    }
+}
+
+fn apply_analysis(family: &mut nose_detect::RefactorFamily, analysis: &StoredFamilyLines) {
+    family.varying_spots.clone_from(&analysis.varying_spots);
+    family.shared_weight = analysis.shared_weight;
+    if let Some(shared) = &analysis.shared {
+        family.shared_lines = shared.display;
+        family.params = shared.params;
+        family.display_params = Some(shared.display_params);
+    }
+}
+
+fn shared_weight(shared: &SharedLines, idf: &LineIdf) -> f64 {
+    let substantive = shared
+        .rank_lines
+        .iter()
+        .filter(|line| !is_trivial_line(line))
+        .map(|line| idf.weight(line))
+        .sum::<f64>();
+    let gate = (substantive / 2.0).clamp(0.0, 1.0);
+    shared.rank_lines.len() as f64 * gate
+}
+
+fn family_key(
+    family: &nose_detect::RefactorFamily,
+    source_digests: &FxHashMap<String, [u8; 32]>,
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nose.family-line-analysis.v1\0");
+    hasher.update((family.locations.len() as u64).to_be_bytes());
+    for location in &family.locations {
+        hash_component(&mut hasher, location.file.as_bytes());
+        hasher.update(location.start_line.to_be_bytes());
+        hasher.update(location.end_line.to_be_bytes());
+        let digest = source_digest(&location.file, source_digests);
+        hasher.update(digest);
+    }
+    hasher.finalize().into()
+}
+
+fn source_digests(context: &CachedLineContext) -> FxHashMap<String, [u8; 32]> {
+    let mut digests = FxHashMap::default();
+    let cwd = std::env::current_dir().ok();
+    for source in &context.source_files {
+        digests.insert(source.path.clone(), source.digest);
+        if let Ok(canonical) = std::fs::canonicalize(&source.path) {
+            digests.insert(canonical.to_string_lossy().into_owned(), source.digest);
+        }
+        if let Some(cwd) = &cwd {
+            digests.insert(
+                crate::path_utils::relativize(&source.path, cwd),
+                source.digest,
+            );
+        }
+    }
+    digests
+}
+
+fn source_digest(path: &str, digests: &FxHashMap<String, [u8; 32]>) -> [u8; 32] {
+    if let Some(digest) = digests.get(path) {
+        return *digest;
+    }
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        if let Some(digest) = digests.get(canonical.to_string_lossy().as_ref()) {
+            return *digest;
+        }
+    }
+    std::fs::read(path)
+        .map(|bytes| Sha256::digest(bytes).into())
+        .unwrap_or([0; 32])
+}
+
+fn hash_component(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn state_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
+    cache_dir
+        .join("family-line-state-v1")
+        .join(format!("{}.msgpack", hex(&workspace)))
+}
+
+fn load_state(path: &Path) -> FamilyLineState {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| rmp_serde::from_slice::<FamilyLineState>(&bytes).ok())
+        .filter(|state| state.schema == STATE_SCHEMA)
+        .unwrap_or_default()
+}
+
+fn store_state(path: &Path, state: &FamilyLineState) {
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(bytes) = rmp_serde::to_vec_named(state) else {
+        return;
+    };
+    let temp = parent.join(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+fn hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}

--- a/crates/nose-cli/tests/cli/cache.rs
+++ b/crates/nose-cli/tests/cli/cache.rs
@@ -2,11 +2,30 @@ use super::*;
 use serde::Deserialize;
 use std::process::Output;
 
+#[path = "cache/incremental.rs"]
+mod incremental;
+
 #[derive(Debug, Eq, PartialEq)]
 struct CacheStats {
     files: usize,
     hits: usize,
     misses: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct DetectionStats {
+    schema: String,
+    state_hit: bool,
+    units_reused: usize,
+    units_added: usize,
+    units_removed: usize,
+    buckets_rebuilt: usize,
+    scores_reused: usize,
+    scores_evaluated: usize,
+    connected_evaluations_reused: usize,
+    connected_evaluations_evaluated: usize,
+    contiguous_streams_reused: usize,
+    contiguous_streams_rebuilt: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -101,6 +120,31 @@ fn invalidation_report(output: &Output) -> InvalidationReport {
     serde_json::from_str(json).expect("valid invalidation JSON")
 }
 
+fn detection_stats(output: &Output) -> DetectionStats {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|line| line.trim_start().starts_with("[detection]"))
+        .unwrap_or_else(|| panic!("missing detection stats in stderr: {stderr}"));
+    let json = line
+        .trim_start()
+        .strip_prefix("[detection] ")
+        .expect("detection stats prefix");
+    serde_json::from_str(json).expect("valid incremental detection JSON")
+}
+
+fn assert_warm_detection_reused(output: &Output) {
+    let stats = detection_stats(output);
+    assert_eq!(stats.schema, "nose.detection-incremental/v1");
+    assert!(stats.state_hit);
+    assert!(stats.units_reused > 0);
+    assert_eq!(stats.units_added, 0);
+    assert_eq!(stats.units_removed, 0);
+    assert_eq!(stats.buckets_rebuilt, 0);
+    assert_eq!(stats.scores_evaluated, 0);
+    assert!(stats.scores_reused > 0);
+}
+
 #[test]
 fn clone_shaped_files_keep_their_own_names_on_a_warm_hit() {
     let project = TempProject::new("cache_reporting_identity");
@@ -120,6 +164,7 @@ fn clone_shaped_files_keep_their_own_names_on_a_warm_hit() {
 
     assert_eq!(cold.stdout, clean.stdout);
     assert_eq!(warm.stdout, clean.stdout);
+    assert_warm_detection_reused(&warm);
     let warm_invalidation = invalidation_report(&warm);
     assert_eq!(
         (
@@ -144,6 +189,11 @@ fn clone_shaped_files_keep_their_own_names_on_a_warm_hit() {
     let cached_after = query(project.path(), Some(&cache));
     assert_ne!(clean_after.stdout, clean.stdout);
     assert_eq!(cached_after.stdout, clean_after.stdout);
+    let changed_detection = detection_stats(&cached_after);
+    assert!(changed_detection.state_hit);
+    assert!(changed_detection.units_added > 0);
+    assert!(changed_detection.units_removed > 0);
+    assert!(changed_detection.buckets_rebuilt > 0);
     assert_eq!(
         cache_stats(&cached_after),
         CacheStats {

--- a/crates/nose-cli/tests/cli/cache/incremental.rs
+++ b/crates/nose-cli/tests/cli/cache/incremental.rs
@@ -1,0 +1,227 @@
+use super::*;
+
+#[derive(Debug, serde::Deserialize)]
+struct LineIndexStats {
+    schema: String,
+    files_reused: usize,
+    files_rebuilt: usize,
+    files_removed: usize,
+    changed_document_frequencies: usize,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct FamilyLineStats {
+    schema: String,
+    families_reused: usize,
+    families_reweighted: usize,
+    families_rebuilt: usize,
+}
+
+fn query_default(project: &Path, cache: Option<&Path>) -> Output {
+    let mut command = Command::new(bin());
+    command.args([
+        "query",
+        project.to_str().unwrap(),
+        "all",
+        "top=0",
+        "--format",
+        "json",
+    ]);
+    if let Some(cache) = cache {
+        command.args(["--cache-dir", cache.to_str().unwrap()]);
+        command.env("NOSE_CACHE_STATS", "1");
+    }
+    let output = command.output().expect("run cached default query");
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn query_incremental_mode(
+    project: &Path,
+    cache: Option<&Path>,
+    mode: Option<&str>,
+    threads: &str,
+) -> Output {
+    let mut command = Command::new(bin());
+    command.args([
+        "query",
+        project.to_str().unwrap(),
+        "all",
+        "top=0",
+        "--min-size",
+        "12",
+        "--min-lines",
+        "3",
+        "--format",
+        "json",
+    ]);
+    if let Some(mode) = mode {
+        command.args(["--mode", mode]);
+    }
+    if let Some(cache) = cache {
+        command.args(["--cache-dir", cache.to_str().unwrap()]);
+    }
+    let output = command
+        .env("RAYON_NUM_THREADS", threads)
+        .output()
+        .expect("run mutation-matrix query");
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn assert_incremental_mode_matches_clean(
+    project: &TempProject,
+    cache: &Path,
+    mode: Option<&str>,
+    threads: &str,
+) {
+    let clean = query_incremental_mode(project.path(), None, mode, "2");
+    let cached = query_incremental_mode(project.path(), Some(cache), mode, threads);
+    assert_eq!(cached.stdout, clean.stdout, "mode {mode:?} diverged");
+}
+
+fn clone_source(name: &str, operator: &str) -> String {
+    format!(
+        "def {name}(items):\n    total = 0\n    for item in items:\n        if item > 0:\n            total = total {operator} item * item\n    return total\n"
+    )
+}
+
+fn prefixed_json<T: serde::de::DeserializeOwned>(output: &Output, prefix: &str) -> T {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|line| line.trim_start().starts_with(prefix))
+        .unwrap_or_else(|| panic!("missing {prefix} stats in stderr: {stderr}"));
+    let json = line
+        .trim_start()
+        .strip_prefix(prefix)
+        .expect("checked prefix")
+        .trim_start();
+    serde_json::from_str(json).expect("valid prefixed stats JSON")
+}
+
+fn assert_warm_default_layers_reused(output: &Output) {
+    let detection = detection_stats(output);
+    assert!(detection.state_hit);
+    assert_eq!(detection.scores_evaluated, 0);
+    assert!(detection.scores_reused > 0);
+    assert_eq!(detection.connected_evaluations_evaluated, 0);
+    assert!(detection.connected_evaluations_reused > 0);
+    assert!(detection.contiguous_streams_reused > 0);
+    assert_eq!(detection.contiguous_streams_rebuilt, 0);
+
+    let lines: LineIndexStats = prefixed_json(output, "[line-index]");
+    assert_eq!(lines.schema, "nose.line-index/v1");
+    assert_eq!(lines.files_reused, 3);
+    assert_eq!(lines.files_rebuilt, 0);
+    assert_eq!(lines.files_removed, 0);
+    assert_eq!(lines.changed_document_frequencies, 0);
+
+    let families: FamilyLineStats = prefixed_json(output, "[family-lines]");
+    assert_eq!(families.schema, "nose.family-line-state/v1");
+    assert!(families.families_reused > 0);
+    assert_eq!(families.families_reweighted, 0);
+    assert_eq!(families.families_rebuilt, 0);
+}
+
+#[test]
+fn default_detection_state_matches_clean_across_warm_and_leaf_edit() {
+    let project = TempProject::new("cache_incremental_default");
+    let source = |name: &str, operator: &str| {
+        format!(
+            "def {name}(items):\n    total = 0\n    for item in items:\n        if item > 0:\n            total = total {operator} item * item\n        else:\n            total = total {operator} 1\n    return total\n"
+        )
+    };
+    project.write("a/one.py", &source("one", "+"));
+    project.write("b/two.py", &source("two", "+"));
+    project.write("c/three.py", &source("three", "-"));
+    let cache = project.path().join(".cache");
+
+    let clean = query_default(project.path(), None);
+    let cold = query_default(project.path(), Some(&cache));
+    let warm = query_default(project.path(), Some(&cache));
+    assert_eq!(cold.stdout, clean.stdout);
+    assert_eq!(warm.stdout, clean.stdout);
+    assert_warm_default_layers_reused(&warm);
+
+    project.write("c/three.py", &format!("\n{}", source("third", "+")));
+    let clean_changed = query_default(project.path(), None);
+    let cached_changed = query_default(project.path(), Some(&cache));
+    assert_eq!(cached_changed.stdout, clean_changed.stdout);
+    let changed_stats = detection_stats(&cached_changed);
+    assert!(changed_stats.state_hit);
+    assert!(changed_stats.units_reused > 0);
+    assert!(changed_stats.scores_reused > 0);
+    assert!(changed_stats.scores_evaluated > 0);
+}
+
+#[test]
+fn add_edit_delete_and_rename_match_clean_in_every_detection_mode() {
+    for (label, mode) in [
+        ("syntax", Some("syntax")),
+        ("semantic", Some("semantic")),
+        ("near", Some("near:0.70")),
+        ("default", None),
+    ] {
+        let project = TempProject::new(&format!("cache_mutations_{label}"));
+        project.write("a/one.py", &clone_source("one", "+"));
+        project.write("b/two.py", &clone_source("two", "+"));
+        let cache = project.path().join(".cache");
+        assert_incremental_mode_matches_clean(&project, &cache, mode, "1");
+
+        project.write("b/two.py", &clone_source("two", "-"));
+        assert_incremental_mode_matches_clean(&project, &cache, mode, "4");
+        project.write("c/three.py", &clone_source("three", "+"));
+        assert_incremental_mode_matches_clean(&project, &cache, mode, "1");
+        fs::rename(
+            project.path().join("c/three.py"),
+            project.path().join("c/renamed.py"),
+        )
+        .unwrap();
+        assert_incremental_mode_matches_clean(&project, &cache, mode, "4");
+        fs::remove_file(project.path().join("b/two.py")).unwrap();
+        assert_incremental_mode_matches_clean(&project, &cache, mode, "1");
+    }
+}
+
+#[test]
+fn final_output_is_independent_of_edit_order_and_thread_count() {
+    let project = TempProject::new("cache_edit_order");
+    let cache_a = project.path().join(".cache-a");
+    let cache_b = project.path().join(".cache-b");
+    let initial_a = clone_source("one", "-");
+    let initial_b = clone_source("two", "-");
+    let final_a = clone_source("one", "+");
+    let final_b = clone_source("two", "+");
+    project.write("a/one.py", &initial_a);
+    project.write("b/two.py", &initial_b);
+    project.write("c/three.py", &clone_source("three", "+"));
+    project.write("d/four.py", &clone_source("four", "+"));
+
+    query_incremental_mode(project.path(), Some(&cache_a), None, "1");
+    project.write("a/one.py", &final_a);
+    query_incremental_mode(project.path(), Some(&cache_a), None, "4");
+    project.write("b/two.py", &final_b);
+    let order_ab = query_incremental_mode(project.path(), Some(&cache_a), None, "1");
+
+    project.write("a/one.py", &initial_a);
+    project.write("b/two.py", &initial_b);
+    query_incremental_mode(project.path(), Some(&cache_b), None, "4");
+    project.write("b/two.py", &final_b);
+    query_incremental_mode(project.path(), Some(&cache_b), None, "1");
+    project.write("a/one.py", &final_a);
+    let order_ba = query_incremental_mode(project.path(), Some(&cache_b), None, "4");
+    let clean = query_incremental_mode(project.path(), None, None, "2");
+
+    assert_eq!(order_ab.stdout, clean.stdout);
+    assert_eq!(order_ba.stdout, clean.stdout);
+    assert_eq!(order_ab.stdout, order_ba.stdout);
+}

--- a/crates/nose-detect/Cargo.toml
+++ b/crates/nose-detect/Cargo.toml
@@ -12,6 +12,8 @@ nose-normalize = { workspace = true }
 rustc-hash = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+sha2 = { workspace = true }
+rmp-serde = { workspace = true }
 
 [dev-dependencies]
 nose-frontend = { workspace = true }

--- a/crates/nose-detect/src/candidates.rs
+++ b/crates/nose-detect/src/candidates.rs
@@ -1,6 +1,5 @@
 use crate::{
     align,
-    cluster::UnionFind,
     detectors::env_or,
     exact_policy::exact_claim_eligible,
     locations::{connected_loc_of, loc_of},
@@ -12,7 +11,7 @@ use crate::{
 use nose_semantics::ValueLaw;
 use rustc_hash::FxHashMap;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum ConnectedRoute {
     Mapped,
     CompleteExit,
@@ -70,7 +69,7 @@ fn group_witness(members: &[usize], units: &[UnitFeat]) -> EquivalenceWitness {
     }
 }
 
-const EXACT_VALUE_BUCKET_ALL_PAIRS_CAP: usize = 48;
+pub(crate) const EXACT_VALUE_BUCKET_ALL_PAIRS_CAP: usize = 48;
 
 pub(crate) fn structural_candidates(
     units: &[UnitFeat],
@@ -113,23 +112,31 @@ pub(crate) fn structural_candidates(
 pub(crate) fn build_groups(
     units: &[UnitFeat],
     accepted: &[(usize, usize, f64)],
-    uf: &mut UnionFind,
     raw_groups: &[Vec<usize>],
     enclosing: &[Option<EnclosingUnit>],
     opts: &DetectOptions,
     trace_accepted_coverage: bool,
 ) -> (Vec<Group>, Vec<Vec<crate::AcceptedEdge>>) {
-    let mut by_root: FxHashMap<usize, (f64, u32)> = FxHashMap::default();
+    let mut member_group = vec![None; units.len()];
+    for (group_index, members) in raw_groups.iter().enumerate() {
+        for &member in members {
+            member_group[member] = Some(group_index);
+        }
+    }
+    let mut by_group = vec![(0.0, 0u32); raw_groups.len()];
     for &(i, _j, s) in accepted {
-        let e = by_root.entry(uf.find(i)).or_insert((0.0, 0));
+        let Some(group_index) = member_group[i] else {
+            continue;
+        };
+        let e = &mut by_group[group_index];
         e.0 += s;
         e.1 += 1;
     }
     let groups = raw_groups
         .iter()
-        .map(|members| {
-            let root = uf.find(members[0]);
-            let (sum, n) = by_root.get(&root).copied().unwrap_or((0.0, 0));
+        .enumerate()
+        .map(|(group_index, members)| {
+            let (sum, n) = by_group[group_index];
             let score = if n == 0 { 0.0 } else { sum / n as f64 };
             let mut locs: Vec<Loc> = members
                 .iter()
@@ -312,13 +319,13 @@ fn exact_value_candidates(units: &[UnitFeat]) -> Vec<(usize, usize)> {
 
 /// An anchor present in more than this many units is boilerplate (a common idiom), not a
 /// specific extractable sub-computation — skip it. Env-overridable.
-fn anchor_max_df() -> usize {
+pub(crate) fn anchor_max_df() -> usize {
     use std::sync::OnceLock;
     static D: OnceLock<usize> = OnceLock::new();
     *D.get_or_init(|| env_or("NOSE_ANCHOR_MAX_DF", 6.0) as usize)
 }
 
-const ANCHOR_PAIR_CAP: usize = 64;
+pub(crate) const ANCHOR_PAIR_CAP: usize = 64;
 
 /// Partial / sub-DAG clone candidates: units that share a RARE heavy anchor — an extractable
 /// common sub-computation that whole-unit Jaccard misses. Index anchor → units; for anchors

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -17,6 +17,9 @@ use nose_il::{Il, Interner, NodeId, UnitKind};
 use nose_normalize::node_tag_valued;
 use rustc_hash::FxHashMap;
 
+mod incremental;
+pub(crate) use incremental::{detect_incremental, IncrementalContiguousState};
+
 /// One file's normalized-IL token stream, in source (pre-order) order.
 ///
 /// Public + serializable because the CLI's `--cache-dir` stores it per file alongside
@@ -190,7 +193,7 @@ impl LineRangeIndex {
 }
 
 #[derive(Clone)]
-struct LocSeed {
+pub(in crate::contiguous) struct LocSeed {
     stream: usize,
     start_line: u32,
     end_line: u32,
@@ -258,6 +261,23 @@ pub(crate) fn detect(
     trace_accepted_coverage: bool,
 ) -> (Vec<crate::Group>, Vec<Vec<crate::AcceptedEdge>>) {
     let (k, mint, minl) = (k(), min_tokens, min_lines);
+    let grams = streams
+        .iter()
+        .map(|stream| kgrams(&stream.tags, k))
+        .collect::<Vec<_>>();
+    let indices = (0..streams.len()).collect::<Vec<_>>();
+    let (locs, pairs) = detect_primitives(streams, &grams, &indices, k, mint, minl);
+    groups_from_primitives(locs, pairs, streams, trace_accepted_coverage)
+}
+
+pub(in crate::contiguous) fn detect_primitives(
+    streams: &[Stream],
+    grams: &[Vec<u64>],
+    stream_indices: &[usize],
+    k: usize,
+    min_tokens: usize,
+    min_lines: u32,
+) -> (Vec<LocSeed>, Vec<(usize, usize)>) {
     // First occurrence of each k-gram, keyed by (hash, language): `(hash, lang) ->
     // (stream, pos)`. Keying on language makes the contiguous channel **same-language
     // by construction** — literal copy-paste (Type-1/2) doesn't cross languages, so a
@@ -266,7 +286,6 @@ pub(crate) fn detect(
     // by the value-graph channel instead. Per-language keying also stops an unrelated
     // collision in one language from masking a real same-language match in another.
     let mut seen: FxHashMap<(u64, nose_il::Lang), (usize, usize)> = FxHashMap::default();
-    let grams: Vec<Vec<u64>> = streams.iter().map(|s| kgrams(&s.tags, k)).collect();
     let ranges: Vec<LineRangeIndex> = streams.iter().map(LineRangeIndex::new).collect();
 
     // Emitted clone instances and the pairs linking them (for union-find clustering).
@@ -275,7 +294,8 @@ pub(crate) fn detect(
     // Dedup identical (file,start,end) instances to one node id.
     let mut loc_id: FxHashMap<(usize, u32, u32), usize> = FxHashMap::default();
 
-    for (si, g) in grams.iter().enumerate() {
+    for &si in stream_indices {
+        let g = &grams[si];
         let lang = streams[si].lang;
         let mut i = 0;
         while i < g.len() {
@@ -286,7 +306,7 @@ pub(crate) fn detect(
                 let self_overlap = sj == si && i.abs_diff(j) < k;
                 if !self_overlap {
                     let len = extend(&streams[sj], j, &streams[si], i);
-                    if len >= mint {
+                    if len >= min_tokens {
                         // Require the run to contain at least one operation — a flat
                         // name/field/literal list (prop list, destructure, import/enum list)
                         // is not extractable logic, however literally it repeats.
@@ -295,7 +315,7 @@ pub(crate) fn detect(
                             .any(|&o| o);
                         if has_op {
                             let lb = loc_seed(si, &ranges[si], streams, i, i + len);
-                            if line_count(&lb) >= minl {
+                            if line_count(&lb) >= min_lines {
                                 let la = loc_seed(sj, &ranges[sj], streams, j, j + len);
                                 let a = intern_loc(&mut locs, &mut loc_id, la);
                                 let b = intern_loc(&mut locs, &mut loc_id, lb);
@@ -316,6 +336,15 @@ pub(crate) fn detect(
         }
     }
 
+    (locs, pairs)
+}
+
+pub(in crate::contiguous) fn groups_from_primitives(
+    locs: Vec<LocSeed>,
+    pairs: Vec<(usize, usize)>,
+    streams: &[Stream],
+    trace_accepted_coverage: bool,
+) -> (Vec<crate::Group>, Vec<Vec<crate::AcceptedEdge>>) {
     if locs.is_empty() {
         return (Vec::new(), Vec::new());
     }

--- a/crates/nose-detect/src/contiguous/incremental.rs
+++ b/crates/nose-detect/src/contiguous/incremental.rs
@@ -1,0 +1,292 @@
+use super::{detect_primitives, groups_from_primitives, k, kgrams, LocSeed, Stream};
+use crate::cluster::UnionFind;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+const STATE_SCHEMA: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+struct StreamKey {
+    digest: [u8; 32],
+    occurrence: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredLocSeed {
+    stream: StreamKey,
+    start_line: u32,
+    end_line: u32,
+    sem: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredComponent {
+    streams: Vec<StreamKey>,
+    locs: Vec<StoredLocSeed>,
+    pairs: Vec<(u32, u32)>,
+}
+
+type DetectionPrimitives = (Vec<LocSeed>, Vec<(usize, usize)>);
+
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct IncrementalContiguousState {
+    schema: u32,
+    components: Vec<StoredComponent>,
+}
+
+#[derive(Default)]
+pub(crate) struct IncrementalContiguousStats {
+    pub(crate) components_reused: usize,
+    pub(crate) components_rebuilt: usize,
+    pub(crate) streams_reused: usize,
+    pub(crate) streams_rebuilt: usize,
+}
+
+pub(crate) fn detect_incremental(
+    streams: &[Stream],
+    min_tokens: usize,
+    min_lines: u32,
+    trace_accepted_coverage: bool,
+    previous: Option<&IncrementalContiguousState>,
+) -> (
+    Vec<crate::Group>,
+    Vec<Vec<crate::AcceptedEdge>>,
+    IncrementalContiguousState,
+    IncrementalContiguousStats,
+) {
+    let window = k();
+    let grams = streams
+        .iter()
+        .map(|stream| kgrams(&stream.tags, window))
+        .collect::<Vec<_>>();
+    let keys = stream_keys(streams);
+    let components = stream_components(streams, &grams);
+    let previous = previous.filter(|state| state.schema == STATE_SCHEMA);
+    let prior = previous
+        .into_iter()
+        .flat_map(|state| &state.components)
+        .map(|component| (component.streams.as_slice(), component))
+        .collect::<BTreeMap<_, _>>();
+    let current_index = keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut groups = Vec::new();
+    let mut edges = Vec::new();
+    let mut stored_components = Vec::with_capacity(components.len());
+    let mut stats = IncrementalContiguousStats::default();
+    for members in components {
+        let member_keys = members.iter().map(|&index| keys[index]).collect::<Vec<_>>();
+        let (locs, pairs, reused) = prior
+            .get(member_keys.as_slice())
+            .and_then(|component| restore_component(component, &current_index))
+            .map_or_else(
+                || {
+                    let (locs, pairs) =
+                        detect_primitives(streams, &grams, &members, window, min_tokens, min_lines);
+                    (locs, pairs, false)
+                },
+                |(locs, pairs)| (locs, pairs, true),
+            );
+        if reused {
+            stats.components_reused += 1;
+            stats.streams_reused += members.len();
+        } else {
+            stats.components_rebuilt += 1;
+            stats.streams_rebuilt += members.len();
+        }
+        let stored = store_component(member_keys, &locs, &pairs, &keys);
+        let (component_groups, component_edges) =
+            groups_from_primitives(locs, pairs, streams, trace_accepted_coverage);
+        groups.extend(component_groups);
+        edges.extend(component_edges);
+        stored_components.push(stored);
+    }
+    (
+        groups,
+        edges,
+        IncrementalContiguousState {
+            schema: STATE_SCHEMA,
+            components: stored_components,
+        },
+        stats,
+    )
+}
+
+fn stream_components(streams: &[Stream], grams: &[Vec<u64>]) -> Vec<Vec<usize>> {
+    let mut union = UnionFind::new(streams.len());
+    let mut first = FxHashMap::default();
+    for (stream, hashes) in grams.iter().enumerate() {
+        for &hash in hashes {
+            if let Some(&other) = first.get(&(streams[stream].lang, hash)) {
+                if other != stream {
+                    union.union(other, stream);
+                }
+            } else {
+                first.insert((streams[stream].lang, hash), stream);
+            }
+        }
+    }
+    let mut by_root = BTreeMap::<usize, Vec<usize>>::new();
+    for index in 0..streams.len() {
+        by_root.entry(union.find(index)).or_default().push(index);
+    }
+    let mut components = by_root.into_values().collect::<Vec<_>>();
+    components.sort_unstable_by_key(|members| members[0]);
+    components
+}
+
+fn stream_keys(streams: &[Stream]) -> Vec<StreamKey> {
+    let digests = streams
+        .iter()
+        .map(|stream| {
+            let bytes = rmp_serde::to_vec_named(stream).expect("Stream serialization cannot fail");
+            let mut hasher = Sha256::new();
+            hasher.update(b"nose.incremental-stream.v1\0");
+            hasher.update((bytes.len() as u64).to_be_bytes());
+            hasher.update(bytes);
+            <[u8; 32]>::from(hasher.finalize())
+        })
+        .collect::<Vec<_>>();
+    let mut occurrences = BTreeMap::<[u8; 32], u32>::new();
+    digests
+        .into_iter()
+        .map(|digest| {
+            let occurrence = occurrences.entry(digest).or_default();
+            let key = StreamKey {
+                digest,
+                occurrence: *occurrence,
+            };
+            *occurrence += 1;
+            key
+        })
+        .collect()
+}
+
+fn store_component(
+    streams: Vec<StreamKey>,
+    locs: &[LocSeed],
+    pairs: &[(usize, usize)],
+    keys: &[StreamKey],
+) -> StoredComponent {
+    StoredComponent {
+        streams,
+        locs: locs
+            .iter()
+            .map(|loc| StoredLocSeed {
+                stream: keys[loc.stream],
+                start_line: loc.start_line,
+                end_line: loc.end_line,
+                sem: loc.sem,
+            })
+            .collect(),
+        pairs: pairs
+            .iter()
+            .map(|&(left, right)| (left as u32, right as u32))
+            .collect(),
+    }
+}
+
+fn restore_component(
+    component: &StoredComponent,
+    current_index: &BTreeMap<StreamKey, usize>,
+) -> Option<DetectionPrimitives> {
+    let locs = component
+        .locs
+        .iter()
+        .map(|loc| {
+            Some(LocSeed {
+                stream: *current_index.get(&loc.stream)?,
+                start_line: loc.start_line,
+                end_line: loc.end_line,
+                sem: loc.sem,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let pairs = component
+        .pairs
+        .iter()
+        .map(|&(left, right)| Some((usize::try_from(left).ok()?, usize::try_from(right).ok()?)))
+        .collect::<Option<Vec<_>>>()?;
+    Some((locs, pairs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(path: &str, tags: &[u64]) -> Stream {
+        let mut value = Stream {
+            path: path.to_owned(),
+            lang: nose_il::Lang::Python,
+            tags: tags.to_vec(),
+            start: (1..=tags.len() as u32).collect(),
+            end: (1..=tags.len() as u32).collect(),
+            op: vec![true; tags.len()],
+        };
+        value.op[0] = true;
+        value
+    }
+
+    #[test]
+    fn unchanged_components_reuse_every_stream() {
+        let shared = (100..130).collect::<Vec<_>>();
+        let streams = vec![stream("a.py", &shared), stream("b.py", &shared)];
+        let (_, _, state, cold) = detect_incremental(&streams, 10, 3, true, None);
+        assert_eq!(cold.streams_rebuilt, 2);
+        let (incremental, edges, _, warm) = detect_incremental(&streams, 10, 3, true, Some(&state));
+        let clean = super::super::detect(&streams, 10, 3, true);
+        assert_eq!(warm.streams_reused, 2);
+        assert_eq!(incremental.len(), clean.0.len());
+        assert_eq!(edges.len(), clean.1.len());
+    }
+
+    #[test]
+    fn leaf_edit_rebuilds_only_its_kgram_component() {
+        let first_shared = (100..130).collect::<Vec<_>>();
+        let second_shared = (1_000..1_030).collect::<Vec<_>>();
+        let before = vec![
+            stream("a.py", &first_shared),
+            stream("b.py", &first_shared),
+            stream("c.py", &second_shared),
+            stream("d.py", &second_shared),
+        ];
+        let (_, _, state, cold) = detect_incremental(&before, 10, 3, true, None);
+        assert_eq!(cold.streams_rebuilt, 4);
+
+        let changed_tags = (2_000..2_030).collect::<Vec<_>>();
+        let after = vec![
+            stream("a.py", &first_shared),
+            stream("b.py", &changed_tags),
+            stream("c.py", &second_shared),
+            stream("d.py", &second_shared),
+        ];
+        let (incremental, _, _, stats) = detect_incremental(&after, 10, 3, true, Some(&state));
+        let clean = super::super::detect(&after, 10, 3, true).0;
+        assert_eq!(stats.streams_reused, 2);
+        assert_eq!(stats.streams_rebuilt, 2);
+        assert_eq!(group_sites(&incremental), group_sites(&clean));
+    }
+
+    fn group_sites(groups: &[crate::Group]) -> Vec<Vec<(String, u32, u32)>> {
+        let mut groups = groups
+            .iter()
+            .map(|group| {
+                let mut members = group
+                    .members
+                    .iter()
+                    .map(|member| (member.file.clone(), member.start_line, member.end_line))
+                    .collect::<Vec<_>>();
+                members.sort();
+                members
+            })
+            .collect::<Vec<_>>();
+        groups.sort();
+        groups
+    }
+}

--- a/crates/nose-detect/src/contiguous/incremental.rs
+++ b/crates/nose-detect/src/contiguous/incremental.rs
@@ -145,7 +145,7 @@ fn stream_keys(streams: &[Stream]) -> Vec<StreamKey> {
     let digests = streams
         .iter()
         .map(|stream| {
-            let bytes = rmp_serde::to_vec_named(stream).expect("Stream serialization cannot fail");
+            let bytes = rmp_serde::to_vec(stream).expect("Stream serialization cannot fail");
             let mut hasher = Sha256::new();
             hasher.update(b"nose.incremental-stream.v1\0");
             hasher.update((bytes.len() as u64).to_be_bytes());

--- a/crates/nose-detect/src/incremental.rs
+++ b/crates/nose-detect/src/incremental.rs
@@ -19,7 +19,7 @@ use crate::contiguous::IncrementalContiguousState;
 use crate::orchestration::ScoredCandidate;
 use serde::{Deserialize, Serialize};
 
-const STATE_SCHEMA: u32 = 3;
+const STATE_SCHEMA: u32 = 4;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub(crate) struct UnitKey([u8; 32]);
@@ -55,12 +55,12 @@ enum BucketKey {
 struct CandidateBucket {
     key: BucketKey,
     members: Vec<UnitKey>,
-    pairs: Vec<UnitPairKey>,
 }
 
 #[derive(Serialize, Deserialize)]
 struct StoredScore {
     pair: UnitPairKey,
+    bucket_count: u16,
     ordinary_score: Option<f64>,
 }
 
@@ -149,6 +149,7 @@ impl IncrementalDetectionStats {
 pub(crate) struct PreparedDetection {
     pub(crate) unit_keys: Vec<UnitKey>,
     pub(crate) candidates: Vec<(usize, usize)>,
+    candidate_counts: Vec<(UnitPairKey, u16)>,
     buckets: Vec<CandidateBucket>,
     previous_scores: Vec<StoredScore>,
     previous_components: Vec<Vec<UnitKey>>,
@@ -174,12 +175,20 @@ pub(crate) fn finish_state(
 ) -> IncrementalDetectionState {
     let scores = scored
         .iter()
-        .map(|candidate| StoredScore {
-            pair: UnitPairKey::new(
-                prepared.unit_keys[candidate.left],
-                prepared.unit_keys[candidate.right],
-            ),
-            ordinary_score: candidate.ordinary_score,
+        .zip(&prepared.candidate_counts)
+        .map(|(candidate, &(pair, bucket_count))| {
+            debug_assert_eq!(
+                pair,
+                UnitPairKey::new(
+                    prepared.unit_keys[candidate.left],
+                    prepared.unit_keys[candidate.right],
+                )
+            );
+            StoredScore {
+                pair,
+                bucket_count,
+                ordinary_score: candidate.ordinary_score,
+            }
         })
         .collect();
     let stored_components = components

--- a/crates/nose-detect/src/incremental.rs
+++ b/crates/nose-detect/src/incremental.rs
@@ -1,0 +1,204 @@
+//! Persistent, delete-capable detection state for cached queries.
+//!
+//! Stable unit identities let the focused submodules update candidate buckets,
+//! pair scores, connected witnesses, structural components, and syntax components
+//! without retaining process-local vector indexes across runs.
+
+mod candidates;
+mod components;
+mod connected;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use candidates::{prepare, score};
+pub(crate) use components::components;
+pub(crate) use connected::connected;
+
+use crate::candidates::ConnectedAccepted;
+use crate::contiguous::IncrementalContiguousState;
+use crate::orchestration::ScoredCandidate;
+use serde::{Deserialize, Serialize};
+
+const STATE_SCHEMA: u32 = 3;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub(crate) struct UnitKey([u8; 32]);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+struct UnitPairKey {
+    left: UnitKey,
+    right: UnitKey,
+}
+
+impl UnitPairKey {
+    fn new(left: UnitKey, right: UnitKey) -> Self {
+        if left <= right {
+            Self { left, right }
+        } else {
+            Self {
+                left: right,
+                right: left,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+enum BucketKey {
+    ValueBand(u64),
+    ShapeBand(u64),
+    ExactValue([u8; 32]),
+    Anchor(u64),
+}
+
+#[derive(Serialize, Deserialize)]
+struct CandidateBucket {
+    key: BucketKey,
+    members: Vec<UnitKey>,
+    pairs: Vec<UnitPairKey>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredScore {
+    pair: UnitPairKey,
+    ordinary_score: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+struct ConnectedEvaluationKey {
+    pair: UnitPairKey,
+    left_context: [u8; 32],
+    right_context: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+struct SameUnitEvaluationKey {
+    unit: UnitKey,
+    file_context: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredConnectedEvaluation {
+    key: ConnectedEvaluationKey,
+    accepted: Vec<StoredConnected>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredSameUnitEvaluation {
+    key: SameUnitEvaluationKey,
+    accepted: Option<StoredConnected>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredConnected {
+    left: UnitKey,
+    right: UnitKey,
+    score: f64,
+    left_lines: (u32, u32),
+    right_lines: (u32, u32),
+    mapped_nodes: u32,
+    holes: u32,
+    complete_exit: bool,
+    route: u8,
+}
+
+/// Binary-owned state. Fields stay private so schema evolution remains an engine
+/// concern; callers only serialize/deserialize the value as one artifact.
+#[derive(Default, Serialize, Deserialize)]
+pub struct IncrementalDetectionState {
+    schema: u32,
+    units: Vec<UnitKey>,
+    buckets: Vec<CandidateBucket>,
+    scores: Vec<StoredScore>,
+    components: Vec<Vec<UnitKey>>,
+    connected: Vec<StoredConnectedEvaluation>,
+    same_unit: Vec<StoredSameUnitEvaluation>,
+    contiguous: Option<IncrementalContiguousState>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct IncrementalDetectionStats {
+    pub schema: &'static str,
+    pub state_hit: bool,
+    pub units_reused: usize,
+    pub units_added: usize,
+    pub units_removed: usize,
+    pub buckets_reused: usize,
+    pub buckets_rebuilt: usize,
+    pub scores_reused: usize,
+    pub scores_evaluated: usize,
+    pub connected_evaluations_reused: usize,
+    pub connected_evaluations_evaluated: usize,
+    pub components_reused: usize,
+    pub components_rebuilt: usize,
+    pub contiguous_streams_reused: usize,
+    pub contiguous_streams_rebuilt: usize,
+    pub contiguous_components_reused: usize,
+    pub contiguous_components_rebuilt: usize,
+}
+
+impl IncrementalDetectionStats {
+    pub(crate) fn new() -> Self {
+        Self {
+            schema: "nose.detection-incremental/v1",
+            ..Self::default()
+        }
+    }
+}
+
+pub(crate) struct PreparedDetection {
+    pub(crate) unit_keys: Vec<UnitKey>,
+    pub(crate) candidates: Vec<(usize, usize)>,
+    buckets: Vec<CandidateBucket>,
+    previous_scores: Vec<StoredScore>,
+    previous_components: Vec<Vec<UnitKey>>,
+    previous_connected: Vec<StoredConnectedEvaluation>,
+    previous_same_unit: Vec<StoredSameUnitEvaluation>,
+    pub(crate) previous_contiguous: Option<IncrementalContiguousState>,
+}
+
+#[derive(Default)]
+pub(crate) struct IncrementalConnected {
+    pub(crate) accepted: Vec<ConnectedAccepted>,
+    pub(crate) same_unit_accepted: Vec<ConnectedAccepted>,
+    evaluations: Vec<StoredConnectedEvaluation>,
+    same_unit_evaluations: Vec<StoredSameUnitEvaluation>,
+}
+
+pub(crate) fn finish_state(
+    prepared: PreparedDetection,
+    scored: &[ScoredCandidate],
+    components: &[Vec<usize>],
+    connected: IncrementalConnected,
+    contiguous: Option<IncrementalContiguousState>,
+) -> IncrementalDetectionState {
+    let scores = scored
+        .iter()
+        .map(|candidate| StoredScore {
+            pair: UnitPairKey::new(
+                prepared.unit_keys[candidate.left],
+                prepared.unit_keys[candidate.right],
+            ),
+            ordinary_score: candidate.ordinary_score,
+        })
+        .collect();
+    let stored_components = components
+        .iter()
+        .map(|members| {
+            members
+                .iter()
+                .map(|&member| prepared.unit_keys[member])
+                .collect()
+        })
+        .collect();
+    IncrementalDetectionState {
+        schema: STATE_SCHEMA,
+        units: prepared.unit_keys,
+        buckets: prepared.buckets,
+        scores,
+        components: stored_components,
+        connected: connected.evaluations,
+        same_unit: connected.same_unit_evaluations,
+        contiguous,
+    }
+}

--- a/crates/nose-detect/src/incremental/candidates.rs
+++ b/crates/nose-detect/src/incremental/candidates.rs
@@ -10,16 +10,35 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+type IndexedCandidates = (Vec<(usize, usize)>, Vec<(UnitPairKey, u16)>);
+
 pub(crate) fn prepare(
     units: &[UnitFeat],
+    stable_unit_keys: Option<&[[u8; 32]]>,
     opts: &DetectOptions,
     previous: Option<IncrementalDetectionState>,
     stats: &mut IncrementalDetectionStats,
 ) -> PreparedDetection {
-    let unit_keys = units.par_iter().map(unit_key).collect::<Vec<_>>();
+    let unit_keys = if let Some(keys) = stable_unit_keys {
+        assert_eq!(keys.len(), units.len());
+        keys.iter().copied().map(UnitKey).collect::<Vec<_>>()
+    } else {
+        units.par_iter().map(unit_key).collect::<Vec<_>>()
+    };
     let previous = previous.filter(|state| state.schema == STATE_SCHEMA);
     stats.state_hit = previous.is_some();
     record_unit_churn(previous.as_ref(), &unit_keys, stats);
+
+    if previous
+        .as_ref()
+        .is_some_and(|state| state.units == unit_keys)
+    {
+        return reuse_unchanged(
+            unit_keys,
+            previous.expect("checked incremental state"),
+            stats,
+        );
+    }
 
     let memberships = candidate_memberships(units, &unit_keys, opts);
     let previous_buckets = previous
@@ -32,49 +51,38 @@ pub(crate) fn prepare(
                 .collect::<BTreeMap<_, _>>()
         })
         .unwrap_or_default();
-    let buckets = memberships
+    let mut counts = previous
+        .as_ref()
         .into_iter()
-        .map(|(key, members)| {
-            if let Some(old) = previous_buckets
-                .get(&key)
-                .filter(|old| old.members == members)
-            {
-                stats.buckets_reused += 1;
-                return CandidateBucket {
-                    key,
-                    members,
-                    pairs: old.pairs.clone(),
-                };
-            }
+        .flat_map(|state| &state.scores)
+        .map(|score| (score.pair, score.bucket_count))
+        .collect::<BTreeMap<_, _>>();
+    let current_bucket_keys = memberships.keys().copied().collect::<BTreeSet<_>>();
+    let mut buckets = Vec::with_capacity(memberships.len());
+    for (key, members) in memberships {
+        if previous_buckets
+            .get(&key)
+            .filter(|old| old.members == members)
+            .is_some()
+        {
+            stats.buckets_reused += 1;
+        } else {
             stats.buckets_rebuilt += 1;
-            CandidateBucket {
-                key,
-                pairs: emit_bucket_pairs(key, &members),
-                members,
+            if let Some(old) = previous_buckets.get(&key) {
+                adjust_pair_counts(&mut counts, key, &old.members, false);
             }
-        })
-        .collect::<Vec<_>>();
-    let by_key = unit_keys
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(index, key)| (key, index))
-        .collect::<HashMap<_, _>>();
-    let mut candidates = buckets
-        .iter()
-        .flat_map(|bucket| &bucket.pairs)
-        .filter_map(|pair| {
-            let left = *by_key.get(&pair.left)?;
-            let right = *by_key.get(&pair.right)?;
-            Some(if left < right {
-                (left, right)
-            } else {
-                (right, left)
-            })
-        })
-        .collect::<Vec<_>>();
-    candidates.sort_unstable();
-    candidates.dedup();
+            adjust_pair_counts(&mut counts, key, &members, true);
+        }
+        buckets.push(CandidateBucket { key, members });
+    }
+    for (&key, old) in &previous_buckets {
+        if !current_bucket_keys.contains(&key) {
+            stats.buckets_rebuilt += 1;
+            adjust_pair_counts(&mut counts, key, &old.members, false);
+        }
+    }
+    counts.retain(|_, count| *count > 0);
+    let (candidates, candidate_counts) = index_candidates(&unit_keys, &counts);
     let (
         previous_scores,
         previous_components,
@@ -95,6 +103,7 @@ pub(crate) fn prepare(
     PreparedDetection {
         unit_keys,
         candidates,
+        candidate_counts,
         buckets,
         previous_scores,
         previous_components,
@@ -102,6 +111,79 @@ pub(crate) fn prepare(
         previous_same_unit,
         previous_contiguous,
     }
+}
+
+fn reuse_unchanged(
+    unit_keys: Vec<UnitKey>,
+    state: IncrementalDetectionState,
+    stats: &mut IncrementalDetectionStats,
+) -> PreparedDetection {
+    stats.buckets_reused = state.buckets.len();
+    let counts = state
+        .scores
+        .iter()
+        .map(|score| (score.pair, score.bucket_count))
+        .collect::<BTreeMap<_, _>>();
+    let (candidates, candidate_counts) = index_candidates(&unit_keys, &counts);
+    PreparedDetection {
+        unit_keys,
+        candidates,
+        candidate_counts,
+        buckets: state.buckets,
+        previous_scores: state.scores,
+        previous_components: state.components,
+        previous_connected: state.connected,
+        previous_same_unit: state.same_unit,
+        previous_contiguous: state.contiguous,
+    }
+}
+
+fn adjust_pair_counts(
+    counts: &mut BTreeMap<UnitPairKey, u16>,
+    key: BucketKey,
+    members: &[UnitKey],
+    add: bool,
+) {
+    for pair in emit_bucket_pairs(key, members) {
+        let count = counts.entry(pair).or_default();
+        if add {
+            *count = count.saturating_add(1);
+        } else {
+            *count = count.saturating_sub(1);
+        }
+    }
+}
+
+fn index_candidates(
+    unit_keys: &[UnitKey],
+    counts: &BTreeMap<UnitPairKey, u16>,
+) -> IndexedCandidates {
+    let by_key = unit_keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<HashMap<_, _>>();
+    let mut rows = counts
+        .iter()
+        .filter_map(|(&pair, &count)| {
+            let left = *by_key.get(&pair.left)?;
+            let right = *by_key.get(&pair.right)?;
+            let indexes = if left < right {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            Some((indexes, pair, count))
+        })
+        .collect::<Vec<_>>();
+    rows.sort_unstable_by_key(|row| row.0);
+    let candidates = rows.iter().map(|row| row.0).collect();
+    let candidate_counts = rows
+        .into_iter()
+        .map(|(_, pair, count)| (pair, count))
+        .collect();
+    (candidates, candidate_counts)
 }
 
 pub(crate) fn score(
@@ -282,7 +364,7 @@ fn all_pairs_capped(members: &[UnitKey], cap: usize) -> Vec<UnitPairKey> {
 }
 
 fn unit_key(unit: &UnitFeat) -> UnitKey {
-    let bytes = rmp_serde::to_vec_named(unit).expect("UnitFeat serialization cannot fail");
+    let bytes = rmp_serde::to_vec(unit).expect("UnitFeat serialization cannot fail");
     UnitKey(digest(b"nose.incremental-unit.v1", &bytes))
 }
 

--- a/crates/nose-detect/src/incremental/candidates.rs
+++ b/crates/nose-detect/src/incremental/candidates.rs
@@ -1,0 +1,306 @@
+use super::*;
+use crate::candidates::{anchor_max_df, ANCHOR_PAIR_CAP, EXACT_VALUE_BUCKET_ALL_PAIRS_CAP};
+use crate::detectors::Detector;
+use crate::exact_policy::exact_claim_eligible;
+use crate::locations::is_nested;
+use crate::lsh::{band_hash, BUCKET_ALL_PAIRS_CAP};
+use crate::{DetectOptions, UnitFeat};
+use rayon::prelude::*;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub(crate) fn prepare(
+    units: &[UnitFeat],
+    opts: &DetectOptions,
+    previous: Option<IncrementalDetectionState>,
+    stats: &mut IncrementalDetectionStats,
+) -> PreparedDetection {
+    let unit_keys = units.par_iter().map(unit_key).collect::<Vec<_>>();
+    let previous = previous.filter(|state| state.schema == STATE_SCHEMA);
+    stats.state_hit = previous.is_some();
+    record_unit_churn(previous.as_ref(), &unit_keys, stats);
+
+    let memberships = candidate_memberships(units, &unit_keys, opts);
+    let previous_buckets = previous
+        .as_ref()
+        .map(|state| {
+            state
+                .buckets
+                .iter()
+                .map(|bucket| (bucket.key, bucket))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let buckets = memberships
+        .into_iter()
+        .map(|(key, members)| {
+            if let Some(old) = previous_buckets
+                .get(&key)
+                .filter(|old| old.members == members)
+            {
+                stats.buckets_reused += 1;
+                return CandidateBucket {
+                    key,
+                    members,
+                    pairs: old.pairs.clone(),
+                };
+            }
+            stats.buckets_rebuilt += 1;
+            CandidateBucket {
+                key,
+                pairs: emit_bucket_pairs(key, &members),
+                members,
+            }
+        })
+        .collect::<Vec<_>>();
+    let by_key = unit_keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<HashMap<_, _>>();
+    let mut candidates = buckets
+        .iter()
+        .flat_map(|bucket| &bucket.pairs)
+        .filter_map(|pair| {
+            let left = *by_key.get(&pair.left)?;
+            let right = *by_key.get(&pair.right)?;
+            Some(if left < right {
+                (left, right)
+            } else {
+                (right, left)
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_unstable();
+    candidates.dedup();
+    let (
+        previous_scores,
+        previous_components,
+        previous_connected,
+        previous_same_unit,
+        previous_contiguous,
+    ) = previous
+        .map(|state| {
+            (
+                state.scores,
+                state.components,
+                state.connected,
+                state.same_unit,
+                state.contiguous,
+            )
+        })
+        .unwrap_or_default();
+    PreparedDetection {
+        unit_keys,
+        candidates,
+        buckets,
+        previous_scores,
+        previous_components,
+        previous_connected,
+        previous_same_unit,
+        previous_contiguous,
+    }
+}
+
+pub(crate) fn score(
+    units: &[UnitFeat],
+    prepared: &PreparedDetection,
+    detector: &dyn Detector,
+    threshold: f64,
+    stats: &mut IncrementalDetectionStats,
+) -> (Vec<ScoredCandidate>, Vec<(usize, usize, f64)>) {
+    let previous = prepared
+        .previous_scores
+        .iter()
+        .map(|score| (score.pair, score.ordinary_score))
+        .collect::<HashMap<_, _>>();
+    let reused = AtomicUsize::new(0);
+    let evaluated = AtomicUsize::new(0);
+    let scored = prepared
+        .candidates
+        .par_iter()
+        .map(|&(left, right)| {
+            let pair = UnitPairKey::new(prepared.unit_keys[left], prepared.unit_keys[right]);
+            let ordinary_score = previous.get(&pair).copied().unwrap_or_else(|| {
+                evaluated.fetch_add(1, Ordering::Relaxed);
+                (!is_nested(&units[left], &units[right]))
+                    .then(|| detector.score(&units[left], &units[right]))
+            });
+            if previous.contains_key(&pair) {
+                reused.fetch_add(1, Ordering::Relaxed);
+            }
+            ScoredCandidate {
+                left,
+                right,
+                ordinary_score,
+            }
+        })
+        .collect::<Vec<_>>();
+    stats.scores_reused = reused.load(Ordering::Relaxed);
+    stats.scores_evaluated = evaluated.load(Ordering::Relaxed);
+    let accepted = scored
+        .iter()
+        .filter_map(|candidate| {
+            candidate
+                .ordinary_score
+                .filter(|&value| value >= threshold)
+                .map(|value| (candidate.left, candidate.right, value))
+        })
+        .collect();
+    (scored, accepted)
+}
+
+fn record_unit_churn(
+    previous: Option<&IncrementalDetectionState>,
+    current: &[UnitKey],
+    stats: &mut IncrementalDetectionStats,
+) {
+    let before = previous
+        .map(|state| state.units.iter().copied().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let after = current.iter().copied().collect::<BTreeSet<_>>();
+    stats.units_reused = before.intersection(&after).count();
+    stats.units_added = after.difference(&before).count();
+    stats.units_removed = before.difference(&after).count();
+}
+
+fn candidate_memberships(
+    units: &[UnitFeat],
+    unit_keys: &[UnitKey],
+    opts: &DetectOptions,
+) -> BTreeMap<BucketKey, Vec<UnitKey>> {
+    let mut buckets = BTreeMap::<BucketKey, Vec<UnitKey>>::new();
+    if opts.value_candidates {
+        append_lsh_memberships(&mut buckets, units, unit_keys, opts.bands, false);
+        for (unit, &key) in units.iter().zip(unit_keys) {
+            if exact_claim_eligible(unit) {
+                buckets
+                    .entry(BucketKey::ExactValue(digest_u64s(&unit.value)))
+                    .or_default()
+                    .push(key);
+            }
+        }
+    }
+    if opts.shape_candidates {
+        append_lsh_memberships(&mut buckets, units, unit_keys, opts.bands, true);
+        let floor = nose_normalize::anchor_min_weight();
+        for (unit, &key) in units.iter().zip(unit_keys) {
+            for anchor in &unit.anchors {
+                if anchor.weight >= floor {
+                    buckets
+                        .entry(BucketKey::Anchor(anchor.hash))
+                        .or_default()
+                        .push(key);
+                }
+            }
+        }
+    }
+    buckets.retain(|_, members| members.len() >= 2);
+    buckets
+}
+
+fn append_lsh_memberships(
+    buckets: &mut BTreeMap<BucketKey, Vec<UnitKey>>,
+    units: &[UnitFeat],
+    unit_keys: &[UnitKey],
+    bands: usize,
+    shape: bool,
+) {
+    let Some(first) = units.first() else { return };
+    let first_signature = if shape {
+        &first.shape_minhash
+    } else {
+        &first.minhash
+    };
+    if first_signature.is_empty() || bands == 0 {
+        return;
+    }
+    let rows = (first_signature.len() / bands).max(1);
+    for (unit, &key) in units.iter().zip(unit_keys) {
+        let signature = if shape {
+            &unit.shape_minhash
+        } else {
+            &unit.minhash
+        };
+        for band in 0..bands {
+            let start = band * rows;
+            if start >= signature.len() {
+                continue;
+            }
+            let end = (start + rows).min(signature.len());
+            let hash = band_hash(band, &signature[start..end]);
+            let bucket = if shape {
+                BucketKey::ShapeBand(hash)
+            } else {
+                BucketKey::ValueBand(hash)
+            };
+            buckets.entry(bucket).or_default().push(key);
+        }
+    }
+}
+
+fn emit_bucket_pairs(key: BucketKey, members: &[UnitKey]) -> Vec<UnitPairKey> {
+    match key {
+        BucketKey::Anchor(_) if members.len() > anchor_max_df() => Vec::new(),
+        BucketKey::Anchor(_) => all_pairs_capped(members, ANCHOR_PAIR_CAP),
+        BucketKey::ExactValue(_) => connected_pairs(members, EXACT_VALUE_BUCKET_ALL_PAIRS_CAP),
+        BucketKey::ValueBand(_) | BucketKey::ShapeBand(_) => {
+            connected_pairs(members, BUCKET_ALL_PAIRS_CAP)
+        }
+    }
+}
+
+fn connected_pairs(members: &[UnitKey], all_pairs_cap: usize) -> Vec<UnitPairKey> {
+    if members.len() <= all_pairs_cap {
+        return all_pairs_capped(members, usize::MAX);
+    }
+    let mut pairs = members
+        .windows(2)
+        .map(|window| UnitPairKey::new(window[0], window[1]))
+        .collect::<Vec<_>>();
+    pairs.extend(
+        members[1..]
+            .iter()
+            .map(|&member| UnitPairKey::new(members[0], member)),
+    );
+    pairs
+}
+
+fn all_pairs_capped(members: &[UnitKey], cap: usize) -> Vec<UnitPairKey> {
+    let mut pairs = Vec::new();
+    'outer: for left in 0..members.len() {
+        for right in (left + 1)..members.len() {
+            pairs.push(UnitPairKey::new(members[left], members[right]));
+            if pairs.len() >= cap {
+                break 'outer;
+            }
+        }
+    }
+    pairs
+}
+
+fn unit_key(unit: &UnitFeat) -> UnitKey {
+    let bytes = rmp_serde::to_vec_named(unit).expect("UnitFeat serialization cannot fail");
+    UnitKey(digest(b"nose.incremental-unit.v1", &bytes))
+}
+
+fn digest_u64s(values: &[u64]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nose.incremental-exact-value.v1\0");
+    hasher.update((values.len() as u64).to_be_bytes());
+    for value in values {
+        hasher.update(value.to_be_bytes());
+    }
+    hasher.finalize().into()
+}
+
+fn digest(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update((domain.len() as u64).to_be_bytes());
+    hasher.update(domain);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    hasher.finalize().into()
+}

--- a/crates/nose-detect/src/incremental/components.rs
+++ b/crates/nose-detect/src/incremental/components.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::cluster::UnionFind;
+use std::collections::{BTreeSet, HashMap};
+
+pub(crate) fn components(
+    prepared: &PreparedDetection,
+    accepted: &[(usize, usize, f64)],
+    threshold: f64,
+    stats: &mut IncrementalDetectionStats,
+) -> Vec<Vec<usize>> {
+    if prepared.previous_components.is_empty() {
+        let groups = clean_components(prepared.unit_keys.len(), accepted);
+        stats.components_rebuilt = groups.len();
+        return groups;
+    }
+    let changes = component_changes(prepared, accepted, threshold);
+    let mut groups = prepared
+        .previous_components
+        .iter()
+        .enumerate()
+        .filter(|(component, _)| !changes.dirty.contains(component))
+        .map(|(_, members)| {
+            members
+                .iter()
+                .map(|member| changes.current_index[member])
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    stats.components_reused = groups.len();
+    let (rebuilt, rebuilt_work) = rebuild_components(&changes, accepted);
+    stats.components_rebuilt = changes.dirty.len().max(rebuilt_work);
+    groups.extend(rebuilt);
+    for group in &mut groups {
+        group.sort_unstable();
+    }
+    groups.sort_unstable_by_key(|group| group[0]);
+    groups
+}
+
+struct ComponentChanges {
+    current_index: HashMap<UnitKey, usize>,
+    dirty: BTreeSet<usize>,
+    affected: BTreeSet<UnitKey>,
+}
+
+fn component_changes(
+    prepared: &PreparedDetection,
+    accepted: &[(usize, usize, f64)],
+    threshold: f64,
+) -> ComponentChanges {
+    let current_index = prepared
+        .unit_keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<HashMap<_, _>>();
+    let previous_component = prepared
+        .previous_components
+        .iter()
+        .enumerate()
+        .flat_map(|(component, members)| {
+            members
+                .iter()
+                .copied()
+                .map(move |member| (member, component))
+        })
+        .collect::<HashMap<_, _>>();
+    let previous_edges = prepared
+        .previous_scores
+        .iter()
+        .filter_map(|score| {
+            score
+                .ordinary_score
+                .filter(|&value| value >= threshold)
+                .map(|_| score.pair)
+        })
+        .collect::<BTreeSet<_>>();
+    let current_edges = accepted
+        .iter()
+        .map(|&(left, right, _)| {
+            UnitPairKey::new(prepared.unit_keys[left], prepared.unit_keys[right])
+        })
+        .collect::<BTreeSet<_>>();
+    let mut dirty = prepared
+        .previous_components
+        .iter()
+        .enumerate()
+        .filter(|(_, members)| {
+            members
+                .iter()
+                .any(|member| !current_index.contains_key(member))
+        })
+        .map(|(component, _)| component)
+        .collect::<BTreeSet<_>>();
+    let mut affected = BTreeSet::new();
+    for pair in previous_edges.symmetric_difference(&current_edges) {
+        for key in [pair.left, pair.right] {
+            affected.insert(key);
+            if let Some(&component) = previous_component.get(&key) {
+                dirty.insert(component);
+            }
+        }
+    }
+    for &component in &dirty {
+        affected.extend(
+            prepared.previous_components[component]
+                .iter()
+                .copied()
+                .filter(|key| current_index.contains_key(key)),
+        );
+    }
+    ComponentChanges {
+        current_index,
+        dirty,
+        affected,
+    }
+}
+
+fn rebuild_components(
+    changes: &ComponentChanges,
+    accepted: &[(usize, usize, f64)],
+) -> (Vec<Vec<usize>>, usize) {
+    let affected_indices = changes
+        .affected
+        .iter()
+        .filter_map(|key| changes.current_index.get(key).copied())
+        .collect::<Vec<_>>();
+    let local_index = affected_indices
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(local, current)| (current, local))
+        .collect::<HashMap<_, _>>();
+    let mut union = UnionFind::new(affected_indices.len());
+    for &(left, right, _) in accepted {
+        if let (Some(&local_left), Some(&local_right)) =
+            (local_index.get(&left), local_index.get(&right))
+        {
+            union.union(local_left, local_right);
+        }
+    }
+    let rebuilt = union
+        .groups(affected_indices.len())
+        .into_iter()
+        .map(|members| {
+            members
+                .into_iter()
+                .map(|member| affected_indices[member])
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let work = rebuilt.len();
+    (rebuilt, work)
+}
+
+fn clean_components(unit_count: usize, accepted: &[(usize, usize, f64)]) -> Vec<Vec<usize>> {
+    let mut union = UnionFind::new(unit_count);
+    for &(left, right, _) in accepted {
+        union.union(left, right);
+    }
+    let mut groups = union.groups(unit_count);
+    for group in &mut groups {
+        group.sort_unstable();
+    }
+    groups.sort_unstable_by_key(|group| group[0]);
+    groups
+}

--- a/crates/nose-detect/src/incremental/connected.rs
+++ b/crates/nose-detect/src/incremental/connected.rs
@@ -1,0 +1,281 @@
+use super::*;
+use crate::candidates::{ConnectedAccepted, ConnectedRoute};
+use crate::detectors::connected_witness_score;
+use crate::locations::enclosing_unit_indices;
+use crate::orchestration::connected_pricing::{
+    connected_seed_indices, evaluate_connected_candidate, same_unit_seed_indices,
+};
+use crate::{DetectOptions, UnitFeat};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+pub(crate) fn connected(
+    units: &[UnitFeat],
+    prepared: &PreparedDetection,
+    scored: &[ScoredCandidate],
+    ordinary: &[(usize, usize, f64)],
+    opts: &DetectOptions,
+    stats: &mut IncrementalDetectionStats,
+) -> IncrementalConnected {
+    if !opts.connected_witnesses {
+        return IncrementalConnected::default();
+    }
+    let contexts = file_contexts(units, &prepared.unit_keys);
+    let current_index = prepared
+        .unit_keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<HashMap<_, _>>();
+    let (accepted, evaluations) = connected_pair_evaluations(
+        units,
+        prepared,
+        scored,
+        ordinary,
+        opts,
+        &contexts,
+        &current_index,
+        stats,
+    );
+    let (same_unit_accepted, same_unit_evaluations) =
+        same_unit_evaluations(units, prepared, opts, &contexts, &current_index, stats);
+    IncrementalConnected {
+        accepted,
+        same_unit_accepted,
+        evaluations,
+        same_unit_evaluations,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn connected_pair_evaluations(
+    units: &[UnitFeat],
+    prepared: &PreparedDetection,
+    scored: &[ScoredCandidate],
+    ordinary: &[(usize, usize, f64)],
+    opts: &DetectOptions,
+    contexts: &[[u8; 32]],
+    current_index: &HashMap<UnitKey, usize>,
+    stats: &mut IncrementalDetectionStats,
+) -> (Vec<ConnectedAccepted>, Vec<StoredConnectedEvaluation>) {
+    let previous = prepared
+        .previous_connected
+        .iter()
+        .map(|evaluation| (evaluation.key, &evaluation.accepted))
+        .collect::<HashMap<_, _>>();
+    let unit_paths = units
+        .iter()
+        .map(|unit| unit.path.as_str())
+        .collect::<Vec<_>>();
+    let unit_weights = units
+        .iter()
+        .map(|unit| unit.connected_tokens.len())
+        .collect::<Vec<_>>();
+    let selected = connected_seed_indices(
+        scored,
+        &unit_paths,
+        &unit_weights,
+        opts.threshold,
+        !opts.emit_pairs,
+    );
+    let enclosing = enclosing_unit_indices(units);
+    let mut units_by_file = HashMap::<&str, Vec<usize>>::new();
+    for (index, unit) in units.iter().enumerate() {
+        units_by_file
+            .entry(unit.path.as_str())
+            .or_default()
+            .push(index);
+    }
+    let ordinary_pairs = ordinary
+        .iter()
+        .map(|&(left, right, _)| (left, right))
+        .collect::<HashSet<_>>();
+    let mut accepted = Vec::new();
+    let mut evaluations = Vec::with_capacity(selected.len());
+    for candidate_index in selected {
+        let candidate = scored[candidate_index];
+        let key = connected_evaluation_key(
+            candidate.left,
+            candidate.right,
+            &prepared.unit_keys,
+            contexts,
+        );
+        let values = if let Some(stored) = previous.get(&key) {
+            stats.connected_evaluations_reused += 1;
+            stored
+                .iter()
+                .filter_map(|value| restore_connected(value, current_index))
+                .collect::<Vec<_>>()
+        } else {
+            stats.connected_evaluations_evaluated += 1;
+            evaluate_connected_candidate(
+                units,
+                &enclosing,
+                units_by_file
+                    .get(units[candidate.left].path.as_str())
+                    .map_or(&[], Vec::as_slice),
+                candidate.left,
+                candidate.right,
+                ordinary_pairs.contains(&(candidate.left, candidate.right)),
+                opts.threshold,
+            )
+        };
+        evaluations.push(StoredConnectedEvaluation {
+            key,
+            accepted: values
+                .iter()
+                .map(|value| store_connected(value, &prepared.unit_keys))
+                .collect(),
+        });
+        accepted.extend(values);
+    }
+    (accepted, evaluations)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn same_unit_evaluations(
+    units: &[UnitFeat],
+    prepared: &PreparedDetection,
+    opts: &DetectOptions,
+    contexts: &[[u8; 32]],
+    current_index: &HashMap<UnitKey, usize>,
+    stats: &mut IncrementalDetectionStats,
+) -> (Vec<ConnectedAccepted>, Vec<StoredSameUnitEvaluation>) {
+    let previous_same = prepared
+        .previous_same_unit
+        .iter()
+        .map(|evaluation| (evaluation.key, evaluation.accepted.as_ref()))
+        .collect::<HashMap<_, _>>();
+    let same_seeds = same_unit_seed_indices(units, !opts.emit_pairs);
+    let mut same_unit_accepted = Vec::new();
+    let mut same_unit_evaluations = Vec::with_capacity(same_seeds.len());
+    for index in same_seeds {
+        let key = SameUnitEvaluationKey {
+            unit: prepared.unit_keys[index],
+            file_context: contexts[index],
+        };
+        let value = if let Some(stored) = previous_same.get(&key) {
+            stats.connected_evaluations_reused += 1;
+            stored.and_then(|value| restore_connected(value, current_index))
+        } else {
+            stats.connected_evaluations_evaluated += 1;
+            crate::connected::same_unit_witness(&units[index].connected_tokens).and_then(
+                |witness| {
+                    let score = connected_witness_score(witness);
+                    (score >= opts.threshold).then_some(ConnectedAccepted {
+                        left: index,
+                        right: index,
+                        score,
+                        witness,
+                        route: ConnectedRoute::SameUnit,
+                    })
+                },
+            )
+        };
+        same_unit_evaluations.push(StoredSameUnitEvaluation {
+            key,
+            accepted: value
+                .as_ref()
+                .map(|value| store_connected(value, &prepared.unit_keys)),
+        });
+        same_unit_accepted.extend(value);
+    }
+    (same_unit_accepted, same_unit_evaluations)
+}
+
+fn file_contexts(units: &[UnitFeat], keys: &[UnitKey]) -> Vec<[u8; 32]> {
+    let mut by_path = BTreeMap::<&str, Vec<UnitKey>>::new();
+    for (unit, &key) in units.iter().zip(keys) {
+        by_path.entry(unit.path.as_str()).or_default().push(key);
+    }
+    let digests = by_path
+        .into_iter()
+        .map(|(path, members)| {
+            let mut bytes = Vec::with_capacity(members.len() * 32);
+            for member in members {
+                bytes.extend_from_slice(&member.0);
+            }
+            (path, digest(b"nose.incremental-file-context.v1", &bytes))
+        })
+        .collect::<HashMap<_, _>>();
+    units
+        .iter()
+        .map(|unit| digests[unit.path.as_str()])
+        .collect()
+}
+
+fn connected_evaluation_key(
+    left: usize,
+    right: usize,
+    keys: &[UnitKey],
+    contexts: &[[u8; 32]],
+) -> ConnectedEvaluationKey {
+    if keys[left] <= keys[right] {
+        ConnectedEvaluationKey {
+            pair: UnitPairKey::new(keys[left], keys[right]),
+            left_context: contexts[left],
+            right_context: contexts[right],
+        }
+    } else {
+        ConnectedEvaluationKey {
+            pair: UnitPairKey::new(keys[left], keys[right]),
+            left_context: contexts[right],
+            right_context: contexts[left],
+        }
+    }
+}
+
+fn store_connected(value: &ConnectedAccepted, keys: &[UnitKey]) -> StoredConnected {
+    StoredConnected {
+        left: keys[value.left],
+        right: keys[value.right],
+        score: value.score,
+        left_lines: value.witness.left_lines,
+        right_lines: value.witness.right_lines,
+        mapped_nodes: value.witness.mapped_nodes,
+        holes: value.witness.holes,
+        complete_exit: value.witness.complete_exit,
+        route: match value.route {
+            ConnectedRoute::Mapped => 1,
+            ConnectedRoute::CompleteExit => 2,
+            ConnectedRoute::Nested => 3,
+            ConnectedRoute::SameUnit => 4,
+        },
+    }
+}
+
+fn restore_connected(
+    value: &StoredConnected,
+    current_index: &HashMap<UnitKey, usize>,
+) -> Option<ConnectedAccepted> {
+    let route = match value.route {
+        1 => ConnectedRoute::Mapped,
+        2 => ConnectedRoute::CompleteExit,
+        3 => ConnectedRoute::Nested,
+        4 => ConnectedRoute::SameUnit,
+        _ => return None,
+    };
+    Some(ConnectedAccepted {
+        left: *current_index.get(&value.left)?,
+        right: *current_index.get(&value.right)?,
+        score: value.score,
+        witness: crate::ConnectedWitness {
+            left_lines: value.left_lines,
+            right_lines: value.right_lines,
+            mapped_nodes: value.mapped_nodes,
+            holes: value.holes,
+            complete_exit: value.complete_exit,
+        },
+        route,
+    })
+}
+
+fn digest(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update((domain.len() as u64).to_be_bytes());
+    hasher.update(domain);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    hasher.finalize().into()
+}

--- a/crates/nose-detect/src/incremental/tests.rs
+++ b/crates/nose-detect/src/incremental/tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::candidates::structural_candidates;
+use crate::{DetectOptions, StructuralDetector, UnitFeat};
+use nose_il::{Corpus, FileId, Interner, Lang};
+
+fn features(source: &[(&str, &str)], opts: &DetectOptions) -> Vec<UnitFeat> {
+    features_in_lang(source, Lang::Python, opts)
+}
+
+fn features_in_lang(source: &[(&str, &str)], lang: Lang, opts: &DetectOptions) -> Vec<UnitFeat> {
+    let interner = Interner::new();
+    let files = source
+        .iter()
+        .enumerate()
+        .map(|(index, (path, text))| {
+            nose_frontend::lower_source(
+                FileId(index as u32),
+                path,
+                text.as_bytes(),
+                lang,
+                &interner,
+            )
+            .expect("Python fixture lowers")
+        })
+        .collect();
+    let corpus = Corpus::new(interner, files);
+    crate::corpus_features(&corpus, opts).units
+}
+
+#[test]
+fn incremental_buckets_match_clean_candidate_generation() {
+    let opts = DetectOptions {
+        shape_candidates: true,
+        ..DetectOptions::default()
+    };
+    let units = features(
+        &[
+            ("a.py", "def f(xs):\n    return sum(x * x for x in xs)\n"),
+            ("b.py", "def g(xs):\n    return sum(x * x for x in xs)\n"),
+            ("c.py", "def h(xs):\n    return sum(x + x for x in xs)\n"),
+        ],
+        &opts,
+    );
+    let mut stats = IncrementalDetectionStats::new();
+    let prepared = prepare(&units, &opts, None, &mut stats);
+    assert_eq!(prepared.candidates, structural_candidates(&units, &opts));
+}
+
+#[test]
+fn unchanged_state_reuses_buckets_and_scores() {
+    let opts = DetectOptions::default();
+    let units = features(
+        &[
+            ("a.py", "def f(xs):\n    return sum(x * x for x in xs)\n"),
+            ("b.py", "def g(xs):\n    return sum(x * x for x in xs)\n"),
+        ],
+        &opts,
+    );
+    let detector = StructuralDetector::strict(opts.jaccard_weight);
+    let mut first_stats = IncrementalDetectionStats::new();
+    let first = prepare(&units, &opts, None, &mut first_stats);
+    let (scored, _) = score(&units, &first, &detector, opts.threshold, &mut first_stats);
+    let components = components(&first, &[], opts.threshold, &mut first_stats);
+    let state = finish_state(
+        first,
+        &scored,
+        &components,
+        IncrementalConnected::default(),
+        None,
+    );
+
+    let mut second_stats = IncrementalDetectionStats::new();
+    let second = prepare(&units, &opts, Some(state), &mut second_stats);
+    let _ = score(
+        &units,
+        &second,
+        &detector,
+        opts.threshold,
+        &mut second_stats,
+    );
+    assert!(second_stats.state_hit);
+    assert_eq!(second_stats.units_reused, units.len());
+    assert_eq!(second_stats.buckets_rebuilt, 0);
+    assert_eq!(second_stats.scores_evaluated, 0);
+    assert_eq!(second_stats.scores_reused, second.candidates.len());
+}
+
+#[test]
+fn deleting_a_same_unit_branch_removes_its_cached_witness() {
+    let opts = DetectOptions {
+        threshold: 0.70,
+        min_lines: 3,
+        min_tokens: 12,
+        shape_candidates: true,
+        connected_witnesses: true,
+        ..DetectOptions::default()
+    };
+    let repeated = r#"
+int set_option(const char *name, const char *value) {
+  if (!strcmp(name, "progress")) {
+    if (!strcmp(value, "true")) options.progress = 1;
+    else if (!strcmp(value, "false")) options.progress = 0;
+    else return -1;
+    return 0;
+  }
+  if (!strcmp(name, "deepen-relative")) {
+    if (!strcmp(value, "true")) options.deepen_relative = 1;
+    else if (!strcmp(value, "false")) options.deepen_relative = 0;
+    else return -1;
+    return 0;
+  }
+  return 1;
+}
+"#;
+    let single = r#"
+int set_option(const char *name, const char *value) {
+  if (!strcmp(name, "progress")) {
+    if (!strcmp(value, "true")) options.progress = 1;
+    else if (!strcmp(value, "false")) options.progress = 0;
+    else return -1;
+    return 0;
+  }
+  return 1;
+}
+"#;
+
+    let first_units = features_in_lang(&[("options.c", repeated)], Lang::C, &opts);
+    let mut first_stats = IncrementalDetectionStats::new();
+    let first = prepare(&first_units, &opts, None, &mut first_stats);
+    let first_connected = connected(&first_units, &first, &[], &[], &opts, &mut first_stats);
+    assert!(
+        !first_connected.same_unit_accepted.is_empty(),
+        "fixture must seed a same-unit accepted edge"
+    );
+    let state = finish_state(first, &[], &[], first_connected, None);
+
+    let second_units = features_in_lang(&[("options.c", single)], Lang::C, &opts);
+    let mut second_stats = IncrementalDetectionStats::new();
+    let second = prepare(&second_units, &opts, Some(state), &mut second_stats);
+    let second_connected = connected(&second_units, &second, &[], &[], &opts, &mut second_stats);
+    assert!(second_connected.same_unit_accepted.is_empty());
+    assert!(second_stats.connected_evaluations_evaluated > 0);
+}

--- a/crates/nose-detect/src/incremental/tests.rs
+++ b/crates/nose-detect/src/incremental/tests.rs
@@ -42,7 +42,7 @@ fn incremental_buckets_match_clean_candidate_generation() {
         &opts,
     );
     let mut stats = IncrementalDetectionStats::new();
-    let prepared = prepare(&units, &opts, None, &mut stats);
+    let prepared = prepare(&units, None, &opts, None, &mut stats);
     assert_eq!(prepared.candidates, structural_candidates(&units, &opts));
 }
 
@@ -58,7 +58,7 @@ fn unchanged_state_reuses_buckets_and_scores() {
     );
     let detector = StructuralDetector::strict(opts.jaccard_weight);
     let mut first_stats = IncrementalDetectionStats::new();
-    let first = prepare(&units, &opts, None, &mut first_stats);
+    let first = prepare(&units, None, &opts, None, &mut first_stats);
     let (scored, _) = score(&units, &first, &detector, opts.threshold, &mut first_stats);
     let components = components(&first, &[], opts.threshold, &mut first_stats);
     let state = finish_state(
@@ -70,7 +70,7 @@ fn unchanged_state_reuses_buckets_and_scores() {
     );
 
     let mut second_stats = IncrementalDetectionStats::new();
-    let second = prepare(&units, &opts, Some(state), &mut second_stats);
+    let second = prepare(&units, None, &opts, Some(state), &mut second_stats);
     let _ = score(
         &units,
         &second,
@@ -126,7 +126,7 @@ int set_option(const char *name, const char *value) {
 
     let first_units = features_in_lang(&[("options.c", repeated)], Lang::C, &opts);
     let mut first_stats = IncrementalDetectionStats::new();
-    let first = prepare(&first_units, &opts, None, &mut first_stats);
+    let first = prepare(&first_units, None, &opts, None, &mut first_stats);
     let first_connected = connected(&first_units, &first, &[], &[], &opts, &mut first_stats);
     assert!(
         !first_connected.same_unit_accepted.is_empty(),
@@ -136,7 +136,7 @@ int set_option(const char *name, const char *value) {
 
     let second_units = features_in_lang(&[("options.c", single)], Lang::C, &opts);
     let mut second_stats = IncrementalDetectionStats::new();
-    let second = prepare(&second_units, &opts, Some(state), &mut second_stats);
+    let second = prepare(&second_units, None, &opts, Some(state), &mut second_stats);
     let second_connected = connected(&second_units, &second, &[], &[], &opts, &mut second_stats);
     assert!(second_connected.same_unit_accepted.is_empty());
     assert!(second_stats.connected_evaluations_evaluated > 0);

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -16,6 +16,7 @@ mod detectors;
 mod exact_policy;
 mod fragment;
 mod il_utils;
+mod incremental;
 mod locations;
 mod lsh;
 mod minhash;
@@ -43,13 +44,15 @@ pub use fragment::{
     Effect, EffectSite, Exit, FragmentContract, FragmentKind, OracleInputProjection, Place,
     ProofFacts,
 };
+pub use incremental::{IncrementalDetectionState, IncrementalDetectionStats};
 pub use model::{
     AbstractionHole, AbstractionWitness, ConnectedWitness, Dump, DupPair, EnclosingUnit,
     EquivalenceWitness, Group, LineSpan, Loc, LocInit, Metrics, Report, UnitLoc,
 };
 pub use options::DetectOptions;
 pub use orchestration::{
-    corpus_features, detect, detect_from_units, detect_from_units_with_accepted_coverage,
+    corpus_features, detect, detect_from_units,
+    detect_from_units_incremental_with_accepted_coverage, detect_from_units_with_accepted_coverage,
     detect_with_accepted_coverage, detect_with_direct_accepted_coverage, detect_with_dump,
     file_stream, units_of_file, CorpusFeatures,
 };

--- a/crates/nose-detect/src/lsh.rs
+++ b/crates/nose-detect/src/lsh.rs
@@ -16,7 +16,7 @@ const SEED: u64 = 0xA24B_AED4_963E_E407;
 /// Hash one band's rows, folding the band index in so band *b*'s hash never aliases
 /// band *b'*'s — a single `u64` key then identifies the whole `(band, value)` bucket.
 #[inline]
-fn band_hash(band: usize, slice: &[u64]) -> u64 {
+pub(crate) fn band_hash(band: usize, slice: &[u64]) -> u64 {
     let mut h = SEED ^ (band as u64).wrapping_mul(0x100_0000_01B3);
     for &x in slice {
         h = (h ^ x).wrapping_mul(0x1000_0000_01B3);
@@ -112,7 +112,7 @@ pub(crate) fn candidates<'a>(
 
 /// Above this bucket size, switch from O(k²) all-pairs to an O(k) connectivity
 /// skeleton (chain + star) — bounds candidate-gen on dense corpora.
-const BUCKET_ALL_PAIRS_CAP: usize = 48;
+pub(crate) const BUCKET_ALL_PAIRS_CAP: usize = 48;
 
 #[inline]
 fn ordered(i: u32, j: u32) -> (u32, u32) {

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -157,6 +157,7 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
     previous: Option<IncrementalDetectionState>,
+    stable_unit_keys: Option<&[[u8; 32]]>,
 ) -> (
     Report,
     Dump,
@@ -165,7 +166,7 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
 ) {
     let mut clk = StageTimer::new();
     let mut stats = IncrementalDetectionStats::new();
-    let prepared = incremental::prepare(&units, opts, previous, &mut stats);
+    let prepared = incremental::prepare(&units, stable_unit_keys, opts, previous, &mut stats);
     clk.lap("candidates");
     let (scored, accepted) =
         incremental::score(&units, &prepared, detector, opts.threshold, &mut stats);

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -11,23 +11,19 @@ use crate::{
         attach_enclosing_units, connected_loc_of, enclosing_unit_indices, enclosing_units,
         is_nested, loc_of,
     },
-    minhash,
     model::{Dump, DupPair, EnclosingUnit, LineSpan, Metrics, Report, UnitLoc},
     options::DetectOptions,
     reinvented::reinvented_helpers,
-    units::{self, UnitFeat},
+    units::UnitFeat,
 };
-use nose_il::{Corpus, Il, Interner};
-use nose_normalize::NormalizeOptions;
+use nose_il::Corpus;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-/// Build one file's syntax-channel token stream from its (raw) IL. Exposed so the
-/// CLI's `--cache-dir` can cache it per file and pass it to [`detect_from_units`] — the
-/// counterpart to [`units_of_file`] for the syntax channel.
-pub fn file_stream(il: &Il, interner: &Interner) -> Stream {
-    contiguous::stream(il, interner)
-}
+use crate::incremental::{self, IncrementalDetectionState, IncrementalDetectionStats};
+
+mod features;
+pub use features::{corpus_features, file_stream, units_of_file, CorpusFeatures};
 
 pub fn detect(corpus: &Corpus, opts: &DetectOptions, detector: &dyn Detector) -> Report {
     detect_with_dump(corpus, opts, detector).0
@@ -83,106 +79,6 @@ impl StageTimer {
         }
         self.last = now;
     }
-}
-
-/// Like [`detect`] but also returns the unit/candidate [`Dump`] for diagnostics.
-/// Normalize one file and extract its detection units. The resulting [`UnitFeat`]s
-/// are interner-independent (every feature is a content-derived hash), so a caller
-/// may pass a throwaway per-file interner — which is exactly what makes caching a
-/// file's units by its source-content hash sound.
-pub fn units_of_file(il: &Il, interner: &Interner, opts: &DetectOptions) -> Vec<UnitFeat> {
-    let norm_opts = NormalizeOptions {
-        cfg_norm: opts.cfg_norm,
-        dce: opts.dce,
-        ..Default::default()
-    };
-    let seeds = minhash::seeds(opts.minhash_k);
-    extract_units_of_file(il, interner, opts, &norm_opts, &seeds)
-}
-
-/// Corpus features ready for detection. The caller may attach query-local evidence to
-/// `units` before handing the immutable feature set to [`detect_from_units`].
-pub struct CorpusFeatures {
-    pub units: Vec<UnitFeat>,
-    pub streams: Vec<Stream>,
-    pub files: usize,
-}
-
-pub fn corpus_features(corpus: &Corpus, opts: &DetectOptions) -> CorpusFeatures {
-    let norm_opts = NormalizeOptions {
-        cfg_norm: opts.cfg_norm,
-        dce: opts.dce,
-        ..Default::default()
-    };
-    let seeds = minhash::seeds(opts.minhash_k);
-    let per_file: Vec<(Vec<UnitFeat>, Option<Stream>)> = corpus
-        .files
-        .par_iter()
-        .map(|il| {
-            let units = if opts.structural {
-                extract_units_of_file(il, &corpus.interner, opts, &norm_opts, &seeds)
-            } else {
-                Vec::new()
-            };
-            // Build contiguous copy-paste streams from raw IL. Alpha-renaming is
-            // function-scoped, so normalized identifiers would vary by enclosing unit;
-            // renamed Type-2/3/4 matches remain the structural channel's job.
-            let stream = opts
-                .contiguous
-                .then(|| contiguous::stream(il, &corpus.interner));
-            (units, stream)
-        })
-        .collect();
-    let unit_count = per_file.iter().map(|(units, _)| units.len()).sum();
-    let stream_count = per_file
-        .iter()
-        .filter(|(_, stream)| stream.is_some())
-        .count();
-    let mut units = Vec::with_capacity(unit_count);
-    let mut streams = Vec::with_capacity(stream_count);
-    for (file_units, stream) in per_file {
-        units.extend(file_units);
-        if let Some(stream) = stream {
-            streams.push(stream);
-        }
-    }
-    CorpusFeatures {
-        units,
-        streams,
-        files: corpus.files.len(),
-    }
-}
-
-/// Keep the normalization/extraction body out of the Rayon closure. This path
-/// is large and hot; sharing one non-inlined implementation with the cached
-/// per-file entry point avoids code-layout-sensitive copies while preserving
-/// the fused normalize-then-extract lifetime.
-#[inline(never)]
-fn extract_units_of_file(
-    il: &Il,
-    interner: &Interner,
-    opts: &DetectOptions,
-    norm_opts: &NormalizeOptions,
-    seeds: &[u64],
-) -> Vec<UnitFeat> {
-    if units::raw_il_is_empty_module(il) || units::large_test_file(il) {
-        return Vec::new();
-    }
-    let n = nose_normalize::normalize(il, interner, norm_opts);
-    let block_units = units::block_units_for_file(&n, opts);
-    units::extract(
-        &n,
-        interner,
-        seeds,
-        opts.min_lines,
-        opts.min_tokens,
-        block_units,
-        units::ExtractFeatures {
-            shape_features: opts.shape_features,
-            abstraction_witnesses: opts.abstraction_witnesses,
-            connected_witnesses: opts.connected_witnesses,
-        },
-    )
 }
 
 pub fn detect_with_dump(
@@ -252,6 +148,72 @@ pub fn detect_from_units_with_accepted_coverage(
     detect_from_units_inner(units, files, streams, opts, detector, true, false)
 }
 
+/// Cached-query entry point with persistent candidate membership and pair-score
+/// reuse. The state is content-addressed by the CLI; this layer owns its schema.
+pub fn detect_from_units_incremental_with_accepted_coverage(
+    units: Vec<UnitFeat>,
+    files: usize,
+    streams: &[Stream],
+    opts: &DetectOptions,
+    detector: &dyn Detector,
+    previous: Option<IncrementalDetectionState>,
+) -> (
+    Report,
+    Dump,
+    IncrementalDetectionState,
+    IncrementalDetectionStats,
+) {
+    let mut clk = StageTimer::new();
+    let mut stats = IncrementalDetectionStats::new();
+    let prepared = incremental::prepare(&units, opts, previous, &mut stats);
+    clk.lap("candidates");
+    let (scored, accepted) =
+        incremental::score(&units, &prepared, detector, opts.threshold, &mut stats);
+    let raw_groups = incremental::components(&prepared, &accepted, opts.threshold, &mut stats);
+    let mut connected =
+        incremental::connected(&units, &prepared, &scored, &accepted, opts, &mut stats);
+    let connected_override = Some((
+        std::mem::take(&mut connected.accepted),
+        std::mem::take(&mut connected.same_unit_accepted),
+    ));
+    let (contiguous_override, contiguous_state) = if opts.contiguous {
+        let (groups, edges, state, contiguous_stats) = contiguous::detect_incremental(
+            streams,
+            opts.contiguous_min_tokens,
+            opts.contiguous_min_lines,
+            false,
+            prepared.previous_contiguous.as_ref(),
+        );
+        stats.contiguous_streams_reused = contiguous_stats.streams_reused;
+        stats.contiguous_streams_rebuilt = contiguous_stats.streams_rebuilt;
+        stats.contiguous_components_reused = contiguous_stats.components_reused;
+        stats.contiguous_components_rebuilt = contiguous_stats.components_rebuilt;
+        (Some((groups, edges)), Some(state))
+    } else {
+        (None, None)
+    };
+    let candidates = prepared.candidates.clone();
+    let state =
+        incremental::finish_state(prepared, &scored, &raw_groups, connected, contiguous_state);
+    let (report, dump) = finish_detection(
+        units,
+        files,
+        streams,
+        opts,
+        detector,
+        &candidates,
+        &scored,
+        accepted,
+        Some(raw_groups),
+        connected_override,
+        contiguous_override,
+        true,
+        false,
+        &mut clk,
+    );
+    (report, dump, state, stats)
+}
+
 fn detect_from_units_inner(
     units: Vec<UnitFeat>,
     files: usize,
@@ -263,8 +225,7 @@ fn detect_from_units_inner(
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
-    let (candidates, accepted, mut connected_accepted, mut same_unit_accepted) = if opts.structural
-    {
+    let (candidates, scored, accepted) = if opts.structural {
         // 3. LSH candidate generation. Semantic runs use the value-graph signature;
         //    near-duplicate runs also use shape signatures so Type-3 edits that
         //    change behavior-defining values still reach the scorer. When both
@@ -275,20 +236,57 @@ fn detect_from_units_inner(
         // 4. Score candidates in parallel; keep accepted pairs.
         let (scored, accepted) =
             score_ordinary_candidates(&units, &candidates, detector, opts.threshold);
-        let connected = if opts.connected_witnesses {
-            score_connected_candidates(&units, &scored, &accepted, opts.threshold, !opts.emit_pairs)
-        } else {
-            Vec::new()
-        };
-        let same_unit = if opts.connected_witnesses {
-            score_same_unit_candidates(&units, opts.threshold, !opts.emit_pairs)
-        } else {
-            Vec::new()
-        };
-        (candidates, accepted, connected, same_unit)
+        (candidates, scored, accepted)
     } else {
         clk.lap("candidates");
-        (Vec::new(), Vec::new(), Vec::new(), Vec::new())
+        (Vec::new(), Vec::new(), Vec::new())
+    };
+
+    finish_detection(
+        units,
+        files,
+        streams,
+        opts,
+        detector,
+        &candidates,
+        &scored,
+        accepted,
+        None,
+        None,
+        None,
+        trace_accepted_coverage,
+        trace_contiguous_coverage,
+        &mut clk,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_detection(
+    units: Vec<UnitFeat>,
+    files: usize,
+    streams: &[Stream],
+    opts: &DetectOptions,
+    detector: &dyn Detector,
+    candidates: &[(usize, usize)],
+    scored: &[ScoredCandidate],
+    accepted: Vec<AcceptedPair>,
+    raw_groups: Option<Vec<Vec<usize>>>,
+    connected_override: Option<(Vec<ConnectedAccepted>, Vec<ConnectedAccepted>)>,
+    contiguous_override: Option<(Vec<crate::Group>, Vec<Vec<crate::AcceptedEdge>>)>,
+    trace_accepted_coverage: bool,
+    trace_contiguous_coverage: bool,
+    clk: &mut StageTimer,
+) -> (Report, Dump) {
+    let (mut connected_accepted, mut same_unit_accepted) = if let Some(cached) = connected_override
+    {
+        cached
+    } else if opts.connected_witnesses {
+        (
+            score_connected_candidates(&units, scored, &accepted, opts.threshold, !opts.emit_pairs),
+            score_same_unit_candidates(&units, opts.threshold, !opts.emit_pairs),
+        )
+    } else {
+        (Vec::new(), Vec::new())
     };
 
     deduplicate_connected(&accepted, &mut connected_accepted, !opts.emit_pairs);
@@ -298,11 +296,13 @@ fn detect_from_units_inner(
     clk.lap("score");
 
     // 5. Cluster.
-    let mut uf = UnionFind::new(units.len());
-    for &(i, j, _) in &accepted {
-        uf.union(i, j);
-    }
-    let raw_groups = uf.groups(units.len());
+    let raw_groups = raw_groups.unwrap_or_else(|| {
+        let mut union = UnionFind::new(units.len());
+        for &(left, right, _) in &accepted {
+            union.union(left, right);
+        }
+        union.groups(units.len())
+    });
     clk.lap("cluster");
 
     let enclosing = enclosing_units(&units);
@@ -318,7 +318,6 @@ fn detect_from_units_inner(
     let (mut groups, mut accepted_group_edges) = build_groups(
         &units,
         &accepted,
-        &mut uf,
         &raw_groups,
         &enclosing,
         opts,
@@ -361,16 +360,26 @@ fn detect_from_units_inner(
     // value-graph channel, so both `detect` and the CLI's `--cache-dir` path produce
     // the same families — the cache supplies cached streams, otherwise this would
     // silently omit every contiguous clone.
-    append_contiguous_groups(
-        &mut report,
-        streams,
-        opts,
-        &units,
-        trace_contiguous_coverage,
-    );
+    if let Some((groups, edges)) = contiguous_override {
+        append_contiguous_output(
+            &mut report,
+            groups,
+            edges,
+            &units,
+            trace_contiguous_coverage,
+        );
+    } else {
+        append_contiguous_groups(
+            &mut report,
+            streams,
+            opts,
+            &units,
+            trace_contiguous_coverage,
+        );
+    }
     clk.lap("contiguous");
 
-    (report, detection_dump(&units, &candidates))
+    (report, detection_dump(&units, candidates))
 }
 
 fn detection_dump(units: &[UnitFeat], candidates: &[(usize, usize)]) -> Dump {
@@ -392,14 +401,14 @@ fn detection_dump(units: &[UnitFeat], candidates: &[(usize, usize)]) -> Dump {
     }
 }
 
-type AcceptedPair = (usize, usize, f64);
+pub(crate) type AcceptedPair = (usize, usize, f64);
 
 #[derive(Clone, Copy, Debug)]
-struct ScoredCandidate {
-    left: usize,
-    right: usize,
+pub(crate) struct ScoredCandidate {
+    pub(crate) left: usize,
+    pub(crate) right: usize,
     /// Nested pairs are intentionally not scored by the ordinary detector.
-    ordinary_score: Option<f64>,
+    pub(crate) ordinary_score: Option<f64>,
 }
 
 fn score_ordinary_candidates(
@@ -472,7 +481,7 @@ fn build_pair_output(
     output
 }
 
-mod connected_pricing;
+pub(crate) mod connected_pricing;
 use connected_pricing::{
     deduplicate_connected, deduplicate_same_unit, score_connected_candidates,
     score_same_unit_candidates,
@@ -488,15 +497,31 @@ fn append_contiguous_groups(
     if !opts.contiguous {
         return;
     }
-    let (mut extra, accepted_edges) = contiguous::detect(
+    let (extra, accepted_edges) = contiguous::detect(
         streams,
         opts.contiguous_min_tokens,
         opts.contiguous_min_lines,
         trace_accepted_coverage,
     );
-    attach_enclosing_units(&mut extra, units);
-    report.metrics.groups += extra.len();
-    report.groups.extend(extra);
+    append_contiguous_output(
+        report,
+        extra,
+        accepted_edges,
+        units,
+        trace_accepted_coverage,
+    );
+}
+
+fn append_contiguous_output(
+    report: &mut Report,
+    mut groups: Vec<crate::Group>,
+    accepted_edges: Vec<Vec<crate::AcceptedEdge>>,
+    units: &[UnitFeat],
+    trace_accepted_coverage: bool,
+) {
+    attach_enclosing_units(&mut groups, units);
+    report.metrics.groups += groups.len();
+    report.groups.extend(groups);
     if trace_accepted_coverage {
         report.accepted_group_edges.extend(accepted_edges);
     }

--- a/crates/nose-detect/src/orchestration/connected_pricing.rs
+++ b/crates/nose-detect/src/orchestration/connected_pricing.rs
@@ -75,7 +75,7 @@ pub(super) fn score_same_unit_candidates(
         .collect()
 }
 
-fn same_unit_seed_indices(units: &[UnitFeat], bound_product_work: bool) -> Vec<usize> {
+pub(crate) fn same_unit_seed_indices(units: &[UnitFeat], bound_product_work: bool) -> Vec<usize> {
     const MIN_SELF_UNIT_NODES: usize = 20;
     const PRODUCT_PER_FILE_CAP: usize = 2;
     const PRODUCT_GLOBAL_CAP: usize = 4_096;
@@ -127,7 +127,7 @@ fn same_unit_seed_indices(units: &[UnitFeat], bound_product_work: bool) -> Vec<u
 /// expensive pair-local proof only for the strongest ordinary near misses, while always
 /// retaining nested seeds because they are the sole route to disjoint descendants.
 /// Endpoints below 18 nodes cannot meet the matcher's lowest complete-exit threshold.
-pub(super) fn connected_seed_indices(
+pub(crate) fn connected_seed_indices(
     candidates: &[ScoredCandidate],
     unit_paths: &[&str],
     unit_weights: &[usize],
@@ -230,7 +230,7 @@ fn record_scored_seed<'a>(
     best.truncate(cap);
 }
 
-fn evaluate_connected_candidate(
+pub(crate) fn evaluate_connected_candidate(
     units: &[UnitFeat],
     enclosing_indices: &[Option<usize>],
     same_file: &[usize],

--- a/crates/nose-detect/src/orchestration/features.rs
+++ b/crates/nose-detect/src/orchestration/features.rs
@@ -1,0 +1,110 @@
+use super::*;
+use crate::{minhash, units};
+use nose_il::{Il, Interner};
+use nose_normalize::NormalizeOptions;
+
+/// Build one file's syntax-channel token stream from its (raw) IL. Exposed so the
+/// CLI's `--cache-dir` can cache it per file and pass it to [`super::detect_from_units`] —
+/// the counterpart to [`units_of_file`] for the syntax channel.
+pub fn file_stream(il: &Il, interner: &Interner) -> Stream {
+    contiguous::stream(il, interner)
+}
+
+/// Normalize one file and extract its detection units. The resulting [`UnitFeat`]s
+/// are interner-independent (every feature is a content-derived hash), so a caller
+/// may pass a throwaway per-file interner — which is exactly what makes caching a
+/// file's units by its source-content hash sound.
+pub fn units_of_file(il: &Il, interner: &Interner, opts: &DetectOptions) -> Vec<UnitFeat> {
+    let norm_opts = NormalizeOptions {
+        cfg_norm: opts.cfg_norm,
+        dce: opts.dce,
+        ..Default::default()
+    };
+    let seeds = minhash::seeds(opts.minhash_k);
+    extract_units_of_file(il, interner, opts, &norm_opts, &seeds)
+}
+
+/// Corpus features ready for detection. The caller may attach query-local evidence to
+/// `units` before handing the immutable feature set to [`super::detect_from_units`].
+pub struct CorpusFeatures {
+    pub units: Vec<UnitFeat>,
+    pub streams: Vec<Stream>,
+    pub files: usize,
+}
+
+pub fn corpus_features(corpus: &Corpus, opts: &DetectOptions) -> CorpusFeatures {
+    let norm_opts = NormalizeOptions {
+        cfg_norm: opts.cfg_norm,
+        dce: opts.dce,
+        ..Default::default()
+    };
+    let seeds = minhash::seeds(opts.minhash_k);
+    let per_file: Vec<(Vec<UnitFeat>, Option<Stream>)> = corpus
+        .files
+        .par_iter()
+        .map(|il| {
+            let units = if opts.structural {
+                extract_units_of_file(il, &corpus.interner, opts, &norm_opts, &seeds)
+            } else {
+                Vec::new()
+            };
+            // Build contiguous copy-paste streams from raw IL. Alpha-renaming is
+            // function-scoped, so normalized identifiers would vary by enclosing unit;
+            // renamed Type-2/3/4 matches remain the structural channel's job.
+            let stream = opts
+                .contiguous
+                .then(|| contiguous::stream(il, &corpus.interner));
+            (units, stream)
+        })
+        .collect();
+    let unit_count = per_file.iter().map(|(units, _)| units.len()).sum();
+    let stream_count = per_file
+        .iter()
+        .filter(|(_, stream)| stream.is_some())
+        .count();
+    let mut units = Vec::with_capacity(unit_count);
+    let mut streams = Vec::with_capacity(stream_count);
+    for (file_units, stream) in per_file {
+        units.extend(file_units);
+        if let Some(stream) = stream {
+            streams.push(stream);
+        }
+    }
+    CorpusFeatures {
+        units,
+        streams,
+        files: corpus.files.len(),
+    }
+}
+
+/// Keep the normalization/extraction body out of the Rayon closure. This path
+/// is large and hot; sharing one non-inlined implementation with the cached
+/// per-file entry point avoids code-layout-sensitive copies while preserving
+/// the fused normalize-then-extract lifetime.
+#[inline(never)]
+fn extract_units_of_file(
+    il: &Il,
+    interner: &Interner,
+    opts: &DetectOptions,
+    norm_opts: &NormalizeOptions,
+    seeds: &[u64],
+) -> Vec<UnitFeat> {
+    if units::raw_il_is_empty_module(il) || units::large_test_file(il) {
+        return Vec::new();
+    }
+    let n = nose_normalize::normalize(il, interner, norm_opts);
+    let block_units = units::block_units_for_file(&n, opts);
+    units::extract(
+        &n,
+        interner,
+        seeds,
+        opts.min_lines,
+        opts.min_tokens,
+        block_units,
+        units::ExtractFeatures {
+            shape_features: opts.shape_features,
+            abstraction_witnesses: opts.abstraction_witnesses,
+            connected_witnesses: opts.connected_witnesses,
+        },
+    )
+}

--- a/crates/nose-detect/src/report/model.rs
+++ b/crates/nose-detect/src/report/model.rs
@@ -132,16 +132,16 @@ pub struct VaryingSpot {
     pub param: u32,
     /// Absolute `[start, end]` source lines of this spot in the FIRST
     /// representative copy (the family's `locations[0]`).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub a_lines: Option<(u32, u32)>,
     /// Absolute `[start, end]` source lines in the second representative copy.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub b_lines: Option<(u32, u32)>,
     /// Trimmed, length-capped text of the spot in the first copy.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub a_text: String,
     /// Trimmed, length-capped text of the spot in the second copy.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub b_text: String,
 }
 

--- a/crates/nose-detect/src/report/model.rs
+++ b/crates/nose-detect/src/report/model.rs
@@ -126,7 +126,7 @@ pub struct RefactorFamily {
 /// One varying spot between a family's two representative copies — the hole an
 /// extracted helper would parameterize. Sides may be one-sided (a pure
 /// insertion/deletion run has lines in only one copy).
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct VaryingSpot {
     /// 1-based parameter index, matching the family's `params` count.
     pub param: u32,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,12 @@ new code should follow the focused owners there rather than growing dispatcher o
 - **Interner-independent features.** A unit's features are content-derived
   hashes, not interner ids, so they're portable across runs — the basis for the
   content-hash cache.
+- **Delete-capable incremental detection.** Cached unit-artifact identities feed persistent LSH
+  bucket membership and pair contribution counts. Additions update their buckets; removed scores
+  dirty and rebuild the old connected components instead of relying on append-only union-find.
+  Connected/same-unit evidence includes its file-context digest, syntax runs are partitioned by
+  shared k-grams, and line-IDF/family weights use source-frequency deltas. The full storage and
+  invalidation contract is in [portable cache artifacts](portable-cache-artifacts.md).
 - **Determinism is a hard invariant.** Output is byte-identical across runs *and*
   thread counts. File ids come from a sorted path list; nothing iterates a
   `HashMap` into the output. There are tests for both.

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -328,9 +328,11 @@ streams, including across checkout paths and after unrelated additions shift `Fi
 
 Importers are invalidated only when a provider's exported literal surface changes. Swift global
 shadow/overload/conformance barriers invalidate Swift dependents, and unresolved dependencies
-fail safe by over-invalidating their language export catalog. Global detection, line-frequency
-ranking reads, and presentation still run on every query; #875 owns the next reuse boundary. Point
-the directory at storage your
+fail safe by over-invalidating their language export catalog. Global candidate buckets, pair
+scores, delete-capable family components, connected/same-unit witnesses, syntax components,
+line-frequency deltas, and family source-line analyses are also reused. An unchanged run therefore
+does not reparse, normalize, rescore, or reread the full line index; query filtering and rendering
+remain request-local. Point the directory at storage your
 CI preserves between runs; see the
 [incremental cache benchmark](incremental-cache-benchmark.md) for the exact performance and
 clean-scan-equivalence contract.
@@ -344,6 +346,9 @@ Set `NOSE_CACHE_STATS=1` to retain the existing `[cache]` unit hit/miss line and
 the affected path closure and reasons, deleted sources, Git-blob versus content identities,
 explicit fail-safe over-invalidation, and digests/invalidation markers for discovery membership,
 semantic-pack influence, Swift global sentinels, and corpus-global line statistics.
+It also emits `[detection]` (`nose.detection-incremental/v1`), `[line-index]`
+(`nose.line-index/v1`), and `[family-lines]` (`nose.family-line-state/v1`) JSON objects so CI and
+benchmarks can distinguish reuse from recomputation without parsing human timing text.
 
 ---
 

--- a/docs/incremental-cache-benchmark.md
+++ b/docs/incremental-cache-benchmark.md
@@ -115,14 +115,42 @@ clean/empty/history equality. Representative history-bearing unit hit/miss closu
 `1/33`, add/delete/rename `3/1`, embedded-region edit `5/1`, restored-mtime edit `3/1`, and Swift
 global barrier `0/3`.
 
+## Checked #875 evidence
+
+The checked [`issue-875-incremental-global-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-875-incremental-global-sympy-paired-2026-07-20.v1.json)
+contains all 180 rows from 30 alternating AB/BA replays of implementation commit `e93bdc05`
+against the checksum-verified published v0.19.0 binary. Both roles independently passed exact
+clean/empty/history output equivalence.
+
+| Phase | Official p50 / p95 | #875 p50 / p95 | #875 delta p50 / p95 |
+| --- | ---: | ---: | ---: |
+| Clean | 1194.41 / 1451.44 ms | 1193.42 / 1428.13 ms | -0.08% / -1.61% |
+| Empty store | 1353.92 / 1667.48 ms | 3080.78 / 3572.17 ms | +127.54% / +114.23% |
+| Warm store | 887.12 / 991.24 ms | 917.04 / 970.76 ms | +3.37% / -2.07% |
+
+The no-op warm path reuses all 318,443 candidate buckets, 647,289 scores, 26,356 connected
+evaluations, 1,584 syntax streams, and 5,172 family-line analyses in the pinned SymPy workload.
+Its candidate stage is 34.0 ms p50 and source-line stage 22.7 ms p50. Warm p95 improves 2.07%,
+while p50 is 3.37% slower; warm p50/p95 RSS improves 19.97%/19.55%. Clean remains neutral.
+
+The empty-store regression is intentionally not normalized away: building the new global state
+more than doubles cold latency and grows the store 17.93% to 448,315,564 bytes. #876 owns compact,
+transactional, bounded generations and must price this measured debt directly.
+
+The checked [`issue-875-mutation-matrix-receipt-2026-07-20.v1.json`](../bench/cache/issue-875-mutation-matrix-receipt-2026-07-20.v1.json)
+seals a 4,356,466-byte, 2,100-row raw report (`e66a61fa…`) covering all 14 mutations over 30
+replays. Every clean/empty/history comparison passed byte-for-byte, including add/delete/rename,
+provider fan-out, semantic-pack and config changes, embedded regions, Swift global barriers, and
+same-size restored-mtime edits.
+
 ## What the current cache actually reuses
 
 The published v0.19.0 cache is schema v11 and the locked #872 candidate is schema v14. #873 moved
-the 0.20 development tree to layered CAS v1 while keeping only units/syntax active. #874 now reuses
-source snapshots, raw lowering, dependency-aware resolved IL, and units/syntax. A warm clean-Git
-hit avoids source reads for lowering and skips parsing; the still-global line-frequency/ranking
-stage may read source later. Dirty, untracked, and non-Git inputs are read so their exact bytes,
-rather than mtime/size, establish identity.
+the 0.20 development tree to layered CAS v1, #874 activated source/raw/resolved IL reuse, and #875
+now reuses global detection, syntax components, line document frequencies, and family-line
+analyses. A warm clean-Git hit avoids source reads for lowering and skips parsing; an unchanged
+line manifest also avoids loading the full line index. Dirty, untracked, and non-Git inputs are
+read so their exact bytes, rather than mtime/size, establish identity.
 
 CAS v1 replaces the u64 entry name with a stage/schema-separated SHA-256 address over the complete
 post-resolution semantic/reporting identity and unit-affecting options. An independent payload
@@ -131,8 +159,9 @@ SHA-256, exact length, and envelope identity make corrupt or misplaced bytes cle
 evidence records remain identity-bearing. Resolved entries add a deterministic
 consumer-visible export/dependency context, so provider-private changes leave importers hot while
 export, ambiguity, deletion/rename, and Swift-global changes reach their consumers. Global
-detection, source-line frequency reads, family construction/ranking, and presentation still
-repeat; #875 owns that boundary.
+detection buckets/pair scores/components, connected and same-unit witnesses, syntax components,
+line frequencies, and family diffs/weights update from persistent state. Query filters, rendering,
+and final presentation remain request-local.
 See [portable cache artifacts](portable-cache-artifacts.md).
 
 #275 is the required cross-file regression. A provider literal and importer that converge with

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -1,8 +1,8 @@
 # Portable cache artifacts
 
 The 0.20 Instant Monorepo cache uses one layered content-addressed store (CAS) contract for every
-analysis stage. #873 defined the portable trust boundary; #874 activates dependency-aware source,
-raw-IL, export-summary, and resolved-IL reuse without changing that storage model.
+analysis stage. #873 defined the portable trust boundary, #874 activated dependency-aware source
+and IL reuse, and #875 adds delete-capable global detection and family-line state.
 
 ## Layer contract
 
@@ -17,7 +17,7 @@ at a different address. The six stable stage identities are:
 | export/dependency summary | actively written and checksummed | deterministic export graph and SCC closure |
 | resolved IL | actively read and written | raw IL plus the region's dependency context |
 | units and syntax streams | actively read and written | resolved IL plus unit-affecting options |
-| global detection indexes | address space defined | #875 incremental detection |
+| global detection indexes | actively read and written | stable unit ids, bucket refcounts, pair scores, components, witnesses, syntax runs, line IDF, and family-line analyses |
 
 Raw and resolved IL use named MessagePack wrapped in fast LZ4 blocks; the decoder rejects a claimed
 region expansion above 512 MiB before allocation. The units layer stays named MessagePack without
@@ -26,8 +26,12 @@ Discovery still walks the selected roots so additions and deletions are visible,
 tracked raw hit needs no source read or parse in the lowering stage. Dependency summaries scan raw
 IL, compute consumer-visible literal surfaces, collapse cycles deterministically, and resolve
 imports against current module/package facts. Only resolved misses run corpus mutation; hits are
-rebound afterward. Global detection, source-line frequency reads, family construction/ranking,
-and presentation remain per-query work for #875.
+rebound afterward. Global detection state uses CAS-derived per-unit identities, updates changed
+bucket memberships, stores one pair plus its bucket contribution count, and rebuilds components
+whose accepted edges changed or disappeared. Syntax runs use the same delete-capable rule over
+shared k-grams. A small source manifest lets an unchanged run reuse line-IDF and family
+diff/weight state without rereading the full line index. Query filtering, formatting, and final
+presentation remain per invocation.
 
 ## Dependency-aware invalidation
 
@@ -48,8 +52,7 @@ unrelated artifacts merely because `FileId`s moved.
 Unknown static dependencies include the language's export catalog in their key. This can invalidate
 more than necessary when an unrelated export changes, but it cannot reuse a stale unresolved fact;
 the path is listed under `over_invalidated`. Discovery membership, semantic-pack influence, and
-corpus-global line-statistics digests are carried in diagnostics now even though their downstream
-global stages remain #875 work.
+corpus-global line-statistics digests also drive the downstream incremental global stages.
 
 The mutable `state-v1` workspace record exists only to explain changes and deleted paths. It is not
 a cache-key or reuse input: deleting or corrupting it loses reason history, never correctness.
@@ -58,6 +61,12 @@ backward-compatible `[cache]` units line. Cold start is summarized globally inst
 every file; history-bearing runs list the exact changed/deleted closure. Resolved `passthrough`
 counts identify regions whose raw IL is already the correct resolved form, so no duplicate payload
 is stored.
+
+The #875 detection, line-index, and family-line records are schema-scoped mutable acceleration
+state. Exact unit/source identities guard reuse, and a missing, corrupt, or incompatible record
+falls back to clean recomputation. #876 owns committing these mutually dependent records as one
+bounded generation; until then each record is atomically replaced but the set is not one
+transaction.
 
 ## Envelope and failure behavior
 
@@ -114,7 +123,8 @@ Focused tests prove:
 
 The #275 provider/importer integration test remains the cross-file safety gate. Focused gates also
 cover unchanged export surfaces, shifted `FileId`s with an active import edge, Swift global
-barriers, unresolved-dependency over-invalidation, and Git-blob/content identity selection. The
+barriers, unresolved-dependency over-invalidation, Git-blob/content identity selection, mutation
+order/thread-count independence, and same-unit witness deletion. The
 benchmark's clean/empty/history equality remains the product-output authority. See
 [continuous integration](continuous-integration.md) for current user-facing cache behavior.
 
@@ -138,3 +148,23 @@ bytes (-6.5%). This remains the before-#874 foundation measurement; the #874 com
 activated parse/resolve result in the
 [incremental cache benchmark](incremental-cache-benchmark.md#checked-874-evidence), while #875
 owns repeated global work.
+
+## Checked #875 performance evidence
+
+The checked [`issue-875-incremental-global-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-875-incremental-global-sympy-paired-2026-07-20.v1.json)
+contains 30 alternating AB/BA replays of implementation commit `e93bdc05` against the
+checksum-verified published v0.19.0 Apple Silicon binary. Both roles independently passed exact
+clean/empty/history output equivalence across all 180 rows.
+
+| Phase | Official p50 / p95 | #875 p50 / p95 | #875 delta p50 / p95 |
+| --- | ---: | ---: | ---: |
+| Clean | 1194.41 / 1451.44 ms | 1193.42 / 1428.13 ms | -0.08% / -1.61% |
+| Empty store | 1353.92 / 1667.48 ms | 3080.78 / 3572.17 ms | +127.54% / +114.23% |
+| Warm store | 887.12 / 991.24 ms | 917.04 / 970.76 ms | +3.37% / -2.07% |
+
+Warm p95 improves while clean performance remains neutral. Warm p50 RSS falls from 1019.16 MiB to
+815.59 MiB (-19.97%), and p95 RSS falls from 1033.39 MiB to 831.33 MiB (-19.55%). The explicit
+cost is first-generation construction: the store grows from 380,153,026 to 448,315,564 bytes
+(+17.93%), and cold latency more than doubles while the new global indexes are built. #876 owns
+transactional compact storage, bounded generations, and reclaiming that cold/store overhead; the
+regression is measured here rather than hidden.


### PR DESCRIPTION
Closes #875

## Summary
- persist stable unit identities, detection buckets, pair-score state, connected/same-unit witnesses, and delete-capable family components
- update line document frequencies and family line analyses by delta while preserving clean-scan ordering
- expose incremental cache statistics and document the state/evidence contracts

## Correctness
- 2,100 mutation replays across add/edit/delete/rename and syntax, semantic, near, and default modes are byte-identical to clean output
- 180 paired SymPy benchmark rows are output-identical
- `cargo test -p nose-detect` and `cargo test -p nose-cli`
- fast local CI gates, Type-4 perimeter checks, docs connectivity, clippy, rustfmt, and file-length ratchet

## Performance
- warm p50: 887.12 ms baseline, 917.04 ms candidate (+3.37%)
- warm p95: 991.24 ms baseline, 970.76 ms candidate (-2.07%)
- warm RSS p50/p95: about 20% lower
- clean p50/p95: neutral to slightly better
- cold p50: 1,353.92 ms baseline, 3,080.78 ms candidate (+127.54%)
- store size: 380,153,026 bytes baseline, 448,315,564 candidate (+17.93%)

The cold-write and store-size debt is explicitly carried into #876, which owns transactional compact cache storage.