### PR TITLE
feat(cache): make incremental storage transactional and bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ break.
 ## [Unreleased]
 
 ### Added
+- Made `--cache-dir` transactional, corruption-safe, concurrent, compact, and bounded (#876).
+  Immutable checksummed records now commit through one complete generation pointer; interrupted
+  or concurrent writers cannot expose partial state, corrupt/oversized entries recompute, and
+  a 5 GiB default budget evicts performance data without changing results. New stable
+  `nose cache status|prune|clear` commands and `--cache-max-bytes` / `[query].cache-max-bytes`
+  expose storage control without deleting unrelated files.
 - Added local `nose.semantic-pack-lock.v1` project authorization for typed v1
   semantic packs. `nose semantic-pack lock/status` content-pin manifest identity,
   semantic digest, selected rows/channels, dependency files, and optional receipts;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -344,6 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +363,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -465,6 +488,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "lasso"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,15 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
-name = "lz4_flex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,8 +541,8 @@ version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
+ "fs2",
  "ignore",
- "lz4_flex",
  "nose-detect",
  "nose-eval",
  "nose-frontend",
@@ -533,6 +557,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "toml",
+ "zstd",
 ]
 
 [[package]]
@@ -673,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +729,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -1084,12 +1121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1155,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1178,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1181,3 +1234,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ memchr = "2"
 toml = "0.8"
 quick-xml = "0.41"
 rmp-serde = "1"
-lz4_flex = "0.14"
+zstd = "0.13.3"
+fs2 = "0.4"
 
 # Centralized lint policy — every crate opts in with `[lints] workspace = true`,
 # so the quality bar is defined once and enforced uniformly. CI runs clippy with

--- a/bench/cache/issue-876-transactional-store-sympy-paired-2026-07-20.v1.json
+++ b/bench/cache/issue-876-transactional-store-sympy-paired-2026-07-20.v1.json
@@ -1,0 +1,10619 @@
+{
+  "environment": {
+    "architecture": "arm64",
+    "logical_cpu_count": 18,
+    "os": "Darwin",
+    "os_release": "25.5.0",
+    "python_version": "3.14.5"
+  },
+  "equivalence": {
+    "candidate": true,
+    "official": true
+  },
+  "measurement": {
+    "cache_stats_required": {
+      "candidate": true,
+      "official": false
+    },
+    "minimum_replays": 30,
+    "order": "alternating-ab-ba",
+    "p95": "nearest-rank",
+    "replays": 30
+  },
+  "provenance": {
+    "candidate": {
+      "binary": "target/release/nose",
+      "binary_code_sha256": "4ab90ae601142636b03670ec3332338ffd2e55997c133316d7a6c5bb28d362f8",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "6b13adaad99a221c14a11ba7258a27c7ab388df5",
+      "binary_sha256": "16e64dff7416311503d45540b07b1c7728b4594b10265d32ae20f8f96f979b54"
+    },
+    "harness": "scripts/cache-query-regression.py",
+    "harness_sha256": "969cbbc8ae98ed7e9a586c931799958e12b4b4858ec53019b56d4859bc6d145d",
+    "mutation_manifest": "bench/cache/mutation-manifest.v1.json",
+    "mutation_manifest_sha256": "13597fba09fb7e9b5e8785ba2a998d232bf86fa3b23103035b324b0c128ecdc6",
+    "official": {
+      "binary": "target/issue-875-baseline/nose-cli-aarch64-apple-darwin/nose",
+      "binary_code_sha256": "e55d0e989993ff1d1d6b4e933dbd3f5ade38203368b8321d3a7842799a95aca6",
+      "binary_code_sha256_algorithm": "sha256/mach-o-zero-uuid-signature-v1",
+      "binary_revision": "0985e6963c58d5a97e523bc532b88aa5e34f2ef9",
+      "binary_sha256": "0f73ea544da06cc175e01c31c383cc4cb86daf3d37a49d74de61dea3724fe0f3",
+      "release_verification": {
+        "archive": "target/issue-875-baseline/nose-cli-aarch64-apple-darwin.tar.xz",
+        "archive_sha256": "097c7e766e9ab756a32cec715897067d1360e145074715168a653962be409981",
+        "target": "aarch64-apple-darwin"
+      }
+    },
+    "official_baseline": "bench/cache/official-v0.19.0-binaries.v1.json",
+    "official_baseline_sha256": "a9e127dea4303378ed57e3274ca8e0d358b5f0ad253912e4316e8c1f0f83639a"
+  },
+  "runs": [
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1037.5224159797654,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1006370816,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.1,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "discover": 29.2,
+        "groups": 9.9,
+        "import-resolve": 44.6,
+        "lower": 482.0,
+        "normalize+extract": 363.2,
+        "parse+lower": 408.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 87.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8102.16195799876,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1379385344,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5513.0,
+        "candidates": 577.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.7,
+        "import-resolve": 28.3,
+        "lower": 1227.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 4.5,
+        "shared_lines": 466.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1836.5827499656007,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 724254720,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1204.9,
+        "candidates": 4.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 25.5,
+        "lower": 488.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 6.0,
+        "shared_lines": 21.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1006.5186669817194,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1001783296,
+      "phase": "clean-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.1,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 31.6,
+        "groups": 10.5,
+        "import-resolve": 46.8,
+        "lower": 469.4,
+        "normalize+extract": 343.8,
+        "parse+lower": 390.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 75.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1071.4184999233112,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090715648,
+      "phase": "empty-store-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.6,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 28.9,
+        "groups": 9.7,
+        "import-resolve": 46.5,
+        "lower": 462.0,
+        "parse+lower": 386.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 15.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 82.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 672.7381660602987,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1054359552,
+      "phase": "history-after",
+      "replay": 1,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 29.5,
+        "groups": 9.8,
+        "import-resolve": 46.7,
+        "lower": 434.5,
+        "parse+lower": 358.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 77.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 992.1660419786349,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1013497856,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.2,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 27.2,
+        "groups": 10.1,
+        "import-resolve": 49.4,
+        "lower": 440.4,
+        "normalize+extract": 368.2,
+        "parse+lower": 363.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 75.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1065.994083066471,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1098842112,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.6,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 25.3,
+        "groups": 10.0,
+        "import-resolve": 51.2,
+        "lower": 458.0,
+        "parse+lower": 381.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 74.8
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 719.1877079894766,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068679168,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.5,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 25.8,
+        "groups": 9.9,
+        "import-resolve": 47.8,
+        "lower": 480.7,
+        "parse+lower": 407.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.0,
+        "shared_lines": 79.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1021.5071670245379,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 978321408,
+      "phase": "clean-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 27.6,
+        "groups": 9.3,
+        "import-resolve": 46.6,
+        "lower": 468.6,
+        "normalize+extract": 366.4,
+        "parse+lower": 394.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 76.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8498.699082992971,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1363492864,
+      "phase": "empty-store-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5760.5,
+        "candidates": 630.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.3,
+        "import-resolve": 29.1,
+        "lower": 1257.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 4.7,
+        "shared_lines": 497.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1895.863916957751,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 710393856,
+      "phase": "history-after",
+      "replay": 2,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1263.4,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 12.2,
+        "import-resolve": 28.3,
+        "lower": 460.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 15.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 2.1,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 6.1,
+        "shared_lines": 30.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1054.3578339274973,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 986513408,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 20.6,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 26.0,
+        "groups": 9.9,
+        "import-resolve": 48.6,
+        "lower": 441.0,
+        "normalize+extract": 421.2,
+        "parse+lower": 366.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.7,
+        "shared_lines": 79.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8769.226957927458,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1369210880,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5825.4,
+        "candidates": 581.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.5,
+        "import-resolve": 29.4,
+        "lower": 1256.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 4.6,
+        "shared_lines": 591.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1872.5916659459472,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 701546496,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1258.9,
+        "candidates": 5.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.6,
+        "import-resolve": 33.1,
+        "lower": 468.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.6,
+        "shared_lines": 22.6
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1073.1092089554295,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 984399872,
+      "phase": "clean-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 23.9,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 26.4,
+        "groups": 10.1,
+        "import-resolve": 56.3,
+        "lower": 433.3,
+        "normalize+extract": 443.8,
+        "parse+lower": 350.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.0,
+        "shared_lines": 78.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1148.5309581039473,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1089519616,
+      "phase": "empty-store-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.9,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 27.4,
+        "groups": 12.2,
+        "import-resolve": 52.1,
+        "lower": 467.9,
+        "parse+lower": 388.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.4,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.5,
+        "shared_lines": 83.6
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 759.7919580293819,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065418752,
+      "phase": "history-after",
+      "replay": 3,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.8,
+        "groups": 10.8,
+        "import-resolve": 51.4,
+        "lower": 510.3,
+        "parse+lower": 431.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 77.0
+      },
+      "store": {
+        "bytes": 380153021,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1093.8523330260068,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 972914688,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.3,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 26.0,
+        "groups": 11.3,
+        "import-resolve": 52.2,
+        "lower": 461.0,
+        "normalize+extract": 428.3,
+        "parse+lower": 382.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 78.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1117.1109579736367,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1096581120,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.4,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 27.1,
+        "groups": 10.3,
+        "import-resolve": 52.3,
+        "lower": 464.6,
+        "parse+lower": 385.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 77.9
+      },
+      "store": {
+        "bytes": 380153032,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 769.0944171044976,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1056686080,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.2,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.1,
+        "groups": 10.7,
+        "import-resolve": 53.0,
+        "lower": 530.8,
+        "parse+lower": 450.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.2,
+        "shared_lines": 80.0
+      },
+      "store": {
+        "bytes": 380153032,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1136.5719169843942,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 977764352,
+      "phase": "clean-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.4,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 34.0,
+        "groups": 13.9,
+        "import-resolve": 44.3,
+        "lower": 508.3,
+        "normalize+extract": 397.6,
+        "parse+lower": 430.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 1.5,
+        "shared_lines": 88.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8754.550084006041,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1373339648,
+      "phase": "empty-store-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 6008.3,
+        "candidates": 600.2,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.0,
+        "import-resolve": 34.6,
+        "lower": 1309.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.6,
+        "shared_lines": 474.6
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1920.2383749652654,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 701661184,
+      "phase": "history-after",
+      "replay": 4,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1248.2,
+        "candidates": 4.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.4,
+        "import-resolve": 26.2,
+        "lower": 526.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 6.0,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1073.4758749604225,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 966033408,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.0,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 26.3,
+        "groups": 11.3,
+        "import-resolve": 43.9,
+        "lower": 425.3,
+        "normalize+extract": 439.6,
+        "parse+lower": 355.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.9,
+        "shared_lines": 81.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8971.327707986347,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1374306304,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5799.5,
+        "candidates": 615.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 29.5,
+        "lower": 1258.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 5.1,
+        "shared_lines": 566.4
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1943.786874995567,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 716128256,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1270.3,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 32.1,
+        "lower": 525.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.6,
+        "shared_lines": 22.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1075.634542037733,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 981893120,
+      "phase": "clean-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.4,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.2,
+        "groups": 10.9,
+        "import-resolve": 57.9,
+        "lower": 433.6,
+        "normalize+extract": 438.9,
+        "parse+lower": 349.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 17.5,
+        "rank_map": 16.7,
+        "rank_sort": 0.5,
+        "score": 0.5,
+        "shared_lines": 77.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1152.8619170421734,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1063288832,
+      "phase": "empty-store-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.6,
+        "cluster": 1.9,
+        "contiguous": 0.8,
+        "discover": 26.1,
+        "groups": 10.7,
+        "import-resolve": 52.1,
+        "lower": 494.6,
+        "parse+lower": 416.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.9,
+        "shared_lines": 79.0
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 779.1018340503797,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1039450112,
+      "phase": "history-after",
+      "replay": 5,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.6,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 28.0,
+        "groups": 10.5,
+        "import-resolve": 49.3,
+        "lower": 528.7,
+        "parse+lower": 451.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.0,
+        "shared_lines": 81.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1085.100791999139,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 991281152,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.6,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 25.4,
+        "groups": 10.1,
+        "import-resolve": 53.2,
+        "lower": 460.9,
+        "normalize+extract": 430.3,
+        "parse+lower": 382.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.1,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.3,
+        "shared_lines": 77.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1173.8191250478849,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1096056832,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.2,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 28.0,
+        "groups": 10.2,
+        "import-resolve": 55.4,
+        "lower": 514.7,
+        "parse+lower": 431.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 84.6
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 802.3257920285687,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1065189376,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.0,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 36.6,
+        "groups": 11.5,
+        "import-resolve": 47.7,
+        "lower": 534.6,
+        "parse+lower": 450.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 83.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1111.4344169618562,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 986644480,
+      "phase": "clean-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.5,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 29.7,
+        "groups": 11.1,
+        "import-resolve": 45.7,
+        "lower": 463.1,
+        "normalize+extract": 422.6,
+        "parse+lower": 387.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.5,
+        "query_render": 15.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 90.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8873.109666979872,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1360445440,
+      "phase": "empty-store-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 6028.0,
+        "candidates": 612.0,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 33.3,
+        "lower": 1342.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.3,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 493.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1890.1041670469567,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 696598528,
+      "phase": "history-after",
+      "replay": 6,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1243.3,
+        "candidates": 6.3,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 13.7,
+        "import-resolve": 26.0,
+        "lower": 478.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 6.2,
+        "shared_lines": 33.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1083.7718748953193,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 988446720,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.5,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 27.6,
+        "groups": 11.6,
+        "import-resolve": 43.6,
+        "lower": 434.9,
+        "normalize+extract": 450.1,
+        "parse+lower": 363.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 1.4,
+        "shared_lines": 78.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9212.467374978587,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1354645504,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5910.1,
+        "candidates": 582.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.6,
+        "import-resolve": 29.5,
+        "lower": 1339.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 588.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1851.1621250072494,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 729415680,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1241.9,
+        "candidates": 5.4,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 12.5,
+        "import-resolve": 26.1,
+        "lower": 455.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.0,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 7.1,
+        "shared_lines": 23.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1053.1461670761928,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1016201216,
+      "phase": "clean-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.4,
+        "cluster": 1.7,
+        "contiguous": 0.8,
+        "discover": 28.5,
+        "groups": 11.0,
+        "import-resolve": 47.2,
+        "lower": 435.1,
+        "normalize+extract": 402.6,
+        "parse+lower": 359.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 86.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1124.0350829903036,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1120141312,
+      "phase": "empty-store-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.3,
+        "cluster": 1.5,
+        "contiguous": 0.9,
+        "discover": 27.8,
+        "groups": 11.3,
+        "import-resolve": 46.8,
+        "lower": 444.0,
+        "parse+lower": 369.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.6,
+        "shared_lines": 81.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 689.9994999403134,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1076051968,
+      "phase": "history-after",
+      "replay": 7,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 22.2,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 25.3,
+        "groups": 10.5,
+        "import-resolve": 49.2,
+        "lower": 425.4,
+        "parse+lower": 350.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.4,
+        "query_render": 14.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 98.1
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1066.8479580199346,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 980697088,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.0,
+        "cluster": 2.1,
+        "contiguous": 0.9,
+        "discover": 29.6,
+        "groups": 13.4,
+        "import-resolve": 49.2,
+        "lower": 451.1,
+        "normalize+extract": 390.5,
+        "parse+lower": 372.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 86.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1197.1814170246944,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1108623360,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 28.4,
+        "groups": 12.7,
+        "import-resolve": 47.1,
+        "lower": 457.6,
+        "parse+lower": 382.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 85.0
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 746.2420839583501,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1036435456,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.5,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 25.5,
+        "groups": 13.5,
+        "import-resolve": 47.7,
+        "lower": 466.1,
+        "parse+lower": 392.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 90.1
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1109.4634170876816,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 986578944,
+      "phase": "clean-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 21.9,
+        "cluster": 1.4,
+        "contiguous": 0.7,
+        "discover": 27.6,
+        "groups": 9.7,
+        "import-resolve": 57.2,
+        "lower": 453.6,
+        "normalize+extract": 455.6,
+        "parse+lower": 368.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 13.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 83.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8737.507833982818,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1379794944,
+      "phase": "empty-store-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5946.4,
+        "candidates": 570.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.5,
+        "import-resolve": 29.9,
+        "lower": 1347.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 515.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1877.5938329054043,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 713146368,
+      "phase": "history-after",
+      "replay": 8,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1277.3,
+        "candidates": 5.7,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.9,
+        "import-resolve": 25.6,
+        "lower": 452.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 6.0,
+        "shared_lines": 22.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1117.606999934651,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 981008384,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 25.8,
+        "cluster": 2.2,
+        "contiguous": 0.9,
+        "discover": 27.3,
+        "groups": 11.7,
+        "import-resolve": 48.5,
+        "lower": 446.8,
+        "normalize+extract": 455.1,
+        "parse+lower": 370.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 0.9,
+        "shared_lines": 85.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8848.227332928218,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1375125504,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5948.2,
+        "candidates": 499.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.3,
+        "import-resolve": 42.7,
+        "lower": 1490.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 4.6,
+        "shared_lines": 555.8
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1891.124750021845,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 705363968,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1240.9,
+        "candidates": 4.5,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.5,
+        "import-resolve": 28.5,
+        "lower": 505.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 6.0,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1057.5992909725755,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 985202688,
+      "phase": "clean-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.2,
+        "cluster": 1.3,
+        "contiguous": 0.7,
+        "discover": 26.3,
+        "groups": 10.5,
+        "import-resolve": 51.9,
+        "lower": 463.9,
+        "normalize+extract": 392.4,
+        "parse+lower": 385.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 14.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 0.7,
+        "shared_lines": 77.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1110.587750095874,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085030400,
+      "phase": "empty-store-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.3,
+        "cluster": 1.2,
+        "contiguous": 0.8,
+        "discover": 25.7,
+        "groups": 10.0,
+        "import-resolve": 51.7,
+        "lower": 460.7,
+        "parse+lower": 383.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 0.6,
+        "shared_lines": 79.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 791.2357919849455,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1066418176,
+      "phase": "history-after",
+      "replay": 9,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.8,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 27.7,
+        "groups": 10.7,
+        "import-resolve": 48.3,
+        "lower": 544.9,
+        "parse+lower": 468.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 2.2,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 86.0
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1141.4385410025716,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1002029056,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.7,
+        "cluster": 1.8,
+        "contiguous": 0.9,
+        "discover": 27.5,
+        "groups": 12.6,
+        "import-resolve": 54.8,
+        "lower": 508.7,
+        "normalize+extract": 406.7,
+        "parse+lower": 426.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.3,
+        "query_render": 14.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.1,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 92.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1332.6885829446837,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1100431360,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 2.5,
+        "contiguous": 1.2,
+        "discover": 27.1,
+        "groups": 17.3,
+        "import-resolve": 67.5,
+        "lower": 537.7,
+        "parse+lower": 443.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 105.4
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 880.3442919161171,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1066745856,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.9,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 35.9,
+        "groups": 15.6,
+        "import-resolve": 73.6,
+        "lower": 539.2,
+        "parse+lower": 429.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 21.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 122.2
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1257.4301670538262,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 982466560,
+      "phase": "clean-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.7,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 26.1,
+        "groups": 14.9,
+        "import-resolve": 68.0,
+        "lower": 450.5,
+        "normalize+extract": 534.5,
+        "parse+lower": 356.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 20.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 113.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9067.337042069994,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1359872000,
+      "phase": "empty-store-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5909.8,
+        "candidates": 524.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.5,
+        "import-resolve": 47.5,
+        "lower": 1779.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.7,
+        "shared_lines": 482.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1897.1065839286894,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 700350464,
+      "phase": "history-after",
+      "replay": 10,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1236.2,
+        "candidates": 4.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 26.5,
+        "lower": 516.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 5.5,
+        "shared_lines": 22.6
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1022.2360419575125,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 976781312,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 22.2,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.9,
+        "groups": 10.4,
+        "import-resolve": 44.0,
+        "lower": 432.3,
+        "normalize+extract": 386.3,
+        "parse+lower": 361.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 83.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8559.665958047844,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1352826880,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5830.9,
+        "candidates": 551.7,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.2,
+        "import-resolve": 31.9,
+        "lower": 1376.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 4.8,
+        "shared_lines": 474.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1852.3946249624714,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 736804864,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1212.5,
+        "candidates": 4.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.2,
+        "import-resolve": 25.9,
+        "lower": 497.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 5.6,
+        "shared_lines": 21.7
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1041.4984590606764,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 988594176,
+      "phase": "clean-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.1,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 25.6,
+        "groups": 10.1,
+        "import-resolve": 48.2,
+        "lower": 481.4,
+        "normalize+extract": 370.2,
+        "parse+lower": 407.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 1.1,
+        "shared_lines": 76.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1118.5351250460371,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1088389120,
+      "phase": "empty-store-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.5,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 24.8,
+        "groups": 11.1,
+        "import-resolve": 51.1,
+        "lower": 481.7,
+        "parse+lower": 405.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.1,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 79.5
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 739.5311670843512,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1050640384,
+      "phase": "history-after",
+      "replay": 11,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.4,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 29.0,
+        "groups": 11.6,
+        "import-resolve": 59.5,
+        "lower": 486.3,
+        "parse+lower": 397.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.2,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 82.7
+      },
+      "store": {
+        "bytes": 380153036,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1190.679790917784,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 978108416,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.8,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 27.4,
+        "groups": 14.8,
+        "import-resolve": 66.7,
+        "lower": 506.9,
+        "normalize+extract": 413.3,
+        "parse+lower": 412.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.0,
+        "query_rank_sort": 3.1,
+        "query_render": 18.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 0.7,
+        "shared_lines": 109.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1499.4031670503318,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1085538304,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.9,
+        "cluster": 2.6,
+        "contiguous": 1.1,
+        "discover": 38.1,
+        "groups": 16.7,
+        "import-resolve": 73.8,
+        "lower": 610.5,
+        "parse+lower": 498.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.5,
+        "shared_lines": 115.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 964.534500031732,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1039237120,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.0,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 40.0,
+        "groups": 15.0,
+        "import-resolve": 73.7,
+        "lower": 608.8,
+        "parse+lower": 495.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 2.2,
+        "shared_lines": 115.0
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1361.370458966121,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 972341248,
+      "phase": "clean-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 32.0,
+        "cluster": 3.0,
+        "contiguous": 1.3,
+        "discover": 29.3,
+        "groups": 18.3,
+        "import-resolve": 69.0,
+        "lower": 555.4,
+        "normalize+extract": 507.3,
+        "parse+lower": 457.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.7,
+        "query_rank_sort": 4.1,
+        "query_render": 22.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.4,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.2,
+        "rank_sort": 0.8,
+        "score": 1.5,
+        "shared_lines": 118.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9058.962584007531,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1393426432,
+      "phase": "empty-store-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5828.0,
+        "candidates": 570.5,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 45.9,
+        "lower": 1807.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 485.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1848.169666947797,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 704987136,
+      "phase": "history-after",
+      "replay": 12,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1242.5,
+        "candidates": 5.2,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 25.7,
+        "lower": 454.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 6.0,
+        "shared_lines": 23.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1190.2741669910029,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 977223680,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.5,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 27.2,
+        "groups": 13.5,
+        "import-resolve": 56.2,
+        "lower": 448.8,
+        "normalize+extract": 495.9,
+        "parse+lower": 365.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.8,
+        "query_render": 17.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.0,
+        "shared_lines": 102.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8839.3025000114,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1359298560,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5820.2,
+        "candidates": 510.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 50.1,
+        "lower": 1643.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.1,
+        "rank_sort": 0.3,
+        "score": 4.9,
+        "shared_lines": 520.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1855.1795419771224,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 739459072,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1240.1,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.5,
+        "import-resolve": 28.5,
+        "lower": 468.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 5.7,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1246.128874947317,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 971325440,
+      "phase": "clean-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.3,
+        "cluster": 2.2,
+        "contiguous": 0.9,
+        "discover": 27.8,
+        "groups": 14.7,
+        "import-resolve": 66.3,
+        "lower": 467.3,
+        "normalize+extract": 507.1,
+        "parse+lower": 373.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 20.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.9,
+        "shared_lines": 104.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1500.4635840887204,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1090945024,
+      "phase": "empty-store-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.9,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 35.7,
+        "groups": 16.5,
+        "import-resolve": 75.3,
+        "lower": 609.2,
+        "parse+lower": 498.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 22.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 121.7
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1031.626332900487,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1073135616,
+      "phase": "history-after",
+      "replay": 13,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 33.9,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 40.6,
+        "groups": 16.4,
+        "import-resolve": 89.1,
+        "lower": 658.2,
+        "parse+lower": 528.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 22.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 121.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1509.0439580380917,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1010483200,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.1,
+        "cluster": 3.0,
+        "contiguous": 1.1,
+        "discover": 41.4,
+        "groups": 18.2,
+        "import-resolve": 84.1,
+        "lower": 569.2,
+        "normalize+extract": 643.9,
+        "parse+lower": 443.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 23.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 115.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1662.338083027862,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1080442880,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 41.9,
+        "cluster": 2.6,
+        "contiguous": 1.2,
+        "discover": 46.7,
+        "groups": 16.9,
+        "import-resolve": 78.6,
+        "lower": 684.4,
+        "parse+lower": 559.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.6,
+        "rank_families": 2.9,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 2.0,
+        "shared_lines": 125.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1007.3255830211565,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1053147136,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.8,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 39.0,
+        "groups": 15.4,
+        "import-resolve": 76.5,
+        "lower": 644.3,
+        "parse+lower": 528.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 113.1
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1402.0227500004694,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 976683008,
+      "phase": "clean-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 34.1,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 35.0,
+        "groups": 16.7,
+        "import-resolve": 67.5,
+        "lower": 528.1,
+        "normalize+extract": 576.3,
+        "parse+lower": 425.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 21.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 116.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9254.651083960198,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1364213760,
+      "phase": "empty-store-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5952.6,
+        "candidates": 525.8,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.9,
+        "import-resolve": 47.7,
+        "lower": 1932.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 480.4
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1906.7849169950932,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 712441856,
+      "phase": "history-after",
+      "replay": 14,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1244.7,
+        "candidates": 5.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.4,
+        "import-resolve": 27.4,
+        "lower": 514.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.8,
+        "shared_lines": 23.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1208.877290948294,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 982892544,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.1,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 28.4,
+        "groups": 15.1,
+        "import-resolve": 61.5,
+        "lower": 453.7,
+        "normalize+extract": 493.8,
+        "parse+lower": 363.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.2,
+        "query_render": 18.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 106.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9184.508916921914,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1351843840,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5964.0,
+        "candidates": 504.5,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.8,
+        "import-resolve": 46.1,
+        "lower": 1864.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 503.6
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1854.0774169377983,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 726466560,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1244.7,
+        "candidates": 4.7,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 28.2,
+        "lower": 462.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.6,
+        "shared_lines": 22.1
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1215.4577920446172,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 998391808,
+      "phase": "clean-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.2,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 27.6,
+        "groups": 15.4,
+        "import-resolve": 68.4,
+        "lower": 461.3,
+        "normalize+extract": 481.2,
+        "parse+lower": 365.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 109.2
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1519.3677499191836,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1097089024,
+      "phase": "empty-store-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.2,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 37.1,
+        "groups": 16.3,
+        "import-resolve": 73.6,
+        "lower": 662.4,
+        "parse+lower": 551.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 115.2
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 949.5203329715878,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1073315840,
+      "phase": "history-after",
+      "replay": 15,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 40.3,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 40.8,
+        "groups": 16.4,
+        "import-resolve": 84.8,
+        "lower": 587.6,
+        "parse+lower": 462.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 116.7
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1451.1572080664337,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 988823552,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.3,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 40.4,
+        "groups": 16.4,
+        "import-resolve": 78.0,
+        "lower": 552.8,
+        "normalize+extract": 615.0,
+        "parse+lower": 434.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 21.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 115.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1556.7289169412106,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1094844416,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.4,
+        "cluster": 2.4,
+        "contiguous": 1.1,
+        "discover": 39.2,
+        "groups": 16.3,
+        "import-resolve": 74.4,
+        "lower": 648.2,
+        "parse+lower": 534.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.4,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 117.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 927.8475829632953,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1064402944,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.0,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 40.2,
+        "groups": 14.7,
+        "import-resolve": 75.8,
+        "lower": 576.8,
+        "parse+lower": 460.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.9,
+        "shared_lines": 113.4
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1343.7621670309454,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 975634432,
+      "phase": "clean-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 2.4,
+        "contiguous": 1.5,
+        "discover": 30.9,
+        "groups": 16.1,
+        "import-resolve": 67.1,
+        "lower": 577.9,
+        "normalize+extract": 480.7,
+        "parse+lower": 479.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 114.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9954.574167029932,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1366556672,
+      "phase": "empty-store-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 6297.5,
+        "candidates": 524.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.3,
+        "import-resolve": 46.2,
+        "lower": 1821.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 4.5,
+        "shared_lines": 648.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1892.734041903168,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 706084864,
+      "phase": "history-after",
+      "replay": 16,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1243.7,
+        "candidates": 6.1,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.8,
+        "import-resolve": 29.5,
+        "lower": 492.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 6.8,
+        "shared_lines": 23.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1325.767625006847,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 967983104,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.3,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 28.2,
+        "groups": 15.2,
+        "import-resolve": 60.7,
+        "lower": 468.1,
+        "normalize+extract": 578.3,
+        "parse+lower": 379.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.6,
+        "query_render": 21.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.0,
+        "shared_lines": 112.7
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9388.52300005965,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1367326720,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5963.4,
+        "candidates": 556.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 54.8,
+        "lower": 2013.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.2,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.3,
+        "score": 4.6,
+        "shared_lines": 480.7
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1853.3867499791086,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 726515712,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1235.5,
+        "candidates": 5.2,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.9,
+        "import-resolve": 26.0,
+        "lower": 460.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 6.0,
+        "shared_lines": 27.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1255.9590419987217,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1001996288,
+      "phase": "clean-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.4,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 28.7,
+        "groups": 14.7,
+        "import-resolve": 67.4,
+        "lower": 464.8,
+        "normalize+extract": 502.0,
+        "parse+lower": 368.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 120.3
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1513.792417012155,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1093795840,
+      "phase": "empty-store-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.3,
+        "cluster": 2.5,
+        "contiguous": 1.1,
+        "discover": 36.0,
+        "groups": 17.2,
+        "import-resolve": 78.0,
+        "lower": 538.5,
+        "parse+lower": 424.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 2.3,
+        "shared_lines": 112.7
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1041.2959159584716,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1084096512,
+      "phase": "history-after",
+      "replay": 17,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.6,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 45.5,
+        "groups": 14.7,
+        "import-resolve": 79.5,
+        "lower": 688.8,
+        "parse+lower": 563.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.0,
+        "query_rank_sort": 3.6,
+        "query_render": 20.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 121.3
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1480.9241249458864,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1022181376,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.8,
+        "cluster": 2.6,
+        "contiguous": 1.2,
+        "discover": 37.6,
+        "groups": 16.0,
+        "import-resolve": 73.4,
+        "lower": 611.2,
+        "normalize+extract": 579.0,
+        "parse+lower": 500.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 22.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.3,
+        "rank_dedup": 0.6,
+        "rank_families": 3.0,
+        "rank_map": 1.7,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 120.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1709.5830420730636,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1100955648,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 37.2,
+        "cluster": 3.5,
+        "contiguous": 1.2,
+        "discover": 41.6,
+        "groups": 17.7,
+        "import-resolve": 83.8,
+        "lower": 718.0,
+        "parse+lower": 592.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.9,
+        "query_render": 23.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.6,
+        "rank_families": 3.0,
+        "rank_map": 1.5,
+        "rank_sort": 0.8,
+        "score": 1.7,
+        "shared_lines": 133.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1038.3120840415359,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1076477952,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 40.1,
+        "cluster": 2.5,
+        "contiguous": 1.2,
+        "discover": 41.3,
+        "groups": 19.0,
+        "import-resolve": 84.3,
+        "lower": 641.0,
+        "parse+lower": 515.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.8,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.7,
+        "query_render": 23.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 3.2,
+        "rank_map": 1.9,
+        "rank_sort": 0.7,
+        "score": 2.6,
+        "shared_lines": 125.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1388.2634580368176,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 969097216,
+      "phase": "clean-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 35.3,
+        "cluster": 2.4,
+        "contiguous": 1.4,
+        "discover": 32.8,
+        "groups": 19.4,
+        "import-resolve": 67.9,
+        "lower": 598.6,
+        "normalize+extract": 495.4,
+        "parse+lower": 497.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 20.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 117.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9166.811041068286,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1384349696,
+      "phase": "empty-store-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5898.9,
+        "candidates": 559.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 47.0,
+        "lower": 1861.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.2,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 502.7
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1846.7724999645725,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 717357056,
+      "phase": "history-after",
+      "replay": 18,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1249.4,
+        "candidates": 5.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.7,
+        "import-resolve": 26.0,
+        "lower": 449.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.5,
+        "rank_map": 0.8,
+        "rank_sort": 0.4,
+        "score": 5.8,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1211.3309589913115,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 962052096,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.2,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 27.5,
+        "groups": 15.2,
+        "import-resolve": 63.9,
+        "lower": 441.8,
+        "normalize+extract": 508.1,
+        "parse+lower": 350.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.0,
+        "query_render": 19.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.0,
+        "shared_lines": 108.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8931.392709026113,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1376665600,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5789.5,
+        "candidates": 509.2,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 11.4,
+        "import-resolve": 49.0,
+        "lower": 1777.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.7,
+        "shared_lines": 486.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1860.0562500068918,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 705347584,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1229.6,
+        "candidates": 4.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.6,
+        "import-resolve": 26.4,
+        "lower": 485.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.2,
+        "shared_lines": 22.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1128.699415945448,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1000603648,
+      "phase": "clean-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.2,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 27.9,
+        "groups": 13.7,
+        "import-resolve": 57.3,
+        "lower": 460.0,
+        "normalize+extract": 426.7,
+        "parse+lower": 374.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.6,
+        "query_render": 16.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.7,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 0.7,
+        "shared_lines": 101.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1388.6460410431027,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1095024640,
+      "phase": "empty-store-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.4,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 36.4,
+        "groups": 15.4,
+        "import-resolve": 69.0,
+        "lower": 555.1,
+        "parse+lower": 449.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.7,
+        "query_render": 21.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 122.8
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 973.9291250007227,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1062453248,
+      "phase": "history-after",
+      "replay": 19,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.5,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 40.2,
+        "groups": 14.9,
+        "import-resolve": 78.8,
+        "lower": 620.0,
+        "parse+lower": 500.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 21.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.6,
+        "rank_families": 2.9,
+        "rank_map": 1.6,
+        "rank_sort": 0.7,
+        "score": 2.4,
+        "shared_lines": 116.1
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1436.062749940902,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 967852032,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.7,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 37.2,
+        "groups": 15.1,
+        "import-resolve": 79.5,
+        "lower": 542.1,
+        "normalize+extract": 610.5,
+        "parse+lower": 425.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.6,
+        "query_render": 22.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 114.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1585.325416061096,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1097007104,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.2,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 38.6,
+        "groups": 15.0,
+        "import-resolve": 74.1,
+        "lower": 676.6,
+        "parse+lower": 563.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.8,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.6,
+        "query_render": 22.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.6,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.7,
+        "shared_lines": 119.5
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 916.8714579427615,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1075871744,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.5,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 40.1,
+        "groups": 15.1,
+        "import-resolve": 81.5,
+        "lower": 554.8,
+        "parse+lower": 433.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 22.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.6,
+        "shared_lines": 115.3
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1332.711625029333,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 974192640,
+      "phase": "clean-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.9,
+        "cluster": 2.3,
+        "contiguous": 1.3,
+        "discover": 28.4,
+        "groups": 16.2,
+        "import-resolve": 64.7,
+        "lower": 566.6,
+        "normalize+extract": 474.3,
+        "parse+lower": 473.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.6,
+        "query_render": 20.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 122.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 9059.286291943863,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1352220672,
+      "phase": "empty-store-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5874.3,
+        "candidates": 546.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 46.9,
+        "lower": 1770.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.7,
+        "shared_lines": 499.1
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1845.237375004217,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 716472320,
+      "phase": "history-after",
+      "replay": 20,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1237.0,
+        "candidates": 5.2,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.9,
+        "import-resolve": 26.2,
+        "lower": 454.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 5.8,
+        "shared_lines": 23.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1132.5634169625118,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 968605696,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 26.4,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 27.6,
+        "groups": 12.1,
+        "import-resolve": 47.2,
+        "lower": 421.8,
+        "normalize+extract": 487.9,
+        "parse+lower": 346.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.3,
+        "query_render": 14.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 84.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8752.444999990985,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1350205440,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5772.6,
+        "candidates": 565.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.3,
+        "import-resolve": 42.3,
+        "lower": 1557.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 506.6
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1856.550666037947,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 699039744,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1247.9,
+        "candidates": 5.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.8,
+        "import-resolve": 26.1,
+        "lower": 457.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.7,
+        "shared_lines": 22.7
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1111.4134169183671,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 981647360,
+      "phase": "clean-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.4,
+        "cluster": 2.5,
+        "contiguous": 1.0,
+        "discover": 26.1,
+        "groups": 14.0,
+        "import-resolve": 47.1,
+        "lower": 415.1,
+        "normalize+extract": 461.9,
+        "parse+lower": 341.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.4,
+        "query_render": 15.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 93.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1307.3739999672398,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1092796416,
+      "phase": "empty-store-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 32.6,
+        "cluster": 2.0,
+        "contiguous": 0.9,
+        "discover": 28.1,
+        "groups": 14.5,
+        "import-resolve": 65.7,
+        "lower": 484.8,
+        "parse+lower": 391.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.0,
+        "query_render": 19.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.5,
+        "shared_lines": 103.9
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 910.9919170150533,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1073496064,
+      "phase": "history-after",
+      "replay": 21,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.9,
+        "cluster": 2.7,
+        "contiguous": 1.0,
+        "discover": 32.6,
+        "groups": 15.1,
+        "import-resolve": 73.5,
+        "lower": 586.0,
+        "parse+lower": 479.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 2.2,
+        "shared_lines": 105.3
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1373.294832999818,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 973471744,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.9,
+        "cluster": 2.2,
+        "contiguous": 1.2,
+        "discover": 33.5,
+        "groups": 16.3,
+        "import-resolve": 75.3,
+        "lower": 587.1,
+        "normalize+extract": 486.7,
+        "parse+lower": 478.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.5,
+        "query_render": 22.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.1,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 2.0,
+        "shared_lines": 119.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1527.5328329298645,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1094238208,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 35.7,
+        "cluster": 2.7,
+        "contiguous": 1.0,
+        "discover": 40.7,
+        "groups": 16.1,
+        "import-resolve": 73.5,
+        "lower": 581.9,
+        "parse+lower": 467.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 22.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.9,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 2.0,
+        "shared_lines": 113.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 984.3834169441834,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1056538624,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.1,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 38.9,
+        "groups": 15.0,
+        "import-resolve": 76.0,
+        "lower": 648.8,
+        "parse+lower": 533.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 19.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.4,
+        "rank_sort": 0.7,
+        "score": 1.5,
+        "shared_lines": 113.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1232.4016250204295,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 991870976,
+      "phase": "clean-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 28.6,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 27.4,
+        "groups": 14.9,
+        "import-resolve": 62.5,
+        "lower": 491.7,
+        "normalize+extract": 476.1,
+        "parse+lower": 401.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 19.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.0,
+        "shared_lines": 106.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8863.598291995004,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1355988992,
+      "phase": "empty-store-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5780.7,
+        "candidates": 497.6,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 10.7,
+        "import-resolve": 49.8,
+        "lower": 1727.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.3,
+        "shared_lines": 484.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1875.0246670097113,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 702185472,
+      "phase": "history-after",
+      "replay": 22,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1231.4,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 26.7,
+        "lower": 499.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.8,
+        "shared_lines": 22.1
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1117.2053338959813,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 970588160,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 27.0,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 27.5,
+        "groups": 14.6,
+        "import-resolve": 46.1,
+        "lower": 466.4,
+        "normalize+extract": 416.2,
+        "parse+lower": 392.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.7,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.5,
+        "query_render": 14.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.4,
+        "shared_lines": 91.8
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8473.576084012166,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1368653824,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5721.3,
+        "candidates": 500.8,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 43.2,
+        "lower": 1401.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 13.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 508.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1864.9215829791501,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 743718912,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1237.6,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.5,
+        "import-resolve": 27.3,
+        "lower": 481.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 5.9,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1045.2516250079498,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1009451008,
+      "phase": "clean-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 21.6,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 26.3,
+        "groups": 11.4,
+        "import-resolve": 48.5,
+        "lower": 427.0,
+        "normalize+extract": 417.4,
+        "parse+lower": 352.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.5,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 1.7,
+        "rank_map": 0.9,
+        "rank_sort": 0.5,
+        "score": 0.8,
+        "shared_lines": 81.0
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1206.2710829777643,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1124417536,
+      "phase": "empty-store-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.8,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 27.6,
+        "groups": 13.4,
+        "import-resolve": 57.5,
+        "lower": 467.7,
+        "parse+lower": 382.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.7,
+        "query_render": 16.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.4,
+        "rank_sort": 0.6,
+        "score": 1.1,
+        "shared_lines": 99.5
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 878.4239169908687,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1083441152,
+      "phase": "history-after",
+      "replay": 23,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.6,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 37.9,
+        "groups": 13.7,
+        "import-resolve": 66.9,
+        "lower": 573.4,
+        "parse+lower": 468.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 18.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.8,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.5,
+        "shared_lines": 103.4
+      },
+      "store": {
+        "bytes": 380153024,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1374.4068329688162,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 970358784,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.4,
+        "cluster": 2.8,
+        "contiguous": 1.1,
+        "discover": 31.2,
+        "groups": 18.9,
+        "import-resolve": 69.2,
+        "lower": 604.5,
+        "normalize+extract": 469.5,
+        "parse+lower": 504.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 118.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1503.1854590633884,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1093599232,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 36.7,
+        "cluster": 2.2,
+        "contiguous": 1.1,
+        "discover": 37.8,
+        "groups": 15.6,
+        "import-resolve": 74.4,
+        "lower": 560.4,
+        "parse+lower": 448.1,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.6,
+        "query_render": 22.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.6,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 117.9
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 952.188958064653,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1054048256,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.4,
+        "cluster": 2.0,
+        "contiguous": 1.0,
+        "discover": 37.1,
+        "groups": 15.0,
+        "import-resolve": 74.8,
+        "lower": 616.8,
+        "parse+lower": 504.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.0,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 112.2
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1217.0032090507448,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 983678976,
+      "phase": "clean-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.6,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 27.7,
+        "groups": 15.0,
+        "import-resolve": 64.9,
+        "lower": 445.6,
+        "normalize+extract": 505.6,
+        "parse+lower": 352.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.1,
+        "query_render": 19.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.7,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.4,
+        "shared_lines": 108.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8838.202541926876,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1358594048,
+      "phase": "empty-store-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5738.1,
+        "candidates": 501.2,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.8,
+        "import-resolve": 48.1,
+        "lower": 1755.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 4.7,
+        "shared_lines": 493.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1871.7593749752268,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 713736192,
+      "phase": "history-after",
+      "replay": 24,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1248.9,
+        "candidates": 5.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 27.1,
+        "lower": 477.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.6,
+        "rank_map": 0.9,
+        "rank_sort": 0.4,
+        "score": 5.8,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1059.9148749606684,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 976666624,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 21.9,
+        "cluster": 1.5,
+        "contiguous": 0.8,
+        "discover": 25.7,
+        "groups": 11.1,
+        "import-resolve": 44.0,
+        "lower": 484.2,
+        "normalize+extract": 382.1,
+        "parse+lower": 414.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.2,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 0.8,
+        "shared_lines": 78.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8627.530582947657,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 79,
+          "misses": 1505,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 79,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1357807616,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5786.0,
+        "candidates": 566.7,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.5,
+        "import-resolve": 36.4,
+        "lower": 1391.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 2.0,
+        "rank_map": 1.3,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 534.8
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1905.339292017743,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 702496768,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1270.8,
+        "candidates": 5.4,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.6,
+        "import-resolve": 30.4,
+        "lower": 487.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.3,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.1,
+        "shared_lines": 22.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1032.7929579652846,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 969064448,
+      "phase": "clean-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.0,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 26.7,
+        "groups": 11.3,
+        "import-resolve": 50.1,
+        "lower": 420.1,
+        "normalize+extract": 408.0,
+        "parse+lower": 343.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.1,
+        "query_render": 13.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.9,
+        "shared_lines": 78.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1198.1930000474676,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1093894144,
+      "phase": "empty-store-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.5,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 25.4,
+        "groups": 13.9,
+        "import-resolve": 54.8,
+        "lower": 476.6,
+        "parse+lower": 396.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.3,
+        "rank_dedup": 0.4,
+        "rank_families": 2.4,
+        "rank_map": 1.4,
+        "rank_sort": 0.5,
+        "score": 1.0,
+        "shared_lines": 91.6
+      },
+      "store": {
+        "bytes": 380153034,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 839.62258300744,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068875776,
+      "phase": "history-after",
+      "replay": 25,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 27.2,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 32.7,
+        "groups": 13.7,
+        "import-resolve": 66.8,
+        "lower": 539.3,
+        "parse+lower": 439.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.6,
+        "query_render": 17.2,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.3,
+        "rank_sort": 0.6,
+        "score": 1.7,
+        "shared_lines": 98.9
+      },
+      "store": {
+        "bytes": 380153034,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1297.9014170123264,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 986562560,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 34.3,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 29.1,
+        "groups": 15.2,
+        "import-resolve": 67.5,
+        "lower": 549.6,
+        "normalize+extract": 460.2,
+        "parse+lower": 452.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.1,
+        "query_render": 20.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.2,
+        "rank_sort": 0.6,
+        "score": 1.2,
+        "shared_lines": 123.1
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1482.08424996119,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1095335936,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 37.3,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 35.7,
+        "groups": 15.4,
+        "import-resolve": 74.1,
+        "lower": 565.2,
+        "parse+lower": 455.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.4,
+        "query_render": 22.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.7,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.3,
+        "rank_sort": 0.8,
+        "score": 1.9,
+        "shared_lines": 116.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 907.5814579846337,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1068449792,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.5,
+        "cluster": 2.3,
+        "contiguous": 1.1,
+        "discover": 37.7,
+        "groups": 15.2,
+        "import-resolve": 73.7,
+        "lower": 560.7,
+        "parse+lower": 449.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.3,
+        "query_render": 20.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.6,
+        "rank_families": 2.6,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 2.1,
+        "shared_lines": 116.6
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1264.7751250769943,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 975093760,
+      "phase": "clean-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 30.1,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 26.1,
+        "groups": 15.3,
+        "import-resolve": 64.9,
+        "lower": 459.6,
+        "normalize+extract": 540.4,
+        "parse+lower": 368.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.9,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.1,
+        "query_render": 19.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 0.7,
+        "shared_lines": 111.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8908.216833951883,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1368719360,
+      "phase": "empty-store-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5698.4,
+        "candidates": 545.1,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.3,
+        "import-resolve": 44.2,
+        "lower": 1783.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.8,
+        "shared_lines": 518.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1856.664750026539,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 733839360,
+      "phase": "history-after",
+      "replay": 26,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1235.9,
+        "candidates": 4.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.1,
+        "import-resolve": 27.0,
+        "lower": 476.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 5.7,
+        "shared_lines": 22.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1017.9941250244156,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 979042304,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 21.4,
+        "cluster": 1.5,
+        "contiguous": 0.7,
+        "discover": 25.9,
+        "groups": 10.2,
+        "import-resolve": 45.6,
+        "lower": 461.0,
+        "normalize+extract": 364.1,
+        "parse+lower": 389.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 13.1,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.9,
+        "shared_lines": 77.9
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8507.108832942322,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1371455488,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5736.7,
+        "candidates": 518.3,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.6,
+        "import-resolve": 35.7,
+        "lower": 1386.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.6,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.5,
+        "shared_lines": 512.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1868.2247919496149,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 721895424,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1262.6,
+        "candidates": 4.9,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.8,
+        "import-resolve": 25.8,
+        "lower": 457.3,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.0,
+        "shared_lines": 22.2
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1049.0069169318303,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1003716608,
+      "phase": "clean-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 19.4,
+        "cluster": 1.4,
+        "contiguous": 0.8,
+        "discover": 27.3,
+        "groups": 10.3,
+        "import-resolve": 46.8,
+        "lower": 420.1,
+        "normalize+extract": 437.6,
+        "parse+lower": 345.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.0,
+        "query_render": 13.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.8,
+        "shared_lines": 77.5
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1152.1542090922594,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1095057408,
+      "phase": "empty-store-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 24.1,
+        "cluster": 1.6,
+        "contiguous": 0.9,
+        "discover": 26.6,
+        "groups": 12.4,
+        "import-resolve": 49.1,
+        "lower": 420.5,
+        "parse+lower": 344.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.4,
+        "rank_families": 1.9,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 84.5
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 747.9391660308465,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1074184192,
+      "phase": "history-after",
+      "replay": 27,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 26.6,
+        "cluster": 1.9,
+        "contiguous": 0.9,
+        "discover": 24.9,
+        "groups": 13.1,
+        "import-resolve": 64.9,
+        "lower": 462.5,
+        "parse+lower": 372.6,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 15.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.4,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.6,
+        "shared_lines": 91.7
+      },
+      "store": {
+        "bytes": 380153033,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1235.222875024192,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1001242624,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.4,
+        "cluster": 2.3,
+        "contiguous": 1.0,
+        "discover": 28.9,
+        "groups": 15.1,
+        "import-resolve": 68.3,
+        "lower": 455.2,
+        "normalize+extract": 518.7,
+        "parse+lower": 358.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 19.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.4,
+        "rank_map": 1.2,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 107.4
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1433.3942088996992,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1082425344,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.4,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 36.2,
+        "groups": 14.9,
+        "import-resolve": 74.7,
+        "lower": 586.9,
+        "parse+lower": 475.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.3,
+        "query_rank_sort": 3.8,
+        "query_render": 22.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 0.8,
+        "shared_lines": 126.5
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 930.4560420569032,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1076903936,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 30.8,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 38.2,
+        "groups": 15.0,
+        "import-resolve": 75.7,
+        "lower": 568.2,
+        "parse+lower": 454.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.7,
+        "query_opp": 1.4,
+        "query_rank_sort": 3.8,
+        "query_render": 23.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.6,
+        "rank_dedup": 0.6,
+        "rank_families": 2.8,
+        "rank_map": 1.5,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 127.4
+      },
+      "store": {
+        "bytes": 380153028,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1214.0459580114111,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 969687040,
+      "phase": "clean-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 29.5,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 26.5,
+        "groups": 14.4,
+        "import-resolve": 62.1,
+        "lower": 504.8,
+        "normalize+extract": 436.3,
+        "parse+lower": 416.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.1,
+        "query_opp": 0.6,
+        "query_rank_sort": 3.5,
+        "query_render": 19.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.2,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.1,
+        "shared_lines": 116.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8954.164708033204,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1355677696,
+      "phase": "empty-store-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5832.2,
+        "candidates": 549.3,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.1,
+        "import-resolve": 47.3,
+        "lower": 1715.2,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.8,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.4,
+        "query_render": 14.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.7,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 4.9,
+        "shared_lines": 486.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1864.9263340048492,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 726614016,
+      "phase": "history-after",
+      "replay": 28,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1236.7,
+        "candidates": 4.6,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.6,
+        "import-resolve": 26.0,
+        "lower": 484.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.0,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.3,
+        "shared_lines": 21.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1018.6450419714674,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 978157568,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 23.1,
+        "cluster": 1.6,
+        "contiguous": 0.8,
+        "discover": 27.1,
+        "groups": 11.4,
+        "import-resolve": 43.0,
+        "lower": 403.9,
+        "normalize+extract": 403.5,
+        "parse+lower": 333.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.5,
+        "query_rank_sort": 2.2,
+        "query_render": 13.0,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.2,
+        "shared_lines": 82.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8506.04733300861,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1360003072,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5746.1,
+        "candidates": 508.8,
+        "cluster": 0.0,
+        "contiguous": 0.9,
+        "groups": 14.0,
+        "import-resolve": 37.7,
+        "lower": 1392.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.8,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.0,
+        "shared_lines": 488.0
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1903.8619169732556,
+      "families": 954,
+      "first_role": "candidate",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 743931904,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1244.7,
+        "candidates": 5.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 11.3,
+        "import-resolve": 26.3,
+        "lower": 512.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.0,
+        "query_render": 12.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.5,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 6.2,
+        "shared_lines": 21.9
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1091.369834030047,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 971603968,
+      "phase": "clean-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 20.0,
+        "cluster": 1.3,
+        "contiguous": 0.8,
+        "discover": 34.1,
+        "groups": 10.1,
+        "import-resolve": 48.2,
+        "lower": 500.0,
+        "normalize+extract": 377.9,
+        "parse+lower": 417.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.3,
+        "query_opp": 1.0,
+        "query_rank_sort": 2.5,
+        "query_render": 15.8,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.2,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.4,
+        "score": 0.7,
+        "shared_lines": 87.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1172.4140000296757,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1081851904,
+      "phase": "empty-store-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 28.1,
+        "cluster": 2.1,
+        "contiguous": 0.9,
+        "discover": 28.2,
+        "groups": 14.5,
+        "import-resolve": 51.2,
+        "lower": 490.4,
+        "parse+lower": 411.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.2,
+        "query_opp": 0.9,
+        "query_rank_sort": 2.4,
+        "query_render": 14.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 6.1,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.0,
+        "rank_sort": 0.5,
+        "score": 1.1,
+        "shared_lines": 89.3
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 743.2133329566568,
+      "families": 969,
+      "first_role": "candidate",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1079263232,
+      "phase": "history-after",
+      "replay": 29,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 25.9,
+        "cluster": 1.7,
+        "contiguous": 0.9,
+        "discover": 30.0,
+        "groups": 12.8,
+        "import-resolve": 65.9,
+        "lower": 472.4,
+        "parse+lower": 376.5,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 0.8,
+        "query_rank_sort": 2.3,
+        "query_render": 14.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.4,
+        "rank_families": 2.0,
+        "rank_map": 1.1,
+        "rank_sort": 0.5,
+        "score": 1.3,
+        "shared_lines": 86.0
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1284.4065419631079,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 989118464,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 31.3,
+        "cluster": 2.1,
+        "contiguous": 1.1,
+        "discover": 29.6,
+        "groups": 15.1,
+        "import-resolve": 67.6,
+        "lower": 553.1,
+        "normalize+extract": 458.5,
+        "parse+lower": 455.8,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.5,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.2,
+        "query_render": 20.4,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.3,
+        "rank_dedup": 0.5,
+        "rank_families": 2.7,
+        "rank_map": 1.5,
+        "rank_sort": 0.6,
+        "score": 1.3,
+        "shared_lines": 109.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 1487.3465829296038,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1099939840,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 38.3,
+        "cluster": 2.2,
+        "contiguous": 1.0,
+        "discover": 36.2,
+        "groups": 15.0,
+        "import-resolve": 73.7,
+        "lower": 530.1,
+        "parse+lower": 420.0,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.6,
+        "query_opp": 1.2,
+        "query_rank_sort": 3.5,
+        "query_render": 22.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.5,
+        "rank_map": 1.3,
+        "rank_sort": 0.7,
+        "score": 1.8,
+        "shared_lines": 114.8
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "official",
+      "cache": null,
+      "elapsed_ms": 939.1790000954643,
+      "families": 969,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1107911,
+      "output_sha256": "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d",
+      "peak_rss_bytes": 1055145984,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 7,
+      "stages_ms": {
+        "candidates": 29.3,
+        "cluster": 2.1,
+        "contiguous": 1.0,
+        "discover": 34.6,
+        "groups": 14.9,
+        "import-resolve": 75.4,
+        "lower": 608.4,
+        "parse+lower": 498.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.4,
+        "query_opp": 1.1,
+        "query_rank_sort": 3.1,
+        "query_render": 19.7,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 7.5,
+        "rank_dedup": 0.5,
+        "rank_families": 2.1,
+        "rank_map": 1.0,
+        "rank_sort": 0.7,
+        "score": 1.6,
+        "shared_lines": 109.9
+      },
+      "store": {
+        "bytes": 380153026,
+        "files": 1500
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": null,
+      "elapsed_ms": 1260.1301659597084,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": null,
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 987496448,
+      "phase": "clean-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "candidates": 31.0,
+        "cluster": 2.3,
+        "contiguous": 1.2,
+        "discover": 29.7,
+        "groups": 14.7,
+        "import-resolve": 60.8,
+        "lower": 487.9,
+        "normalize+extract": 494.7,
+        "parse+lower": 397.4,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 1.0,
+        "query_opp": 0.5,
+        "query_rank_sort": 3.5,
+        "query_render": 20.9,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 8.0,
+        "rank_dedup": 0.5,
+        "rank_families": 2.3,
+        "rank_map": 1.1,
+        "rank_sort": 0.7,
+        "score": 1.3,
+        "shared_lines": 115.6
+      },
+      "store": null,
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 80,
+        "misses": 1504,
+        "read_bytes": 11760,
+        "written_bytes": 57711599
+      },
+      "elapsed_ms": 8865.372792002745,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [
+          "cold-start"
+        ],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 80,
+          "misses": 1504,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1510,
+          "misses": 74,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 80,
+          "misses": 1503,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 1363902464,
+      "phase": "empty-store-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 5700.4,
+        "candidates": 562.0,
+        "cluster": 0.0,
+        "contiguous": 0.7,
+        "groups": 10.4,
+        "import-resolve": 42.0,
+        "lower": 1750.7,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.4,
+        "query_rank_sort": 2.1,
+        "query_render": 12.6,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.9,
+        "rank_dedup": 0.3,
+        "rank_families": 1.7,
+        "rank_map": 1.0,
+        "rank_sort": 0.3,
+        "score": 5.0,
+        "shared_lines": 501.5
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    },
+    {
+      "binary_role": "candidate",
+      "cache": {
+        "files": 1584,
+        "hits": 1584,
+        "misses": 0,
+        "read_bytes": 57723359,
+        "written_bytes": 0
+      },
+      "elapsed_ms": 1841.155624948442,
+      "families": 954,
+      "first_role": "official",
+      "invalidation": {
+        "corpus_global_line_statistics_digest": "5447762c69c429b943899c28374b786494325b3aa10a06b98b4c36f0191855eb",
+        "discovery_membership_digest": "25a0b20500946ba30b73dcc8b6e9bf85d24a67ec8b2fb2859651bf37237d8c2f",
+        "global_invalidations": [],
+        "invalidated": [],
+        "over_invalidated": [],
+        "raw_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "resolved_il": {
+          "hits": 1584,
+          "misses": 0,
+          "passthrough": 1510
+        },
+        "schema": "nose.invalidation/v1",
+        "semantic_pack_digest": "a07a785e43a1bebf32db9b2dc322b6b1aa23784e1b577b81a6ee7386795f76f2",
+        "source_identities": {
+          "content_sha256": 0,
+          "git_blob": 1584
+        },
+        "source_snapshots": {
+          "hits": 1583,
+          "misses": 0,
+          "passthrough": 0
+        },
+        "swift_global_digest": "428aa566c31265ebe506b1a180a50ec7360cecb1a7075ee7b84b2a0cf8ececad"
+      },
+      "output_bytes": 1091036,
+      "output_sha256": "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d",
+      "peak_rss_bytes": 713457664,
+      "phase": "history-after",
+      "replay": 30,
+      "schema_version": 9,
+      "stages_ms": {
+        "cache": 1241.5,
+        "candidates": 5.2,
+        "cluster": 0.0,
+        "contiguous": 0.8,
+        "groups": 11.6,
+        "import-resolve": 26.0,
+        "lower": 447.9,
+        "query_activate": 0.0,
+        "query_filter": 0.0,
+        "query_gate": 0.6,
+        "query_opp": 0.3,
+        "query_rank_sort": 2.1,
+        "query_render": 13.3,
+        "query_since": 0.0,
+        "query_sort": 0.0,
+        "query_surface": 5.8,
+        "rank_dedup": 0.3,
+        "rank_families": 1.9,
+        "rank_map": 1.1,
+        "rank_sort": 0.4,
+        "score": 6.4,
+        "shared_lines": 23.3
+      },
+      "store": {
+        "bytes": 148668018,
+        "files": 4594
+      },
+      "workload_id": "sympy"
+    }
+  ],
+  "schema": "nose.cache_query_comparison/v1",
+  "source_identity": "a8e6f459bb51308c817df086021e29239a398ac2e4cd82c7057a53128d1ccd3e",
+  "status": "passed",
+  "summary": {
+    "candidate": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1163.4230419876985,
+            "p95": 1388.2634580368176
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 977494016.0,
+            "p95": 991870976
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 26.75,
+              "p95": 34.1
+            },
+            "cluster": {
+              "p50": 2.1,
+              "p95": 2.4
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.4
+            },
+            "discover": {
+              "p50": 27.6,
+              "p95": 34.0
+            },
+            "groups": {
+              "p50": 14.15,
+              "p95": 18.3
+            },
+            "import-resolve": {
+              "p50": 56.7,
+              "p95": 68.0
+            },
+            "lower": {
+              "p50": 462.05,
+              "p95": 577.9
+            },
+            "normalize+extract": {
+              "p50": 464.95000000000005,
+              "p95": 576.3
+            },
+            "parse+lower": {
+              "p50": 383.35,
+              "p95": 479.8
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.75,
+              "p95": 1.0
+            },
+            "query_opp": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "query_rank_sort": {
+              "p50": 2.65,
+              "p95": 3.6
+            },
+            "query_render": {
+              "p50": 16.35,
+              "p95": 21.2
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.45,
+              "p95": 8.0
+            },
+            "rank_dedup": {
+              "p50": 0.45,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.2,
+              "p95": 2.7
+            },
+            "rank_map": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "rank_sort": {
+              "p50": 0.55,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.25,
+              "p95": 1.7
+            },
+            "shared_lines": {
+              "p50": 97.3,
+              "p95": 118.3
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 80.0,
+              "p95": 80
+            },
+            "misses": {
+              "p50": 1504.0,
+              "p95": 1504
+            },
+            "read_bytes": {
+              "p50": 11760.0,
+              "p95": 11760
+            },
+            "written_bytes": {
+              "p50": 57711599.0,
+              "p95": 57711599
+            }
+          },
+          "elapsed_ms": {
+            "p50": 8864.485541998874,
+            "p95": 9388.52300005965
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1364058112.0,
+            "p95": 1384349696
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 5826.7,
+              "p95": 6028.0
+            },
+            "candidates": {
+              "p50": 550.5,
+              "p95": 615.7
+            },
+            "cluster": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "contiguous": {
+              "p50": 0.7,
+              "p95": 0.9
+            },
+            "groups": {
+              "p50": 10.6,
+              "p95": 11.5
+            },
+            "import-resolve": {
+              "p50": 42.95,
+              "p95": 50.1
+            },
+            "lower": {
+              "p50": 1600.45,
+              "p95": 1932.1
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "query_opp": {
+              "p50": 0.3,
+              "p95": 0.4
+            },
+            "query_rank_sort": {
+              "p50": 2.1,
+              "p95": 2.3
+            },
+            "query_render": {
+              "p50": 12.8,
+              "p95": 14.2
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 5.8,
+              "p95": 6.1
+            },
+            "rank_dedup": {
+              "p50": 0.3,
+              "p95": 0.3
+            },
+            "rank_families": {
+              "p50": 1.8,
+              "p95": 2.0
+            },
+            "rank_map": {
+              "p50": 1.0,
+              "p95": 1.3
+            },
+            "rank_sort": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "score": {
+              "p50": 4.8,
+              "p95": 5.1
+            },
+            "shared_lines": {
+              "p50": 500.3,
+              "p95": 591.9
+            }
+          },
+          "store_bytes": {
+            "p50": 148668018.0,
+            "p95": 148668018
+          }
+        },
+        "history-after": {
+          "cache": {
+            "files": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "hits": {
+              "p50": 1584.0,
+              "p95": 1584
+            },
+            "misses": {
+              "p50": 0.0,
+              "p95": 0
+            },
+            "read_bytes": {
+              "p50": 57723359.0,
+              "p95": 57723359
+            },
+            "written_bytes": {
+              "p50": 0.0,
+              "p95": 0
+            }
+          },
+          "elapsed_ms": {
+            "p50": 1866.575562977232,
+            "p95": 1920.2383749652654
+          },
+          "output_sha256": [
+            "84d7a4fab5360bf05e08a9c06af6f92f73305545994aca674b666da41e41fa9d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 713596928.0,
+            "p95": 743718912
+          },
+          "stages_ms": {
+            "cache": {
+              "p50": 1242.9,
+              "p95": 1270.8
+            },
+            "candidates": {
+              "p50": 5.0,
+              "p95": 6.1
+            },
+            "cluster": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "contiguous": {
+              "p50": 0.7,
+              "p95": 0.9
+            },
+            "groups": {
+              "p50": 11.5,
+              "p95": 12.5
+            },
+            "import-resolve": {
+              "p50": 26.35,
+              "p95": 32.1
+            },
+            "lower": {
+              "p50": 477.85,
+              "p95": 525.8
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "query_opp": {
+              "p50": 0.3,
+              "p95": 0.4
+            },
+            "query_rank_sort": {
+              "p50": 2.0,
+              "p95": 2.3
+            },
+            "query_render": {
+              "p50": 12.9,
+              "p95": 14.3
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 5.9,
+              "p95": 6.2
+            },
+            "rank_dedup": {
+              "p50": 0.3,
+              "p95": 0.3
+            },
+            "rank_families": {
+              "p50": 1.7,
+              "p95": 2.0
+            },
+            "rank_map": {
+              "p50": 1.0,
+              "p95": 1.2
+            },
+            "rank_sort": {
+              "p50": 0.4,
+              "p95": 0.5
+            },
+            "score": {
+              "p50": 6.0,
+              "p95": 6.8
+            },
+            "shared_lines": {
+              "p50": 22.3,
+              "p95": 30.2
+            }
+          },
+          "store_bytes": {
+            "p50": 148668018.0,
+            "p95": 148668018
+          }
+        }
+      }
+    },
+    "official": {
+      "sympy": {
+        "clean-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1120.0564164319076,
+            "p95": 1480.9241249458864
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 988708864.0,
+            "p95": 1016201216
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 26.7,
+              "p95": 35.2
+            },
+            "cluster": {
+              "p50": 2.0,
+              "p95": 2.8
+            },
+            "contiguous": {
+              "p50": 0.9,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 27.85,
+              "p95": 40.4
+            },
+            "groups": {
+              "p50": 13.55,
+              "p95": 18.2
+            },
+            "import-resolve": {
+              "p50": 56.8,
+              "p95": 79.5
+            },
+            "lower": {
+              "p50": 464.35,
+              "p95": 604.5
+            },
+            "normalize+extract": {
+              "p50": 438.25,
+              "p95": 615.0
+            },
+            "parse+lower": {
+              "p50": 382.5,
+              "p95": 500.1
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.2,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 0.9,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 2.45,
+              "p95": 3.6
+            },
+            "query_render": {
+              "p50": 15.600000000000001,
+              "p95": 22.8
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 6.2,
+              "p95": 8.3
+            },
+            "rank_dedup": {
+              "p50": 0.4,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.2,
+              "p95": 3.0
+            },
+            "rank_map": {
+              "p50": 1.15,
+              "p95": 1.7
+            },
+            "rank_sort": {
+              "p50": 0.55,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.15,
+              "p95": 1.9
+            },
+            "shared_lines": {
+              "p50": 92.6,
+              "p95": 120.4
+            }
+          },
+          "store_bytes": null
+        },
+        "empty-store-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 1320.0312914559618,
+            "p95": 1662.338083027862
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1094541312.0,
+            "p95": 1120141312
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 28.9,
+              "p95": 38.3
+            },
+            "cluster": {
+              "p50": 2.1,
+              "p95": 2.7
+            },
+            "contiguous": {
+              "p50": 0.95,
+              "p95": 1.2
+            },
+            "discover": {
+              "p50": 28.65,
+              "p95": 41.6
+            },
+            "groups": {
+              "p50": 14.7,
+              "p95": 17.3
+            },
+            "import-resolve": {
+              "p50": 66.6,
+              "p95": 78.6
+            },
+            "lower": {
+              "p50": 522.4000000000001,
+              "p95": 684.4
+            },
+            "parse+lower": {
+              "p50": 422.2,
+              "p95": 563.8
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.45,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 1.15,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.1,
+              "p95": 3.8
+            },
+            "query_render": {
+              "p50": 19.9,
+              "p95": 22.9
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 7.3,
+              "p95": 8.1
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.45,
+              "p95": 2.9
+            },
+            "rank_map": {
+              "p50": 1.2,
+              "p95": 1.5
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.8
+            },
+            "score": {
+              "p50": 1.5,
+              "p95": 2.0
+            },
+            "shared_lines": {
+              "p50": 104.65,
+              "p95": 126.5
+            }
+          },
+          "store_bytes": {
+            "p50": 380153026.0,
+            "p95": 380153034
+          }
+        },
+        "history-after": {
+          "cache": null,
+          "elapsed_ms": {
+            "p50": 893.9628749503754,
+            "p95": 1038.3120840415359
+          },
+          "output_sha256": [
+            "687e713fb10ee56a8d2f20d9453e0ab45d0bd3928dfe05bc031d6154d319547d"
+          ],
+          "peak_rss_bytes": {
+            "p50": 1066582016.0,
+            "p95": 1083441152
+          },
+          "stages_ms": {
+            "candidates": {
+              "p50": 29.5,
+              "p95": 40.1
+            },
+            "cluster": {
+              "p50": 2.05,
+              "p95": 2.5
+            },
+            "contiguous": {
+              "p50": 1.0,
+              "p95": 1.1
+            },
+            "discover": {
+              "p50": 36.25,
+              "p95": 41.3
+            },
+            "groups": {
+              "p50": 14.7,
+              "p95": 16.4
+            },
+            "import-resolve": {
+              "p50": 73.55,
+              "p95": 84.8
+            },
+            "lower": {
+              "p50": 557.75,
+              "p95": 658.2
+            },
+            "parse+lower": {
+              "p50": 452.75,
+              "p95": 533.9
+            },
+            "query_activate": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_filter": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_gate": {
+              "p50": 1.4,
+              "p95": 1.7
+            },
+            "query_opp": {
+              "p50": 1.1,
+              "p95": 1.3
+            },
+            "query_rank_sort": {
+              "p50": 3.0,
+              "p95": 3.7
+            },
+            "query_render": {
+              "p50": 19.7,
+              "p95": 23.1
+            },
+            "query_since": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_sort": {
+              "p50": 0.0,
+              "p95": 0.0
+            },
+            "query_surface": {
+              "p50": 7.1,
+              "p95": 8.0
+            },
+            "rank_dedup": {
+              "p50": 0.5,
+              "p95": 0.6
+            },
+            "rank_families": {
+              "p50": 2.3499999999999996,
+              "p95": 2.9
+            },
+            "rank_map": {
+              "p50": 1.2,
+              "p95": 1.6
+            },
+            "rank_sort": {
+              "p50": 0.6,
+              "p95": 0.7
+            },
+            "score": {
+              "p50": 1.5,
+              "p95": 2.4
+            },
+            "shared_lines": {
+              "p50": 107.6,
+              "p95": 125.4
+            }
+          },
+          "store_bytes": {
+            "p50": 380153026.0,
+            "p95": 380153034
+          }
+        }
+      }
+    }
+  },
+  "workload": {
+    "commit": "da4a5fa52418ae593a941d4ba585cfef87a31870",
+    "id": "sympy",
+    "kind": "real",
+    "path": "bench/repos/sympy"
+  }
+}

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "11d89b35b7a0831568f4aec531e828a9ab54ad26",
+  "product_crates_tree": "2847ec4d90a6203e771f8f8d207a24237cf76974",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/Cargo.toml
+++ b/crates/nose-cli/Cargo.toml
@@ -30,7 +30,8 @@ ignore = { workspace = true }
 rustc-hash = { workspace = true }
 sha2 = { workspace = true }
 rmp-serde = { workspace = true }
-lz4_flex = { workspace = true }
+zstd = { workspace = true }
+fs2 = { workspace = true }
 
 [dev-dependencies]
 nose-il = { workspace = true }

--- a/crates/nose-cli/src/cache.rs
+++ b/crates/nose-cli/src/cache.rs
@@ -12,10 +12,12 @@
 //! so checkout moves and sorted `FileId` shifts do not fan out invalidation.
 //!
 //! Every stage uses the checksummed CAS envelope. Corrupt, truncated, or misplaced
-//! entries are misses; the mutable workspace state is diagnostics-only and never a
-//! correctness input. `NOSE_CACHE_STATS` also emits a machine-readable
+//! entries are misses. Immutable state records commit through one complete workspace
+//! generation; exact identities keep them acceleration-only, never correctness inputs.
+//! `NOSE_CACHE_STATS` also emits a machine-readable
 //! `nose.invalidation/v1` closure with exact reasons and explicit over-invalidation.
 
+mod admin;
 mod detection;
 mod digest;
 mod lines;
@@ -23,20 +25,25 @@ mod portable_il;
 mod resolved;
 mod source;
 mod store;
+mod transaction;
 
 use nose_detect::{DetectOptions, Stream, UnitFeat};
 use nose_il::Corpus;
-use rayon::prelude::*;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
+pub(crate) use self::admin::{
+    clear as clear_store, prune as prune_store, status as store_status, PruneReport,
+    DEFAULT_MAX_BYTES,
+};
 pub(crate) use self::detection::{
     load_detection_state, store_detection_state, DetectionCacheIdentity,
 };
 use self::digest::ContentDigest;
 pub(crate) use self::lines::{build_line_index, LineIndexStats};
-pub(crate) use self::resolved::CachedCorpus;
-use self::store::{ArtifactKey, ArtifactStage, LayeredCas};
+pub(crate) use self::resolved::{CachedCorpus, InvalidationReport};
+use self::store::{ArtifactKey, ArtifactStage};
+pub(crate) use self::transaction::CacheRun;
 
 #[derive(Clone)]
 pub(crate) struct CachedSourceFile {
@@ -45,9 +52,8 @@ pub(crate) struct CachedSourceFile {
 }
 
 pub(crate) struct CachedLineContext {
-    pub(crate) cache_dir: std::path::PathBuf,
-    pub(crate) workspace_digest: [u8; 32],
     pub(crate) source_files: Vec<CachedSourceFile>,
+    pub(crate) run: CacheRun,
 }
 
 pub(crate) fn build_corpus_cached(
@@ -55,12 +61,14 @@ pub(crate) fn build_corpus_cached(
     exclude: &[String],
     dir: &Path,
     semantic_packs: &nose_semantics::SemanticPackSet,
+    max_bytes: u64,
 ) -> CachedCorpus {
-    let raw = source::build_raw_corpus_cached(roots, exclude, dir);
-    resolved::build_resolved_corpus_cached(raw, dir, semantic_pack_digest(semantic_packs))
+    let run = CacheRun::with_limit(dir, max_bytes);
+    let raw = source::build_raw_corpus_cached(roots, exclude, &run);
+    resolved::build_resolved_corpus_cached(raw, &run, semantic_pack_digest(semantic_packs))
 }
 
-pub(crate) fn invalidation_report_json(report: &resolved::InvalidationReport) -> String {
+pub(crate) fn invalidation_report_json(report: &InvalidationReport) -> String {
     serde_json::to_string(report).expect("invalidation report is always JSON serializable")
 }
 
@@ -72,6 +80,10 @@ pub(crate) fn incremental_detection_stats_json(
 
 pub(crate) fn line_index_stats_json(stats: &LineIndexStats) -> String {
     serde_json::to_string(stats).expect("line index stats are JSON serializable")
+}
+
+pub(crate) fn enforce_run_budget(run: CacheRun) {
+    admin::enforce_run_budget(run);
 }
 
 fn semantic_pack_digest(packs: &nose_semantics::SemanticPackSet) -> ContentDigest {
@@ -121,83 +133,89 @@ pub(crate) struct CacheStats {
 /// normalize+extract step is cached. A cache hit needs no interner (features are
 /// content-derived); a miss recomputes and writes back.
 #[cfg(test)]
-fn build_units_cached(corpus: &Corpus, opts: &DetectOptions, dir: &Path) -> CachedUnits {
-    build_units_cached_inner(corpus, opts, dir, None)
+fn build_units_cached(mut corpus: Corpus, opts: &DetectOptions, dir: &Path) -> CachedUnits {
+    build_units_cached_inner(&mut corpus, opts, &CacheRun::new(dir), None)
 }
 
 pub(crate) fn build_units_cached_with_context(
-    corpus: &Corpus,
+    corpus: &mut Corpus,
     opts: &DetectOptions,
-    dir: &Path,
+    run: &CacheRun,
     resolution_contexts: &[[u8; 32]],
 ) -> CachedUnits {
     assert_eq!(corpus.files.len(), resolution_contexts.len());
-    build_units_cached_inner(corpus, opts, dir, Some(resolution_contexts))
+    build_units_cached_inner(corpus, opts, run, Some(resolution_contexts))
 }
 
 fn build_units_cached_inner(
-    corpus: &Corpus,
+    corpus: &mut Corpus,
     opts: &DetectOptions,
-    dir: &Path,
+    run: &CacheRun,
     resolution_contexts: Option<&[[u8; 32]]>,
 ) -> CachedUnits {
-    let cas = LayeredCas::new(dir);
+    let cas = run.cas();
     let options = options_digest(opts);
     let hits = AtomicUsize::new(0);
     let misses = AtomicUsize::new(0);
     let read_bytes = AtomicU64::new(0);
     let written_bytes = AtomicU64::new(0);
 
-    let per_file: Vec<(Vec<UnitFeat>, Stream, ContentDigest, String)> = corpus
-        .files
-        .par_iter()
+    // Detection owns the resolved IL after semantic-pack registries and query scope
+    // have been built. Drain it here so each file can be released as soon as its
+    // cached features are restored; retaining the whole resolved corpus alongside
+    // every UnitFeat makes warm cache hits peak near a clean scan's RSS.
+    let files = std::mem::take(&mut corpus.files);
+    let interner = &corpus.interner;
+    let restore = |(index, il): (usize, nose_il::Il)| {
+        let path = il.meta.path.clone();
+        let resolved = portable_il::semantic_digest(&il, interner);
+        let context = resolution_contexts.map(|contexts| contexts[index].as_slice());
+        let key = match context {
+            Some(context) => ArtifactKey::derive(
+                ArtifactStage::UnitsSyntax,
+                UNITS_SYNTAX_SCHEMA,
+                &[resolved.as_bytes(), options.as_bytes(), context],
+            ),
+            None => ArtifactKey::derive(
+                ArtifactStage::UnitsSyntax,
+                UNITS_SYNTAX_SCHEMA,
+                &[resolved.as_bytes(), options.as_bytes()],
+            ),
+        };
+
+        if let Some(entry) = cas.load(key) {
+            read_bytes.fetch_add(entry.stored_bytes, Ordering::Relaxed);
+            if let Ok((mut units, mut stream)) =
+                rmp_serde::from_slice::<(Vec<UnitFeat>, Stream)>(&entry.payload)
+            {
+                hits.fetch_add(1, Ordering::Relaxed);
+                retarget(&mut units, &mut stream, &path);
+                return (units, stream, key.digest, path);
+            }
+        }
+
+        misses.fetch_add(1, Ordering::Relaxed);
+        let mut units = nose_detect::units_of_file(&il, interner, opts);
+        let mut stream = nose_detect::file_stream(&il, interner);
+        // Checkout paths are presentation state, not payload identity. Blank
+        // them before serialization and restore them for this query.
+        retarget(&mut units, &mut stream, "");
+        // Named MessagePack preserves serde's default/skip compatibility
+        // while avoiding JSON's decimal expansion of feature hashes.
+        let payload = rmp_serde::to_vec_named(&(&units, &stream));
+        retarget(&mut units, &mut stream, &path);
+        if let Ok(payload) = payload {
+            if let Ok(bytes) = cas.store(key, &payload) {
+                written_bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
+        }
+        (units, stream, key.digest, path)
+    };
+    let per_file = files
+        .into_iter()
         .enumerate()
-        .map(|(index, il)| {
-            let path = il.meta.path.clone();
-            let resolved = portable_il::semantic_digest(il, &corpus.interner);
-            let context = resolution_contexts.map(|contexts| contexts[index].as_slice());
-            let key = match context {
-                Some(context) => ArtifactKey::derive(
-                    ArtifactStage::UnitsSyntax,
-                    UNITS_SYNTAX_SCHEMA,
-                    &[resolved.as_bytes(), options.as_bytes(), context],
-                ),
-                None => ArtifactKey::derive(
-                    ArtifactStage::UnitsSyntax,
-                    UNITS_SYNTAX_SCHEMA,
-                    &[resolved.as_bytes(), options.as_bytes()],
-                ),
-            };
-
-            if let Some(entry) = cas.load(key) {
-                read_bytes.fetch_add(entry.stored_bytes, Ordering::Relaxed);
-                if let Ok((mut units, mut stream)) =
-                    rmp_serde::from_slice::<(Vec<UnitFeat>, Stream)>(&entry.payload)
-                {
-                    hits.fetch_add(1, Ordering::Relaxed);
-                    retarget(&mut units, &mut stream, &path);
-                    return (units, stream, key.digest, path);
-                }
-            }
-
-            misses.fetch_add(1, Ordering::Relaxed);
-            let mut units = nose_detect::units_of_file(il, &corpus.interner, opts);
-            let mut stream = nose_detect::file_stream(il, &corpus.interner);
-            // Checkout paths are presentation state, not payload identity. Blank
-            // them before serialization and restore them for this query.
-            retarget(&mut units, &mut stream, "");
-            // Named MessagePack preserves serde's default/skip compatibility
-            // while avoiding JSON's decimal expansion of feature hashes.
-            let payload = rmp_serde::to_vec_named(&(&units, &stream));
-            retarget(&mut units, &mut stream, &path);
-            if let Ok(payload) = payload {
-                if let Ok(bytes) = cas.store(key, &payload) {
-                    written_bytes.fetch_add(bytes, Ordering::Relaxed);
-                }
-            }
-            (units, stream, key.digest, path)
-        })
-        .collect();
+        .map(restore)
+        .collect::<Vec<_>>();
 
     let files = per_file.len();
     let mut all_units = Vec::new();
@@ -283,7 +301,7 @@ mod tests {
 
         let readable = std::fs::read(&bad).is_ok();
         let corpus = nose_frontend::lower_corpus_filtered(&[dir.as_path()], &[]);
-        let out = build_units_cached(&corpus, &DetectOptions::default(), &cache);
+        let out = build_units_cached(corpus, &DetectOptions::default(), &cache);
 
         let _ = std::fs::set_permissions(&bad, std::fs::Permissions::from_mode(0o644));
         let _ = std::fs::remove_dir_all(&dir);
@@ -315,12 +333,12 @@ mod tests {
         let stale = cache.join("v14-deadbeef");
         std::fs::create_dir_all(&stale).unwrap();
         std::fs::write(stale.join("legacy.json"), b"[]").unwrap();
-        let first = build_units_cached(&corpus, &options, &cache);
+        let first = build_units_cached(corpus.clone(), &options, &cache);
         assert!(!first.units.is_empty());
-        let second = build_units_cached(&corpus, &options, &cache);
+        let second = build_units_cached(corpus, &options, &cache);
         assert_eq!(second.units.len(), first.units.len());
         assert_eq!(second.stats.hits, 1);
-        assert!(cache.join("cas-v1/units-syntax").is_dir());
+        assert!(cache.join("cas-v2/units-syntax").is_dir());
         assert!(stale.is_dir(), "the legacy bucket should remain untouched");
 
         let _ = std::fs::remove_dir_all(&root);
@@ -341,10 +359,10 @@ mod tests {
 
         let options = DetectOptions::default();
         let first_corpus = nose_frontend::lower_corpus_filtered(&[source_a.as_path()], &[]);
-        let first = build_units_cached(&first_corpus, &options, &cache);
+        let first = build_units_cached(first_corpus, &options, &cache);
         assert_eq!((first.stats.hits, first.stats.misses), (0, 1));
         let second_corpus = nose_frontend::lower_corpus_filtered(&[source_b.as_path()], &[]);
-        let second = build_units_cached(&second_corpus, &options, &cache);
+        let second = build_units_cached(second_corpus, &options, &cache);
         assert_eq!((second.stats.hits, second.stats.misses), (1, 0));
         assert!(second
             .units
@@ -368,7 +386,7 @@ mod tests {
         std::fs::write(source.join("same.py"), "def f(x):\n    return x\n").unwrap();
         let options = DetectOptions::default();
         let corpus = nose_frontend::lower_corpus_filtered(&[source.as_path()], &[]);
-        let first = build_units_cached(&corpus, &options, &cache);
+        let first = build_units_cached(corpus.clone(), &options, &cache);
         assert_eq!((first.stats.hits, first.stats.misses), (0, 1));
 
         let mut changed = corpus.clone();
@@ -382,9 +400,9 @@ mod tests {
             Vec::new(),
             EvidenceStatus::Asserted,
         ));
-        let second = build_units_cached(&changed, &options, &cache);
+        let second = build_units_cached(changed.clone(), &options, &cache);
         assert_eq!((second.stats.hits, second.stats.misses), (0, 1));
-        let third = build_units_cached(&changed, &options, &cache);
+        let third = build_units_cached(changed, &options, &cache);
         assert_eq!((third.stats.hits, third.stats.misses), (1, 0));
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/nose-cli/src/cache/admin.rs
+++ b/crates/nose-cli/src/cache/admin.rs
@@ -1,0 +1,360 @@
+//! Bounded cache administration and garbage collection.
+
+use super::transaction::{live_state_paths, CacheRun};
+use fs2::FileExt;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+pub(crate) const DEFAULT_MAX_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+
+const LEGACY_NAMES: &[&str] = &[
+    "cas-v1",
+    "state-v1",
+    "detection-state-v1",
+    "line-index-state-v1",
+    "line-index-manifest-v1",
+    "family-line-state-v1",
+];
+const ACTIVE_NAMES: &[&str] = &["cas-v2", "state-v2"];
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CacheStatus {
+    pub(crate) schema: &'static str,
+    pub(crate) root: String,
+    pub(crate) max_bytes: u64,
+    pub(crate) bytes: u64,
+    pub(crate) files: usize,
+    pub(crate) generations: usize,
+    pub(crate) active_generations: usize,
+    pub(crate) reclaimable_bytes: u64,
+    pub(crate) reclaimable_files: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PruneReport {
+    pub(crate) schema: &'static str,
+    pub(crate) before_bytes: u64,
+    pub(crate) after_bytes: u64,
+    pub(crate) max_bytes: u64,
+    pub(crate) removed_bytes: u64,
+    pub(crate) removed_files: usize,
+}
+
+#[derive(Clone)]
+struct FileInfo {
+    path: PathBuf,
+    bytes: u64,
+    modified: u64,
+}
+
+pub(crate) fn status(root: &Path, max_bytes: u64) -> CacheStatus {
+    let active = collect_named(root, ACTIVE_NAMES);
+    let legacy = collect_named(root, LEGACY_NAMES);
+    let live = live_state_paths(root);
+    let orphaned = active
+        .iter()
+        .filter(|file| is_generation_file(&file.path) && !live.contains(&file.path))
+        .collect::<Vec<_>>();
+    CacheStatus {
+        schema: "nose.cache-status/v1",
+        root: root.display().to_string(),
+        max_bytes,
+        bytes: bytes(&active) + bytes(&legacy),
+        files: active.len() + legacy.len(),
+        generations: active
+            .iter()
+            .filter(|file| extension(&file.path) == Some("manifest"))
+            .count(),
+        active_generations: live
+            .iter()
+            .filter(|path| extension(path) == Some("manifest"))
+            .count(),
+        reclaimable_bytes: bytes(&legacy) + orphaned.iter().map(|file| file.bytes).sum::<u64>(),
+        reclaimable_files: legacy.len() + orphaned.len(),
+    }
+}
+
+pub(crate) fn prune(root: &Path, max_bytes: u64) -> std::io::Result<PruneReport> {
+    let _lease = exclusive_store_lease(root)?;
+    prune_locked(root, max_bytes)
+}
+
+fn prune_locked(root: &Path, max_bytes: u64) -> std::io::Result<PruneReport> {
+    let before = status(root, max_bytes);
+    let mut removed_files = 0;
+    let mut removed_bytes = 0;
+    for name in LEGACY_NAMES {
+        let path = root.join(name);
+        let files = collect_tree(&path);
+        if remove_path(&path).is_ok() {
+            removed_files += files.len();
+            removed_bytes += bytes(&files);
+        }
+    }
+
+    let live = live_state_paths(root);
+    let active = collect_named(root, ACTIVE_NAMES);
+    for file in active.iter().filter(|file| {
+        is_temporary(&file.path) || (is_generation_file(&file.path) && !live.contains(&file.path))
+    }) {
+        if std::fs::remove_file(&file.path).is_ok() {
+            removed_files += 1;
+            removed_bytes += file.bytes;
+        }
+    }
+
+    let mut remaining = collect_named(root, ACTIVE_NAMES);
+    let mut total = bytes(&remaining);
+    if total > max_bytes {
+        remaining.sort_by_key(|file| (eviction_tier(&file.path, &live), file.modified));
+        for file in remaining {
+            if total <= max_bytes || eviction_tier(&file.path, &live) == u8::MAX {
+                continue;
+            }
+            if std::fs::remove_file(&file.path).is_ok() {
+                total = total.saturating_sub(file.bytes);
+                removed_files += 1;
+                removed_bytes += file.bytes;
+            }
+        }
+    }
+    remove_empty_directories(&root.join("cas-v2"));
+    remove_empty_directories(&root.join("state-v2"));
+    let after = status(root, max_bytes).bytes;
+    Ok(PruneReport {
+        schema: "nose.cache-prune/v1",
+        before_bytes: before.bytes,
+        after_bytes: after,
+        max_bytes,
+        removed_bytes,
+        removed_files,
+    })
+}
+
+pub(crate) fn clear(root: &Path) -> std::io::Result<PruneReport> {
+    let _lease = exclusive_store_lease(root)?;
+    let before = status(root, DEFAULT_MAX_BYTES);
+    for name in LEGACY_NAMES.iter().chain(ACTIVE_NAMES) {
+        remove_path(&root.join(name))?;
+    }
+    Ok(PruneReport {
+        schema: "nose.cache-clear/v1",
+        before_bytes: before.bytes,
+        after_bytes: 0,
+        max_bytes: 0,
+        removed_bytes: before.bytes,
+        removed_files: before.files,
+    })
+}
+
+pub(super) fn enforce_run_budget(run: CacheRun) {
+    let written_bytes = run.written_bytes();
+    let root = run.root().to_path_buf();
+    let max_bytes = run.max_bytes();
+    // Releasing the run's shared lease before acquiring the exclusive prune
+    // lease avoids self-deadlock and lets all concurrent writers finish first.
+    drop(run);
+    if written_bytes == 0 {
+        return;
+    }
+    if let Err(error) = prune(&root, max_bytes) {
+        if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+            eprintln!("  [cache-prune] skipped: {error}");
+        }
+    }
+}
+
+fn collect_named(root: &Path, names: &[&str]) -> Vec<FileInfo> {
+    names
+        .iter()
+        .flat_map(|name| collect_tree(&root.join(name)))
+        .collect()
+}
+
+fn collect_tree(root: &Path) -> Vec<FileInfo> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() || metadata.is_file() {
+            files.push(FileInfo {
+                path,
+                bytes: metadata.len(),
+                modified: metadata
+                    .modified()
+                    .ok()
+                    .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                    .map_or(0, |duration| duration.as_secs()),
+            });
+            continue;
+        }
+        if let Ok(entries) = std::fs::read_dir(path) {
+            pending.extend(entries.flatten().map(|entry| entry.path()));
+        }
+    }
+    files
+}
+
+fn eviction_tier(path: &Path, live: &BTreeSet<PathBuf>) -> u8 {
+    if is_temporary(path) || (is_generation_file(path) && !live.contains(path)) {
+        0
+    } else if extension(path) == Some("artifact") {
+        1
+    } else if extension(path) == Some("state") {
+        2
+    } else if extension(path) == Some("manifest") {
+        3
+    } else if path.file_name().and_then(|name| name.to_str()) == Some("CURRENT") {
+        4
+    } else if path.file_name().and_then(|name| name.to_str()) == Some("LOCK") {
+        u8::MAX
+    } else {
+        5
+    }
+}
+
+fn exclusive_store_lease(root: &Path) -> std::io::Result<File> {
+    std::fs::create_dir_all(root)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(".nose-cache.lock"))?;
+    FileExt::lock_exclusive(&file)?;
+    Ok(file)
+}
+
+fn is_state_object(path: &Path) -> bool {
+    matches!(extension(path), Some("state" | "manifest"))
+}
+
+fn is_generation_file(path: &Path) -> bool {
+    is_state_object(path) || path.file_name().and_then(|name| name.to_str()) == Some("CURRENT")
+}
+
+fn is_temporary(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.') && name.ends_with(".tmp"))
+}
+
+fn extension(path: &Path) -> Option<&str> {
+    path.extension().and_then(|extension| extension.to_str())
+}
+
+fn bytes(files: &[FileInfo]) -> u64 {
+    files.iter().map(|file| file.bytes).sum()
+}
+
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            std::fs::remove_dir_all(path)
+        }
+        Ok(_) => std::fs::remove_file(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_empty_directories(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    let children = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    for child in &children {
+        if child.is_dir() {
+            remove_empty_directories(child);
+        }
+    }
+    std::fs::read_dir(root)
+        .ok()
+        .is_some_and(|mut entries| entries.next().is_none())
+        && std::fs::remove_dir(root).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_store(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "nose_admin_{label}_{}_{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn prune_removes_legacy_orphans_and_oldest_cas_without_touching_other_files() {
+        let root = temp_store("prune");
+        std::fs::create_dir_all(root.join("cas-v1")).unwrap();
+        std::fs::write(root.join("cas-v1/legacy"), vec![1; 50]).unwrap();
+        std::fs::create_dir_all(root.join("cas-v2/raw-il/aa")).unwrap();
+        std::fs::write(root.join("cas-v2/raw-il/aa/old.artifact"), vec![2; 80]).unwrap();
+        std::fs::write(root.join("keep.txt"), vec![3; 90]).unwrap();
+
+        let report = prune(&root, 0).unwrap();
+        assert!(report.removed_bytes >= 130);
+        assert!(root.join("keep.txt").is_file());
+        assert!(!root.join("cas-v1").exists());
+        assert!(!root.join("cas-v2/raw-il/aa/old.artifact").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn status_counts_only_managed_cache_paths() {
+        let root = temp_store("status");
+        std::fs::create_dir_all(root.join("cas-v2/raw-il/aa")).unwrap();
+        std::fs::write(root.join("cas-v2/raw-il/aa/entry.artifact"), vec![0; 11]).unwrap();
+        std::fs::write(root.join("unrelated"), vec![0; 99]).unwrap();
+        let report = status(&root, DEFAULT_MAX_BYTES);
+        assert_eq!(report.bytes, 11);
+        assert_eq!(report.files, 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prune_reclaims_superseded_generations_and_keeps_current_state() {
+        let root = temp_store("generations");
+        let first = CacheRun::new(&root);
+        first.set_workspace([9; 32]);
+        first.store("line-index", 1, b"old");
+        first.commit().unwrap();
+        drop(first);
+
+        let second = CacheRun::new(&root);
+        second.set_workspace([9; 32]);
+        second.store("line-index", 1, b"new");
+        second.commit().unwrap();
+        drop(second);
+
+        let before = status(&root, DEFAULT_MAX_BYTES);
+        assert_eq!(before.generations, 2);
+        assert_eq!(before.active_generations, 1);
+        assert!(before.reclaimable_files >= 2);
+        prune(&root, DEFAULT_MAX_BYTES).unwrap();
+
+        let reader = CacheRun::new(&root);
+        reader.set_workspace([9; 32]);
+        assert_eq!(
+            reader.load("line-index", 1).as_deref(),
+            Some(b"new".as_slice())
+        );
+        assert_eq!(status(&root, DEFAULT_MAX_BYTES).generations, 1);
+        drop(reader);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/nose-cli/src/cache/detection.rs
+++ b/crates/nose-cli/src/cache/detection.rs
@@ -1,20 +1,18 @@
 //! Process-boundary persistence for `nose-detect`'s opaque incremental state.
 
 use super::digest::ContentDigest;
+use super::CacheRun;
 use nose_detect::{DetectOptions, IncrementalDetectionState};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
-static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const STATE_SCHEMA: u32 = 1;
 
 pub(crate) struct DetectionCacheIdentity {
-    workspace: [u8; 32],
     query: ContentDigest,
 }
 
 impl DetectionCacheIdentity {
     pub(crate) fn new(
-        workspace: [u8; 32],
+        _workspace: [u8; 32],
         semantic_packs: [u8; 32],
         opts: &DetectOptions,
         detector: &dyn nose_detect::Detector,
@@ -22,7 +20,6 @@ impl DetectionCacheIdentity {
         let options = options_bytes(opts);
         let environment = influential_environment();
         Self {
-            workspace,
             query: ContentDigest::derive(
                 b"nose.incremental-detection-query.v1",
                 &[
@@ -34,43 +31,29 @@ impl DetectionCacheIdentity {
             ),
         }
     }
+
+    fn slot(&self) -> String {
+        format!("detection/{}", self.query.hex())
+    }
 }
 
 pub(crate) fn load_detection_state(
-    root: &Path,
+    run: &CacheRun,
     identity: &DetectionCacheIdentity,
 ) -> Option<IncrementalDetectionState> {
-    let bytes = std::fs::read(state_path(root, identity)).ok()?;
+    let bytes = run.load(&identity.slot(), STATE_SCHEMA)?;
     rmp_serde::from_slice(&bytes).ok()
 }
 
 pub(crate) fn store_detection_state(
-    root: &Path,
+    run: &CacheRun,
     identity: &DetectionCacheIdentity,
     state: &IncrementalDetectionState,
 ) {
-    let path = state_path(root, identity);
-    let Some(parent) = path.parent() else { return };
-    if std::fs::create_dir_all(parent).is_err() {
-        return;
-    }
     let Ok(bytes) = rmp_serde::to_vec(state) else {
         return;
     };
-    let temp = parent.join(format!(
-        ".{}.{}.tmp",
-        std::process::id(),
-        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-    ));
-    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, &path).is_err() {
-        let _ = std::fs::remove_file(&temp);
-    }
-}
-
-fn state_path(root: &Path, identity: &DetectionCacheIdentity) -> PathBuf {
-    root.join("detection-state-v1")
-        .join(hex(&identity.workspace))
-        .join(format!("{}.msgpack", identity.query.hex()))
+    run.store(&identity.slot(), STATE_SCHEMA, &bytes);
 }
 
 fn options_bytes(opts: &DetectOptions) -> Vec<u8> {
@@ -112,15 +95,6 @@ fn influential_environment() -> Vec<u8> {
         .collect::<Vec<_>>();
     rows.sort();
     rows.into_iter().flatten().collect()
-}
-
-fn hex(bytes: &[u8; 32]) -> String {
-    let mut out = String::with_capacity(64);
-    for byte in bytes {
-        use std::fmt::Write as _;
-        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/nose-cli/src/cache/lines.rs
+++ b/crates/nose-cli/src/cache/lines.rs
@@ -1,25 +1,26 @@
-use super::CachedSourceFile;
+use super::{CacheRun, CachedSourceFile};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
-const STATE_SCHEMA: u32 = 1;
-static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const STATE_SCHEMA: u32 = 3;
+const STATE_SLOT: &str = "line-index";
+const MANIFEST_SLOT: &str = "line-manifest";
+#[cfg(test)]
+static TEST_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[derive(Default, Deserialize, Serialize)]
 struct LineIndexState {
     schema: u32,
+    lines: Vec<String>,
+    document_frequency: Vec<u32>,
     files: BTreeMap<String, StoredFileLines>,
-    document_frequency: BTreeMap<String, u32>,
 }
 
 #[derive(Deserialize, Serialize)]
 struct StoredFileLines {
     digest: [u8; 32],
-    lines: Vec<String>,
-    unique_substantive: Vec<String>,
+    unique_substantive: Vec<u32>,
 }
 
 #[derive(Eq, PartialEq, Deserialize, Serialize)]
@@ -46,112 +47,93 @@ pub(crate) struct LineIndexStats {
 }
 
 pub(crate) fn build_line_index(
-    cache_dir: &Path,
-    workspace: [u8; 32],
+    run: &CacheRun,
     source_files: &[CachedSourceFile],
     force_full: bool,
 ) -> (CachedLineIndex, LineIndexStats) {
-    let path = state_path(cache_dir, workspace);
-    let manifest_path = manifest_path(cache_dir, workspace);
     let manifest = current_manifest(source_files);
     if !force_full {
-        if let Some(reused) = reuse_unchanged_index(&manifest_path, &manifest) {
+        if let Some(reused) = reuse_unchanged_index(run, &manifest) {
             return reused;
         }
     }
-    let loaded = load_state(&path);
+    let loaded = load_state(run);
     let state_hit = loaded.is_some();
     let previous = loaded.unwrap_or_default();
-    let mut document_frequency = previous.document_frequency.clone();
-    let current_paths = source_files
-        .iter()
-        .map(|file| file.path.as_str())
-        .collect::<BTreeSet<_>>();
-    let mut changed_lines = FxHashSet::default();
+    let mut registry = previous
+        .lines
+        .into_iter()
+        .enumerate()
+        .map(|(index, line)| (line, index as u32))
+        .collect::<FxHashMap<_, _>>();
+    let mut document_frequency = previous.document_frequency;
+    let mut previous_files = previous.files;
+    let mut changed_ids = FxHashSet::default();
     let mut stats = LineIndexStats {
         schema: "nose.line-index/v1",
         ..LineIndexStats::default()
     };
-    for (path, file) in &previous.files {
-        if !current_paths.contains(path.as_str()) {
-            apply_frequency_delta(
-                &mut document_frequency,
-                &file.unique_substantive,
-                false,
-                &mut changed_lines,
-            );
-            stats.files_removed += 1;
-        }
-    }
-
     let mut files = BTreeMap::new();
     for source in source_files {
-        if let Some(previous_file) = previous
-            .files
-            .get(&source.path)
-            .filter(|file| file.digest == source.digest)
-        {
-            stats.files_reused += 1;
-            files.insert(
-                source.path.clone(),
-                StoredFileLines {
-                    digest: previous_file.digest,
-                    lines: previous_file.lines.clone(),
-                    unique_substantive: previous_file.unique_substantive.clone(),
-                },
-            );
-            continue;
-        }
-        if let Some(previous_file) = previous.files.get(&source.path) {
+        if let Some(previous_file) = previous_files.remove(&source.path) {
+            if previous_file.digest == source.digest {
+                stats.files_reused += 1;
+                files.insert(source.path.clone(), previous_file);
+                continue;
+            }
             apply_frequency_delta(
                 &mut document_frequency,
                 &previous_file.unique_substantive,
                 false,
-                &mut changed_lines,
+                &mut changed_ids,
             );
         }
         let Some(text) = std::fs::read_to_string(&source.path).ok() else {
             continue;
         };
-        let lines = text.lines().map(str::to_string).collect::<Vec<_>>();
-        let unique_substantive = unique_substantive_lines(&lines);
+        let unique_substantive = intern_lines(
+            unique_substantive_lines(&text),
+            &mut registry,
+            &mut document_frequency,
+        );
         apply_frequency_delta(
             &mut document_frequency,
             &unique_substantive,
             true,
-            &mut changed_lines,
+            &mut changed_ids,
         );
         stats.files_rebuilt += 1;
         files.insert(
             source.path.clone(),
             StoredFileLines {
                 digest: source.digest,
-                lines,
                 unique_substantive,
             },
         );
     }
-    document_frequency.retain(|_, count| *count > 0);
+    for (_, removed) in previous_files {
+        apply_frequency_delta(
+            &mut document_frequency,
+            &removed.unique_substantive,
+            false,
+            &mut changed_ids,
+        );
+        stats.files_removed += 1;
+    }
+    let (lines, document_frequency, files, changed_lines) =
+        compact_lines(registry, document_frequency, files, &changed_ids);
     stats.changed_document_frequencies = changed_lines.len();
     let state = LineIndexState {
         schema: STATE_SCHEMA,
-        files,
+        lines,
         document_frequency,
+        files,
     };
-    finish_index(
-        &path,
-        &manifest_path,
-        &manifest,
-        state,
-        state_hit,
-        stats,
-        changed_lines,
-    )
+    finish_index(run, &manifest, state, state_hit, stats, changed_lines)
 }
 
 fn finish_index(
-    path: &Path,
-    manifest_path: &Path,
+    run: &CacheRun,
     manifest: &LineIndexManifest,
     state: LineIndexState,
     state_hit: bool,
@@ -159,22 +141,24 @@ fn finish_index(
     changed_lines: FxHashSet<String>,
 ) -> (CachedLineIndex, LineIndexStats) {
     if !state_hit || stats.files_rebuilt > 0 || stats.files_removed > 0 {
-        store_state(path, &state);
+        store_state(run, &state);
     }
-    store_manifest(manifest_path, manifest);
+    store_manifest(run, manifest);
+    let LineIndexState {
+        lines,
+        document_frequency,
+        files,
+        ..
+    } = state;
+    let file_count = files.len();
     let index = CachedLineIndex {
-        document_frequency: state
-            .document_frequency
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect(),
-        files: state
-            .files
-            .iter()
-            .map(|(path, file)| (path.clone(), Some(file.lines.clone())))
-            .collect(),
+        document_frequency: lines.into_iter().zip(document_frequency).collect(),
+        // Source slices are needed only for families that cannot reuse their
+        // analysis. FileLineCache reads those few files lazily; duplicating every
+        // source line in both persistent state and the query heap dominated leaf RSS.
+        files: FxHashMap::default(),
         changed_lines,
-        file_count: state.files.len(),
+        file_count,
         complete: true,
     };
     (index, stats)
@@ -191,10 +175,10 @@ fn current_manifest(source_files: &[CachedSourceFile]) -> LineIndexManifest {
 }
 
 fn reuse_unchanged_index(
-    path: &Path,
+    run: &CacheRun,
     current: &LineIndexManifest,
 ) -> Option<(CachedLineIndex, LineIndexStats)> {
-    (load_manifest(path).as_ref() == Some(current)).then(|| {
+    (load_manifest(run).as_ref() == Some(current)).then(|| {
         (
             CachedLineIndex {
                 document_frequency: FxHashMap::default(),
@@ -212,10 +196,10 @@ fn reuse_unchanged_index(
     })
 }
 
-fn unique_substantive_lines(lines: &[String]) -> Vec<String> {
-    let mut unique = lines
-        .iter()
-        .map(|line| line.trim())
+fn unique_substantive_lines(text: &str) -> Vec<String> {
+    let mut unique = text
+        .lines()
+        .map(str::trim)
         .filter(|line| !crate::source_lines::is_trivial_line(line))
         .map(str::to_string)
         .collect::<BTreeSet<_>>()
@@ -225,78 +209,164 @@ fn unique_substantive_lines(lines: &[String]) -> Vec<String> {
     unique
 }
 
+fn intern_lines(
+    lines: Vec<String>,
+    registry: &mut FxHashMap<String, u32>,
+    frequencies: &mut Vec<u32>,
+) -> Vec<u32> {
+    lines
+        .into_iter()
+        .map(|line| match registry.entry(line) {
+            std::collections::hash_map::Entry::Occupied(entry) => *entry.get(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let id = frequencies.len() as u32;
+                frequencies.push(0);
+                entry.insert(id);
+                id
+            }
+        })
+        .collect()
+}
+
 fn apply_frequency_delta(
-    frequencies: &mut BTreeMap<String, u32>,
-    lines: &[String],
+    frequencies: &mut [u32],
+    lines: &[u32],
     add: bool,
-    changed: &mut FxHashSet<String>,
+    changed: &mut FxHashSet<u32>,
 ) {
-    for line in lines {
-        let value = frequencies.entry(line.clone()).or_default();
+    for &line in lines {
+        let Some(value) = frequencies.get_mut(line as usize) else {
+            continue;
+        };
         if add {
             *value += 1;
         } else {
             *value = value.saturating_sub(1);
         }
-        changed.insert(line.clone());
+        changed.insert(line);
     }
 }
 
-fn state_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
-    cache_dir
-        .join("line-index-state-v1")
-        .join(format!("{}.msgpack", hex(&workspace)))
+type CompactedLines = (
+    Vec<String>,
+    Vec<u32>,
+    BTreeMap<String, StoredFileLines>,
+    FxHashSet<String>,
+);
+
+fn compact_lines(
+    registry: FxHashMap<String, u32>,
+    frequencies: Vec<u32>,
+    mut files: BTreeMap<String, StoredFileLines>,
+    changed_ids: &FxHashSet<u32>,
+) -> CompactedLines {
+    let mut by_id = (0..frequencies.len()).map(|_| None).collect::<Vec<_>>();
+    for (line, id) in registry {
+        if let Some(slot) = by_id.get_mut(id as usize) {
+            *slot = Some(line);
+        }
+    }
+    let changed_lines = changed_ids
+        .iter()
+        .filter_map(|id| by_id.get(*id as usize)?.as_ref().cloned())
+        .collect();
+    let mut remap = vec![u32::MAX; frequencies.len()];
+    let mut lines = Vec::new();
+    let mut compact_frequencies = Vec::new();
+    for (old_id, (line, frequency)) in by_id.into_iter().zip(frequencies).enumerate() {
+        if frequency == 0 {
+            continue;
+        }
+        remap[old_id] = lines.len() as u32;
+        lines.push(line.expect("every line id is registered"));
+        compact_frequencies.push(frequency);
+    }
+    for file in files.values_mut() {
+        for id in &mut file.unique_substantive {
+            *id = remap[*id as usize];
+        }
+    }
+    (lines, compact_frequencies, files, changed_lines)
 }
 
-fn manifest_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
-    cache_dir
-        .join("line-index-manifest-v1")
-        .join(format!("{}.msgpack", hex(&workspace)))
-}
-
-fn load_state(path: &Path) -> Option<LineIndexState> {
-    std::fs::read(path)
-        .ok()
+fn load_state(run: &CacheRun) -> Option<LineIndexState> {
+    run.load(STATE_SLOT, STATE_SCHEMA)
         .and_then(|bytes| rmp_serde::from_slice::<LineIndexState>(&bytes).ok())
-        .filter(|state| state.schema == STATE_SCHEMA)
+        .filter(|state| {
+            state.schema == STATE_SCHEMA
+                && state.lines.len() == state.document_frequency.len()
+                && state.files.values().all(|file| {
+                    file.unique_substantive
+                        .iter()
+                        .all(|id| (*id as usize) < state.lines.len())
+                })
+        })
 }
 
-fn load_manifest(path: &Path) -> Option<LineIndexManifest> {
-    std::fs::read(path)
-        .ok()
+fn load_manifest(run: &CacheRun) -> Option<LineIndexManifest> {
+    run.load(MANIFEST_SLOT, STATE_SCHEMA)
         .and_then(|bytes| rmp_serde::from_slice(&bytes).ok())
         .filter(|manifest: &LineIndexManifest| manifest.schema == STATE_SCHEMA)
 }
 
-fn store_manifest(path: &Path, manifest: &LineIndexManifest) {
-    store_bytes(path, rmp_serde::to_vec(manifest));
+fn store_manifest(run: &CacheRun, manifest: &LineIndexManifest) {
+    store_bytes(run, MANIFEST_SLOT, rmp_serde::to_vec(manifest));
 }
 
-fn store_state(path: &Path, state: &LineIndexState) {
-    store_bytes(path, rmp_serde::to_vec(state));
+fn store_state(run: &CacheRun, state: &LineIndexState) {
+    store_bytes(run, STATE_SLOT, rmp_serde::to_vec(state));
 }
 
-fn store_bytes(path: &Path, bytes: Result<Vec<u8>, rmp_serde::encode::Error>) {
-    let Some(parent) = path.parent() else { return };
-    if std::fs::create_dir_all(parent).is_err() {
-        return;
-    }
+fn store_bytes(run: &CacheRun, slot: &str, bytes: Result<Vec<u8>, rmp_serde::encode::Error>) {
     let Ok(bytes) = bytes else { return };
-    let temp = parent.join(format!(
-        ".{}.{}.tmp",
-        std::process::id(),
-        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-    ));
-    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
-        let _ = std::fs::remove_file(&temp);
-    }
+    run.store(slot, STATE_SCHEMA, &bytes);
 }
 
-fn hex(bytes: &[u8; 32]) -> String {
-    let mut out = String::with_capacity(64);
-    for byte in bytes {
-        use std::fmt::Write as _;
-        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn changed_file_updates_compact_dictionary_without_stale_lines() {
+        let root = std::env::temp_dir().join(format!(
+            "nose_line_index_{}_{}",
+            std::process::id(),
+            TEST_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let source = root.join("source");
+        let cache = root.join("cache");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&source).unwrap();
+        let a = source.join("a.py");
+        let b = source.join("b.py");
+        std::fs::write(&a, "shared\nold\n").unwrap();
+        std::fs::write(&b, "shared\nother\n").unwrap();
+        let run = CacheRun::new(&cache);
+        run.set_workspace([7; 32]);
+        let mut sources = vec![
+            CachedSourceFile {
+                path: a.to_string_lossy().into_owned(),
+                digest: [1; 32],
+            },
+            CachedSourceFile {
+                path: b.to_string_lossy().into_owned(),
+                digest: [2; 32],
+            },
+        ];
+        let (first, first_stats) = build_line_index(&run, &sources, true);
+        assert_eq!(first_stats.files_rebuilt, 2);
+        assert_eq!(first.document_frequency["shared"], 2);
+
+        std::fs::write(&a, "shared\nnew\n").unwrap();
+        sources[0].digest = [3; 32];
+        let (second, second_stats) = build_line_index(&run, &sources, false);
+        assert_eq!(second_stats.files_reused, 1);
+        assert_eq!(second_stats.files_rebuilt, 1);
+        assert_eq!(second.document_frequency["shared"], 2);
+        assert_eq!(second.document_frequency["new"], 1);
+        assert!(!second.document_frequency.contains_key("old"));
+        assert!(second.changed_lines.contains("old"));
+        assert!(second.changed_lines.contains("new"));
+        let _ = std::fs::remove_dir_all(&root);
     }
-    out
 }

--- a/crates/nose-cli/src/cache/portable_il.rs
+++ b/crates/nose-cli/src/cache/portable_il.rs
@@ -12,8 +12,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 
-const PORTABLE_IL_SCHEMA: u32 = 3;
+const PORTABLE_IL_SCHEMA: u32 = 4;
 const MAX_PORTABLE_IL_BYTES: usize = 512 * 1024 * 1024;
+const PORTABLE_ZSTD_LEVEL: i32 = 7;
 
 #[derive(Serialize, Deserialize)]
 struct PortableIl {
@@ -103,23 +104,30 @@ pub(super) fn encode(il: &Il, interner: &Interner) -> Result<Vec<u8>> {
     if bytes.len() > MAX_PORTABLE_IL_BYTES {
         bail!("portable IL exceeds the per-region cache safety limit");
     }
-    Ok(lz4_flex::compress_prepend_size(&bytes))
+    let compressed =
+        zstd::bulk::compress(&bytes, PORTABLE_ZSTD_LEVEL).context("compress portable IL")?;
+    let mut framed = Vec::with_capacity(8 + compressed.len());
+    framed.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+    framed.extend_from_slice(&compressed);
+    Ok(framed)
 }
 
 /// Restore an artifact into the caller's shared interner and current checkout.
 /// Invalid symbol ids, schema drift, or region corruption fail closed.
 pub(super) fn decode(bytes: &[u8], interner: &Interner, file: FileId, path: String) -> Result<Il> {
     let declared = bytes
-        .get(..4)
+        .get(..8)
         .and_then(|size| size.try_into().ok())
-        .map(u32::from_le_bytes)
-        .map(|size| size as usize)
-        .context("portable IL lacks an LZ4 size prefix")?;
-    if declared > MAX_PORTABLE_IL_BYTES {
+        .map(u64::from_be_bytes)
+        .context("portable IL lacks a decoded-size prefix")?;
+    if declared > MAX_PORTABLE_IL_BYTES as u64 {
         bail!("portable IL expands beyond the per-region safety limit");
     }
     let decompressed =
-        lz4_flex::decompress_size_prepended(bytes).context("decompress portable IL")?;
+        zstd::bulk::decompress(&bytes[8..], declared as usize).context("decompress portable IL")?;
+    if decompressed.len() != declared as usize {
+        bail!("portable IL decoded length does not match its prefix");
+    }
     let mut portable: PortableIl =
         rmp_serde::from_slice(&decompressed).context("deserialize portable IL")?;
     if portable.schema != PORTABLE_IL_SCHEMA {

--- a/crates/nose-cli/src/cache/resolved.rs
+++ b/crates/nose-cli/src/cache/resolved.rs
@@ -2,17 +2,16 @@ use super::digest::ContentDigest;
 use super::portable_il;
 use super::source::{RawCorpus, SourceIdentityKind};
 use super::store::{ArtifactKey, ArtifactStage, LayeredCas};
+use super::CacheRun;
 use nose_frontend::ResolutionDependency;
 use nose_il::Corpus;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 const EXPORT_DEPENDENCY_SCHEMA: u32 = 1;
-const RESOLVED_IL_SCHEMA: u32 = 3;
-static STATE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const RESOLVED_IL_SCHEMA: u32 = 4;
+const WORKSPACE_STATE_SCHEMA: u32 = 1;
 
 pub(crate) struct CachedCorpus {
     pub(crate) corpus: Corpus,
@@ -21,6 +20,7 @@ pub(crate) struct CachedCorpus {
     pub(crate) workspace_digest: [u8; 32],
     pub(crate) semantic_pack_digest: [u8; 32],
     pub(crate) source_files: Vec<super::CachedSourceFile>,
+    pub(crate) run: CacheRun,
 }
 
 #[derive(Debug, Serialize)]
@@ -110,18 +110,18 @@ type CorpusFile = nose_il::Il;
 
 pub(super) fn build_resolved_corpus_cached(
     mut raw: RawCorpus,
-    dir: &Path,
+    run: &CacheRun,
     semantic_pack_digest: ContentDigest,
 ) -> CachedCorpus {
     let workspace_digest = *raw.workspace_digest.as_bytes();
     let source_files = raw.source_files.clone();
-    let cas = LayeredCas::new(dir);
+    run.set_workspace(workspace_digest);
+    let cas = run.cas();
     let summary =
         nose_frontend::resolution_dependency_summary(&raw.corpus.files, &raw.corpus.interner);
     debug_assert_eq!(raw.corpus.files.len(), raw.regions.len());
     debug_assert_eq!(summary.files.len(), raw.regions.len());
-    let state_path = state_path(dir, raw.workspace_digest);
-    let previous_state = load_state(&state_path);
+    let previous_state = load_state(run);
     let current_state = workspace_state(&raw, &summary, semantic_pack_digest);
     store_dependency_summary(&cas, &raw, &summary);
     let resolved_keys = resolved_artifact_keys(&raw, &summary.files);
@@ -140,7 +140,7 @@ pub(super) fn build_resolved_corpus_cached(
         &current_state,
         semantic_pack_digest,
     );
-    store_state(&state_path, &current_state);
+    store_state(run, &current_state);
     CachedCorpus {
         unit_contexts: summary
             .files
@@ -152,6 +152,7 @@ pub(super) fn build_resolved_corpus_cached(
         workspace_digest,
         semantic_pack_digest: *semantic_pack_digest.as_bytes(),
         source_files,
+        run: run.clone(),
     }
 }
 
@@ -521,33 +522,17 @@ fn global_invalidations(
     out
 }
 
-fn state_path(dir: &Path, workspace: ContentDigest) -> PathBuf {
-    dir.join("state-v1")
-        .join(format!("{}.json", workspace.hex()))
+fn load_state(run: &CacheRun) -> Option<WorkspaceState> {
+    let bytes = run.load("resolved-workspace", WORKSPACE_STATE_SCHEMA)?;
+    let state = rmp_serde::from_slice::<WorkspaceState>(&bytes).ok()?;
+    (state.schema == WORKSPACE_STATE_SCHEMA).then_some(state)
 }
 
-fn load_state(path: &Path) -> Option<WorkspaceState> {
-    let bytes = std::fs::read(path).ok()?;
-    let state = serde_json::from_slice::<WorkspaceState>(&bytes).ok()?;
-    (state.schema == 1).then_some(state)
-}
-
-fn store_state(path: &Path, state: &WorkspaceState) {
-    let Some(parent) = path.parent() else { return };
-    if std::fs::create_dir_all(parent).is_err() {
-        return;
-    }
-    let Ok(bytes) = serde_json::to_vec(state) else {
+fn store_state(run: &CacheRun, state: &WorkspaceState) {
+    let Ok(bytes) = rmp_serde::to_vec(state) else {
         return;
     };
-    let temp = parent.join(format!(
-        ".{}.{}.tmp",
-        std::process::id(),
-        STATE_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-    ));
-    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
-        let _ = std::fs::remove_file(&temp);
-    }
+    run.store("resolved-workspace", WORKSPACE_STATE_SCHEMA, &bytes);
 }
 
 fn hex(bytes: [u8; 32]) -> String {

--- a/crates/nose-cli/src/cache/source.rs
+++ b/crates/nose-cli/src/cache/source.rs
@@ -1,7 +1,7 @@
 use super::digest::ContentDigest;
 use super::portable_il;
 use super::store::{ArtifactKey, ArtifactStage, LayeredCas};
-use super::CachedSourceFile;
+use super::{CacheRun, CachedSourceFile};
 use nose_il::{Corpus, FileId, Il, Interner, Lang};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const SOURCE_SNAPSHOT_SCHEMA: u32 = 1;
-const RAW_IL_SCHEMA: u32 = 3;
+const RAW_IL_SCHEMA: u32 = 4;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -63,11 +63,11 @@ struct SourceResult {
 pub(super) fn build_raw_corpus_cached(
     roots: &[&Path],
     exclude: &[String],
-    dir: &Path,
+    run: &CacheRun,
 ) -> RawCorpus {
     let paths = nose_frontend::discover_unique_paths(roots, exclude);
     let git = GitCatalog::new(roots);
-    let cas = LayeredCas::new(dir);
+    let cas = run.cas();
     let interner = Interner::new();
     let results = paths
         .par_iter()

--- a/crates/nose-cli/src/cache/store.rs
+++ b/crates/nose-cli/src/cache/store.rs
@@ -111,8 +111,13 @@ impl LayeredCas {
         })
     }
 
-    /// Publish a complete checksummed envelope. A successful return means the
-    /// payload and its directory entry have been synced before readers can see it.
+    /// Publish a complete checksummed envelope.
+    ///
+    /// The complete payload is written before the atomic rename. Neither the
+    /// immutable file nor its directory entry is individually synced: losing or
+    /// corrupting an entry in a machine crash is a verified cache miss, while
+    /// syncing thousands of objects serializes first-generation construction.
+    /// Mutable generation manifests retain the stronger sync boundary.
     pub(super) fn store(&self, key: ArtifactKey, payload: &[u8]) -> std::io::Result<u64> {
         if payload.len() > MAX_PAYLOAD_BYTES {
             return Err(std::io::Error::new(
@@ -128,10 +133,9 @@ impl LayeredCas {
         std::fs::create_dir_all(parent)?;
         let bytes = encode_envelope(key, payload);
         let temp = temporary_path(parent, &key.digest.hex());
-        write_synced(&temp, &bytes)?;
+        write_complete(&temp, &bytes)?;
         match publish(&temp, &target) {
             Ok(()) => {
-                sync_parent(parent)?;
                 let stored = bytes.len() as u64;
                 if let Some(counter) = &self.written_bytes {
                     counter.fetch_add(stored, Ordering::Relaxed);
@@ -180,9 +184,14 @@ pub(super) fn temporary_path(parent: &Path, suffix: &str) -> PathBuf {
 }
 
 pub(super) fn write_synced(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let file = write_complete(path, bytes)?;
+    file.sync_all()
+}
+
+fn write_complete(path: &Path, bytes: &[u8]) -> std::io::Result<File> {
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(bytes)?;
-    file.sync_all()
+    Ok(file)
 }
 
 #[cfg(unix)]

--- a/crates/nose-cli/src/cache/store.rs
+++ b/crates/nose-cli/src/cache/store.rs
@@ -1,16 +1,21 @@
 use super::digest::ContentDigest;
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
-const MAGIC: &[u8; 8] = b"NOSECAS1";
-const FORMAT_SCHEMA: u32 = 1;
-const HEADER_LEN: usize = 8 + 4 + 1 + 3 + 4 + 32 + 8 + 32;
+const MAGIC: &[u8; 8] = b"NOSECAS2";
+const FORMAT_SCHEMA: u32 = 2;
+const FLAG_ZSTD: u8 = 1;
+const ZSTD_LEVEL: i32 = 7;
+const HEADER_LEN: usize = 8 + 4 + 1 + 1 + 2 + 4 + 32 + 8 + 8 + 32;
+const MAX_PAYLOAD_BYTES: usize = 1024 * 1024 * 1024;
+const MAX_STORED_BYTES: u64 = MAX_PAYLOAD_BYTES as u64 + HEADER_LEN as u64;
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
-/// Stable layer ids. All six #873 stages share one envelope and address space;
-/// later issues can activate layers without inventing another storage format.
+/// Stable layer ids. The layer schema in each key evolves independently from
+/// the shared envelope schema.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub(super) enum ArtifactStage {
@@ -19,7 +24,7 @@ pub(super) enum ArtifactStage {
     ExportDependencySummary = 3,
     ResolvedIl = 4,
     UnitsSyntax = 5,
-    GlobalDetectionIndex = 6,
+    StateRecord = 6,
 }
 
 impl ArtifactStage {
@@ -30,7 +35,7 @@ impl ArtifactStage {
             3 => Self::ExportDependencySummary,
             4 => Self::ResolvedIl,
             5 => Self::UnitsSyntax,
-            6 => Self::GlobalDetectionIndex,
+            6 => Self::StateRecord,
             _ => return None,
         })
     }
@@ -42,7 +47,7 @@ impl ArtifactStage {
             Self::ExportDependencySummary => "export-dependency-summary",
             Self::ResolvedIl => "resolved-il",
             Self::UnitsSyntax => "units-syntax",
-            Self::GlobalDetectionIndex => "global-detection-index",
+            Self::StateRecord => "state-record",
         }
     }
 }
@@ -77,52 +82,62 @@ pub(super) struct CasRead {
 
 pub(super) struct LayeredCas {
     root: PathBuf,
+    written_bytes: Option<Arc<AtomicU64>>,
 }
 
 impl LayeredCas {
+    #[cfg(test)]
     pub(super) fn new(root: &Path) -> Self {
+        Self::tracked(root, None)
+    }
+
+    pub(super) fn with_write_counter(root: &Path, written_bytes: Arc<AtomicU64>) -> Self {
+        Self::tracked(root, Some(written_bytes))
+    }
+
+    fn tracked(root: &Path, written_bytes: Option<Arc<AtomicU64>>) -> Self {
         Self {
-            root: root.join("cas-v1"),
+            root: root.join("cas-v2"),
+            written_bytes,
         }
     }
 
     pub(super) fn load(&self, key: ArtifactKey) -> Option<CasRead> {
-        let bytes = std::fs::read(self.path(key)).ok()?;
-        let stored_bytes = bytes.len() as u64;
-        let payload = validate_envelope(&bytes, key)?;
+        let path = self.path(key);
+        let (payload, stored_bytes) = read_envelope_file(&path, key)?;
         Some(CasRead {
-            payload: payload.to_vec(),
+            payload,
             stored_bytes,
         })
     }
 
-    /// Atomically publish a complete checksummed envelope. An invalid existing
-    /// entry is replaced; readers that race the rename see either complete file.
+    /// Publish a complete checksummed envelope. A successful return means the
+    /// payload and its directory entry have been synced before readers can see it.
     pub(super) fn store(&self, key: ArtifactKey, payload: &[u8]) -> std::io::Result<u64> {
-        if let Some(existing) = self.load(key) {
-            let _ = existing;
+        if payload.len() > MAX_PAYLOAD_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "cache payload exceeds the decoded-size limit",
+            ));
+        }
+        if self.load(key).is_some() {
             return Ok(0);
         }
         let target = self.path(key);
         let parent = target.parent().expect("CAS entries always have a parent");
         std::fs::create_dir_all(parent)?;
-        let bytes = envelope(key, payload);
-        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-        let temp = parent.join(format!(
-            ".{}.{}.{}.tmp",
-            std::process::id(),
-            sequence,
-            key.digest.hex()
-        ));
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp)?;
-        file.write_all(&bytes)?;
-        file.flush()?;
-        drop(file);
+        let bytes = encode_envelope(key, payload);
+        let temp = temporary_path(parent, &key.digest.hex());
+        write_synced(&temp, &bytes)?;
         match publish(&temp, &target) {
-            Ok(()) => Ok(bytes.len() as u64),
+            Ok(()) => {
+                sync_parent(parent)?;
+                let stored = bytes.len() as u64;
+                if let Some(counter) = &self.written_bytes {
+                    counter.fetch_add(stored, Ordering::Relaxed);
+                }
+                Ok(stored)
+            }
             Err(error) => {
                 let _ = std::fs::remove_file(&temp);
                 Err(error)
@@ -139,60 +154,134 @@ impl LayeredCas {
     }
 }
 
+pub(super) fn read_envelope_file(path: &Path, key: ArtifactKey) -> Option<(Vec<u8>, u64)> {
+    let stored_bytes = std::fs::metadata(path).ok()?.len();
+    if stored_bytes > MAX_STORED_BYTES {
+        warn_corrupt(path, "stored length exceeds the cache limit");
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    match decode_envelope(&bytes, key) {
+        Some(payload) => Some((payload, stored_bytes)),
+        None => {
+            warn_corrupt(path, "invalid header, checksum, or compressed payload");
+            None
+        }
+    }
+}
+
+pub(super) fn temporary_path(parent: &Path, suffix: &str) -> PathBuf {
+    parent.join(format!(
+        ".{}.{}.{}.tmp",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        suffix
+    ))
+}
+
+pub(super) fn write_synced(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
+}
+
 #[cfg(unix)]
-fn publish(temp: &Path, target: &Path) -> std::io::Result<()> {
-    // POSIX rename replaces atomically: concurrent readers never observe a
-    // partially written envelope, and concurrent writers of one key converge.
+pub(super) fn sync_parent(parent: &Path) -> std::io::Result<()> {
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+pub(super) fn sync_parent(_parent: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(super) fn publish(temp: &Path, target: &Path) -> std::io::Result<()> {
+    // POSIX replacement is atomic. Concurrent writers of one content key
+    // converge on identical bytes.
     std::fs::rename(temp, target)
 }
 
 #[cfg(not(unix))]
-fn publish(temp: &Path, target: &Path) -> std::io::Result<()> {
-    // `rename` cannot replace on every supported non-Unix filesystem. A racing
-    // reader may conservatively miss during this repair window, but can never
-    // consume partial bytes because `temp` was fully synced first.
+pub(super) fn publish(temp: &Path, target: &Path) -> std::io::Result<()> {
     if target.exists() {
         std::fs::remove_file(target)?;
     }
     std::fs::rename(temp, target)
 }
 
-fn envelope(key: ArtifactKey, payload: &[u8]) -> Vec<u8> {
+pub(super) fn encode_envelope(key: ArtifactKey, payload: &[u8]) -> Vec<u8> {
+    // Portable IL regions already carry independently bounded Zstandard frames.
+    // Recompressing their bundle raises cold latency and warm peak memory without
+    // materially shrinking it.
+    let compressed = (!matches!(key.stage, ArtifactStage::RawIl | ArtifactStage::ResolvedIl))
+        .then(|| zstd::bulk::compress(payload, ZSTD_LEVEL).ok())
+        .flatten();
+    let (flags, stored) = if compressed
+        .as_ref()
+        .is_some_and(|compressed| compressed.len() < payload.len())
+    {
+        (FLAG_ZSTD, compressed.as_deref().unwrap_or_default())
+    } else {
+        (0, payload)
+    };
     let checksum = ContentDigest::sha256(payload);
-    let mut bytes = Vec::with_capacity(HEADER_LEN + payload.len());
+    let mut bytes = Vec::with_capacity(HEADER_LEN + stored.len());
     bytes.extend_from_slice(MAGIC);
     bytes.extend_from_slice(&FORMAT_SCHEMA.to_be_bytes());
     bytes.push(key.stage as u8);
-    bytes.extend_from_slice(&[0; 3]);
+    bytes.push(flags);
+    bytes.extend_from_slice(&[0; 2]);
     bytes.extend_from_slice(&key.schema.to_be_bytes());
     bytes.extend_from_slice(key.digest.as_bytes());
+    bytes.extend_from_slice(&(stored.len() as u64).to_be_bytes());
     bytes.extend_from_slice(&(payload.len() as u64).to_be_bytes());
     bytes.extend_from_slice(checksum.as_bytes());
-    bytes.extend_from_slice(payload);
+    bytes.extend_from_slice(stored);
     bytes
 }
 
-fn validate_envelope(bytes: &[u8], key: ArtifactKey) -> Option<&[u8]> {
+pub(super) fn decode_envelope(bytes: &[u8], key: ArtifactKey) -> Option<Vec<u8>> {
     if bytes.len() < HEADER_LEN || &bytes[..8] != MAGIC {
         return None;
     }
     let format = u32::from_be_bytes(bytes[8..12].try_into().ok()?);
     let stage = ArtifactStage::from_code(bytes[12])?;
+    let flags = bytes[13];
     let schema = u32::from_be_bytes(bytes[16..20].try_into().ok()?);
     let digest = ContentDigest::from_bytes(bytes[20..52].try_into().ok()?);
-    let payload_len = u64::from_be_bytes(bytes[52..60].try_into().ok()?);
-    let checksum = ContentDigest::from_bytes(bytes[60..92].try_into().ok()?);
+    let stored_len = u64::from_be_bytes(bytes[52..60].try_into().ok()?);
+    let payload_len = u64::from_be_bytes(bytes[60..68].try_into().ok()?);
+    let checksum = ContentDigest::from_bytes(bytes[68..100].try_into().ok()?);
     if format != FORMAT_SCHEMA
         || stage != key.stage
         || schema != key.schema
         || digest != key.digest
-        || payload_len > usize::MAX as u64
-        || HEADER_LEN.checked_add(payload_len as usize)? != bytes.len()
+        || flags & !FLAG_ZSTD != 0
+        || stored_len > MAX_STORED_BYTES
+        || payload_len > MAX_PAYLOAD_BYTES as u64
+        || HEADER_LEN.checked_add(stored_len as usize)? != bytes.len()
     {
         return None;
     }
-    let payload = &bytes[HEADER_LEN..];
-    (ContentDigest::sha256(payload) == checksum).then_some(payload)
+    let stored = &bytes[HEADER_LEN..];
+    let payload = if flags & FLAG_ZSTD != 0 {
+        zstd::bulk::decompress(stored, payload_len as usize).ok()?
+    } else {
+        if stored_len != payload_len {
+            return None;
+        }
+        stored.to_vec()
+    };
+    (payload.len() == payload_len as usize && ContentDigest::sha256(&payload) == checksum)
+        .then_some(payload)
+}
+
+fn warn_corrupt(path: &Path, reason: &str) {
+    eprintln!(
+        "warning: ignoring corrupt cache entry {}: {reason}; recomputing",
+        path.display()
+    );
 }
 
 #[cfg(test)]
@@ -215,7 +304,7 @@ mod tests {
             ArtifactStage::ExportDependencySummary,
             ArtifactStage::ResolvedIl,
             ArtifactStage::UnitsSyntax,
-            ArtifactStage::GlobalDetectionIndex,
+            ArtifactStage::StateRecord,
         ];
         let keys = stages.map(|stage| ArtifactKey::derive(stage, 1, &[b"same content"]));
         for (index, key) in keys.iter().enumerate() {
@@ -224,7 +313,16 @@ mod tests {
     }
 
     #[test]
-    fn corruption_and_truncation_are_cache_misses() {
+    fn compression_and_round_trip_preserve_payload() {
+        let key = ArtifactKey::derive(ArtifactStage::UnitsSyntax, 3, &[b"input"]);
+        let payload = vec![7; 64 * 1024];
+        let bytes = encode_envelope(key, &payload);
+        assert!(bytes.len() < payload.len() / 4);
+        assert_eq!(decode_envelope(&bytes, key), Some(payload));
+    }
+
+    #[test]
+    fn corruption_truncation_and_oversized_lengths_are_cache_misses() {
         let root = temp_store("corruption");
         let _ = std::fs::remove_dir_all(&root);
         let cas = LayeredCas::new(&root);
@@ -243,6 +341,10 @@ mod tests {
         truncated.truncate(HEADER_LEN + 3);
         std::fs::write(&path, truncated).unwrap();
         assert!(cas.load(key).is_none());
+
+        let mut oversized = encode_envelope(key, b"small");
+        oversized[60..68].copy_from_slice(&((MAX_PAYLOAD_BYTES as u64) + 1).to_be_bytes());
+        assert!(decode_envelope(&oversized, key).is_none());
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/nose-cli/src/cache/transaction.rs
+++ b/crates/nose-cli/src/cache/transaction.rs
@@ -1,0 +1,479 @@
+//! Transactional mutable cache generations.
+//!
+//! Immutable records are written first. A generation manifest names a complete
+//! set of records, and `CURRENT` is atomically replaced last. Readers therefore
+//! see either the previous complete generation or the new complete generation.
+
+use super::digest::ContentDigest;
+use super::store::{
+    encode_envelope, publish, read_envelope_file, sync_parent, temporary_path, write_synced,
+    ArtifactKey, ArtifactStage, LayeredCas,
+};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+const GENERATION_SCHEMA: u32 = 1;
+const POINTER_SCHEMA: u32 = 1;
+const MAX_POINTER_BYTES: u64 = 64 * 1024;
+
+#[derive(Clone)]
+pub(crate) struct CacheRun {
+    root: PathBuf,
+    max_bytes: u64,
+    written_bytes: Arc<AtomicU64>,
+    inner: Arc<Mutex<RunState>>,
+    // Keep pruning and clearing out of the interval between publishing an
+    // immutable record and committing the generation that references it.
+    _store_lease: Option<Arc<File>>,
+}
+
+#[derive(Default)]
+struct RunState {
+    workspace: Option<[u8; 32]>,
+    base: GenerationManifest,
+    pending: BTreeMap<String, StateRecordRef>,
+}
+
+#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct GenerationManifest {
+    schema: u32,
+    workspace: [u8; 32],
+    sequence: u64,
+    records: BTreeMap<String, StateRecordRef>,
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+struct StateRecordRef {
+    schema: u32,
+    digest: [u8; 32],
+}
+
+#[derive(Deserialize, Serialize)]
+struct CurrentPointer {
+    schema: u32,
+    generation: String,
+    manifest_digest: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommitFault {
+    BeforeManifest,
+    AfterManifest,
+    BeforeCurrent,
+}
+
+impl CacheRun {
+    #[cfg(test)]
+    pub(crate) fn new(root: &Path) -> Self {
+        Self::with_limit(root, super::admin::DEFAULT_MAX_BYTES)
+    }
+
+    pub(crate) fn with_limit(root: &Path, max_bytes: u64) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            max_bytes,
+            written_bytes: Arc::new(AtomicU64::new(0)),
+            inner: Arc::new(Mutex::new(RunState::default())),
+            _store_lease: shared_store_lease(root).map(Arc::new),
+        }
+    }
+
+    pub(super) fn cas(&self) -> LayeredCas {
+        LayeredCas::with_write_counter(&self.root, Arc::clone(&self.written_bytes))
+    }
+
+    pub(crate) fn set_workspace(&self, workspace: [u8; 32]) {
+        let mut inner = self.inner.lock().expect("cache run mutex poisoned");
+        if let Some(existing) = inner.workspace {
+            debug_assert_eq!(existing, workspace);
+            return;
+        }
+        inner.workspace = Some(workspace);
+        inner.base = load_current(&self.root, workspace).unwrap_or_else(|| GenerationManifest {
+            schema: GENERATION_SCHEMA,
+            workspace,
+            ..GenerationManifest::default()
+        });
+    }
+
+    pub(crate) fn load(&self, slot: &str, schema: u32) -> Option<Vec<u8>> {
+        let (workspace, record) = {
+            let inner = self.inner.lock().expect("cache run mutex poisoned");
+            let workspace = inner.workspace?;
+            let record = inner
+                .pending
+                .get(slot)
+                .or_else(|| inner.base.records.get(slot))?
+                .clone();
+            (workspace, record)
+        };
+        if record.schema != schema {
+            return None;
+        }
+        let key = record_key(record.schema, record.digest);
+        let path = record_path(&self.root, workspace, record.digest);
+        read_envelope_file(&path, key).map(|(payload, _)| payload)
+    }
+
+    pub(crate) fn store(&self, slot: &str, schema: u32, payload: &[u8]) {
+        let workspace = {
+            let inner = self.inner.lock().expect("cache run mutex poisoned");
+            let Some(workspace) = inner.workspace else {
+                return;
+            };
+            workspace
+        };
+        let key = ArtifactKey::derive(
+            ArtifactStage::StateRecord,
+            schema,
+            &[&workspace, slot.as_bytes(), payload],
+        );
+        let path = record_path(&self.root, workspace, *key.digest.as_bytes());
+        if read_envelope_file(&path, key).is_none() {
+            let Some(parent) = path.parent() else { return };
+            if std::fs::create_dir_all(parent).is_err() {
+                return;
+            }
+            let bytes = encode_envelope(key, payload);
+            let temp = temporary_path(parent, &key.digest.hex());
+            if write_synced(&temp, &bytes).is_err() {
+                let _ = std::fs::remove_file(&temp);
+                return;
+            }
+            if publish(&temp, &path).is_err() || sync_parent(parent).is_err() {
+                let _ = std::fs::remove_file(&temp);
+                return;
+            }
+            self.written_bytes
+                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+        }
+        let mut inner = self.inner.lock().expect("cache run mutex poisoned");
+        let record = StateRecordRef {
+            schema,
+            digest: *key.digest.as_bytes(),
+        };
+        if inner
+            .pending
+            .get(slot)
+            .or_else(|| inner.base.records.get(slot))
+            == Some(&record)
+        {
+            return;
+        }
+        inner.pending.insert(slot.to_owned(), record);
+    }
+
+    pub(crate) fn commit(&self) -> std::io::Result<()> {
+        self.commit_inner(None)
+    }
+
+    pub(crate) fn written_bytes(&self) -> u64 {
+        self.written_bytes.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(super) fn max_bytes(&self) -> u64 {
+        self.max_bytes
+    }
+
+    fn commit_inner(&self, fault: Option<CommitFault>) -> std::io::Result<()> {
+        let (workspace, pending) = {
+            let inner = self.inner.lock().expect("cache run mutex poisoned");
+            let Some(workspace) = inner.workspace else {
+                return Ok(());
+            };
+            if inner.pending.is_empty() {
+                return Ok(());
+            }
+            (workspace, inner.pending.clone())
+        };
+        let workspace_dir = workspace_dir(&self.root, workspace);
+        std::fs::create_dir_all(&workspace_dir)?;
+        let lock = open_lock(&workspace_dir)?;
+        FileExt::lock_exclusive(&lock)?;
+
+        let mut next = load_current(&self.root, workspace).unwrap_or_else(|| GenerationManifest {
+            schema: GENERATION_SCHEMA,
+            workspace,
+            ..GenerationManifest::default()
+        });
+        next.sequence = next.sequence.saturating_add(1);
+        next.records.extend(pending);
+        inject(fault, CommitFault::BeforeManifest)?;
+        let (generation, manifest_digest) = write_manifest(&self.root, &next)?;
+        inject(fault, CommitFault::AfterManifest)?;
+        inject(fault, CommitFault::BeforeCurrent)?;
+        write_current(&self.root, workspace, &generation, manifest_digest)?;
+
+        let mut inner = self.inner.lock().expect("cache run mutex poisoned");
+        inner.base = next;
+        inner.pending.clear();
+        Ok(())
+    }
+}
+
+fn shared_store_lease(root: &Path) -> Option<File> {
+    std::fs::create_dir_all(root).ok()?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(".nose-cache.lock"))
+        .ok()?;
+    FileExt::lock_shared(&file).ok()?;
+    Some(file)
+}
+
+fn inject(actual: Option<CommitFault>, expected: CommitFault) -> std::io::Result<()> {
+    if actual == Some(expected) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            format!("injected cache commit interruption at {expected:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn open_lock(workspace_dir: &Path) -> std::io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(workspace_dir.join("LOCK"))
+}
+
+fn load_current(root: &Path, workspace: [u8; 32]) -> Option<GenerationManifest> {
+    load_current_named(root, workspace).map(|(manifest, _)| manifest)
+}
+
+fn load_current_named(root: &Path, workspace: [u8; 32]) -> Option<(GenerationManifest, String)> {
+    let pointer_path = workspace_dir(root, workspace).join("CURRENT");
+    if std::fs::metadata(&pointer_path).ok()?.len() > MAX_POINTER_BYTES {
+        eprintln!(
+            "warning: ignoring oversized cache generation pointer {}; recomputing",
+            pointer_path.display()
+        );
+        return None;
+    }
+    let pointer_key = pointer_key(workspace);
+    let (payload, _) = read_envelope_file(&pointer_path, pointer_key)?;
+    let pointer = rmp_serde::from_slice::<CurrentPointer>(&payload).ok()?;
+    if pointer.schema != POINTER_SCHEMA {
+        return None;
+    }
+    let key = record_key(GENERATION_SCHEMA, pointer.manifest_digest);
+    let path = workspace_dir(root, workspace)
+        .join("generations")
+        .join(&pointer.generation);
+    let (payload, _) = read_envelope_file(&path, key)?;
+    let manifest = rmp_serde::from_slice::<GenerationManifest>(&payload).ok()?;
+    (manifest.schema == GENERATION_SCHEMA && manifest.workspace == workspace)
+        .then_some((manifest, pointer.generation))
+}
+
+pub(super) fn live_state_paths(root: &Path) -> std::collections::BTreeSet<PathBuf> {
+    let mut live = std::collections::BTreeSet::new();
+    let state_root = root.join("state-v2");
+    let Ok(workspaces) = std::fs::read_dir(&state_root) else {
+        return live;
+    };
+    for workspace in workspaces.flatten() {
+        let Ok(workspace_bytes) = parse_hex_32(&workspace.file_name().to_string_lossy()) else {
+            continue;
+        };
+        let Some((manifest, generation)) = load_current_named(root, workspace_bytes) else {
+            continue;
+        };
+        let dir = workspace.path();
+        live.insert(dir.join("CURRENT"));
+        live.insert(dir.join("generations").join(generation));
+        for record in manifest.records.values() {
+            live.insert(record_path(root, workspace_bytes, record.digest));
+        }
+    }
+    live
+}
+
+fn write_manifest(
+    root: &Path,
+    manifest: &GenerationManifest,
+) -> std::io::Result<(String, [u8; 32])> {
+    let payload = rmp_serde::to_vec(manifest).map_err(invalid_data)?;
+    let key = ArtifactKey::derive(
+        ArtifactStage::StateRecord,
+        GENERATION_SCHEMA,
+        &[&manifest.workspace, b"generation", &payload],
+    );
+    let generation = format!("{:020}-{}.manifest", manifest.sequence, key.digest.hex());
+    let dir = workspace_dir(root, manifest.workspace).join("generations");
+    std::fs::create_dir_all(&dir)?;
+    let target = dir.join(&generation);
+    if read_envelope_file(&target, key).is_none() {
+        let bytes = encode_envelope(key, &payload);
+        let temp = temporary_path(&dir, &key.digest.hex());
+        write_synced(&temp, &bytes)?;
+        publish(&temp, &target)?;
+        sync_parent(&dir)?;
+    }
+    Ok((generation, *key.digest.as_bytes()))
+}
+
+fn write_current(
+    root: &Path,
+    workspace: [u8; 32],
+    generation: &str,
+    manifest_digest: [u8; 32],
+) -> std::io::Result<()> {
+    let pointer = CurrentPointer {
+        schema: POINTER_SCHEMA,
+        generation: generation.to_owned(),
+        manifest_digest,
+    };
+    let payload = rmp_serde::to_vec(&pointer).map_err(invalid_data)?;
+    let key = pointer_key(workspace);
+    let bytes = encode_envelope(key, &payload);
+    let dir = workspace_dir(root, workspace);
+    let target = dir.join("CURRENT");
+    let temp = temporary_path(&dir, "CURRENT");
+    write_synced(&temp, &bytes)?;
+    publish(&temp, &target)?;
+    sync_parent(&dir)
+}
+
+fn pointer_key(workspace: [u8; 32]) -> ArtifactKey {
+    ArtifactKey::derive(
+        ArtifactStage::StateRecord,
+        POINTER_SCHEMA,
+        &[&workspace, b"CURRENT"],
+    )
+}
+
+fn record_key(schema: u32, digest: [u8; 32]) -> ArtifactKey {
+    ArtifactKey {
+        stage: ArtifactStage::StateRecord,
+        schema,
+        digest: ContentDigest::from_bytes(digest),
+    }
+}
+
+fn workspace_dir(root: &Path, workspace: [u8; 32]) -> PathBuf {
+    root.join("state-v2").join(hex(&workspace))
+}
+
+fn record_path(root: &Path, workspace: [u8; 32], digest: [u8; 32]) -> PathBuf {
+    let hex = hex(&digest);
+    workspace_dir(root, workspace)
+        .join("objects")
+        .join(&hex[..2])
+        .join(format!("{}.state", &hex[2..]))
+}
+
+fn invalid_data(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn hex(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}
+
+fn parse_hex_32(text: &str) -> Result<[u8; 32], ()> {
+    if text.len() != 64 {
+        return Err(());
+    }
+    let mut out = [0; 32];
+    for (index, pair) in text.as_bytes().chunks_exact(2).enumerate() {
+        let pair = std::str::from_utf8(pair).map_err(|_| ())?;
+        out[index] = u8::from_str_radix(pair, 16).map_err(|_| ())?;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_store(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "nose_generation_{label}_{}_{}",
+            std::process::id(),
+            TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn interruption_at_every_commit_stage_keeps_the_previous_generation_visible() {
+        for fault in [
+            CommitFault::BeforeManifest,
+            CommitFault::AfterManifest,
+            CommitFault::BeforeCurrent,
+        ] {
+            let root = temp_store("fault");
+            let _ = std::fs::remove_dir_all(&root);
+            let first = CacheRun::new(&root);
+            first.set_workspace([3; 32]);
+            first.store("line-index", 1, b"old");
+            first.commit().unwrap();
+
+            let interrupted = CacheRun::new(&root);
+            interrupted.set_workspace([3; 32]);
+            interrupted.store("line-index", 1, b"new");
+            assert!(interrupted.commit_inner(Some(fault)).is_err());
+
+            let reader = CacheRun::new(&root);
+            reader.set_workspace([3; 32]);
+            assert_eq!(
+                reader.load("line-index", 1).as_deref(),
+                Some(b"old".as_slice())
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn concurrent_commits_merge_disjoint_slots() {
+        let root = temp_store("merge");
+        let _ = std::fs::remove_dir_all(&root);
+        let first = CacheRun::new(&root);
+        let second = CacheRun::new(&root);
+        first.set_workspace([4; 32]);
+        second.set_workspace([4; 32]);
+        first.store("a", 1, b"alpha");
+        second.store("b", 1, b"beta");
+        first.commit().unwrap();
+        second.commit().unwrap();
+
+        let reader = CacheRun::new(&root);
+        reader.set_workspace([4; 32]);
+        assert_eq!(reader.load("a", 1).as_deref(), Some(b"alpha".as_slice()));
+        assert_eq!(reader.load("b", 1).as_deref(), Some(b"beta".as_slice()));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn state_schema_mismatch_is_a_cache_miss() {
+        let root = temp_store("schema");
+        let writer = CacheRun::new(&root);
+        writer.set_workspace([5; 32]);
+        writer.store("family-lines", 1, b"payload");
+        writer.commit().unwrap();
+        assert!(writer.load("family-lines", 2).is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/nose-cli/src/cache_commands.rs
+++ b/crates/nose-cli/src/cache_commands.rs
@@ -1,0 +1,54 @@
+use crate::cli_args::{CacheCmd, StatsFormat};
+use anyhow::Result;
+
+pub(crate) fn run(cmd: CacheCmd) -> Result<()> {
+    match cmd {
+        CacheCmd::Status {
+            dir,
+            max_bytes,
+            format,
+        } => {
+            let report = crate::cache::store_status(&dir, max_bytes);
+            if format == StatsFormat::Json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                println!("cache: {}", report.root);
+                println!("size: {} bytes in {} files", report.bytes, report.files);
+                println!("limit: {} bytes", report.max_bytes);
+                println!(
+                    "generations: {} active / {} total",
+                    report.active_generations, report.generations
+                );
+                println!(
+                    "reclaimable: {} bytes in {} files",
+                    report.reclaimable_bytes, report.reclaimable_files
+                );
+            }
+            Ok(())
+        }
+        CacheCmd::Prune {
+            dir,
+            max_bytes,
+            format,
+        } => {
+            let report = crate::cache::prune_store(&dir, max_bytes)?;
+            print_mutation(&report, format)
+        }
+        CacheCmd::Clear { dir, format } => {
+            let report = crate::cache::clear_store(&dir)?;
+            print_mutation(&report, format)
+        }
+    }
+}
+
+fn print_mutation(report: &crate::cache::PruneReport, format: StatsFormat) -> Result<()> {
+    if format == StatsFormat::Json {
+        println!("{}", serde_json::to_string_pretty(report)?);
+    } else {
+        println!(
+            "removed {} bytes in {} files; cache is now {} bytes",
+            report.removed_bytes, report.removed_files, report.after_bytes
+        );
+    }
+    Ok(())
+}

--- a/crates/nose-cli/src/capabilities.rs
+++ b/crates/nose-cli/src/capabilities.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-const CAPABILITIES_SCHEMA_VERSION: u32 = 7;
+const CAPABILITIES_SCHEMA_VERSION: u32 = 8;
 
 #[derive(serde::Serialize)]
 struct Report {
@@ -45,6 +45,9 @@ struct Commands {
 #[derive(serde::Serialize)]
 struct Schemas {
     capabilities: Vec<u32>,
+    cache_status: Vec<&'static str>,
+    cache_prune: Vec<&'static str>,
+    cache_clear: Vec<&'static str>,
     query_json: Vec<u32>,
     semantic_packs: Vec<&'static str>,
     semantic_pack_locks: Vec<&'static str>,
@@ -120,7 +123,14 @@ impl Report {
                 doctor_json: false,
             },
             commands: Commands {
-                stable: vec!["capabilities", "il", "query", "semantic-pack", "stats"],
+                stable: vec![
+                    "cache",
+                    "capabilities",
+                    "il",
+                    "query",
+                    "semantic-pack",
+                    "stats",
+                ],
                 deprecated: Vec::new(),
             },
             schemas: current_schemas(),
@@ -130,6 +140,7 @@ impl Report {
                 output_formats: vec!["human", "json", "markdown", "sarif"],
                 sort_keys: vec!["extractability", "value", "sites", "hazard"],
                 config_keys: vec![
+                    "cache-max-bytes",
                     "exclude",
                     "generated-paths",
                     "ignore-file",
@@ -160,6 +171,9 @@ impl Report {
 fn current_schemas() -> Schemas {
     Schemas {
         capabilities: vec![CAPABILITIES_SCHEMA_VERSION],
+        cache_status: vec!["nose.cache-status/v1"],
+        cache_prune: vec!["nose.cache-prune/v1"],
+        cache_clear: vec!["nose.cache-clear/v1"],
         query_json: vec![
             crate::schema_versions::QUERY_BASE_JSON_SCHEMA_VERSION,
             crate::schema_versions::QUERY_JSON_SCHEMA_VERSION,

--- a/crates/nose-cli/src/cli_args.rs
+++ b/crates/nose-cli/src/cli_args.rs
@@ -130,6 +130,9 @@ pub(crate) enum Cmd {
         /// Cache per-file analysis under this directory; re-runs reuse it for unchanged files.
         #[arg(long, value_name = "DIR")]
         cache_dir: Option<PathBuf>,
+        /// Maximum managed cache size; accepts byte counts or KiB/MiB/GiB suffixes. [default: 5GiB]
+        #[arg(long, value_name = "SIZE", requires = "cache_dir", value_parser = parse_byte_size)]
+        cache_max_bytes: Option<u64>,
         /// Structured-ignore file for suppressed families; auto-read `nose.ignore.json` when present.
         #[arg(long, value_name = "FILE")]
         ignore_file: Option<PathBuf>,
@@ -224,6 +227,11 @@ pub(crate) enum Cmd {
     },
     /// Emit the machine-readable capability contract for integrations.
     Capabilities,
+    /// Inspect or reclaim an incremental analysis cache.
+    Cache {
+        #[command(subcommand)]
+        cmd: CacheCmd,
+    },
     /// Validate semantic-pack v0 manifests/fixtures or compile typed v1 manifests.
     #[command(name = "semantic-pack")]
     SemanticPack {
@@ -345,6 +353,35 @@ pub(crate) enum Cmd {
 }
 
 #[derive(Subcommand)]
+pub(crate) enum CacheCmd {
+    /// Report active, historical, and reclaimable cache storage.
+    Status {
+        #[arg(long, value_name = "DIR")]
+        dir: PathBuf,
+        #[arg(long, default_value = "5GiB", value_name = "SIZE", value_parser = parse_byte_size)]
+        max_bytes: u64,
+        #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
+        format: StatsFormat,
+    },
+    /// Remove old schemas, orphaned generations, and entries beyond the size limit.
+    Prune {
+        #[arg(long, value_name = "DIR")]
+        dir: PathBuf,
+        #[arg(long, default_value = "5GiB", value_name = "SIZE", value_parser = parse_byte_size)]
+        max_bytes: u64,
+        #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
+        format: StatsFormat,
+    },
+    /// Remove every nose-managed entry while preserving unrelated files in the directory.
+    Clear {
+        #[arg(long, value_name = "DIR")]
+        dir: PathBuf,
+        #[arg(long, value_enum, default_value_t = StatsFormat::Human)]
+        format: StatsFormat,
+    },
+}
+
+#[derive(Subcommand)]
 pub(crate) enum SemanticPackCmd {
     /// Check local semantic-pack v0 manifests or compile typed v1 manifests.
     Check {
@@ -445,6 +482,7 @@ pub(crate) struct QueryArgs {
     pub(crate) config: Option<PathBuf>,
     pub(crate) mode: Vec<DetectionMode>,
     pub(crate) cache_dir: Option<PathBuf>,
+    pub(crate) cache_max_bytes: Option<u64>,
     pub(crate) fail_on: Option<FailOn>,
     pub(crate) baseline: Option<PathBuf>,
     pub(crate) ignore_file: Option<PathBuf>,
@@ -457,6 +495,32 @@ pub(crate) struct QueryArgs {
     pub(crate) min_size: Option<usize>,
     pub(crate) min_lines: Option<u32>,
     pub(crate) scope: ScopeFilter,
+}
+
+fn parse_byte_size(value: &str) -> Result<u64, String> {
+    let trimmed = value.trim();
+    let split = trimmed
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (number, suffix) = trimmed.split_at(split);
+    let number = number
+        .parse::<u64>()
+        .map_err(|_| format!("invalid cache size `{value}`"))?;
+    let multiplier = match suffix.to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "kib" => 1024,
+        "mib" => 1024 * 1024,
+        "gib" => 1024 * 1024 * 1024,
+        "tib" => 1024_u64.pow(4),
+        _ => {
+            return Err(format!(
+                "invalid cache size suffix in `{value}`; use B, KiB, MiB, GiB, or TiB"
+            ))
+        }
+    };
+    number
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("cache size `{value}` is too large"))
 }
 
 /// `--scope`: which test-boundary side of the report to keep. An explicit
@@ -482,5 +546,18 @@ impl ScopeFilter {
             ScopeFilter::Prod => family.scope != "test",
             ScopeFilter::Test => family.scope == "test",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_byte_size;
+
+    #[test]
+    fn cache_sizes_accept_exact_binary_units_and_reject_ambiguous_suffixes() {
+        assert_eq!(parse_byte_size("512").unwrap(), 512);
+        assert_eq!(parse_byte_size("2GiB").unwrap(), 2 * 1024 * 1024 * 1024);
+        assert!(parse_byte_size("2GB").is_err());
+        assert!(parse_byte_size("18446744073709551615TiB").is_err());
     }
 }

--- a/crates/nose-cli/src/command_dispatch.rs
+++ b/crates/nose-cli/src/command_dispatch.rs
@@ -28,6 +28,7 @@ pub(crate) fn run() -> Result<()> {
             no_cfg_norm,
         } => cmd_il(path, format, normalized, no_cfg_norm),
         Cmd::Capabilities => capabilities::print(),
+        Cmd::Cache { cmd } => crate::cache_commands::run(cmd),
         Cmd::SemanticPack { cmd } => match cmd {
             SemanticPackCmd::Check {
                 paths,

--- a/crates/nose-cli/src/config.rs
+++ b/crates/nose-cli/src/config.rs
@@ -14,6 +14,7 @@
 //! ignore-file = "nose.ignore.json"
 //! semantic-packs = ["semantic-packs/python-math-prod.json"]
 //! semantic-pack-lock = "nose.semantic-pack-lock.json"
+//! cache-max-bytes = 5368709120
 //! ```
 
 use serde::Deserialize;
@@ -42,6 +43,8 @@ pub(crate) struct QueryConfig {
     pub semantic_packs: Vec<PathBuf>,
     /// Content-pinned v1 project lock. It is mutually exclusive with `semantic-packs`.
     pub semantic_pack_lock: Option<PathBuf>,
+    /// Maximum managed `--cache-dir` storage. The default is 5GiB.
+    pub cache_max_bytes: Option<u64>,
 }
 
 #[derive(Deserialize, Default)]
@@ -131,11 +134,12 @@ mod tests {
     fn valid_config_still_loads() {
         let p = write_cfg(
             "ok",
-            "[query]\nmin-value = 200\nmin-size = 30\ngenerated-paths = [\"generated/**\"]\nignore-file = \"nose.ignore.json\"\nsemantic-packs = [\"packs\"]\n",
+            "[query]\nmin-value = 200\nmin-size = 30\ncache-max-bytes = 1048576\ngenerated-paths = [\"generated/**\"]\nignore-file = \"nose.ignore.json\"\nsemantic-packs = [\"packs\"]\n",
         );
         let cfg = load_query(Some(&p)).expect("valid config must load");
         assert_eq!(cfg.min_value, Some(200.0));
         assert_eq!(cfg.min_size, Some(30));
+        assert_eq!(cfg.cache_max_bytes, Some(1_048_576));
         assert_eq!(cfg.generated_paths, vec!["generated/**"]);
         assert_eq!(
             cfg.ignore_file,

--- a/crates/nose-cli/src/lib.rs
+++ b/crates/nose-cli/src/lib.rs
@@ -1,6 +1,7 @@
 mod baseline;
 mod baseline_comparison;
 mod cache;
+mod cache_commands;
 mod capabilities;
 mod cli_args;
 mod command_dispatch;

--- a/crates/nose-cli/src/query_commands.rs
+++ b/crates/nose-cli/src/query_commands.rs
@@ -300,6 +300,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
         exclude,
         generated_path,
         cache_dir,
+        cache_max_bytes,
         ignore_file,
         semantic_pack,
         semantic_pack_lock,
@@ -325,6 +326,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
         config,
         mode,
         cache_dir,
+        cache_max_bytes,
         fail_on,
         baseline,
         ignore_file,
@@ -342,9 +344,7 @@ pub(super) fn run_query_cmd(cmd: Cmd) -> Result<()> {
     if let Some(base_ref) = &q.base {
         return run_query_base(&args, base_ref, &q, &path_arg);
     }
-
-    let refs = paths_as_refs(&args.paths);
-    let mut dataset = build_query_dataset(&args, &refs)?;
+    let mut dataset = build_query_dataset(&args, &paths_as_refs(&args.paths))?;
     if args.write_baseline {
         return write_query_baseline(&args, &dataset.families);
     }

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -405,23 +405,14 @@ fn detect_cached_or_clean(
     let (Some(run), Some((workspace, pack_digest))) = (cache_run, cache_identity_parts) else {
         return nose_detect::detect_from_units_with_accepted_coverage(
             units, files, streams, opts, detector,
-        )
-        .0;
+        );
     };
     let identity = cache::DetectionCacheIdentity::new(workspace, pack_digest, opts, detector);
     let previous = cache::load_detection_state(run, &identity);
-    let (report, _dump, state, stats) =
-        nose_detect::detect_from_units_incremental_with_accepted_coverage(
-            units, files, streams, opts, detector, previous, unit_keys,
-        );
-    if !stats.state_hit
-        || stats.units_added > 0
-        || stats.units_removed > 0
-        || stats.buckets_rebuilt > 0
-        || stats.scores_evaluated > 0
-        || stats.connected_evaluations_evaluated > 0
-        || stats.contiguous_streams_rebuilt > 0
-    {
+    let (report, state, stats) = nose_detect::detect_from_units_incremental_with_accepted_coverage(
+        units, files, streams, opts, detector, previous, unit_keys,
+    );
+    if let Some(state) = state {
         cache::store_detection_state(run, &identity, &state);
     }
     if std::env::var_os("NOSE_CACHE_STATS").is_some() {

--- a/crates/nose-cli/src/query_dataset.rs
+++ b/crates/nose-cli/src/query_dataset.rs
@@ -45,6 +45,7 @@ pub(super) fn build_query_dataset(
             &opts,
             detector.as_ref(),
             &semantic_packs,
+            settings.cache_max_bytes,
         );
 
     let mut families = time_stage("rank_families", || nose_detect::rank_families(&report));
@@ -97,6 +98,7 @@ pub(super) fn build_query_dataset(
             line_context.as_ref(),
         )
     });
+    finish_cache_run(line_context);
     let sort = settings.sort;
     time_stage("query_rank_sort", || {
         families.sort_by(|a, b| {
@@ -127,6 +129,21 @@ pub(super) fn build_query_dataset(
         reinvented,
         opts,
     })
+}
+
+fn finish_cache_run(context: Option<cache::CachedLineContext>) {
+    let Some(context) = context else { return };
+    if let Err(error) = context.run.commit() {
+        if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+            eprintln!("  [cache-generation] commit skipped: {error}");
+        }
+    } else if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+        eprintln!(
+            "  [cache-generation] written_bytes={}",
+            context.run.written_bytes()
+        );
+    }
+    cache::enforce_run_budget(context.run);
 }
 
 /// `direct_edges` is the richer representation needed by the `base=` divergence view.
@@ -160,6 +177,7 @@ pub(super) struct QuerySettings {
     pub(super) exclude: Vec<String>,
     pub(super) generated_paths: GeneratedPathAssertions,
     pub(super) ignore_set: Option<ignores::IgnoreSet>,
+    pub(super) cache_max_bytes: u64,
 }
 
 pub(super) fn resolve_query_semantic_packs(
@@ -205,6 +223,10 @@ fn resolve_query_settings(
     let channels = DetectionChannels::resolve(args.mode.clone(), cfg.mode, QUERY_DEFAULT_MODES)?;
     let min_lines = args.min_lines.or(cfg.min_lines).unwrap_or(5);
     let min_tokens = args.min_size.or(cfg.min_size).unwrap_or(24);
+    let cache_max_bytes = args
+        .cache_max_bytes
+        .or(cfg.cache_max_bytes)
+        .unwrap_or(cache::DEFAULT_MAX_BYTES);
     let ignore_file = args.ignore_file.clone().or(cfg.ignore_file);
     let semantic_packs = semantic_pack_set_from_inputs(
         cfg.semantic_packs,
@@ -234,6 +256,7 @@ fn resolve_query_settings(
             exclude,
             generated_paths,
             ignore_set,
+            cache_max_bytes,
         },
         semantic_packs,
     ))
@@ -241,6 +264,14 @@ fn resolve_query_settings(
 
 /// With --cache-dir, build units per file through the on-disk cache (skips
 /// normalize/extract for unchanged files); otherwise lower the whole corpus.
+type DetectionReport = (
+    nose_detect::Report,
+    QueryScope,
+    nose_semantics::SemanticPackNearRegistry,
+    nose_semantics::SemanticPackExternalExactRegistry,
+    Option<cache::CachedLineContext>,
+);
+
 fn query_detect_report(
     args: &QueryArgs,
     refs: &[&std::path::Path],
@@ -248,21 +279,17 @@ fn query_detect_report(
     opts: &nose_detect::DetectOptions,
     detector: &dyn nose_detect::Detector,
     semantic_packs: &nose_semantics::SemanticPackSet,
-) -> (
-    nose_detect::Report,
-    QueryScope,
-    nose_semantics::SemanticPackNearRegistry,
-    nose_semantics::SemanticPackExternalExactRegistry,
-    Option<cache::CachedLineContext>,
-) {
+    cache_max_bytes: u64,
+) -> DetectionReport {
     let (mut corpus, invalidation_report, unit_contexts, cache_identity_parts, line_context) =
         if let Some(dir) = &args.cache_dir {
-            let cached =
-                time_lower(|| cache::build_corpus_cached(refs, exclude, dir, semantic_packs));
+            let cached = time_lower(|| {
+                cache::build_corpus_cached(refs, exclude, dir, semantic_packs, cache_max_bytes)
+            });
+            let run = cached.run.clone();
             let line_context = cache::CachedLineContext {
-                cache_dir: dir.clone(),
-                workspace_digest: cached.workspace_digest,
                 source_files: cached.source_files,
+                run,
             };
             (
                 cached.corpus,
@@ -280,14 +307,7 @@ fn query_detect_report(
                 None,
             )
         };
-    if std::env::var_os("NOSE_CACHE_STATS").is_some() {
-        if let Some(report) = &invalidation_report {
-            eprintln!(
-                "  [invalidation] {}",
-                cache::invalidation_report_json(report)
-            );
-        }
-    }
+    print_invalidation(invalidation_report.as_ref());
     let scope = QueryScope::from_corpus(&corpus);
     let semantic_pack_evidence =
         nose_semantics::SemanticPackEvidenceIndex::build(semantic_packs, &corpus);
@@ -302,7 +322,7 @@ fn query_detect_report(
         &corpus,
     );
     semantic_pack_external_exact.apply(&mut corpus);
-    let (mut units, unit_keys, streams, files) = if let Some(dir) = &args.cache_dir {
+    let (mut units, unit_keys, streams, files) = if args.cache_dir.is_some() {
         let cache::CachedUnits {
             units,
             unit_keys,
@@ -311,9 +331,12 @@ fn query_detect_report(
             stats,
         } = time_stage("cache", || {
             cache::build_units_cached_with_context(
-                &corpus,
+                &mut corpus,
                 opts,
-                dir,
+                &line_context
+                    .as_ref()
+                    .expect("cached corpus includes a cache run")
+                    .run,
                 unit_contexts
                     .as_deref()
                     .expect("cached corpus includes unit contexts"),
@@ -338,9 +361,11 @@ fn query_detect_report(
                 semantic_pack_near.protocols_for_unit(&unit.path, unit.start_line, unit.end_line);
         }
     }
+    drop(semantic_pack_evidence);
+    drop(corpus);
     let report = detect_cached_or_clean(
-        args,
         cache_identity_parts,
+        line_context.as_ref().map(|context| &context.run),
         (units, unit_keys.as_deref()),
         files,
         &streams,
@@ -356,9 +381,20 @@ fn query_detect_report(
     )
 }
 
+fn print_invalidation(report: Option<&cache::InvalidationReport>) {
+    if std::env::var_os("NOSE_CACHE_STATS").is_some() {
+        if let Some(report) = report {
+            eprintln!(
+                "  [invalidation] {}",
+                cache::invalidation_report_json(report)
+            );
+        }
+    }
+}
+
 fn detect_cached_or_clean(
-    args: &QueryArgs,
     cache_identity_parts: Option<([u8; 32], [u8; 32])>,
+    cache_run: Option<&cache::CacheRun>,
     detection_units: (Vec<nose_detect::UnitFeat>, Option<&[[u8; 32]]>),
     files: usize,
     streams: &[nose_detect::Stream],
@@ -366,15 +402,14 @@ fn detect_cached_or_clean(
     detector: &dyn nose_detect::Detector,
 ) -> nose_detect::Report {
     let (units, unit_keys) = detection_units;
-    let (Some(dir), Some((workspace, pack_digest))) = (&args.cache_dir, cache_identity_parts)
-    else {
+    let (Some(run), Some((workspace, pack_digest))) = (cache_run, cache_identity_parts) else {
         return nose_detect::detect_from_units_with_accepted_coverage(
             units, files, streams, opts, detector,
         )
         .0;
     };
     let identity = cache::DetectionCacheIdentity::new(workspace, pack_digest, opts, detector);
-    let previous = cache::load_detection_state(dir, &identity);
+    let previous = cache::load_detection_state(run, &identity);
     let (report, _dump, state, stats) =
         nose_detect::detect_from_units_incremental_with_accepted_coverage(
             units, files, streams, opts, detector, previous, unit_keys,
@@ -387,7 +422,7 @@ fn detect_cached_or_clean(
         || stats.connected_evaluations_evaluated > 0
         || stats.contiguous_streams_rebuilt > 0
     {
-        cache::store_detection_state(dir, &identity, &state);
+        cache::store_detection_state(run, &identity, &state);
     }
     if std::env::var_os("NOSE_CACHE_STATS").is_some() {
         eprintln!(

--- a/crates/nose-cli/src/source_lines.rs
+++ b/crates/nose-cli/src/source_lines.rs
@@ -438,12 +438,8 @@ pub(crate) fn cached_line_idf(
     usize,
     bool,
 ) {
-    let (index, stats) = crate::cache::build_line_index(
-        &context.cache_dir,
-        context.workspace_digest,
-        &context.source_files,
-        force_full,
-    );
+    let (index, stats) =
+        crate::cache::build_line_index(&context.run, &context.source_files, force_full);
     let mut files = index.files;
     let aliases = files
         .iter()

--- a/crates/nose-cli/src/source_lines/incremental.rs
+++ b/crates/nose-cli/src/source_lines/incremental.rs
@@ -6,11 +6,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 const STATE_SCHEMA: u32 = 1;
-static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const STATE_SLOT: &str = "family-lines";
 
 #[derive(Default, Deserialize, Serialize)]
 struct FamilyLineState {
@@ -43,8 +41,8 @@ pub(crate) fn apply_cached_family_lines(
     file_count: usize,
     line_index_complete: bool,
 ) -> Option<FamilyLineStats> {
-    let path = state_path(&context.cache_dir, context.workspace_digest);
-    let previous = load_state(&path);
+    let mut previous = load_state(&context.run);
+    let previous_len = previous.families.len();
     let digests = source_digests(context);
     if !line_index_complete
         && families
@@ -69,7 +67,7 @@ pub(crate) fn apply_cached_family_lines(
         .filter(|family| family.languages == 1 && family.locations.len() >= 2)
     {
         let key = family_key(family, &digests);
-        let analysis = if let Some(stored) = previous.families.get(&key) {
+        let analysis = if let Some(mut stored) = previous.families.remove(&key) {
             let needs_reweight = stored.file_count != file_count
                 || stored.shared.as_ref().is_some_and(|shared| {
                     shared
@@ -77,7 +75,6 @@ pub(crate) fn apply_cached_family_lines(
                         .iter()
                         .any(|line| changed_lines.contains(line))
                 });
-            let mut stored = stored.clone();
             if needs_reweight {
                 stored.shared_weight = stored
                     .shared
@@ -96,12 +93,10 @@ pub(crate) fn apply_cached_family_lines(
         apply_analysis(family, &analysis);
         current.insert(key, analysis);
     }
-    if stats.families_reweighted > 0
-        || stats.families_rebuilt > 0
-        || current.len() != previous.families.len()
+    if stats.families_reweighted > 0 || stats.families_rebuilt > 0 || current.len() != previous_len
     {
         store_state(
-            &path,
+            &context.run,
             &FamilyLineState {
                 schema: STATE_SCHEMA,
                 families: current,
@@ -208,47 +203,20 @@ fn hash_component(hasher: &mut Sha256, bytes: &[u8]) {
     hasher.update(bytes);
 }
 
-fn state_path(cache_dir: &Path, workspace: [u8; 32]) -> PathBuf {
-    cache_dir
-        .join("family-line-state-v1")
-        .join(format!("{}.msgpack", hex(&workspace)))
-}
-
-fn load_state(path: &Path) -> FamilyLineState {
-    std::fs::read(path)
-        .ok()
+fn load_state(run: &crate::cache::CacheRun) -> FamilyLineState {
+    run.load(STATE_SLOT, STATE_SCHEMA)
         .and_then(|bytes| rmp_serde::from_slice::<FamilyLineState>(&bytes).ok())
         .filter(|state| state.schema == STATE_SCHEMA)
         .unwrap_or_default()
 }
 
-fn store_state(path: &Path, state: &FamilyLineState) {
-    let Some(parent) = path.parent() else { return };
-    if std::fs::create_dir_all(parent).is_err() {
-        return;
-    }
+fn store_state(run: &crate::cache::CacheRun, state: &FamilyLineState) {
     // `VaryingSpot` omits empty optional fields, which requires a named map: compact
     // tuple encoding would shift the remaining fields and fail closed on reload.
     let Ok(bytes) = rmp_serde::to_vec_named(state) else {
         return;
     };
-    let temp = parent.join(format!(
-        ".{}.{}.tmp",
-        std::process::id(),
-        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-    ));
-    if std::fs::write(&temp, bytes).is_ok() && std::fs::rename(&temp, path).is_err() {
-        let _ = std::fs::remove_file(&temp);
-    }
-}
-
-fn hex(bytes: &[u8; 32]) -> String {
-    let mut out = String::with_capacity(64);
-    for byte in bytes {
-        use std::fmt::Write as _;
-        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
-    }
-    out
+    run.store(STATE_SLOT, STATE_SCHEMA, &bytes);
 }
 
 #[cfg(test)]

--- a/crates/nose-cli/tests/cli/cache.rs
+++ b/crates/nose-cli/tests/cli/cache.rs
@@ -4,6 +4,8 @@ use std::process::Output;
 
 #[path = "cache/incremental.rs"]
 mod incremental;
+#[path = "cache/transactional.rs"]
+mod transactional;
 
 #[derive(Debug, Eq, PartialEq)]
 struct CacheStats {

--- a/crates/nose-cli/tests/cli/cache/transactional.rs
+++ b/crates/nose-cli/tests/cli/cache/transactional.rs
@@ -1,0 +1,205 @@
+use super::*;
+
+fn clone_project(tag: &str) -> TempProject {
+    let project = TempProject::new(tag);
+    for (path, name) in [
+        ("a/one.py", "one"),
+        ("b/two.py", "two"),
+        ("c/three.py", "three"),
+    ] {
+        project.write(
+            path,
+            &format!(
+                "def {name}(items):\n    total = 0\n    for item in items:\n        if item > 0:\n            total = total + item * item\n    return total\n"
+            ),
+        );
+    }
+    project
+}
+
+fn query_with_limit(project: &Path, cache: &Path, limit: Option<&str>) -> Output {
+    let mut command = Command::new(bin());
+    command.args([
+        "query",
+        project.to_str().unwrap(),
+        "all",
+        "top=0",
+        "--format",
+        "json",
+        "--cache-dir",
+        cache.to_str().unwrap(),
+    ]);
+    if let Some(limit) = limit {
+        command.args(["--cache-max-bytes", limit]);
+    }
+    let output = command.output().expect("run transactional cache query");
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn managed_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.join("cas-v2"), root.join("state-v2")];
+    while let Some(path) = pending.pop() {
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.is_file() {
+            files.push(path);
+        } else if let Ok(entries) = fs::read_dir(path) {
+            pending.extend(entries.flatten().map(|entry| entry.path()));
+        }
+    }
+    files
+}
+
+#[test]
+fn concurrent_processes_publish_one_readable_store() {
+    let project = clone_project("cache_concurrent");
+    let cache = project.path().join(".cache");
+    let clean = query(project.path(), None);
+    let command = || {
+        let mut command = Command::new(bin());
+        command.args([
+            "query",
+            project.path().to_str().unwrap(),
+            "all",
+            "top=0",
+            "--format",
+            "json",
+            "--cache-dir",
+            cache.to_str().unwrap(),
+        ]);
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command
+    };
+    let first = command().spawn().expect("spawn first cache writer");
+    let second = command().spawn().expect("spawn second cache writer");
+    let first = first.wait_with_output().expect("join first cache writer");
+    let second = second.wait_with_output().expect("join second cache writer");
+    assert!(first.status.success());
+    assert!(second.status.success());
+    assert_eq!(first.stdout, clean.stdout);
+    assert_eq!(second.stdout, clean.stdout);
+    assert_eq!(
+        query_with_limit(project.path(), &cache, None).stdout,
+        clean.stdout
+    );
+}
+
+#[test]
+fn corruption_and_truncation_recompute_without_changing_output() {
+    let project = clone_project("cache_corruption_v2");
+    let cache = project.path().join(".cache");
+    let clean = query(project.path(), None);
+    assert_eq!(
+        query_with_limit(project.path(), &cache, None).stdout,
+        clean.stdout
+    );
+    let files = managed_files(&cache);
+    assert!(files
+        .iter()
+        .any(|path| path.extension().is_some_and(|ext| ext == "artifact")));
+    assert!(files
+        .iter()
+        .any(|path| path.file_name().is_some_and(|name| name == "CURRENT")));
+    for (index, path) in files.into_iter().enumerate() {
+        if path.file_name().is_some_and(|name| name == "LOCK") {
+            continue;
+        }
+        let mut bytes = fs::read(&path).unwrap();
+        if bytes.is_empty() {
+            continue;
+        }
+        if index % 2 == 0 {
+            bytes.truncate(bytes.len() / 2);
+        } else {
+            let last = bytes.len() - 1;
+            bytes[last] ^= 0xff;
+        }
+        fs::write(path, bytes).unwrap();
+    }
+    let repaired = query_with_limit(project.path(), &cache, None);
+    assert_eq!(repaired.stdout, clean.stdout);
+    assert!(
+        String::from_utf8_lossy(&repaired.stderr).contains("ignoring corrupt cache"),
+        "corrupt entries should produce actionable warnings"
+    );
+}
+
+#[test]
+fn eviction_and_cache_commands_affect_performance_only() {
+    let project = clone_project("cache_prune_cli");
+    let cache = project.path().join(".cache");
+    let clean = query(project.path(), None);
+    let bounded = query_with_limit(project.path(), &cache, Some("1KiB"));
+    assert_eq!(bounded.stdout, clean.stdout);
+
+    let status = Command::new(bin())
+        .args([
+            "cache",
+            "status",
+            "--dir",
+            cache.to_str().unwrap(),
+            "--format",
+            "json",
+            "--max-bytes",
+            "1KiB",
+        ])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status["schema"], "nose.cache-status/v1");
+    assert!(status["bytes"].as_u64().unwrap() <= 1024);
+
+    let cleared = Command::new(bin())
+        .args([
+            "cache",
+            "clear",
+            "--dir",
+            cache.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(cleared.status.success());
+    assert_eq!(
+        query_with_limit(project.path(), &cache, None).stdout,
+        clean.stdout
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_store_hits_and_computes_misses() {
+    let project = clone_project("cache_read_only");
+    let cache = project.path().join(".cache");
+    let clean = query(project.path(), None);
+    assert_eq!(
+        query_with_limit(project.path(), &cache, None).stdout,
+        clean.stdout
+    );
+    let protected = Command::new("chmod")
+        .args(["-R", "a-w", cache.to_str().unwrap()])
+        .status()
+        .unwrap();
+    assert!(protected.success());
+    let warm = query_with_limit(project.path(), &cache, None);
+    assert_eq!(warm.stdout, clean.stdout);
+    project.write(
+        "c/three.py",
+        "def three(items):\n    return sum(item * item for item in items if item > 0)\n",
+    );
+    let clean_changed = query(project.path(), None);
+    let read_only_miss = query_with_limit(project.path(), &cache, None);
+    assert_eq!(read_only_miss.stdout, clean_changed.stdout);
+    let _ = Command::new("chmod")
+        .args(["-R", "u+w", cache.to_str().unwrap()])
+        .status();
+}

--- a/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
+++ b/crates/nose-cli/tests/cli/commands/capabilities_robustness.rs
@@ -12,7 +12,7 @@ fn capabilities_command_emits_machine_readable_contract() {
     let json: serde_json::Value =
         serde_json::from_str(&out).expect("capabilities must emit valid JSON");
 
-    assert_eq!(json["schema_version"], 7);
+    assert_eq!(json["schema_version"], 8);
     assert_eq!(json["tool"]["name"], "nose");
     assert_eq!(json["tool"]["version"], env!("CARGO_PKG_VERSION"));
     assert!(
@@ -60,10 +60,29 @@ fn capabilities_command_lists_stable_commands_and_schemas() {
 
     assert_eq!(
         json_array_strings(&json["commands"], "stable"),
-        vec!["capabilities", "il", "query", "semantic-pack", "stats"]
+        vec![
+            "cache",
+            "capabilities",
+            "il",
+            "query",
+            "semantic-pack",
+            "stats"
+        ]
     );
     assert!(json_array_strings(&json["commands"], "deprecated").is_empty());
-    assert_eq!(json["schemas"]["capabilities"][0], 7);
+    assert_eq!(json["schemas"]["capabilities"][0], 8);
+    assert_eq!(
+        json["schemas"]["cache_status"],
+        serde_json::json!(["nose.cache-status/v1"])
+    );
+    assert_eq!(
+        json["schemas"]["cache_prune"],
+        serde_json::json!(["nose.cache-prune/v1"])
+    );
+    assert_eq!(
+        json["schemas"]["cache_clear"],
+        serde_json::json!(["nose.cache-clear/v1"])
+    );
     assert_eq!(json["schemas"]["query_json"], serde_json::json!([8, 9]));
     assert_eq!(
         json["schemas"]["semantic_packs"],
@@ -144,6 +163,7 @@ fn capabilities_command_reports_query_surface() {
 }
 
 fn assert_caller_generated_path_capability(json: &serde_json::Value) {
+    assert!(json_array_strings(&json["query"], "config_keys").contains(&"cache-max-bytes"));
     assert!(json_array_strings(&json["query"], "config_keys").contains(&"generated-paths"));
     assert_eq!(
         json["query"]["capabilities"]["caller_generated_paths"],

--- a/crates/nose-detect/src/contiguous.rs
+++ b/crates/nose-detect/src/contiguous.rs
@@ -286,7 +286,10 @@ pub(in crate::contiguous) fn detect_primitives(
     // by the value-graph channel instead. Per-language keying also stops an unrelated
     // collision in one language from masking a real same-language match in another.
     let mut seen: FxHashMap<(u64, nose_il::Lang), (usize, usize)> = FxHashMap::default();
-    let ranges: Vec<LineRangeIndex> = streams.iter().map(LineRangeIndex::new).collect();
+    let mut ranges = (0..streams.len()).map(|_| None).collect::<Vec<_>>();
+    for &stream in stream_indices {
+        ranges[stream] = Some(LineRangeIndex::new(&streams[stream]));
+    }
 
     // Emitted clone instances and the pairs linking them (for union-find clustering).
     let mut locs: Vec<LocSeed> = Vec::new();
@@ -314,9 +317,23 @@ pub(in crate::contiguous) fn detect_primitives(
                             .iter()
                             .any(|&o| o);
                         if has_op {
-                            let lb = loc_seed(si, &ranges[si], streams, i, i + len);
+                            let lb = loc_seed(
+                                si,
+                                ranges[si]
+                                    .as_ref()
+                                    .expect("selected stream has a range index"),
+                                streams,
+                                i,
+                                i + len,
+                            );
                             if line_count(&lb) >= min_lines {
-                                let la = loc_seed(sj, &ranges[sj], streams, j, j + len);
+                                let la = loc_seed(
+                                    sj,
+                                    ranges[sj].as_ref().expect("seen stream has a range index"),
+                                    streams,
+                                    j,
+                                    j + len,
+                                );
                                 let a = intern_loc(&mut locs, &mut loc_id, la);
                                 let b = intern_loc(&mut locs, &mut loc_id, lb);
                                 if a != b {

--- a/crates/nose-detect/src/contiguous/incremental.rs
+++ b/crates/nose-detect/src/contiguous/incremental.rs
@@ -1,11 +1,10 @@
 use super::{detect_primitives, groups_from_primitives, k, kgrams, LocSeed, Stream};
 use crate::cluster::UnionFind;
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
-const STATE_SCHEMA: u32 = 1;
+const STATE_SCHEMA: u32 = 2;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 struct StreamKey {
@@ -33,6 +32,7 @@ type DetectionPrimitives = (Vec<LocSeed>, Vec<(usize, usize)>);
 #[derive(Default, Serialize, Deserialize)]
 pub(crate) struct IncrementalContiguousState {
     schema: u32,
+    streams: Vec<StreamKey>,
     components: Vec<StoredComponent>,
 }
 
@@ -49,7 +49,7 @@ pub(crate) fn detect_incremental(
     min_tokens: usize,
     min_lines: u32,
     trace_accepted_coverage: bool,
-    previous: Option<&IncrementalContiguousState>,
+    previous: Option<IncrementalContiguousState>,
 ) -> (
     Vec<crate::Group>,
     Vec<Vec<crate::AcceptedEdge>>,
@@ -57,14 +57,19 @@ pub(crate) fn detect_incremental(
     IncrementalContiguousStats,
 ) {
     let window = k();
-    let grams = streams
-        .iter()
-        .map(|stream| kgrams(&stream.tags, window))
-        .collect::<Vec<_>>();
     let keys = stream_keys(streams);
-    let components = stream_components(streams, &grams);
     let previous = previous.filter(|state| state.schema == STATE_SCHEMA);
+    if previous.as_ref().is_some_and(|state| state.streams == keys) {
+        return reuse_unchanged(
+            streams,
+            keys,
+            previous.expect("checked state"),
+            trace_accepted_coverage,
+        );
+    }
+    let components = stream_components(streams, window);
     let prior = previous
+        .as_ref()
         .into_iter()
         .flat_map(|state| &state.components)
         .map(|component| (component.streams.as_slice(), component))
@@ -87,6 +92,10 @@ pub(crate) fn detect_incremental(
             .and_then(|component| restore_component(component, &current_index))
             .map_or_else(
                 || {
+                    let mut grams = (0..streams.len()).map(|_| Vec::new()).collect::<Vec<_>>();
+                    for &member in &members {
+                        grams[member] = kgrams(&streams[member].tags, window);
+                    }
                     let (locs, pairs) =
                         detect_primitives(streams, &grams, &members, window, min_tokens, min_lines);
                     (locs, pairs, false)
@@ -112,25 +121,93 @@ pub(crate) fn detect_incremental(
         edges,
         IncrementalContiguousState {
             schema: STATE_SCHEMA,
+            streams: keys,
             components: stored_components,
         },
         stats,
     )
 }
 
-fn stream_components(streams: &[Stream], grams: &[Vec<u64>]) -> Vec<Vec<usize>> {
+fn reuse_unchanged(
+    streams: &[Stream],
+    keys: Vec<StreamKey>,
+    state: IncrementalContiguousState,
+    trace_accepted_coverage: bool,
+) -> (
+    Vec<crate::Group>,
+    Vec<Vec<crate::AcceptedEdge>>,
+    IncrementalContiguousState,
+    IncrementalContiguousStats,
+) {
+    let current_index = keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect::<BTreeMap<_, _>>();
+    let mut groups = Vec::new();
+    let mut edges = Vec::new();
+    for component in &state.components {
+        let (locs, pairs) = restore_component(component, &current_index)
+            .expect("an unchanged stream set restores every component");
+        let (component_groups, component_edges) =
+            groups_from_primitives(locs, pairs, streams, trace_accepted_coverage);
+        groups.extend(component_groups);
+        edges.extend(component_edges);
+    }
+    let stats = IncrementalContiguousStats {
+        components_reused: state.components.len(),
+        streams_reused: streams.len(),
+        ..IncrementalContiguousStats::default()
+    };
+    (groups, edges, state, stats)
+}
+
+#[derive(Clone, Copy)]
+struct GramOwner {
+    hash: u64,
+    stream: u32,
+    lang: nose_il::Lang,
+}
+
+fn stream_components(streams: &[Stream], window: usize) -> Vec<Vec<usize>> {
     let mut union = UnionFind::new(streams.len());
-    let mut first = FxHashMap::default();
-    for (stream, hashes) in grams.iter().enumerate() {
-        for &hash in hashes {
-            if let Some(&other) = first.get(&(streams[stream].lang, hash)) {
-                if other != stream {
-                    union.union(other, stream);
-                }
-            } else {
-                first.insert((streams[stream].lang, hash), stream);
+    let gram_count = streams
+        .iter()
+        .map(|stream| stream.tags.len().saturating_sub(window.saturating_sub(1)))
+        .sum();
+    let mut owners = Vec::with_capacity(gram_count);
+    for (stream, item) in streams.iter().enumerate() {
+        owners.extend(
+            kgrams(&item.tags, window)
+                .into_iter()
+                .map(|hash| GramOwner {
+                    hash,
+                    stream: stream as u32,
+                    lang: item.lang,
+                }),
+        );
+    }
+    owners.sort_unstable_by(|left, right| {
+        left.hash
+            .cmp(&right.hash)
+            .then_with(|| left.lang.name().cmp(right.lang.name()))
+            .then(left.stream.cmp(&right.stream))
+    });
+    let mut start = 0;
+    while start < owners.len() {
+        let first = owners[start];
+        let mut end = start + 1;
+        while end < owners.len() && owners[end].hash == first.hash && owners[end].lang == first.lang
+        {
+            end += 1;
+        }
+        for owner in &owners[start + 1..end] {
+            if owner.stream != first.stream {
+                union.union(first.stream as usize, owner.stream as usize);
             }
         }
+        start = end;
     }
     let mut by_root = BTreeMap::<usize, Vec<usize>>::new();
     for index in 0..streams.len() {
@@ -239,7 +316,7 @@ mod tests {
         let streams = vec![stream("a.py", &shared), stream("b.py", &shared)];
         let (_, _, state, cold) = detect_incremental(&streams, 10, 3, true, None);
         assert_eq!(cold.streams_rebuilt, 2);
-        let (incremental, edges, _, warm) = detect_incremental(&streams, 10, 3, true, Some(&state));
+        let (incremental, edges, _, warm) = detect_incremental(&streams, 10, 3, true, Some(state));
         let clean = super::super::detect(&streams, 10, 3, true);
         assert_eq!(warm.streams_reused, 2);
         assert_eq!(incremental.len(), clean.0.len());
@@ -266,7 +343,7 @@ mod tests {
             stream("c.py", &second_shared),
             stream("d.py", &second_shared),
         ];
-        let (incremental, _, _, stats) = detect_incremental(&after, 10, 3, true, Some(&state));
+        let (incremental, _, _, stats) = detect_incremental(&after, 10, 3, true, Some(state));
         let clean = super::super::detect(&after, 10, 3, true).0;
         assert_eq!(stats.streams_reused, 2);
         assert_eq!(stats.streams_rebuilt, 2);

--- a/crates/nose-detect/src/incremental.rs
+++ b/crates/nose-detect/src/incremental.rs
@@ -19,7 +19,7 @@ use crate::contiguous::IncrementalContiguousState;
 use crate::orchestration::ScoredCandidate;
 use serde::{Deserialize, Serialize};
 
-const STATE_SCHEMA: u32 = 4;
+const STATE_SCHEMA: u32 = 6;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub(crate) struct UnitKey([u8; 32]);
@@ -54,14 +54,24 @@ enum BucketKey {
 #[derive(Serialize, Deserialize)]
 struct CandidateBucket {
     key: BucketKey,
-    members: Vec<UnitKey>,
+    members: Vec<u32>,
 }
 
 #[derive(Serialize, Deserialize)]
 struct StoredScore {
-    pair: UnitPairKey,
+    left: u32,
+    right: u32,
     bucket_count: u16,
     ordinary_score: Option<f64>,
+}
+
+impl StoredScore {
+    fn pair(&self, units: &[UnitKey]) -> Option<UnitPairKey> {
+        Some(UnitPairKey::new(
+            *units.get(self.left as usize)?,
+            *units.get(self.right as usize)?,
+        ))
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -116,6 +126,21 @@ pub struct IncrementalDetectionState {
     contiguous: Option<IncrementalContiguousState>,
 }
 
+impl IncrementalDetectionState {
+    fn is_valid(&self) -> bool {
+        self.schema == STATE_SCHEMA
+            && self.scores.iter().all(|score| {
+                (score.left as usize) < self.units.len()
+                    && (score.right as usize) < self.units.len()
+            })
+            && self
+                .buckets
+                .iter()
+                .flat_map(|bucket| &bucket.members)
+                .all(|&member| (member as usize) < self.units.len())
+    }
+}
+
 #[derive(Debug, Default, Serialize)]
 pub struct IncrementalDetectionStats {
     pub schema: &'static str,
@@ -149,9 +174,11 @@ impl IncrementalDetectionStats {
 pub(crate) struct PreparedDetection {
     pub(crate) unit_keys: Vec<UnitKey>,
     pub(crate) candidates: Vec<(usize, usize)>,
-    candidate_counts: Vec<(UnitPairKey, u16)>,
+    candidate_counts: Vec<u16>,
     buckets: Vec<CandidateBucket>,
     previous_scores: Vec<StoredScore>,
+    previous_unit_keys: Vec<UnitKey>,
+    previous_scores_aligned: bool,
     previous_components: Vec<Vec<UnitKey>>,
     previous_connected: Vec<StoredConnectedEvaluation>,
     previous_same_unit: Vec<StoredSameUnitEvaluation>,
@@ -175,20 +202,12 @@ pub(crate) fn finish_state(
 ) -> IncrementalDetectionState {
     let scores = scored
         .iter()
-        .zip(&prepared.candidate_counts)
-        .map(|(candidate, &(pair, bucket_count))| {
-            debug_assert_eq!(
-                pair,
-                UnitPairKey::new(
-                    prepared.unit_keys[candidate.left],
-                    prepared.unit_keys[candidate.right],
-                )
-            );
-            StoredScore {
-                pair,
-                bucket_count,
-                ordinary_score: candidate.ordinary_score,
-            }
+        .zip(prepared.candidate_counts)
+        .map(|(candidate, bucket_count)| StoredScore {
+            left: candidate.left as u32,
+            right: candidate.right as u32,
+            bucket_count,
+            ordinary_score: candidate.ordinary_score,
         })
         .collect();
     let stored_components = components

--- a/crates/nose-detect/src/incremental/candidates.rs
+++ b/crates/nose-detect/src/incremental/candidates.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-type IndexedCandidates = (Vec<(usize, usize)>, Vec<(UnitPairKey, u16)>);
+type IndexedCandidates = (Vec<(usize, usize)>, Vec<u16>);
 
 pub(crate) fn prepare(
     units: &[UnitFeat],
@@ -25,7 +25,7 @@ pub(crate) fn prepare(
     } else {
         units.par_iter().map(unit_key).collect::<Vec<_>>()
     };
-    let previous = previous.filter(|state| state.schema == STATE_SCHEMA);
+    let mut previous = previous.filter(IncrementalDetectionState::is_valid);
     stats.state_hit = previous.is_some();
     record_unit_churn(previous.as_ref(), &unit_keys, stats);
 
@@ -40,50 +40,35 @@ pub(crate) fn prepare(
         );
     }
 
-    let memberships = candidate_memberships(units, &unit_keys, opts);
-    let previous_buckets = previous
-        .as_ref()
-        .map(|state| {
-            state
-                .buckets
-                .iter()
-                .map(|bucket| (bucket.key, bucket))
-                .collect::<BTreeMap<_, _>>()
-        })
-        .unwrap_or_default();
     let mut counts = previous
         .as_ref()
         .into_iter()
-        .flat_map(|state| &state.scores)
-        .map(|score| (score.pair, score.bucket_count))
+        .flat_map(|state| {
+            state.scores.iter().filter_map(|score| {
+                score
+                    .pair(&state.units)
+                    .map(|pair| (pair, score.bucket_count))
+            })
+        })
         .collect::<BTreeMap<_, _>>();
-    let current_bucket_keys = memberships.keys().copied().collect::<BTreeSet<_>>();
-    let mut buckets = Vec::with_capacity(memberships.len());
-    for (key, members) in memberships {
-        if previous_buckets
-            .get(&key)
-            .filter(|old| old.members == members)
-            .is_some()
-        {
-            stats.buckets_reused += 1;
-        } else {
-            stats.buckets_rebuilt += 1;
-            if let Some(old) = previous_buckets.get(&key) {
-                adjust_pair_counts(&mut counts, key, &old.members, false);
-            }
-            adjust_pair_counts(&mut counts, key, &members, true);
+    let buckets = if let Some(state) = previous.as_mut() {
+        update_candidate_buckets(units, &unit_keys, opts, state, &mut counts, stats)
+    } else {
+        let memberships = candidate_memberships(units, &unit_keys, opts);
+        stats.buckets_rebuilt = memberships.len();
+        for (&key, members) in &memberships {
+            adjust_pair_counts(&mut counts, key, members, true);
         }
-        buckets.push(CandidateBucket { key, members });
-    }
-    for (&key, old) in &previous_buckets {
-        if !current_bucket_keys.contains(&key) {
-            stats.buckets_rebuilt += 1;
-            adjust_pair_counts(&mut counts, key, &old.members, false);
-        }
-    }
+        let positions = unit_index(&unit_keys);
+        memberships
+            .into_iter()
+            .map(|(key, members)| store_bucket(key, &members, &positions))
+            .collect()
+    };
     counts.retain(|_, count| *count > 0);
     let (candidates, candidate_counts) = index_candidates(&unit_keys, &counts);
     let (
+        previous_unit_keys,
         previous_scores,
         previous_components,
         previous_connected,
@@ -92,6 +77,7 @@ pub(crate) fn prepare(
     ) = previous
         .map(|state| {
             (
+                state.units,
                 state.scores,
                 state.components,
                 state.connected,
@@ -106,6 +92,8 @@ pub(crate) fn prepare(
         candidate_counts,
         buckets,
         previous_scores,
+        previous_unit_keys,
+        previous_scores_aligned: false,
         previous_components,
         previous_connected,
         previous_same_unit,
@@ -119,23 +107,101 @@ fn reuse_unchanged(
     stats: &mut IncrementalDetectionStats,
 ) -> PreparedDetection {
     stats.buckets_reused = state.buckets.len();
-    let counts = state
+    let candidates = state
         .scores
         .iter()
-        .map(|score| (score.pair, score.bucket_count))
-        .collect::<BTreeMap<_, _>>();
-    let (candidates, candidate_counts) = index_candidates(&unit_keys, &counts);
+        .map(|score| (score.left as usize, score.right as usize))
+        .collect();
+    let candidate_counts = state
+        .scores
+        .iter()
+        .map(|score| score.bucket_count)
+        .collect();
     PreparedDetection {
         unit_keys,
         candidates,
         candidate_counts,
         buckets: state.buckets,
         previous_scores: state.scores,
+        previous_unit_keys: state.units,
+        previous_scores_aligned: true,
         previous_components: state.components,
         previous_connected: state.connected,
         previous_same_unit: state.same_unit,
         previous_contiguous: state.contiguous,
     }
+}
+
+fn update_candidate_buckets(
+    units: &[UnitFeat],
+    unit_keys: &[UnitKey],
+    opts: &DetectOptions,
+    state: &mut IncrementalDetectionState,
+    counts: &mut BTreeMap<UnitPairKey, u16>,
+    stats: &mut IncrementalDetectionStats,
+) -> Vec<CandidateBucket> {
+    let current = unit_keys.iter().copied().collect::<BTreeSet<_>>();
+    let previous = state.units.iter().copied().collect::<BTreeSet<_>>();
+    let added_indices = unit_keys
+        .iter()
+        .enumerate()
+        .filter_map(|(index, key)| (!previous.contains(key)).then_some(index))
+        .collect::<Vec<_>>();
+    let mut additions =
+        candidate_memberships_selected(units, unit_keys, opts, added_indices.iter().copied(), None);
+    let old_keys = state
+        .buckets
+        .iter()
+        .map(|bucket| bucket.key)
+        .collect::<BTreeSet<_>>();
+    let new_keys = additions
+        .keys()
+        .filter(|key| !old_keys.contains(key))
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let new_memberships =
+        candidate_memberships_selected(units, unit_keys, opts, 0..units.len(), Some(&new_keys));
+    let current_positions = unit_index(unit_keys);
+    let mut buckets = Vec::with_capacity(state.buckets.len() + new_memberships.len());
+    for old in std::mem::take(&mut state.buckets) {
+        let old_members = old
+            .members
+            .iter()
+            .map(|&member| state.units[member as usize])
+            .collect::<Vec<_>>();
+        let added = additions.remove(&old.key).unwrap_or_default();
+        let removed = old_members.iter().any(|member| !current.contains(member));
+        if !removed && added.is_empty() {
+            stats.buckets_reused += 1;
+            buckets.push(store_bucket(old.key, &old_members, &current_positions));
+            continue;
+        }
+
+        let mut members = old_members
+            .iter()
+            .copied()
+            .filter(|member| current.contains(member))
+            .chain(added)
+            .collect::<Vec<_>>();
+        members.sort_unstable_by_key(|member| current_positions[member]);
+        members.dedup();
+        adjust_pair_counts(counts, old.key, &old_members, false);
+        if members.len() >= 2 {
+            adjust_pair_counts(counts, old.key, &members, true);
+            buckets.push(store_bucket(old.key, &members, &current_positions));
+        }
+        stats.buckets_rebuilt += 1;
+    }
+    for (key, members) in new_memberships {
+        if members.len() < 2 {
+            continue;
+        }
+        adjust_pair_counts(counts, key, &members, true);
+        buckets.push(store_bucket(key, &members, &current_positions));
+        stats.buckets_rebuilt += 1;
+    }
+    buckets.sort_unstable_by_key(|bucket| bucket.key);
+    buckets
 }
 
 fn adjust_pair_counts(
@@ -158,12 +224,7 @@ fn index_candidates(
     unit_keys: &[UnitKey],
     counts: &BTreeMap<UnitPairKey, u16>,
 ) -> IndexedCandidates {
-    let by_key = unit_keys
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(index, key)| (key, index))
-        .collect::<HashMap<_, _>>();
+    let by_key = unit_index(unit_keys);
     let mut rows = counts
         .iter()
         .filter_map(|(&pair, &count)| {
@@ -179,11 +240,31 @@ fn index_candidates(
         .collect::<Vec<_>>();
     rows.sort_unstable_by_key(|row| row.0);
     let candidates = rows.iter().map(|row| row.0).collect();
-    let candidate_counts = rows
-        .into_iter()
-        .map(|(_, pair, count)| (pair, count))
-        .collect();
+    let candidate_counts = rows.into_iter().map(|(_, _, count)| count).collect();
     (candidates, candidate_counts)
+}
+
+fn unit_index(unit_keys: &[UnitKey]) -> HashMap<UnitKey, usize> {
+    unit_keys
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, key)| (key, index))
+        .collect()
+}
+
+fn store_bucket(
+    key: BucketKey,
+    members: &[UnitKey],
+    positions: &HashMap<UnitKey, usize>,
+) -> CandidateBucket {
+    CandidateBucket {
+        key,
+        members: members
+            .iter()
+            .map(|member| positions[member] as u32)
+            .collect(),
+    }
 }
 
 pub(crate) fn score(
@@ -193,24 +274,45 @@ pub(crate) fn score(
     threshold: f64,
     stats: &mut IncrementalDetectionStats,
 ) -> (Vec<ScoredCandidate>, Vec<(usize, usize, f64)>) {
-    let previous = prepared
-        .previous_scores
-        .iter()
-        .map(|score| (score.pair, score.ordinary_score))
-        .collect::<HashMap<_, _>>();
+    let previous = (!prepared.previous_scores_aligned).then(|| {
+        prepared
+            .previous_scores
+            .iter()
+            .filter_map(|score| {
+                score
+                    .pair(&prepared.previous_unit_keys)
+                    .map(|pair| (pair, score.ordinary_score))
+            })
+            .collect::<HashMap<_, _>>()
+    });
     let reused = AtomicUsize::new(0);
     let evaluated = AtomicUsize::new(0);
     let scored = prepared
         .candidates
         .par_iter()
-        .map(|&(left, right)| {
+        .enumerate()
+        .map(|(index, &(left, right))| {
             let pair = UnitPairKey::new(prepared.unit_keys[left], prepared.unit_keys[right]);
-            let ordinary_score = previous.get(&pair).copied().unwrap_or_else(|| {
+            let cached = if prepared.previous_scores_aligned {
+                debug_assert_eq!(
+                    (
+                        prepared.previous_scores[index].left as usize,
+                        prepared.previous_scores[index].right as usize,
+                    ),
+                    (left, right)
+                );
+                Some(prepared.previous_scores[index].ordinary_score)
+            } else {
+                previous
+                    .as_ref()
+                    .and_then(|scores| scores.get(&pair).copied())
+            };
+            let ordinary_score = cached.unwrap_or_else(|| {
                 evaluated.fetch_add(1, Ordering::Relaxed);
                 (!is_nested(&units[left], &units[right]))
                     .then(|| detector.score(&units[left], &units[right]))
             });
-            if previous.contains_key(&pair) {
+            if cached.is_some() {
                 reused.fetch_add(1, Ordering::Relaxed);
             }
             ScoredCandidate {
@@ -253,73 +355,90 @@ fn candidate_memberships(
     unit_keys: &[UnitKey],
     opts: &DetectOptions,
 ) -> BTreeMap<BucketKey, Vec<UnitKey>> {
-    let mut buckets = BTreeMap::<BucketKey, Vec<UnitKey>>::new();
-    if opts.value_candidates {
-        append_lsh_memberships(&mut buckets, units, unit_keys, opts.bands, false);
-        for (unit, &key) in units.iter().zip(unit_keys) {
-            if exact_claim_eligible(unit) {
-                buckets
-                    .entry(BucketKey::ExactValue(digest_u64s(&unit.value)))
-                    .or_default()
-                    .push(key);
-            }
-        }
-    }
-    if opts.shape_candidates {
-        append_lsh_memberships(&mut buckets, units, unit_keys, opts.bands, true);
-        let floor = nose_normalize::anchor_min_weight();
-        for (unit, &key) in units.iter().zip(unit_keys) {
-            for anchor in &unit.anchors {
-                if anchor.weight >= floor {
-                    buckets
-                        .entry(BucketKey::Anchor(anchor.hash))
-                        .or_default()
-                        .push(key);
-                }
-            }
-        }
-    }
+    let mut buckets = candidate_memberships_selected(units, unit_keys, opts, 0..units.len(), None);
     buckets.retain(|_, members| members.len() >= 2);
     buckets
 }
 
-fn append_lsh_memberships(
-    buckets: &mut BTreeMap<BucketKey, Vec<UnitKey>>,
+fn candidate_memberships_selected(
     units: &[UnitFeat],
     unit_keys: &[UnitKey],
-    bands: usize,
-    shape: bool,
-) {
-    let Some(first) = units.first() else { return };
-    let first_signature = if shape {
+    opts: &DetectOptions,
+    indices: impl IntoIterator<Item = usize>,
+    target_keys: Option<&BTreeSet<BucketKey>>,
+) -> BTreeMap<BucketKey, Vec<UnitKey>> {
+    let mut buckets = BTreeMap::new();
+    let value_rows = signature_rows(units, opts.bands, false);
+    let shape_rows = signature_rows(units, opts.bands, true);
+    for index in indices {
+        let unit = &units[index];
+        let key = unit_keys[index];
+        for_each_bucket_key(unit, opts, value_rows, shape_rows, |bucket| {
+            if target_keys.is_none_or(|targets| targets.contains(&bucket)) {
+                buckets.entry(bucket).or_insert_with(Vec::new).push(key);
+            }
+        });
+    }
+    buckets
+}
+
+fn signature_rows(units: &[UnitFeat], bands: usize, shape: bool) -> Option<usize> {
+    let first = units.first()?;
+    let signature = if shape {
         &first.shape_minhash
     } else {
         &first.minhash
     };
-    if first_signature.is_empty() || bands == 0 {
-        return;
-    }
-    let rows = (first_signature.len() / bands).max(1);
-    for (unit, &key) in units.iter().zip(unit_keys) {
-        let signature = if shape {
-            &unit.shape_minhash
-        } else {
-            &unit.minhash
-        };
-        for band in 0..bands {
-            let start = band * rows;
-            if start >= signature.len() {
-                continue;
-            }
-            let end = (start + rows).min(signature.len());
-            let hash = band_hash(band, &signature[start..end]);
-            let bucket = if shape {
-                BucketKey::ShapeBand(hash)
-            } else {
-                BucketKey::ValueBand(hash)
-            };
-            buckets.entry(bucket).or_default().push(key);
+    (!signature.is_empty() && bands > 0).then(|| (signature.len() / bands).max(1))
+}
+
+fn for_each_bucket_key(
+    unit: &UnitFeat,
+    opts: &DetectOptions,
+    value_rows: Option<usize>,
+    shape_rows: Option<usize>,
+    mut visit: impl FnMut(BucketKey),
+) {
+    if opts.value_candidates {
+        if let Some(rows) = value_rows {
+            visit_lsh_buckets(&unit.minhash, opts.bands, rows, false, &mut visit);
         }
+        if exact_claim_eligible(unit) {
+            visit(BucketKey::ExactValue(digest_u64s(&unit.value)));
+        }
+    }
+    if opts.shape_candidates {
+        if let Some(rows) = shape_rows {
+            visit_lsh_buckets(&unit.shape_minhash, opts.bands, rows, true, &mut visit);
+        }
+        let floor = nose_normalize::anchor_min_weight();
+        for anchor in &unit.anchors {
+            if anchor.weight >= floor {
+                visit(BucketKey::Anchor(anchor.hash));
+            }
+        }
+    }
+}
+
+fn visit_lsh_buckets(
+    signature: &[u64],
+    bands: usize,
+    rows: usize,
+    shape: bool,
+    visit: &mut impl FnMut(BucketKey),
+) {
+    for band in 0..bands {
+        let start = band * rows;
+        if start >= signature.len() {
+            continue;
+        }
+        let end = (start + rows).min(signature.len());
+        let hash = band_hash(band, &signature[start..end]);
+        visit(if shape {
+            BucketKey::ShapeBand(hash)
+        } else {
+            BucketKey::ValueBand(hash)
+        });
     }
 }
 

--- a/crates/nose-detect/src/incremental/components.rs
+++ b/crates/nose-detect/src/incremental/components.rs
@@ -73,7 +73,7 @@ fn component_changes(
             score
                 .ordinary_score
                 .filter(|&value| value >= threshold)
-                .map(|_| score.pair)
+                .and_then(|_| score.pair(&prepared.previous_unit_keys))
         })
         .collect::<BTreeSet<_>>();
     let current_edges = accepted

--- a/crates/nose-detect/src/model.rs
+++ b/crates/nose-detect/src/model.rs
@@ -326,6 +326,7 @@ pub struct UnitLoc {
 /// Diagnostic dump: all extracted units and all LSH candidate index pairs (into
 /// `units`). Lets the evaluator split recall loss across extraction / candidate
 /// generation / scoring.
+#[derive(Default)]
 pub struct Dump {
     pub units: Vec<UnitLoc>,
     pub candidates: Vec<(u32, u32)>,

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -26,7 +26,7 @@ mod features;
 pub use features::{corpus_features, file_stream, units_of_file, CorpusFeatures};
 
 pub fn detect(corpus: &Corpus, opts: &DetectOptions, detector: &dyn Detector) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, false, false, false).0
+    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::REPORT).0
 }
 
 /// Product-query detection with compact direct accepted-edge provenance retained
@@ -37,7 +37,7 @@ pub fn detect_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, true, false, false).0
+    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::ACCEPTED_COVERAGE).0
 }
 
 /// Divergent-edit detection counterpart that also retains direct copy-paste-run
@@ -48,7 +48,40 @@ pub fn detect_with_direct_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, true, true, false).0
+    detect_with_dump_inner(
+        corpus,
+        opts,
+        detector,
+        DetectionOutput::DIRECT_ACCEPTED_COVERAGE,
+    )
+    .0
+}
+
+#[derive(Clone, Copy)]
+struct DetectionOutput {
+    trace_accepted_coverage: bool,
+    trace_contiguous_coverage: bool,
+    build_dump: bool,
+}
+
+impl DetectionOutput {
+    const REPORT: Self = Self {
+        trace_accepted_coverage: false,
+        trace_contiguous_coverage: false,
+        build_dump: false,
+    };
+    const ACCEPTED_COVERAGE: Self = Self {
+        trace_accepted_coverage: true,
+        ..Self::REPORT
+    };
+    const DIRECT_ACCEPTED_COVERAGE: Self = Self {
+        trace_contiguous_coverage: true,
+        ..Self::ACCEPTED_COVERAGE
+    };
+    const DUMP: Self = Self {
+        build_dump: true,
+        ..Self::REPORT
+    };
 }
 
 /// Per-stage wall-clock timing, printed to stderr when `NOSE_TIME` is set. A
@@ -86,16 +119,14 @@ pub fn detect_with_dump(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_with_dump_inner(corpus, opts, detector, false, false, true)
+    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::DUMP)
 }
 
 fn detect_with_dump_inner(
     corpus: &Corpus,
     opts: &DetectOptions,
     detector: &dyn Detector,
-    trace_accepted_coverage: bool,
-    trace_contiguous_coverage: bool,
-    build_dump: bool,
+    output: DetectionOutput,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -112,16 +143,7 @@ fn detect_with_dump_inner(
     // `detect_from_units` runs its own `StageTimer` for the detection sub-phases
     // (candidates/score/groups/contiguous), so no lap here — a single outer lap would
     // mislabel the whole call (group scoring dwarfs contiguous) as "contiguous".
-    detect_from_units_inner(
-        units,
-        files,
-        &streams,
-        opts,
-        detector,
-        trace_accepted_coverage,
-        trace_contiguous_coverage,
-        build_dump,
-    )
+    detect_from_units_inner(units, files, &streams, opts, detector, output)
 }
 
 /// Run candidate-generation → scoring → clustering over already-built `units` (the
@@ -136,7 +158,7 @@ pub fn detect_from_units(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_from_units_inner(units, files, streams, opts, detector, false, false, true)
+    detect_from_units_inner(units, files, streams, opts, detector, DetectionOutput::DUMP)
 }
 
 /// Cached-query counterpart to [`detect_with_accepted_coverage`].
@@ -147,7 +169,15 @@ pub fn detect_from_units_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_from_units_inner(units, files, streams, opts, detector, true, false, false).0
+    detect_from_units_inner(
+        units,
+        files,
+        streams,
+        opts,
+        detector,
+        DetectionOutput::ACCEPTED_COVERAGE,
+    )
+    .0
 }
 
 /// Cached-query entry point with persistent candidate membership and pair-score
@@ -232,9 +262,7 @@ fn detect_from_units_inner(
     streams: &[Stream],
     opts: &DetectOptions,
     detector: &dyn Detector,
-    trace_accepted_coverage: bool,
-    trace_contiguous_coverage: bool,
-    build_dump: bool,
+    output: DetectionOutput,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -267,9 +295,9 @@ fn detect_from_units_inner(
         None,
         None,
         None,
-        trace_accepted_coverage,
-        trace_contiguous_coverage,
-        build_dump,
+        output.trace_accepted_coverage,
+        output.trace_contiguous_coverage,
+        output.build_dump,
         &mut clk,
     )
 }

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -26,7 +26,7 @@ mod features;
 pub use features::{corpus_features, file_stream, units_of_file, CorpusFeatures};
 
 pub fn detect(corpus: &Corpus, opts: &DetectOptions, detector: &dyn Detector) -> Report {
-    detect_with_dump(corpus, opts, detector).0
+    detect_with_dump_inner(corpus, opts, detector, false, false, false).0
 }
 
 /// Product-query detection with compact direct accepted-edge provenance retained
@@ -37,7 +37,7 @@ pub fn detect_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, true, false).0
+    detect_with_dump_inner(corpus, opts, detector, true, false, false).0
 }
 
 /// Divergent-edit detection counterpart that also retains direct copy-paste-run
@@ -48,7 +48,7 @@ pub fn detect_with_direct_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, true, true).0
+    detect_with_dump_inner(corpus, opts, detector, true, true, false).0
 }
 
 /// Per-stage wall-clock timing, printed to stderr when `NOSE_TIME` is set. A
@@ -86,7 +86,7 @@ pub fn detect_with_dump(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_with_dump_inner(corpus, opts, detector, false, false)
+    detect_with_dump_inner(corpus, opts, detector, false, false, true)
 }
 
 fn detect_with_dump_inner(
@@ -95,6 +95,7 @@ fn detect_with_dump_inner(
     detector: &dyn Detector,
     trace_accepted_coverage: bool,
     trace_contiguous_coverage: bool,
+    build_dump: bool,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -119,6 +120,7 @@ fn detect_with_dump_inner(
         detector,
         trace_accepted_coverage,
         trace_contiguous_coverage,
+        build_dump,
     )
 }
 
@@ -134,7 +136,7 @@ pub fn detect_from_units(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_from_units_inner(units, files, streams, opts, detector, false, false)
+    detect_from_units_inner(units, files, streams, opts, detector, false, false, true)
 }
 
 /// Cached-query counterpart to [`detect_with_accepted_coverage`].
@@ -144,8 +146,8 @@ pub fn detect_from_units_with_accepted_coverage(
     streams: &[Stream],
     opts: &DetectOptions,
     detector: &dyn Detector,
-) -> (Report, Dump) {
-    detect_from_units_inner(units, files, streams, opts, detector, true, false)
+) -> Report {
+    detect_from_units_inner(units, files, streams, opts, detector, true, false, false).0
 }
 
 /// Cached-query entry point with persistent candidate membership and pair-score
@@ -160,8 +162,7 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
     stable_unit_keys: Option<&[[u8; 32]]>,
 ) -> (
     Report,
-    Dump,
-    IncrementalDetectionState,
+    Option<IncrementalDetectionState>,
     IncrementalDetectionStats,
 ) {
     let mut clk = StageTimer::new();
@@ -193,10 +194,18 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
     } else {
         (None, None)
     };
-    let candidates = prepared.candidates.clone();
-    let state =
-        incremental::finish_state(prepared, &scored, &raw_groups, connected, contiguous_state);
-    let (report, dump) = finish_detection(
+    let candidates = std::mem::take(&mut prepared.candidates);
+    let state_changed = !stats.state_hit
+        || stats.units_added > 0
+        || stats.units_removed > 0
+        || stats.buckets_rebuilt > 0
+        || stats.scores_evaluated > 0
+        || stats.connected_evaluations_evaluated > 0
+        || stats.contiguous_streams_rebuilt > 0;
+    let state = state_changed.then(|| {
+        incremental::finish_state(prepared, &scored, &raw_groups, connected, contiguous_state)
+    });
+    let report = finish_detection(
         units,
         files,
         streams,
@@ -210,9 +219,11 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
         contiguous_override,
         true,
         false,
+        false,
         &mut clk,
-    );
-    (report, dump, state, stats)
+    )
+    .0;
+    (report, state, stats)
 }
 
 fn detect_from_units_inner(
@@ -223,6 +234,7 @@ fn detect_from_units_inner(
     detector: &dyn Detector,
     trace_accepted_coverage: bool,
     trace_contiguous_coverage: bool,
+    build_dump: bool,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -257,6 +269,7 @@ fn detect_from_units_inner(
         None,
         trace_accepted_coverage,
         trace_contiguous_coverage,
+        build_dump,
         &mut clk,
     )
 }
@@ -276,6 +289,7 @@ fn finish_detection(
     contiguous_override: Option<(Vec<crate::Group>, Vec<Vec<crate::AcceptedEdge>>)>,
     trace_accepted_coverage: bool,
     trace_contiguous_coverage: bool,
+    build_dump: bool,
     clk: &mut StageTimer,
 ) -> (Report, Dump) {
     let (mut connected_accepted, mut same_unit_accepted) = if let Some(cached) = connected_override
@@ -380,7 +394,12 @@ fn finish_detection(
     }
     clk.lap("contiguous");
 
-    (report, detection_dump(&units, candidates))
+    let dump = if build_dump {
+        detection_dump(&units, candidates)
+    } else {
+        Dump::default()
+    };
+    (report, dump)
 }
 
 fn detection_dump(units: &[UnitFeat], candidates: &[(usize, usize)]) -> Dump {

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -26,7 +26,7 @@ mod features;
 pub use features::{corpus_features, file_stream, units_of_file, CorpusFeatures};
 
 pub fn detect(corpus: &Corpus, opts: &DetectOptions, detector: &dyn Detector) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::REPORT).0
+    detect_with_dump_inner(corpus, opts, detector, false, false, false).0
 }
 
 /// Product-query detection with compact direct accepted-edge provenance retained
@@ -37,7 +37,7 @@ pub fn detect_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::ACCEPTED_COVERAGE).0
+    detect_with_dump_inner(corpus, opts, detector, true, false, false).0
 }
 
 /// Divergent-edit detection counterpart that also retains direct copy-paste-run
@@ -48,40 +48,7 @@ pub fn detect_with_direct_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_with_dump_inner(
-        corpus,
-        opts,
-        detector,
-        DetectionOutput::DIRECT_ACCEPTED_COVERAGE,
-    )
-    .0
-}
-
-#[derive(Clone, Copy)]
-struct DetectionOutput {
-    trace_accepted_coverage: bool,
-    trace_contiguous_coverage: bool,
-    build_dump: bool,
-}
-
-impl DetectionOutput {
-    const REPORT: Self = Self {
-        trace_accepted_coverage: false,
-        trace_contiguous_coverage: false,
-        build_dump: false,
-    };
-    const ACCEPTED_COVERAGE: Self = Self {
-        trace_accepted_coverage: true,
-        ..Self::REPORT
-    };
-    const DIRECT_ACCEPTED_COVERAGE: Self = Self {
-        trace_contiguous_coverage: true,
-        ..Self::ACCEPTED_COVERAGE
-    };
-    const DUMP: Self = Self {
-        build_dump: true,
-        ..Self::REPORT
-    };
+    detect_with_dump_inner(corpus, opts, detector, true, true, false).0
 }
 
 /// Per-stage wall-clock timing, printed to stderr when `NOSE_TIME` is set. A
@@ -119,14 +86,16 @@ pub fn detect_with_dump(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_with_dump_inner(corpus, opts, detector, DetectionOutput::DUMP)
+    detect_with_dump_inner(corpus, opts, detector, false, false, true)
 }
 
 fn detect_with_dump_inner(
     corpus: &Corpus,
     opts: &DetectOptions,
     detector: &dyn Detector,
-    output: DetectionOutput,
+    trace_accepted_coverage: bool,
+    trace_contiguous_coverage: bool,
+    build_dump: bool,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -143,7 +112,16 @@ fn detect_with_dump_inner(
     // `detect_from_units` runs its own `StageTimer` for the detection sub-phases
     // (candidates/score/groups/contiguous), so no lap here — a single outer lap would
     // mislabel the whole call (group scoring dwarfs contiguous) as "contiguous".
-    detect_from_units_inner(units, files, &streams, opts, detector, output)
+    detect_from_units_inner(
+        units,
+        files,
+        &streams,
+        opts,
+        detector,
+        trace_accepted_coverage,
+        trace_contiguous_coverage,
+        build_dump,
+    )
 }
 
 /// Run candidate-generation → scoring → clustering over already-built `units` (the
@@ -158,7 +136,7 @@ pub fn detect_from_units(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> (Report, Dump) {
-    detect_from_units_inner(units, files, streams, opts, detector, DetectionOutput::DUMP)
+    detect_from_units_inner(units, files, streams, opts, detector, false, false, true)
 }
 
 /// Cached-query counterpart to [`detect_with_accepted_coverage`].
@@ -169,15 +147,7 @@ pub fn detect_from_units_with_accepted_coverage(
     opts: &DetectOptions,
     detector: &dyn Detector,
 ) -> Report {
-    detect_from_units_inner(
-        units,
-        files,
-        streams,
-        opts,
-        detector,
-        DetectionOutput::ACCEPTED_COVERAGE,
-    )
-    .0
+    detect_from_units_inner(units, files, streams, opts, detector, true, false, false).0
 }
 
 /// Cached-query entry point with persistent candidate membership and pair-score
@@ -256,13 +226,16 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
     (report, state, stats)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn detect_from_units_inner(
     units: Vec<UnitFeat>,
     files: usize,
     streams: &[Stream],
     opts: &DetectOptions,
     detector: &dyn Detector,
-    output: DetectionOutput,
+    trace_accepted_coverage: bool,
+    trace_contiguous_coverage: bool,
+    build_dump: bool,
 ) -> (Report, Dump) {
     let mut clk = StageTimer::new();
 
@@ -295,9 +268,9 @@ fn detect_from_units_inner(
         None,
         None,
         None,
-        output.trace_accepted_coverage,
-        output.trace_contiguous_coverage,
-        output.build_dump,
+        trace_accepted_coverage,
+        trace_contiguous_coverage,
+        build_dump,
         &mut clk,
     )
 }

--- a/crates/nose-detect/src/orchestration.rs
+++ b/crates/nose-detect/src/orchestration.rs
@@ -166,7 +166,7 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
 ) {
     let mut clk = StageTimer::new();
     let mut stats = IncrementalDetectionStats::new();
-    let prepared = incremental::prepare(&units, stable_unit_keys, opts, previous, &mut stats);
+    let mut prepared = incremental::prepare(&units, stable_unit_keys, opts, previous, &mut stats);
     clk.lap("candidates");
     let (scored, accepted) =
         incremental::score(&units, &prepared, detector, opts.threshold, &mut stats);
@@ -183,7 +183,7 @@ pub fn detect_from_units_incremental_with_accepted_coverage(
             opts.contiguous_min_tokens,
             opts.contiguous_min_lines,
             false,
-            prepared.previous_contiguous.as_ref(),
+            prepared.previous_contiguous.take(),
         );
         stats.contiguous_streams_reused = contiguous_stats.streams_reused;
         stats.contiguous_streams_rebuilt = contiguous_stats.streams_rebuilt;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,10 @@ new code should follow the focused owners there rather than growing dispatcher o
   Connected/same-unit evidence includes its file-context digest, syntax runs are partitioned by
   shared k-grams, and line-IDF/family weights use source-frequency deltas. The full storage and
   invalidation contract is in [portable cache artifacts](portable-cache-artifacts.md).
+- **Transactional, bounded cache state.** Immutable, checksummed records are published before one
+  complete generation manifest; its `CURRENT` pointer is replaced last. Concurrent query processes
+  share the store while prune/clear wait for writers. Schema-scoped garbage collection and a 5 GiB
+  default budget make eviction a performance event rather than a correctness event.
 - **Determinism is a hard invariant.** Output is byte-identical across runs *and*
   thread counts. File ids come from a sorted path list; nothing iterates a
   `HashMap` into the output. There are tests for both.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -26,7 +26,7 @@ nose capabilities
 
 ```json
 {
-  "schema_version": 7,
+  "schema_version": 8,
   "tool": {
     "name": "nose",
     "version": "<version>"
@@ -42,11 +42,14 @@ nose capabilities
     "doctor_json": false
   },
   "commands": {
-    "stable": ["capabilities", "il", "query", "semantic-pack", "stats"],
+    "stable": ["cache", "capabilities", "il", "query", "semantic-pack", "stats"],
     "deprecated": []
   },
   "schemas": {
-    "capabilities": [7],
+    "capabilities": [8],
+    "cache_status": ["nose.cache-status/v1"],
+    "cache_prune": ["nose.cache-prune/v1"],
+    "cache_clear": ["nose.cache-clear/v1"],
     "query_json": [8, 9],
     "semantic_packs": ["nose.semantic-pack.v0", "nose.semantic-pack.v1"],
     "semantic_pack_locks": ["nose.semantic-pack-lock.v1"],
@@ -63,6 +66,7 @@ nose capabilities
     "output_formats": ["human", "json", "markdown", "sarif"],
     "sort_keys": ["extractability", "value", "sites", "hazard"],
     "config_keys": [
+      "cache-max-bytes",
       "exclude",
       "generated-paths",
       "ignore-file",
@@ -164,11 +168,11 @@ release so it can't drift.
 The JSON example above is compared against `nose capabilities` by the CLI integration test;
 only `tool.version` and the platform values are normalized for the local build.
 
-## Version 7 Fields
+## Version 8 Fields
 
 | field | type | meaning |
 |---|---|---|
-| `schema_version` | integer | Capabilities contract version. Version 7 is documented here. |
+| `schema_version` | integer | Capabilities contract version. Version 8 is documented here. |
 | `tool.name` | string | Always `nose`. |
 | `tool.version` | string | Package version of the installed binary. |
 | `platform.os` | string | Rust target OS name, such as `linux`, `macos`, or `windows`. |
@@ -178,8 +182,11 @@ only `tool.version` and the platform values are normalized for the local build.
 | `interfaces.version_json` | boolean | Whether `nose --version --json` is supported. Version 1 reports `false`. |
 | `interfaces.doctor_json` | boolean | Whether `nose doctor --json` is supported. Version 1 reports `false`. |
 | `commands.stable` | array | Stable user-facing commands that integrations may invoke (incl. `query`, the interactive exploration surface — see [usage › nose query](usage.md#nose-query), with its versioned [query-JSON](query-json.md) contract). Hidden research commands are intentionally omitted. |
-| `commands.deprecated` | array | Commands that still work but are being retired. Version 7 reports an empty array. |
+| `commands.deprecated` | array | Commands that still work but are being retired. Version 8 reports an empty array. |
 | `schemas.capabilities` | array | Supported capabilities schema versions. |
+| `schemas.cache_status` | array | Supported `nose cache status --format json` schemas. |
+| `schemas.cache_prune` | array | Supported `nose cache prune --format json` schemas. |
+| `schemas.cache_clear` | array | Supported `nose cache clear --format json` schemas. |
 | `schemas.query_json` | array | Supported `nose query --format json` schema versions ([query-json](query-json.md)). |
 | `schemas.semantic_packs` | array | Supported semantic-pack manifest API versions, currently `nose.semantic-pack.v0` and `nose.semantic-pack.v1`. |
 | `schemas.semantic_pack_locks` | array | Supported project-lock API versions, currently `nose.semantic-pack-lock.v1`. |
@@ -202,18 +209,18 @@ only `tool.version` and the platform values are normalized for the local build.
 | `semantic_packs.project_lock_output_formats` | array | Supported lock/status report formats. |
 | `semantic_packs.conformance` | array | Supported conformance input sources: local manifest files/directories. |
 | `semantic_packs.conformance_output_formats` | array | Supported `nose semantic-pack check --format` values. |
-| `semantic_packs.inventory` | array | Supported inventory sources. Version 7 reports `compiled-builtin`. |
+| `semantic_packs.inventory` | array | Supported inventory sources. Version 8 reports `compiled-builtin`. |
 | `semantic_packs.inventory_output_formats` | array | Supported `nose semantic-pack inventory --format` values. |
-| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 7 reports `compiled-builtin`. |
+| `semantic_packs.adoption_gates` | array | Supported adoption-gate report sources. Version 8 reports `compiled-builtin`. |
 | `semantic_packs.adoption_gate_output_formats` | array | Supported `nose semantic-pack adoption-gates --format` values. |
-| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 7 reports `policy`. |
+| `semantic_packs.compatibility` | array | Supported compatibility report sources. Version 8 reports `policy`. |
 | `semantic_packs.compatibility_output_formats` | array | Supported `nose semantic-pack compatibility --format` values. |
 | `semantic_packs.trust` | array | Supported trust policy labels. |
 | `semantic_packs.external_packs_enabled_by_default` | boolean | Always `false`; external packs require explicit CLI/config opt-in. |
 | `semantic_packs.external_pack_influence` | string | Current external boundary: unlocked/v0 metadata, dependency-backed locked v1 near influence, or receipt-backed external-claim exact. |
-| `semantic_packs.external_exact_operations` | array | Closed external-exact kernel operations; version 7 contains only `collection-factory`. |
+| `semantic_packs.external_exact_operations` | array | Closed external-exact kernel operations; version 8 contains only `collection-factory`. |
 | `semantic_packs.external_influence_blockers` | array | Stable blocker labels that currently prevent external rows from influencing analysis. |
-| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 7 reports `none`; nose analyzes fixture source but never executes fixture programs, recognizers, parser/lowering plugins, producer code, or sandboxed code. |
+| `semantic_packs.external_pack_execution` | string | Current external pack execution support. Version 8 reports `none`; nose analyzes fixture source but never executes fixture programs, recognizers, parser/lowering plugins, producer code, or sandboxed code. |
 | `il.output_formats` | array | Supported `nose il --format` values. |
 | `il.normalized` | boolean | Whether `nose il --normalized` is supported. |
 | `il.cfg_norm_toggle` | boolean | Whether `nose il --no-cfg-norm` is supported. |
@@ -235,7 +242,7 @@ is limited to the operation advertised by `external_exact_operations`.
 
 ## Query Capability Flags
 
-Version 7 defines these `query.capabilities` keys:
+Version 8 defines these `query.capabilities` keys:
 
 | key | meaning |
 |---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ ignore-file = "nose.ignore.json"
 semantic-packs = ["semantic-packs/python-math-prod.json"]
 # Or, for content-pinned typed v1 authorization instead of unlocked paths:
 # semantic-pack-lock = "nose.semantic-pack-lock.json"
+cache-max-bytes = 5368709120 # 5 GiB; used when --cache-dir is present
 ```
 
 Pass an alternate file with `--config <file>`. A malformed config is a **hard
@@ -42,6 +43,7 @@ term — `nose query` spells `sort` as the DSL term `sort=`, not `--sort`).
 
 | key | type | default | CLI override |
 |---|---|---|---|
+| `cache-max-bytes` | int (bytes) | `5368709120` (5 GiB) | `--cache-max-bytes` |
 | `exclude` | list of globs | `[]` | `--exclude` |
 | `generated-paths` | list of root-anchored globs | `[]` | `--generated-path` |
 | `mode` | list of `syntax`\|`semantic`\|`near[:T]` | `["syntax", "semantic", "near"]` | `--mode` |
@@ -62,6 +64,11 @@ mode = ["syntax"]                          # jscpd-style gate (exact copy-paste 
 # mode = ["syntax", "semantic"]            # exact channels only, no fuzzy near
 # mode = ["syntax", "semantic", "near"]    # same as omitting mode (the default)
 ```
+
+`cache-max-bytes` bounds nose-managed files below `--cache-dir`. It does not choose or enable a
+cache directory; keep the location as a CLI/CI workflow choice. A run that writes cache data
+automatically prunes old schemas, superseded generations, orphaned state, and then the oldest
+artifacts until it reaches the limit. Eviction changes only future run time, never query output.
 
 `min-size` (and the advanced `min-lines`) apply to both structural units and the syntax
 copy-paste floor. For `--mode syntax`, they are the jscpd-style size gate.

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -341,6 +341,14 @@ clean-scan-equivalence contract.
 nose query src --cache-dir .nose-cache --fail-on any
 ```
 
+The cache defaults to a 5 GiB managed budget. Override it per run with
+`--cache-max-bytes 2GiB`, or commit the byte count as `[query].cache-max-bytes` in `nose.toml`.
+Only runs that write data trigger automatic pruning; fully warm runs avoid a storage scan. Use
+`nose cache status --dir .nose-cache --format json` to monitor usage, `nose cache prune` for an
+explicit budget pass, and `nose cache clear` to discard managed data. Prune/clear wait for active
+writers, preserve unrelated files, and can only make a later query slower: missing or evicted data
+is recomputed.
+
 Set `NOSE_CACHE_STATS=1` to retain the existing `[cache]` unit hit/miss line and add one
 `[invalidation]` JSON object (`nose.invalidation/v1`). It reports source/raw/resolved layer counts,
 the affected path closure and reasons, deleted sources, Git-blob versus content identities,

--- a/docs/dogfooding-history.md
+++ b/docs/dogfooding-history.md
@@ -1347,3 +1347,12 @@ context/export assignment-counting representative moves from
 including only two shared lines across 204 reported lines. No new avoidable
 duplication is accepted; the budget increase records only the returning numeric
 policy family.
+
+The #876 transactional-store closeout keeps the reviewed count at 28. The
+cache and accepted-coverage source movement changes the representative ID of
+the already reviewed cross-engine candidate enumeration family from
+`3fefab5ac16598ec` to `0225963d07a476fe`. Its only members remain
+`nose-markdown::fingerprint::candidate_pairs` and
+`nose-detect::candidates::anchor_candidates`; the family still shares ten lines
+across independent Markdown and semantic-detection candidate engines. No new
+duplication or budget is accepted.

--- a/docs/incremental-cache-benchmark.md
+++ b/docs/incremental-cache-benchmark.md
@@ -143,6 +143,37 @@ replays. Every clean/empty/history comparison passed byte-for-byte, including ad
 provider fan-out, semantic-pack and config changes, embedded regions, Swift global barriers, and
 same-size restored-mtime edits.
 
+## Checked #876 evidence
+
+The checked [`issue-876-transactional-store-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-876-transactional-store-sympy-paired-2026-07-20.v1.json)
+contains all 180 rows from 30 alternating AB/BA replays of implementation commit `6b13adaa`
+against the checksum-verified published v0.19.0 binary. Both roles independently passed exact
+clean/empty/history output equivalence.
+
+| Phase | Official p50 / p95 | #876 p50 / p95 | #876 delta p50 / p95 |
+| --- | ---: | ---: | ---: |
+| Clean | 1120.06 / 1480.92 ms | 1163.42 / 1388.26 ms | +3.87% / -6.26% |
+| Empty store | 1320.03 / 1662.34 ms | 8864.49 / 9388.52 ms | +571.54% / +464.78% |
+| Warm store | 893.96 / 1038.31 ms | 1866.58 / 1920.24 ms | +108.80% / +84.94% |
+
+The active store is 148,668,018 bytes for 27,214,294 bytes of Python source: 5.46× source and
+60.89% smaller than the official binary's 380,153,026-byte store. This passes both #876 disk
+gates. Clean p50/p95 RSS is 1.13%/2.39% below official, so the clean resource gate also passes.
+
+The remaining resource gate is deliberately not marked complete. Warm no-op p50/p95 RSS is
+713,596,928/743,718,912 bytes, 66.91%/68.64% of official rather than the required ≤60%. A separate
+one-run leaf-edit characterization measured 809,074,688 bytes against official's 1,086,472,192
+bytes (74.47%); it is diagnostic, not 30-replay release evidence. The warm path still restores the
+whole corpus and every unit before applying the incremental global state. #877 owns eliminating
+that whole-corpus restoration while integrating policy and base/current views; #876 remains open
+until the leaf-update criterion is measured there.
+
+The first-generation cost is also visible rather than normalized away. Per-object filesystem sync
+was removed only for immutable, checksummed CAS entries—a lost or corrupt entry is a safe miss—while
+generation manifests and `CURRENT` retain file-and-directory sync. Compact serialization and
+compression still make the empty-store and warm runs slower than v0.19. #877 must avoid paying
+restore work on view-only changes and warm updates rather than weakening integrity or disk bounds.
+
 ## What the current cache actually reuses
 
 The published v0.19.0 cache is schema v11 and the locked #872 candidate is schema v14. #873 moved

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -2,7 +2,8 @@
 
 The 0.20 Instant Monorepo cache uses one layered content-addressed store (CAS) contract for every
 analysis stage. #873 defined the portable trust boundary, #874 activated dependency-aware source
-and IL reuse, and #875 adds delete-capable global detection and family-line state.
+and IL reuse, #875 added delete-capable global state, and #876 commits that state transactionally
+inside a bounded store.
 
 ## Layer contract
 
@@ -17,11 +18,12 @@ at a different address. The six stable stage identities are:
 | export/dependency summary | actively written and checksummed | deterministic export graph and SCC closure |
 | resolved IL | actively read and written | raw IL plus the region's dependency context |
 | units and syntax streams | actively read and written | resolved IL plus unit-affecting options |
-| global detection indexes | actively read and written | stable unit ids, bucket refcounts, pair scores, components, witnesses, syntax runs, line IDF, and family-line analyses |
+| transactional state | actively read and written | stable detection indexes, manifests, line IDF, family-line analyses, and diagnostics |
 
-Raw and resolved IL use named MessagePack wrapped in fast LZ4 blocks; the decoder rejects a claimed
-region expansion above 512 MiB before allocation. The units layer stays named MessagePack without
-compression because those payloads are already compact feature hashes and dominate warm reads.
+Raw and resolved IL use independently bounded Zstandard-framed MessagePack regions inside the
+shared envelope; the decoder rejects a region above 512 MiB before decompression. Keeping regions
+independent avoids inflating every file in a parallel warm load. Units and global acceleration
+state use envelope-level Zstandard compression because they dominate the remaining store size.
 Discovery still walks the selected roots so additions and deletions are visible, but a clean
 tracked raw hit needs no source read or parse in the lowering stage. Dependency summaries scan raw
 IL, compute consumer-visible literal surfaces, collapse cycles deterministically, and resolve
@@ -54,35 +56,48 @@ more than necessary when an unrelated export changes, but it cannot reuse a stal
 the path is listed under `over_invalidated`. Discovery membership, semantic-pack influence, and
 corpus-global line-statistics digests also drive the downstream incremental global stages.
 
-The mutable `state-v1` workspace record exists only to explain changes and deleted paths. It is not
-a cache-key or reuse input: deleting or corrupting it loses reason history, never correctness.
+The workspace diagnostic record exists only to explain changes and deleted paths. It is not a
+cache-key or reuse input: deleting or corrupting it loses reason history, never correctness.
 Under `NOSE_CACHE_STATS=1`, stderr includes one `nose.invalidation/v1` JSON closure alongside the
 backward-compatible `[cache]` units line. Cold start is summarized globally instead of listing
 every file; history-bearing runs list the exact changed/deleted closure. Resolved `passthrough`
 counts identify regions whose raw IL is already the correct resolved form, so no duplicate payload
 is stored.
 
-The #875 detection, line-index, and family-line records are schema-scoped mutable acceleration
-state. Exact unit/source identities guard reuse, and a missing, corrupt, or incompatible record
-falls back to clean recomputation. #876 owns committing these mutually dependent records as one
-bounded generation; until then each record is atomically replaced but the set is not one
-transaction.
+Detection, line-index, family-line, source-manifest, and diagnostic records are immutable
+MessagePack state objects. A generation manifest names one complete slot set and a checksummed
+`CURRENT` pointer is replaced last. An interrupted writer therefore leaves the previous generation
+visible; an unreferenced object or manifest is reclaimable. Concurrent processes share a run lease,
+serialize commits per workspace, reload the latest generation under that lock, and merge disjoint
+slot updates. `prune` and `clear` acquire the exclusive store lease only after active queries finish.
+Exact unit/source identities still guard reuse, so missing, evicted, corrupt, or incompatible state
+always falls back to clean recomputation.
 
 ## Envelope and failure behavior
 
-CAS v1 entries live below `cas-v1/<stage>/<digest-prefix>/`. A fixed binary header binds:
+CAS v2 entries live below `cas-v2/<stage>/<digest-prefix>/`; generation state lives below
+`state-v2/<workspace>/`. A fixed binary header binds:
 
-- the `NOSECAS1` magic and envelope schema;
+- the `NOSECAS2` magic and envelope schema;
 - stage id and stage-local schema;
 - the complete 256-bit requested address;
 - exact payload length; and
 - an independent SHA-256 checksum of the payload.
 
-Writers finish a private temporary file before atomic publication. Readers validate every header
-field, exact file length, and checksum before deserialization. A missing, truncated,
+Payloads are Zstandard-compressed only when that reduces their size. Stored and decoded lengths are
+bounded before allocation/decompression. Writers finish and sync a private temporary file before
+atomic publication, then sync the containing directory. Readers validate every header field,
+exact file length, decoded length, and checksum before deserialization. A missing, truncated,
 corrupt, wrong-stage, wrong-schema, or misplaced entry is a cache miss and recomputes; no failure
 path returns unchecked bytes. Concurrent writers of one address converge on complete envelopes,
 while a racing reader can at worst miss and recompute.
+
+The managed store defaults to 5 GiB and can be changed with `--cache-max-bytes` or
+`[query].cache-max-bytes`. Runs that wrote data remove old schema directories, temporary files,
+superseded generations, and orphaned state before evicting the oldest remaining artifacts to the
+budget. `nose cache status|prune|clear --dir <dir>` exposes the same lifecycle explicitly and never
+removes unrelated files below the chosen directory. Eviction can reduce reuse but cannot alter a
+query result.
 
 The payload checksum is deliberately separate from the semantic address. The address proves that
 the requested stage inputs match; the checksum proves that storage returned the exact bytes that
@@ -120,6 +135,10 @@ Focused tests prove:
 - raw and resolved portable round trips produce byte-identical detector JSON;
 - script, style, and markup regions have stable distinct subidentities; and
 - corruption and truncation fail closed.
+- interruption before/after manifest publication keeps the previous complete generation visible;
+- concurrent processes produce byte-identical output and leave a readable merged store;
+- oversized envelopes, bit flips, and truncation warn and recompute; and
+- read-only hits, read-only misses, explicit eviction, and tiny automatic budgets preserve output.
 
 The #275 provider/importer integration test remains the cross-file safety gate. Focused gates also
 cover unchanged export surfaces, shifted `FileId`s with an active import edge, Swift global

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -85,12 +85,15 @@ CAS v2 entries live below `cas-v2/<stage>/<digest-prefix>/`; generation state li
 - an independent SHA-256 checksum of the payload.
 
 Payloads are Zstandard-compressed only when that reduces their size. Stored and decoded lengths are
-bounded before allocation/decompression. Writers finish and sync a private temporary file before
-atomic publication, then sync the containing directory. Readers validate every header field,
-exact file length, decoded length, and checksum before deserialization. A missing, truncated,
-corrupt, wrong-stage, wrong-schema, or misplaced entry is a cache miss and recomputes; no failure
-path returns unchecked bytes. Concurrent writers of one address converge on complete envelopes,
-while a racing reader can at worst miss and recompute.
+bounded before allocation/decompression. Writers finish a private temporary file before atomic
+publication. Immutable CAS files and directory entries are not individually synced: losing or
+corrupting one in a machine crash is a verified cache miss, while serially syncing thousands of
+objects makes first-generation construction scale with filesystem flush latency. Mutable
+generation manifests and `CURRENT` retain the stronger file-and-directory sync boundary. Readers
+validate every header field, exact file length, decoded length, and checksum before deserialization.
+A missing, truncated, corrupt, wrong-stage, wrong-schema, or misplaced entry is a cache miss and
+recomputes; no failure path returns unchecked bytes. Concurrent writers of one address converge on
+complete envelopes, while a racing reader can at worst miss and recompute.
 
 The managed store defaults to 5 GiB and can be changed with `--cache-max-bytes` or
 `[query].cache-max-bytes`. Runs that wrote data remove old schema directories, temporary files,

--- a/docs/portable-cache-artifacts.md
+++ b/docs/portable-cache-artifacts.md
@@ -190,3 +190,24 @@ cost is first-generation construction: the store grows from 380,153,026 to 448,3
 (+17.93%), and cold latency more than doubles while the new global indexes are built. #876 owns
 transactional compact storage, bounded generations, and reclaiming that cold/store overhead; the
 regression is measured here rather than hidden.
+
+## Checked #876 performance evidence
+
+The checked [`issue-876-transactional-store-sympy-paired-2026-07-20.v1.json`](../bench/cache/issue-876-transactional-store-sympy-paired-2026-07-20.v1.json)
+contains 30 alternating AB/BA replays of implementation commit `6b13adaa` against the
+checksum-verified published v0.19.0 Apple Silicon binary. Both roles passed exact
+clean/empty/history output equivalence across all 180 rows.
+
+| Phase | Official p50 / p95 | #876 p50 / p95 | #876 delta p50 / p95 |
+| --- | ---: | ---: | ---: |
+| Clean | 1120.06 / 1480.92 ms | 1163.42 / 1388.26 ms | +3.87% / -6.26% |
+| Empty store | 1320.03 / 1662.34 ms | 8864.49 / 9388.52 ms | +571.54% / +464.78% |
+| Warm store | 893.96 / 1038.31 ms | 1866.58 / 1920.24 ms | +108.80% / +84.94% |
+
+The store falls to 148,668,018 bytes, 60.89% below official and 5.46× the workload's
+27,214,294 source bytes. Clean p50/p95 RSS is 1.13%/2.39% below official. Warm no-op p50/p95 RSS
+falls by 33.09%/31.36%, but remains 66.91%/68.64% of official and therefore does not satisfy the
+≤60% warm leaf gate. A separate one-run leaf-edit characterization reached only 74.47% of
+official RSS. #877 owns removing the remaining whole-corpus restoration and producing the checked
+leaf-update evidence before #876 closes. Empty-store compression and warm restore latency remain
+explicit in the table; neither is waived by the disk and clean-RSS passes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,6 +34,7 @@ from-source `./target/release/nose`.
 | Open one family with its extraction skeleton | `nose query <path> id=<fam> full` |
 | Catch a missed sibling edit in a diff or PR | `nose query <path> base=<ref>` |
 | Gate CI on duplication | `nose query <path> --fail-on any` |
+| Inspect or reclaim a query cache | `nose cache status|prune|clear --dir <cache>` |
 | Read the result as machine-readable JSON | `nose query <path> --format json` ([query-json](query-json.md)) |
 | Ask what an installed binary supports | `nose capabilities` |
 | Check a local semantic-pack manifest | `nose semantic-pack check <file-or-dir>` |
@@ -109,7 +110,7 @@ A typical loop: `nose query .` → `nose query . witness=exact` → `nose query 
 
 `nose query` accepts the same **analysis flags** as the detection pipeline — `--mode`
 (see [Detection modes](#detection-modes)), `--min-size`, `--min-value`, `--min-members`, `--exclude`,
-`--cache-dir`, `--ignore-file`, `--semantic-pack`, `--config` — so the dataset it explores is
+`--cache-dir`, `--cache-max-bytes`, `--ignore-file`, `--semantic-pack`, `--config` — so the dataset it explores is
 configured by flag while scope/sort/top are the DSL's `scope=`/`sort=`/`top=`. It also takes the
 **CI gate** — `--fail-on any` / `--fail-on new` with `--baseline`/`--write-baseline` — and
 drops structured-ignored families. The gate follows the untruncated family selection addressed
@@ -251,6 +252,8 @@ mode flags are documented under [Ranking](#ranking) and [Detection modes](#detec
 | `--root <path>` / `-r <path>` | analyze another root; repeat for multi-root query runs. With `--root`, bare positional arguments are query terms. |
 | `--exclude <glob>` | skip paths matching a gitignore-syntax glob (repeatable) |
 | `--generated-path <glob>` | assert that files matching this root-anchored glob are generated; repeatable and recoverable with `all top=0` |
+| `--cache-dir <dir>` | reuse portable, checksummed analysis artifacts and transactional incremental state |
+| `--cache-max-bytes <SIZE>` | bound the managed cache (default `5GiB`; accepts bytes or KiB/MiB/GiB/TiB) |
 | `--ignore-file <file>` | suppress accepted families using a structured ignore file with reason/owner/expiry metadata |
 | `--semantic-pack <file-or-dir>` | load local semantic-pack v0 metadata or compile a typed v1 manifest for provenance/digest reporting; unlocked external packs are metadata-only |
 | `--semantic-pack-lock <file>` | validate one content-pinned typed v1 project lock before analysis; eligible rows may support near candidates or receipt-backed collection-factory exact claims, and unlocked pack paths cannot be mixed in |
@@ -265,7 +268,7 @@ Use terms for report shaping: `sort=KEY`, `top=N`, `scope=prod|test|mixed`, `gro
 `id=<fam> full`, and `reinvented`. `--format json` emits the stable
 [query-json](query-json.md) contract.
 
-**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--config`, `--generated-path`, `--semantic-pack`, `--semantic-pack-lock`) is covered in
+**Workflow** (`--baseline`, `--write-baseline`, `--fail-on any|new`, `--ignore-file`, `--cache-dir`, `--cache-max-bytes`, `--config`, `--generated-path`, `--semantic-pack`, `--semantic-pack-lock`) is covered in
 [continuous-integration](continuous-integration.md), [configuration](configuration.md), and [semantic-pack-loading](semantic-pack-loading.md).
 Structured suppressions are covered in [structured-ignores](structured-ignores.md).
 
@@ -287,6 +290,14 @@ and may change to improve readability. The stable contract is documented in
 
 ## Other commands
 
+- `nose cache status --dir <dir> [--max-bytes 5GiB] [--format human|json]` — report managed
+  bytes/files, live and historical generations, and immediately reclaimable storage.
+- `nose cache prune --dir <dir> [--max-bytes 5GiB] [--format human|json]` — remove old schemas,
+  orphaned generations, and the oldest entries above the budget. Active queries finish before
+  pruning starts.
+- `nose cache clear --dir <dir> [--format human|json]` — remove only nose-managed cache data;
+  unrelated files under the directory are preserved. All three JSON forms carry the schemas
+  advertised by [`nose capabilities`](capabilities.md).
 - `nose query <paths> base=<ref>` — flags clones changed inconsistently in a diff
   (a copy edited, its siblings missed); use `base=HEAD` for uncommitted changes and
   `base=origin/main --mode syntax,semantic --fail-on any` for a PR gate; see

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -9,7 +9,7 @@
     "3cdf8f9a869d1932",
     "5ad08a3c9ab9f5c3",
     "770bd29db214f114",
-    "3fefab5ac16598ec",
+    "0225963d07a476fe",
     "8d3e36bdd11cf2c0",
     "95e83331abfa623f",
     "2bca2e8582b7d7a7",

--- a/scripts/semantic-regression-smoke.sh
+++ b/scripts/semantic-regression-smoke.sh
@@ -142,9 +142,8 @@ if [[ -z "$baseline_binary" ]]; then
   # Cargo's package fingerprints do not distinguish two worktrees of the same
   # package version in one target directory. Without this workspace-only clean,
   # the head build can reuse a base-worktree rlib across an internal API change
-  # and fail (or, worse, produce a mixed-revision binary). Keep downloaded and
-  # third-party dependency artifacts, but rebuild every workspace member from
-  # the head tree.
+  # and fail (or, worse, produce a mixed-revision binary). Keep the Cargo cache,
+  # but rebuild the release target from the head tree.
   (
     cd "$worktree_root/head"
     cargo clean --release --workspace --target-dir "$cargo_target"

--- a/scripts/semantic-regression-smoke.sh
+++ b/scripts/semantic-regression-smoke.sh
@@ -139,6 +139,16 @@ if [[ -z "$baseline_binary" ]]; then
   )
   baseline_binary="$(pwd)/target/semantic-regression/baseline-nose"
   cp "$cargo_target/release/nose" "$baseline_binary"
+  # Cargo's package fingerprints do not distinguish two worktrees of the same
+  # package version in one target directory. Without this workspace-only clean,
+  # the head build can reuse a base-worktree rlib across an internal API change
+  # and fail (or, worse, produce a mixed-revision binary). Keep downloaded and
+  # third-party dependency artifacts, but rebuild every workspace member from
+  # the head tree.
+  (
+    cd "$worktree_root/head"
+    cargo clean --release --workspace --target-dir "$cargo_target"
+  )
   (
     cd "$worktree_root/head"
     cargo build --release --locked --target-dir "$cargo_target"
@@ -148,7 +158,7 @@ if [[ -z "$baseline_binary" ]]; then
   build_mode="worktrees"
   base_build_cwd="$worktree_root/base"
   head_build_cwd="$worktree_root/head"
-  build_command="cargo build --release --locked --target-dir $cargo_target"
+  build_command="cargo build --release --locked --target-dir $cargo_target (workspace artifacts cleaned between revisions)"
 else
   build_mode="prebuilt"
   base_build_cwd=""


### PR DESCRIPTION
## Summary

- publish checksummed CAS v2 artifacts and mutable state through immutable records plus a generation committed by `CURRENT` last
- add concurrent-process locking, corruption/size fail-safe misses, independently versioned compact artifacts, 5 GiB default budgeting, GC, and `nose cache status|prune|clear`
- compact detection/line state and avoid rebuilding diagnostic and unchanged detection output on product cache hits
- keep immutable CAS publication atomic without per-object fsync; mutable generation manifests and `CURRENT` retain file-and-directory durability
- record 30-replay AB/BA evidence against the checksum-verified official v0.19.0 Apple Silicon binary

## Evidence

- candidate and official output equivalence: 180/180 rows for each role
- store: 380,153,026 -> 148,668,018 bytes (-60.89%), 5.46x analyzed source
- clean RSS p50/p95: -1.13% / -2.39% vs official
- clean runtime p50/p95: +3.87% / -6.26% vs official
- warm no-op RSS p50/p95: 66.91% / 68.64% of official
- one-run leaf-update characterization: 74.47% of official RSS

The disk and clean-RSS criteria pass. The <=60% warm leaf criterion does not: the current path still restores the complete corpus and units before applying incremental global state. #877 owns eliminating that restoration while integrating policy and base/current views. This PR therefore uses `Refs #876`; #876 remains open until that checked leaf evidence passes.

Empty-store p50 is 8.86 s and warm p50 is 1.87 s versus official 1.32 s / 0.89 s. Those costs are recorded rather than waived. Per-object filesystem synchronization was removed only where loss/corruption becomes a verified cache miss; compact compression/restore costs remain explicit for #877.

## Validation

- `cargo test --workspace --release`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check-file-lengths.py`
- `./scripts/check-docs.sh`
- `python3 scripts/cache-query-regression.py --validate-report bench/cache/issue-876-transactional-store-sympy-paired-2026-07-20.v1.json`

Refs #876
