### PR TITLE
Make runtime controls order-aware

### DIFF
--- a/bench/recall_loss/README.md
+++ b/bench/recall_loss/README.md
@@ -14,6 +14,9 @@ and the resulting no-go optimization decision.
 `issue-908-normalize-extract-performance-2026-07-19.v1.json` binds the inherited Guava
 and MinIO rows to the shared MinHash hot path, the output-identical optimization, and
 the fixed r40 checker evidence.
+`issue-927-order-aware-control-decision-ledger-2026-07-21.v1.json` binds the original
+#892 r40 primary/control hashes to all 11 legacy-versus-order-aware decision changes;
+the other 215 runtime signals are explicitly accounted for as unchanged.
 `issue-925-caller-generated-path-closeout-2026-07-19.v1.json` binds the root-anchored
 caller provenance contract to fresh Check/Pydantic outcomes, determinism hashes, and its
 published-v0.19.0 66-repository runtime price with same-binary control.

--- a/bench/recall_loss/issue-927-order-aware-control-decision-ledger-2026-07-21.v1.json
+++ b/bench/recall_loss/issue-927-order-aware-control-decision-ledger-2026-07-21.v1.json
@@ -1,0 +1,104 @@
+{
+  "schema": "nose.query_control_decision_ledger.v1",
+  "issue": 927,
+  "policy": "paired-alternating-sign-v1",
+  "thresholds": {
+    "max_runtime_delta_pct": 5.0,
+    "min_runtime_delta_ms": 5.0,
+    "sign_test_p_max": 0.05
+  },
+  "inputs": {
+    "source_record": "bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json",
+    "source_record_sha256": "e603d720d77f0d2e9d69d7aa4bf2f679fbfc1a30c2fc178c8434613a0c8f6b04",
+    "primary_sha256": "a539b07ede84b3531b28623a4b84278fe5225ad1c4327c5331a9d5e191fc948a",
+    "same_binary_control_sha256": "a3e615b896b9520604ddcd19ed60e2a0e6390746179513c1ab5541e9f987fb63",
+    "schema": "nose.query_regression_harness.v2",
+    "repositories": 9,
+    "iterations": 40,
+    "blocks_per_order": 20
+  },
+  "replay": {
+    "signals": 226,
+    "unchanged": 215,
+    "changed": 11,
+    "legacy_states": {
+      "triggered": 4,
+      "inconclusive": 0,
+      "within-threshold": 222
+    },
+    "order_aware_states": {
+      "triggered": 0,
+      "inconclusive": 8,
+      "within-threshold": 218
+    },
+    "historical_conclusions_rewritten": false
+  },
+  "changes": [
+    {
+      "signal": "alamofire:lower",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": 1.8000000000000114, "adjusted_pct": 1.475409836065583},
+      "order_aware": {"state": "inconclusive", "raw_ms": 3.599999999999998, "control_ms": 0.17499999999999716, "correction_ms": 0.17499999999999716, "adjusted_ms": 3.4250000000000007, "adjusted_pct": 2.8073770491803285, "supporting_blocks": 20, "sign_test_p": 0.5626853438097896, "baseline_current_ms": 0.17499999999999716, "baseline_current_material": false, "current_baseline_ms": 6.675000000000004, "current_baseline_material": true, "reason": "order-conflict"}
+    },
+    {
+      "signal": "bat:parse+lower",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": 5.150000000000006, "adjusted_pct": 4.963855421686753},
+      "order_aware": {"state": "inconclusive", "raw_ms": 5.150000000000006, "control_ms": 0.37499999999999645, "correction_ms": 0.37499999999999645, "adjusted_ms": 4.775000000000009, "adjusted_pct": 4.602409638554226, "supporting_blocks": 18, "sign_test_p": 0.7852047460783069, "baseline_current_ms": 4.225000000000012, "baseline_current_material": false, "current_baseline_ms": 5.325000000000006, "current_baseline_material": true, "reason": "order-conflict"}
+    },
+    {
+      "signal": "etcd:lower",
+      "scope": "stage",
+      "legacy": {"state": "triggered", "adjusted_ms": 5.549999999999983, "adjusted_pct": 6.517909571344665},
+      "order_aware": {"state": "within-threshold", "raw_ms": -0.32500000000000284, "control_ms": -1.5249999999999986, "correction_ms": 0.0, "adjusted_ms": -0.32500000000000284, "adjusted_pct": -0.3816793893129804, "supporting_blocks": 14, "sign_test_p": 0.9807613458578999, "baseline_current_ms": 0.04999999999999716, "baseline_current_material": false, "current_baseline_ms": -0.7000000000000028, "current_baseline_material": false, "reason": "negative-control-does-not-inflate"}
+    },
+    {
+      "signal": "etcd:parse+lower",
+      "scope": "stage",
+      "legacy": {"state": "triggered", "adjusted_ms": 5.900000000000006, "adjusted_pct": 10.554561717352426},
+      "order_aware": {"state": "within-threshold", "raw_ms": -0.4999999999999982, "control_ms": -1.549999999999999, "correction_ms": 0.0, "adjusted_ms": -0.4999999999999982, "adjusted_pct": -0.8944543828264727, "supporting_blocks": 13, "sign_test_p": 0.9917054983125126, "baseline_current_ms": -0.14999999999999858, "baseline_current_material": false, "current_baseline_ms": -0.8499999999999979, "current_baseline_material": false, "reason": "negative-control-does-not-inflate"}
+    },
+    {
+      "signal": "guava:normalize+extract",
+      "scope": "stage",
+      "legacy": {"state": "triggered", "adjusted_ms": 26.5, "adjusted_pct": 7.393973214285715},
+      "order_aware": {"state": "within-threshold", "raw_ms": 4.050000000000011, "control_ms": 0.17499999999999716, "correction_ms": 0.17499999999999716, "adjusted_ms": 3.875000000000014, "adjusted_pct": 1.0811941964285754, "supporting_blocks": 16, "sign_test_p": 0.923070027918584, "baseline_current_ms": 6.9750000000000085, "baseline_current_material": false, "current_baseline_ms": 0.7750000000000199, "current_baseline_material": false, "reason": "order-neutral-point-below-both-thresholds"}
+    },
+    {
+      "signal": "minio:lower",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": -2.7500000000000284, "adjusted_pct": -2.0676691729323524},
+      "order_aware": {"state": "inconclusive", "raw_ms": -0.8250000000000028, "control_ms": -1.9250000000000043, "correction_ms": 0.0, "adjusted_ms": -0.8250000000000028, "adjusted_pct": -0.6203007518797014, "supporting_blocks": 13, "sign_test_p": 0.9917054983125126, "baseline_current_ms": 7.6499999999999915, "baseline_current_material": true, "current_baseline_ms": -9.299999999999997, "current_baseline_material": false, "reason": "order-conflict"}
+    },
+    {
+      "signal": "minio:normalize+extract",
+      "scope": "stage",
+      "legacy": {"state": "triggered", "adjusted_ms": 7.049999999999983, "adjusted_pct": 6.385869565217376},
+      "order_aware": {"state": "inconclusive", "raw_ms": 3.1000000000000014, "control_ms": -4.099999999999998, "correction_ms": 0.0, "adjusted_ms": 3.1000000000000014, "adjusted_pct": 2.8079710144927548, "supporting_blocks": 20, "sign_test_p": 0.5626853438097896, "baseline_current_ms": 9.900000000000006, "baseline_current_material": true, "current_baseline_ms": -3.700000000000003, "current_baseline_material": false, "reason": "order-conflict"}
+    },
+    {
+      "signal": "netty:normalize+extract",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": 12.100000000000051, "adjusted_pct": 4.751619870410387},
+      "order_aware": {"state": "inconclusive", "raw_ms": 12.299999999999997, "control_ms": -11.975000000000009, "correction_ms": 0.0, "adjusted_ms": 12.299999999999997, "adjusted_pct": 4.830159041822108, "supporting_blocks": 16, "sign_test_p": 0.923070027918584, "baseline_current_ms": -3.6500000000000057, "baseline_current_material": false, "current_baseline_ms": 28.25, "current_baseline_material": true, "reason": "order-conflict"}
+    },
+    {
+      "signal": "regex:lower",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": 1.5499999999999972, "adjusted_pct": 1.5004840271055153},
+      "order_aware": {"state": "inconclusive", "raw_ms": 1.6750000000000007, "control_ms": 0.04999999999999716, "correction_ms": 0.04999999999999716, "adjusted_ms": 1.6250000000000036, "adjusted_pct": 1.5730880929332076, "supporting_blocks": 17, "sign_test_p": 0.8659063744726154, "baseline_current_ms": 5.400000000000006, "baseline_current_material": true, "current_baseline_ms": -2.1499999999999986, "current_baseline_material": false, "reason": "order-conflict"}
+    },
+    {
+      "signal": "rxswift",
+      "scope": "repo",
+      "legacy": {"state": "within-threshold", "adjusted_ms": -9.058583120349795, "adjusted_pct": -1.6994064619559595},
+      "order_aware": {"state": "inconclusive", "raw_ms": 3.865083446726203, "control_ms": -2.363333565881476, "correction_ms": 0.0, "adjusted_ms": 3.865083446726203, "adjusted_pct": 0.7250965960239362, "supporting_blocks": 11, "sign_test_p": 0.9988892831133853, "baseline_current_ms": -19.78479156969115, "baseline_current_material": false, "current_baseline_ms": 27.514958463143557, "current_baseline_material": true, "reason": "order-conflict"}
+    },
+    {
+      "signal": "rxswift:lower",
+      "scope": "stage",
+      "legacy": {"state": "within-threshold", "adjusted_ms": 0.29999999999999716, "adjusted_pct": 0.27713625866050545},
+      "order_aware": {"state": "inconclusive", "raw_ms": -0.42499999999999716, "control_ms": -2.4250000000000007, "correction_ms": 0.0, "adjusted_ms": -0.42499999999999716, "adjusted_pct": -0.3926096997690505, "supporting_blocks": 14, "sign_test_p": 0.9807613458578999, "baseline_current_ms": -7.29999999999999, "baseline_current_material": false, "current_baseline_ms": 6.449999999999996, "current_baseline_material": true, "reason": "order-conflict"}
+    }
+  ]
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -193,6 +193,7 @@ fundamentals; the rest is grouped by area.
 - [hazard-benchmark](hazard-benchmark.md) — the evaluation criteria and labeled dataset hazard is measured against (repo selection, graded labels, quantitative sufficiency).
 - [hazard-release-checklist](hazard-release-checklist.md) — what to do for the hazard ranking on every new nose release (one-page runbook: refresh the dataset, re-tune, re-validate).
 - [runtime triage](runtime-triage.md) — reproducible query-runtime regression triage: harness, classification policy, timing knobs, and when not to optimize.
+- [order-aware performance controls](order-aware-performance-controls.md) — the preregistered paired-block estimator, one-sided same-binary correction, exact sign-test decision rule, and frozen #892 decision ledger.
 - [Ruby redefinition runtime triage](runtime-triage-ruby-redefinitions-2026-07-10.md) — #807 diagnosis, indexed same-file facts, focused noise control, and all-corpus output evidence.
 - [0.19.0 release evidence](release-evidence-0.19.0.md) — the official v0.18.0 baseline comparison, accepted-coverage reporting hot-path fix, v6 product-quality reproduction, and recall-loss gate for the 0.19.0 release candidate.
 - [0.18.0 release evidence](release-evidence-0.18.0.md) — the pre-release performance pass, all-corpus query-regression, and recall-loss gate for the 0.18.0 release candidate.

--- a/docs/order-aware-performance-controls.md
+++ b/docs/order-aware-performance-controls.md
@@ -1,0 +1,108 @@
+# Order-aware performance controls
+
+This document preregisters the prospective runtime decision contract for #927. It was
+committed before replaying the frozen #892 r40 primary and same-binary control through
+the new estimator. The existing 5% and 5 ms materiality thresholds do not change.
+
+## Applicability and compatibility
+
+The contract applies automatically to `nose.query_regression_harness.v3` reports.
+Historical v1 and v2 reports retain their original decisions unless an explicit
+historical-evaluation command selects this policy. Such a replay is a decision ledger,
+not a rewrite of the #892 or #907 conclusions.
+
+Product-output drift is evaluated before runtime. The code-identical-binary shortcut is
+also unchanged: two matching code identities cannot establish a code regression, even
+when full executable digests differ because of build metadata.
+
+## Measurement design
+
+Each repository is measured in alternating paired blocks. A block contains exactly one
+baseline and one current observation. Odd blocks run baseline first and even blocks run
+current first. Version 3 records the block number, position, and order explicitly rather
+than requiring a consumer to infer them from array position.
+
+A metric is eligible only when all of these conditions hold:
+
+- every included block has exactly one observation for each label;
+- at least five complete blocks exist, with at least two blocks in each order stratum;
+- the order-stratum counts differ by at most one;
+- aggregate rows have a complete repository set in every included block;
+- all elapsed and stage values are finite and non-negative.
+
+Missing, duplicate, or malformed blocks are insufficient evidence. They are never
+silently dropped. A primary run with insufficient evidence requests one focused rerun;
+insufficient focused evidence fails closed without starting another rerun loop.
+
+## Estimator
+
+For block `i`, let `d_i = current_i - baseline_i`. Compute the median `d_i` separately
+for baseline-first and current-first blocks, then average the two stratum medians. This
+is the order-neutral primary effect. Aggregate effects are computed from the per-block
+sum across repositories, not from independently aggregated side medians.
+
+The same estimator is applied independently to the same-binary control. Its adjustment
+is deliberately one-sided:
+
+```text
+control_correction = max(order_neutral_control_effect, 0)
+adjusted_effect = order_neutral_primary_effect - control_correction
+```
+
+A positive control movement estimates shared slowdown and may reduce an apparent
+product regression. A negative control remains visible as a diagnostic but contributes
+zero correction: an independently noisy speedup cannot manufacture evidence that the
+product became slower. Primary and control runs are not treated as paired with each
+other because they were not interleaved in one randomized block sequence.
+
+## Decision rule
+
+For each complete primary block, subtract the non-negative control correction from
+`d_i`. A block supports material regression only when the adjusted difference is
+strictly greater than both 5 ms and 5% of that block's baseline value. Let `k` be the
+number of supporting blocks among `n`. Evidence support is the exact one-sided sign
+test under `P(support) = 0.5`:
+
+```text
+p = sum(combination(n, j) for j in k..n) / 2^n
+```
+
+Support requires `p <= 0.05`. Both order strata must also have adjusted median movement
+strictly above both thresholds. A runtime signal triggers only when:
+
+1. the order-neutral adjusted point estimate exceeds 5 ms and 5%;
+2. the exact sign test supports it; and
+3. both execution orders independently agree on the direction and materiality.
+
+If the point estimate is material but support, order consistency, or required blocks
+are missing, the signal is `inconclusive`. A primary inconclusive signal requests the
+single focused rerun. A focused inconclusive signal fails as insufficient evidence;
+it does not pass and does not request another measurement.
+
+## Preregistered synthetic expectations
+
+- A stable true regression above both thresholds triggers in both orders.
+- Positive same-binary drift reduces the measured product effect but cannot increase it.
+- Negative same-binary drift is reported and contributes zero correction.
+- A pure first/second-position bias disagrees between order strata and is inconclusive.
+- High-variance mixed-sign measurements that produce a material point estimate without
+  sign-test support are inconclusive.
+- Missing or duplicate rounds are insufficient evidence.
+- A code-identical comparison passes through the existing shortcut.
+- Any product-output drift still follows the existing exact declaration gate regardless
+  of runtime evidence.
+
+## Frozen historical evaluation input
+
+The later evaluation is bound to the already-published #892 source artifact and these
+original r40 files:
+
+- source record:
+  `bench/recall_loss/issue-892-official-v0.19.0-performance-2026-07-18.v1.json`;
+- primary SHA-256:
+  `a539b07ede84b3531b28623a4b84278fe5225ad1c4327c5331a9d5e191fc948a`;
+- same-binary control SHA-256:
+  `a3e615b896b9520604ddcd19ed60e2a0e6390746179513c1ab5541e9f987fb63`.
+
+The implementation may be corrected if it fails this written contract, but the
+contract will not be tuned after observing which historical rows change decision.

--- a/docs/order-aware-performance-controls.md
+++ b/docs/order-aware-performance-controls.md
@@ -106,3 +106,35 @@ original r40 files:
 
 The implementation may be corrected if it fails this written contract, but the
 contract will not be tuned after observing which historical rows change decision.
+
+## Frozen replay outcome
+
+The policy was implemented after the preregistration commit and then replayed once on
+the two SHA-bound #892 r40 reports. The compact
+[decision ledger](../bench/recall_loss/issue-927-order-aware-control-decision-ledger-2026-07-21.v1.json)
+records all 226 runtime signals: 215 retain their legacy state and exactly 11 change.
+The four legacy triggers become three `within-threshold` rows and one `inconclusive`
+row. Seven formerly clear rows expose a material split between execution orders and
+therefore also become `inconclusive`; this is intentional fail-closed behavior, not a
+new regression claim.
+
+| Signal | Legacy | Order-aware | Why |
+| --- | --- | --- | --- |
+| `etcd:lower` | triggered | within threshold | negative control no longer inflates; both order medians are below threshold |
+| `etcd:parse+lower` | triggered | within threshold | negative control no longer inflates; both order medians are below threshold |
+| `guava:normalize+extract` | triggered | within threshold | order-neutral adjusted effect is 3.88 ms / 1.08% |
+| `minio:normalize+extract` | triggered | inconclusive | baseline-first is material; current-first moves in the opposite direction |
+| `alamofire:lower` | within threshold | inconclusive | only current-first is material |
+| `bat:parse+lower` | within threshold | inconclusive | only current-first is material |
+| `minio:lower` | within threshold | inconclusive | the two order medians have opposite signs |
+| `netty:normalize+extract` | within threshold | inconclusive | only current-first is material |
+| `regex:lower` | within threshold | inconclusive | only baseline-first is material |
+| `rxswift` | within threshold | inconclusive | repository medians split by execution order |
+| `rxswift:lower` | within threshold | inconclusive | the two order medians have opposite signs |
+
+The replay does not rewrite #892 or #907. Version 2 reports still use the legacy
+estimator by default; `--runtime-policy order-aware-v1` is an explicit historical
+evaluation switch. New version 3 reports record pair order and position directly and
+select the new policy automatically. The merge smoke now takes the minimum five
+eligible primary blocks; a material or inconclusive primary signal gets exactly one
+six-block focused rerun, after which a trigger or remaining inconclusive result fails.

--- a/docs/runtime-triage.md
+++ b/docs/runtime-triage.md
@@ -17,8 +17,11 @@ the deeper classification step after that bounded gate identifies a material sig
 The broad gate answers whether product output or runtime moved. Run
 `scripts/check-query-regression.py` on that artifact to make the no-behavior-change
 decision mechanical: hashes, byte counts, and family counts must stay identical, while
-runtime is compared against a configured percentage threshold after subtracting any
-same-binary control. Runtime triage answers why a remaining measured slowdown moved.
+runtime is compared against configured percentage and absolute thresholds using the
+[order-aware same-binary control contract](order-aware-performance-controls.md).
+Positive control drift may reduce a primary movement, while a negative independent
+control never inflates it. Runtime triage answers why a remaining measured slowdown
+moved.
 Do not skip the classification step just because a repo looks slow: capability-growth
 cost, measurement noise, lower/front-end cost, and value-graph hot paths call for
 different actions.

--- a/docs/semantic-regression-smoke.md
+++ b/docs/semantic-regression-smoke.md
@@ -74,13 +74,20 @@ declares its cost acceptable.
 
 ## Runtime policy
 
-The first pass takes two measurements, pairing base and head back-to-back within
-each repository and reversing that pair order on the next iteration. This prevents
-runner load or temperature changes across the corpus from accumulating on only one
-binary. It also runs a base-vs-base same-binary control with the same repo-local
-pairing. The harness records wall time and every stage emitted by `NOSE_TIME=1`.
-A signal crosses the material threshold only when its
-control-adjusted increase is both:
+The first pass takes five paired measurements, running base and head back-to-back
+within each repository and reversing that pair order on every iteration. Five is the
+smallest sample that can satisfy the exact one-sided sign test. This prevents runner
+load, process position, or temperature changes from accumulating on only one binary.
+It also runs a base-vs-base same-binary control with the same repo-local pairing. The
+harness records each block's order and position, wall time, and every stage emitted by
+`NOSE_TIME=1`.
+
+The [order-aware control contract](order-aware-performance-controls.md) computes the
+median current-minus-base movement within each execution order and averages those two
+strata. A positive same-binary movement may reduce the result; a negative control is
+diagnostic only and can never inflate it. A signal crosses the material threshold only
+when its adjusted point estimate, exact sign-test support, and both execution-order
+strata agree that the increase is both:
 
 - greater than 5%; and
 - greater than 5 ms.
@@ -89,12 +96,13 @@ The checker evaluates the aggregate, each repository, and each reported stage.
 A repository or stage can therefore fail even when faster controls dilute the
 aggregate.
 
-A first-pass threshold crossing is not yet a hard regression failure. It exits
-with the dedicated focused-rerun status, selects the affected repositories (or the
-whole slice for an aggregate signal), and repeats six measurements after one warmup
-with another same-binary control. Six samples give base and head exactly three
-first-in-pair measurements each. Only a material signal confirmed by that balanced
-focused run fails the runtime comparison.
+A first-pass threshold crossing or statistically inconclusive order split is not yet a
+hard regression failure. It exits with the dedicated focused-rerun status, selects the
+affected repositories (or the whole slice for an aggregate signal), and repeats six
+measurements after one warmup with another same-binary control. Six samples give base
+and head exactly three first-in-pair measurements each. A material signal confirmed by
+that balanced focused run fails, as does evidence that remains inconclusive. There is
+no second focused loop.
 
 ## Deterministic Ruby scaling tripwire
 

--- a/scripts/check-query-regression.py
+++ b/scripts/check-query-regression.py
@@ -876,8 +876,15 @@ def evaluate_gate(
     status["focused_repos"] = focused_repos
     if focused_report is None:
         status["status"] = "focused-rerun-required"
+        if uses_order_aware(report, runtime_policy):
+            message = "runtime evidence needs a focused rerun for "
+        else:
+            # Preserve the checked schema-v2 closeout text byte-for-byte. The
+            # order-aware wording is prospective with schema v3; historical
+            # evidence chains remain reproducible under the legacy policy.
+            message = "runtime threshold crossed; focused rerun required for "
         raise CheckFailed(
-            "runtime evidence needs a focused rerun for " + ", ".join(focused_repos),
+            message + ", ".join(focused_repos),
             status=status,
             exit_code=3,
         )

--- a/scripts/check-query-regression.py
+++ b/scripts/check-query-regression.py
@@ -12,11 +12,15 @@ from pathlib import Path
 from typing import Any
 
 from query_regression_summary import summarize_runs
+from query_regression_control import run_self_test as run_order_aware_self_test
+from query_regression_control import runtime_signals as order_aware_runtime_signals
 
 
 STATUS_SCHEMA = "nose.semantic_regression_check.v1"
 EXPECTED_DRIFT_SCHEMA = "nose.semantic_regression_expected_drift.v1"
-REPORT_SCHEMA = "nose.query_regression_harness.v2"
+REPORT_SCHEMA_V2 = "nose.query_regression_harness.v2"
+REPORT_SCHEMA_V3 = "nose.query_regression_harness.v3"
+REPORT_SCHEMAS = (REPORT_SCHEMA_V2, REPORT_SCHEMA_V3)
 OUTPUT_KEYS = ("hashes", "bytes", "families", "schema_versions", "surface_counts")
 HEX_RE = re.compile(r"^[0-9a-f]+$")
 
@@ -112,7 +116,7 @@ def require_nonnegative_int(parent: dict[str, Any], key: str, label: str) -> int
     return value
 
 
-def validate_v2_report(
+def validate_structured_report(
     report: dict[str, Any], label: str, *, require_corpus_provenance: bool = False
 ) -> None:
     repos = require_repos(report, label)
@@ -122,6 +126,15 @@ def validate_v2_report(
     if iterations == 0:
         raise CheckFailed(f"{label}.measurement.iterations: expected a positive integer")
     require_nonnegative_int(measurement, "warmups", f"{label}.measurement")
+    if report.get("schema") == REPORT_SCHEMA_V3:
+        design = require_object(measurement, "design", f"{label}.measurement")
+        expected_design = {
+            "kind": "paired-alternating-blocks/v1",
+            "block": "iteration",
+            "orders": ["baseline-current", "current-baseline"],
+        }
+        if design != expected_design:
+            raise CheckFailed(f"{label}.measurement.design: unsupported paired-block design")
 
     provenance = require_provenance(report, label)
     for key in ("baseline_binary_sha256", "current_binary_sha256"):
@@ -247,6 +260,16 @@ def validate_v2_report(
         if identity in observed_runs:
             raise CheckFailed(f"{run_label}: duplicate measurement identity {identity}")
         observed_runs.add(identity)
+        if report.get("schema") == REPORT_SCHEMA_V3:
+            pair_order = require_string(run, "pair_order", run_label)
+            expected_order = "baseline-current" if identity[2] % 2 else "current-baseline"
+            if pair_order != expected_order:
+                raise CheckFailed(f"{run_label}.pair_order: does not alternate by block")
+            pair_position = require_nonnegative_int(run, "pair_position", run_label)
+            first_label = "baseline" if pair_order == "baseline-current" else "current"
+            expected_position = 0 if identity[1] == first_label else 1
+            if pair_position != expected_position:
+                raise CheckFailed(f"{run_label}.pair_position: does not match pair order")
         require_nonnegative_int(run, "bytes", run_label)
         require_nonnegative_int(run, "families", run_label)
         require_nonnegative_int(run, "schema_version", run_label)
@@ -277,15 +300,15 @@ def validate_report_contract(
     report: dict[str, Any], label: str, *, require_corpus_provenance: bool = False
 ) -> str:
     schema = report.get("schema")
-    if schema == REPORT_SCHEMA:
-        validate_v2_report(
+    if schema in REPORT_SCHEMAS:
+        validate_structured_report(
             report, label, require_corpus_provenance=require_corpus_provenance
         )
-        return "v2"
+        return "v3" if schema == REPORT_SCHEMA_V3 else "v2"
     if schema is not None:
         raise CheckFailed(f"{label}.schema: unsupported query regression schema {schema!r}")
     if require_corpus_provenance:
-        raise CheckFailed(f"{label}: corpus provenance requires schema {REPORT_SCHEMA}")
+        raise CheckFailed(f"{label}: corpus provenance requires a structured report schema")
     forbidden = {"measurement", "environment", "execution", "corpus"} & report.keys()
     if forbidden:
         raise CheckFailed(f"{label}: schema-less report contains v2 fields: {sorted(forbidden)}")
@@ -343,7 +366,7 @@ def validate_same_binary_control(
         raise CheckFailed("same-binary control command does not match report command")
     if require_repos(report, "report") != require_repos(control, "same-binary control"):
         raise CheckFailed("same-binary control repo set does not match report repo set")
-    if report.get("schema") == REPORT_SCHEMA:
+    if report.get("schema") in REPORT_SCHEMAS:
         if control.get("schema") != report.get("schema"):
             raise CheckFailed("same-binary control harness schema does not match report")
         if report.get("measurement") != control.get("measurement"):
@@ -369,7 +392,7 @@ def validate_same_binary_control(
         raise CheckFailed(
             "same-binary control code identity must match the report baseline or current binary"
         )
-    if report_kind == "v2":
+    if report_kind in ("v2", "v3"):
         control_base_source = control_provenance.get("baseline_source_sha")
         control_current_source = control_provenance.get("current_source_sha")
         if control_base_source != control_current_source:
@@ -487,7 +510,7 @@ def time_signal(
     }
 
 
-def runtime_signals(
+def legacy_runtime_signals(
     report: dict[str, Any],
     control: dict[str, Any] | None,
     *,
@@ -528,7 +551,7 @@ def runtime_signals(
     ]
     # Historical v1 artifacts were explicitly aggregate-only. Keep those
     # reproducible; the v2 CI contract adds per-repo and per-stage enforcement.
-    if report.get("schema") != REPORT_SCHEMA:
+    if report.get("schema") not in REPORT_SCHEMAS:
         return signals
     for repo, rows in sorted(summary["by_repo"].items()):
         baseline = require_object(rows, "baseline", repo)
@@ -600,6 +623,51 @@ def runtime_signals(
                 )
             )
     return signals
+
+
+def uses_order_aware(report: dict[str, Any], runtime_policy: str) -> bool:
+    return runtime_policy == "order-aware-v1" or (
+        runtime_policy == "auto" and report.get("schema") == REPORT_SCHEMA_V3
+    )
+
+
+def runtime_signals(
+    report: dict[str, Any],
+    control: dict[str, Any] | None,
+    *,
+    max_delta_pct: float,
+    min_delta_ms: float,
+    runtime_policy: str,
+) -> list[dict[str, Any]]:
+    provenance = require_provenance(report, "report")
+    if binary_code_identity(provenance, "baseline") == binary_code_identity(
+        provenance, "current"
+    ):
+        return legacy_runtime_signals(
+            report,
+            report,
+            max_delta_pct=max_delta_pct,
+            min_delta_ms=min_delta_ms,
+        )
+    use_order_aware = uses_order_aware(report, runtime_policy)
+    if use_order_aware:
+        if report.get("schema") not in REPORT_SCHEMAS:
+            raise CheckFailed("order-aware runtime policy requires a v2 or v3 report")
+        try:
+            return order_aware_runtime_signals(
+                report,
+                control,
+                max_delta_pct=max_delta_pct,
+                min_delta_ms=min_delta_ms,
+            )
+        except ValueError as error:
+            raise CheckFailed(f"order-aware runtime evidence is malformed: {error}") from error
+    return legacy_runtime_signals(
+        report,
+        control,
+        max_delta_pct=max_delta_pct,
+        min_delta_ms=min_delta_ms,
+    )
 
 
 def validate_focused_report(
@@ -679,6 +747,7 @@ def report_phase(
     *,
     max_delta_pct: float,
     min_delta_ms: float,
+    runtime_policy: str,
     require_corpus_provenance: bool = False,
 ) -> dict[str, Any]:
     validate_report_contract(
@@ -694,18 +763,27 @@ def report_phase(
     drifts = output_drift_repos(require_summary(report, "report"))
     authorized, unexpected, unused = authorize_drifts(report, drifts, manifest)
     signals = runtime_signals(
-        report, control, max_delta_pct=max_delta_pct, min_delta_ms=min_delta_ms
+        report,
+        control,
+        max_delta_pct=max_delta_pct,
+        min_delta_ms=min_delta_ms,
+        runtime_policy=runtime_policy,
     )
+    runtime = {
+        "signals": signals,
+        "triggered": [signal for signal in signals if signal["triggered"]],
+    }
+    if uses_order_aware(report, runtime_policy):
+        runtime["inconclusive"] = [
+            signal for signal in signals if signal.get("inconclusive", False)
+        ]
     return {
         "output": {
             "authorized_drifts": authorized,
             "unexpected_drifts": unexpected,
             "unused_declarations": unused,
         },
-        "runtime": {
-            "signals": signals,
-            "triggered": [signal for signal in signals if signal["triggered"]],
-        },
+        "runtime": runtime,
     }
 
 
@@ -721,6 +799,7 @@ def evaluate_gate(
     min_focused_iterations: int = 5,
     require_same_binary_control: bool = False,
     require_corpus_provenance: bool = False,
+    runtime_policy: str = "auto",
 ) -> dict[str, Any]:
     max_runtime_delta_pct = finite_number(
         max_runtime_delta_pct, "max_runtime_delta_pct"
@@ -738,21 +817,29 @@ def evaluate_gate(
         raise CheckFailed("min_focused_iterations: expected a positive integer")
     if require_same_binary_control and same_binary_control is None:
         raise CheckFailed("same-binary control is required")
+    if runtime_policy not in ("auto", "legacy", "order-aware-v1"):
+        raise CheckFailed("runtime_policy: expected auto, legacy, or order-aware-v1")
     primary = report_phase(
         report,
         same_binary_control,
         expected_drift_manifest,
         max_delta_pct=max_runtime_delta_pct,
         min_delta_ms=min_runtime_delta_ms,
+        runtime_policy=runtime_policy,
         require_corpus_provenance=require_corpus_provenance,
     )
+    thresholds = {
+        "max_runtime_delta_pct": max_runtime_delta_pct,
+        "min_runtime_delta_ms": min_runtime_delta_ms,
+        "min_focused_iterations": min_focused_iterations,
+    }
+    if runtime_policy != "auto" or report.get("schema") == REPORT_SCHEMA_V3:
+        thresholds["runtime_policy"] = (
+            "order-aware-v1" if uses_order_aware(report, runtime_policy) else "legacy"
+        )
     status = {
         "schema": STATUS_SCHEMA,
-        "thresholds": {
-            "max_runtime_delta_pct": max_runtime_delta_pct,
-            "min_runtime_delta_ms": min_runtime_delta_ms,
-            "min_focused_iterations": min_focused_iterations,
-        },
+        "thresholds": thresholds,
         "primary": primary,
         "focused": None,
         "focused_repos": [],
@@ -775,16 +862,22 @@ def evaluate_gate(
         raise CheckFailed("; ".join(reasons), status=status)
 
     triggered = primary["runtime"]["triggered"]
-    if not triggered:
+    inconclusive = primary["runtime"].get("inconclusive", [])
+    needs_focus = triggered + inconclusive
+    if not needs_focus:
         return status
     all_repos = sorted(require_repos(report, "report"))
-    triggered_repos = sorted({signal["repo"] for signal in triggered if signal["repo"]})
-    focused_repos = all_repos if any(signal["scope"] == "aggregate" for signal in triggered) else triggered_repos
+    affected_repos = sorted({signal["repo"] for signal in needs_focus if signal["repo"]})
+    focused_repos = (
+        all_repos
+        if any(signal["scope"] == "aggregate" for signal in needs_focus)
+        else affected_repos
+    )
     status["focused_repos"] = focused_repos
     if focused_report is None:
         status["status"] = "focused-rerun-required"
         raise CheckFailed(
-            "runtime threshold crossed; focused rerun required for " + ", ".join(focused_repos),
+            "runtime evidence needs a focused rerun for " + ", ".join(focused_repos),
             status=status,
             exit_code=3,
         )
@@ -803,6 +896,7 @@ def evaluate_gate(
         expected_drift_manifest,
         max_delta_pct=max_runtime_delta_pct,
         min_delta_ms=min_runtime_delta_ms,
+        runtime_policy=runtime_policy,
         require_corpus_provenance=require_corpus_provenance,
     )
     status["focused"] = focused
@@ -810,6 +904,18 @@ def evaluate_gate(
     if focused_output["unexpected_drifts"] or focused_output["unused_declarations"]:
         status["status"] = "fail"
         raise CheckFailed("focused rerun output drift is not exactly declared", status=status)
+    if focused["runtime"].get("inconclusive"):
+        status["status"] = "fail"
+        labels = [
+            signal["repo"] + (f":{signal['stage']}" if signal["stage"] else "")
+            if signal["repo"]
+            else "aggregate"
+            for signal in focused["runtime"]["inconclusive"]
+        ]
+        raise CheckFailed(
+            "focused runtime evidence remains insufficient in " + ", ".join(labels),
+            status=status,
+        )
     if focused["runtime"]["triggered"]:
         status["status"] = "fail"
         labels = [
@@ -860,7 +966,7 @@ def sample_report(
                 }
             )
     return {
-        "schema": REPORT_SCHEMA,
+        "schema": REPORT_SCHEMA_V2,
         "command": "nose query <repo> all top=0 --mode semantic --format json",
         "repos": ["repo-a"],
         "measurement": {"iterations": iterations, "warmups": 0},
@@ -923,6 +1029,25 @@ def sample_control(*, delta: float = 2.0, iterations: int = 1) -> dict[str, Any]
     return report
 
 
+def sample_v3(report: dict[str, Any]) -> dict[str, Any]:
+    report = json.loads(json.dumps(report))
+    report["schema"] = REPORT_SCHEMA_V3
+    report["measurement"]["design"] = {
+        "kind": "paired-alternating-blocks/v1",
+        "block": "iteration",
+        "orders": ["baseline-current", "current-baseline"],
+    }
+    for run in report["runs"]:
+        baseline_first = run["iteration"] % 2 == 1
+        run["pair_order"] = "baseline-current" if baseline_first else "current-baseline"
+        first_label = "baseline" if baseline_first else "current"
+        run["pair_position"] = 0 if run["label"] == first_label else 1
+    report["runs"].sort(
+        key=lambda run: (run["iteration"], run["repo"], run["pair_position"])
+    )
+    return report
+
+
 def expected_manifest(hash_current: str = SAMPLE_CHANGED_HASH) -> dict[str, Any]:
     return {
         "schema": EXPECTED_DRIFT_SCHEMA,
@@ -941,7 +1066,29 @@ def expected_manifest(hash_current: str = SAMPLE_CHANGED_HASH) -> dict[str, Any]
 
 
 def run_self_test() -> None:
+    run_order_aware_self_test()
     evaluate_gate(sample_report())
+    v3_primary = sample_v3(sample_report(delta=2.0, iterations=2))
+    v3_control = sample_v3(sample_control(delta=-3.0, iterations=2))
+    v3_focused = sample_v3(sample_report(delta=2.0, iterations=6))
+    v3_focused_control = sample_v3(sample_control(delta=-3.0, iterations=6))
+    v3_status = evaluate_gate(
+        v3_primary,
+        same_binary_control=v3_control,
+        focused_report=v3_focused,
+        focused_same_binary_control=v3_focused_control,
+    )
+    assert v3_status["status"] == "pass"
+    assert v3_status["focused"] is not None
+    assert evaluate_gate(
+        sample_v3(sample_report(delta=2.0, iterations=5)),
+        same_binary_control=sample_v3(sample_control(delta=0.0, iterations=5)),
+    )["status"] == "pass"
+    raw_sub_floor = sample_v3(sample_report(delta=2.5, iterations=6))
+    negative_control = sample_v3(sample_control(delta=-3.0, iterations=6))
+    assert evaluate_gate(
+        raw_sub_floor, same_binary_control=negative_control
+    )["status"] == "pass"
     tampered_run = sample_report()
     tampered_run["runs"][1]["sha256"] = SAMPLE_CHANGED_HASH
     try:
@@ -1011,7 +1158,7 @@ def run_self_test() -> None:
     try:
         evaluate_gate(legacy, require_corpus_provenance=True)
     except CheckFailed as error:
-        assert "corpus provenance requires schema" in str(error)
+        assert "corpus provenance requires a structured report schema" in str(error)
     else:
         raise AssertionError("semantic smoke mode must reject schema-less reports")
     for threshold_name, kwargs in (
@@ -1149,7 +1296,8 @@ def markdown_summary(status: dict[str, Any], report: dict[str, Any]) -> str:
             delta += f" / {pct:+.2f}%"
         lines.append(
             f"| `{label}` | {signal['baseline_ms']:.2f} ms | {signal['current_ms']:.2f} ms | "
-            f"{delta} | {'triggered' if signal['triggered'] else 'within threshold'} |"
+            f"{delta} | "
+            f"{'triggered' if signal['triggered'] else 'inconclusive' if signal.get('inconclusive') else 'within threshold'} |"
         )
     output = primary["output"]
     if status["focused"] is not None:
@@ -1183,6 +1331,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-focused-iterations", type=int, default=5)
     parser.add_argument("--require-same-binary-control", action="store_true")
     parser.add_argument("--require-corpus-provenance", action="store_true")
+    parser.add_argument(
+        "--runtime-policy",
+        choices=("auto", "legacy", "order-aware-v1"),
+        default="auto",
+    )
     parser.add_argument("--status-output", type=Path)
     parser.add_argument("--markdown-output", type=Path)
     parser.add_argument("--check-status", type=Path)
@@ -1229,6 +1382,7 @@ def main() -> int:
         "min_focused_iterations": args.min_focused_iterations,
         "require_same_binary_control": args.require_same_binary_control,
         "require_corpus_provenance": args.require_corpus_provenance,
+        "runtime_policy": args.runtime_policy,
     }
     try:
         status = evaluate_gate(report, **kwargs)

--- a/scripts/query-regression-harness.py
+++ b/scripts/query-regression-harness.py
@@ -24,7 +24,8 @@ from query_regression_summary import summarize_runs
 
 
 DEFAULT_QUERY_ARGS = ("query", "{repo}", "all", "top=0", "--mode", "semantic", "--format", "json")
-SCHEMA = "nose.query_regression_harness.v2"
+SCHEMA = "nose.query_regression_harness.v3"
+PAIR_ORDERS = ("baseline-current", "current-baseline")
 TIME_RE = re.compile(r"\[time\]\s+([a-zA-Z0-9_+\-]+)\s+([0-9.]+)ms")
 
 
@@ -176,12 +177,16 @@ def run_once(
     observations = query_observations(
         result.stdout, source=f"{label} {repo_name} iteration {iteration}"
     )
+    pair_order = PAIR_ORDERS[0] if iteration % 2 else PAIR_ORDERS[1]
+    first_label = "baseline" if pair_order == PAIR_ORDERS[0] else "current"
     return {
         "bytes": len(result.stdout),
         "elapsed_ms": elapsed_ms,
         **observations,
         "iteration": iteration,
         "label": label,
+        "pair_order": pair_order,
+        "pair_position": 0 if label == first_label else 1,
         "repo": repo_name,
         "sha256": hashlib.sha256(result.stdout).hexdigest(),
         "stages_ms": parse_stage_timings(result.stderr),
@@ -371,6 +376,8 @@ def run_self_test() -> None:
             query_args=("-c", probe, "{repo}"),
         )
         assert observation["families"] == 0
+        assert observation["pair_order"] == "baseline-current"
+        assert observation["pair_position"] == 0
     print("query regression harness self-test passed")
 
 
@@ -461,7 +468,15 @@ def main() -> int:
         "command": "nose " + " ".join(query_args).replace("{repo}", "<repo>"),
         "corpus": corpus,
         "environment": measurement_environment(),
-        "measurement": {"iterations": args.iterations, "warmups": args.warmups},
+        "measurement": {
+            "iterations": args.iterations,
+            "warmups": args.warmups,
+            "design": {
+                "kind": "paired-alternating-blocks/v1",
+                "block": "iteration",
+                "orders": list(PAIR_ORDERS),
+            },
+        },
         "execution": {
             "repo_argument": "<repo-id>",
             "working_directory": repos_root.as_posix(),

--- a/scripts/query_regression_control.py
+++ b/scripts/query_regression_control.py
@@ -1,0 +1,375 @@
+"""Order-aware paired runtime estimator for query-regression reports."""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass
+from typing import Any
+
+
+POLICY = "paired-alternating-sign-v1"
+MIN_BLOCKS = 5
+MIN_BLOCKS_PER_ORDER = 2
+ORDERS = ("baseline-current", "current-baseline")
+
+
+class ControlEvidenceError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Block:
+    iteration: int
+    order: str
+    baseline: float
+    current: float
+
+    @property
+    def delta(self) -> float:
+        return self.current - self.baseline
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        raise ControlEvidenceError("cannot estimate an empty block stratum")
+    return statistics.median(values)
+
+
+def _run_order(
+    report: dict[str, Any],
+    baseline: tuple[int, dict[str, Any]],
+    current: tuple[int, dict[str, Any]],
+) -> str:
+    baseline_index, baseline_run = baseline
+    current_index, current_run = current
+    explicit = baseline_run.get("pair_order")
+    if explicit is not None:
+        if explicit not in ORDERS or current_run.get("pair_order") != explicit:
+            raise ControlEvidenceError("paired runs disagree on explicit pair_order")
+        expected_positions = (0, 1) if explicit == ORDERS[0] else (1, 0)
+        positions = (baseline_run.get("pair_position"), current_run.get("pair_position"))
+        if positions != expected_positions:
+            raise ControlEvidenceError("paired runs have invalid explicit pair_position")
+        return explicit
+    if report.get("schema") == "nose.query_regression_harness.v3":
+        raise ControlEvidenceError("v3 paired runs require explicit order metadata")
+    return ORDERS[0] if baseline_index < current_index else ORDERS[1]
+
+
+def _paired_runs(
+    report: dict[str, Any], repo: str
+) -> list[tuple[int, str, dict[str, Any], dict[str, Any]]]:
+    by_iteration: dict[int, dict[str, tuple[int, dict[str, Any]]]] = {}
+    for index, run in enumerate(report.get("runs", [])):
+        if run.get("repo") != repo:
+            continue
+        iteration = run.get("iteration")
+        label = run.get("label")
+        if not isinstance(iteration, int) or label not in ("baseline", "current"):
+            raise ControlEvidenceError(f"{repo}: malformed paired run identity")
+        labels = by_iteration.setdefault(iteration, {})
+        if label in labels:
+            raise ControlEvidenceError(f"{repo}: duplicate {label} block {iteration}")
+        labels[label] = (index, run)
+    pairs = []
+    for iteration, labels in sorted(by_iteration.items()):
+        if set(labels) != {"baseline", "current"}:
+            raise ControlEvidenceError(f"{repo}: incomplete block {iteration}")
+        baseline = labels["baseline"]
+        current = labels["current"]
+        pairs.append(
+            (iteration, _run_order(report, baseline, current), baseline[1], current[1])
+        )
+    return pairs
+
+
+def _blocks(
+    report: dict[str, Any],
+    *,
+    scope: str,
+    repo: str | None,
+    stage: str | None,
+) -> list[Block]:
+    repos = report.get("repos", []) if repo is None else [repo]
+    paired = {name: _paired_runs(report, name) for name in repos}
+    iterations = sorted({row[0] for rows in paired.values() for row in rows})
+    blocks = []
+    for iteration in iterations:
+        selected = []
+        for name in repos:
+            matches = [row for row in paired[name] if row[0] == iteration]
+            if len(matches) != 1:
+                raise ControlEvidenceError(
+                    f"{scope}: block {iteration} does not cover the complete repository set"
+                )
+            selected.append(matches[0])
+        orders = {row[1] for row in selected}
+        if len(orders) != 1:
+            raise ControlEvidenceError(f"{scope}: block {iteration} has mixed pair order")
+
+        def value(run: dict[str, Any]) -> float:
+            if stage is None:
+                raw = run.get("elapsed_ms")
+            else:
+                stages = run.get("stages_ms", {})
+                raw = stages.get(stage, 0.0) if isinstance(stages, dict) else None
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                raise ControlEvidenceError(f"{scope}: block {iteration} has non-numeric time")
+            number = float(raw)
+            if not math.isfinite(number) or number < 0:
+                raise ControlEvidenceError(f"{scope}: block {iteration} has invalid time")
+            return number
+
+        blocks.append(
+            Block(
+                iteration=iteration,
+                order=next(iter(orders)),
+                baseline=sum(value(row[2]) for row in selected),
+                current=sum(value(row[3]) for row in selected),
+            )
+        )
+    return blocks
+
+
+def _eligible(blocks: list[Block]) -> tuple[bool, str | None]:
+    counts = {order: sum(block.order == order for block in blocks) for order in ORDERS}
+    if len(blocks) < MIN_BLOCKS:
+        return False, f"need at least {MIN_BLOCKS} complete blocks"
+    if min(counts.values()) < MIN_BLOCKS_PER_ORDER:
+        return False, f"need at least {MIN_BLOCKS_PER_ORDER} blocks in each order"
+    if abs(counts[ORDERS[0]] - counts[ORDERS[1]]) > 1:
+        return False, "pair orders are not balanced"
+    return True, None
+
+
+def _order_neutral_effect(blocks: list[Block]) -> float:
+    return sum(
+        _median([block.delta for block in blocks if block.order == order])
+        for order in ORDERS
+    ) / 2.0
+
+
+def _sign_tail(successes: int, total: int) -> float:
+    return sum(math.comb(total, count) for count in range(successes, total + 1)) / (2**total)
+
+
+def estimate_metric(
+    blocks: list[Block],
+    control_blocks: list[Block],
+    *,
+    max_delta_pct: float,
+    min_delta_ms: float,
+) -> dict[str, Any]:
+    eligible, reason = _eligible(blocks)
+    control_eligible, control_reason = _eligible(control_blocks)
+    if not eligible or not control_eligible:
+        return {
+            "policy": POLICY,
+            "state": "insufficient",
+            "reason": reason or f"control: {control_reason}",
+            "blocks": len(blocks),
+            "control_blocks": len(control_blocks),
+        }
+    if [(block.iteration, block.order) for block in blocks] != [
+        (block.iteration, block.order) for block in control_blocks
+    ]:
+        return {
+            "policy": POLICY,
+            "state": "insufficient",
+            "reason": "primary and control block designs differ",
+            "blocks": len(blocks),
+            "control_blocks": len(control_blocks),
+        }
+    raw_effect = _order_neutral_effect(blocks)
+    control_effect = _order_neutral_effect(control_blocks)
+    correction = max(control_effect, 0.0)
+    adjusted_effect = raw_effect - correction
+    baseline_ms = _median([block.baseline for block in blocks])
+    adjusted_pct = (adjusted_effect / baseline_ms) * 100.0 if baseline_ms > 0 else None
+    point_material = adjusted_effect > min_delta_ms and (
+        adjusted_pct is None or adjusted_pct > max_delta_pct
+    )
+    adjusted_blocks = [(block, block.delta - correction) for block in blocks]
+    successes = sum(
+        delta > min_delta_ms
+        and (block.baseline <= 0 or (delta / block.baseline) * 100.0 > max_delta_pct)
+        for block, delta in adjusted_blocks
+    )
+    sign_p = _sign_tail(successes, len(blocks))
+    order_consistent = True
+    any_order_material = False
+    order_rows = {}
+    for order in ORDERS:
+        order_blocks = [(block, delta) for block, delta in adjusted_blocks if block.order == order]
+        order_delta = _median([delta for _, delta in order_blocks])
+        order_baseline = _median([block.baseline for block, _ in order_blocks])
+        order_pct = (order_delta / order_baseline) * 100.0 if order_baseline > 0 else None
+        material = order_delta > min_delta_ms and (
+            order_pct is None or order_pct > max_delta_pct
+        )
+        any_order_material = any_order_material or material
+        order_consistent = order_consistent and material
+        order_rows[order] = {
+            "blocks": len(order_blocks),
+            "adjusted_median_ms": order_delta,
+            "adjusted_median_pct": order_pct,
+            "material": material,
+        }
+    supported = sign_p <= 0.05
+    triggered = point_material and supported and order_consistent
+    order_conflict = any_order_material and not order_consistent
+    state = (
+        "triggered"
+        if triggered
+        else "inconclusive"
+        if point_material or order_conflict
+        else "within-threshold"
+    )
+    return {
+        "policy": POLICY,
+        "state": state,
+        "blocks": len(blocks),
+        "raw_effect_ms": raw_effect,
+        "control_effect_ms": control_effect,
+        "control_correction_ms": correction,
+        "adjusted_effect_ms": adjusted_effect,
+        "adjusted_effect_pct": adjusted_pct,
+        "supporting_blocks": successes,
+        "sign_test_p": sign_p,
+        "supported": supported,
+        "order_consistent": order_consistent,
+        "order_conflict": order_conflict,
+        "by_order": order_rows,
+    }
+
+
+def runtime_signals(
+    report: dict[str, Any],
+    control: dict[str, Any] | None,
+    *,
+    max_delta_pct: float,
+    min_delta_ms: float,
+) -> list[dict[str, Any]]:
+    specifications: list[tuple[str, str | None, str | None]] = [("aggregate", None, None)]
+    for repo in sorted(report.get("repos", [])):
+        specifications.append(("repo", repo, None))
+        stages = sorted(
+            {
+                stage
+                for run in report.get("runs", [])
+                if run.get("repo") == repo and isinstance(run.get("stages_ms"), dict)
+                for stage in run["stages_ms"]
+            }
+        )
+        specifications.extend(("stage", repo, stage) for stage in stages)
+    signals = []
+    for scope, repo, stage in specifications:
+        blocks = _blocks(report, scope=scope, repo=repo, stage=stage)
+        control_blocks = (
+            _blocks(control, scope=scope, repo=repo, stage=stage)
+            if control is not None
+            else [Block(block.iteration, block.order, 0.0, 0.0) for block in blocks]
+        )
+        evidence = estimate_metric(
+            blocks,
+            control_blocks,
+            max_delta_pct=max_delta_pct,
+            min_delta_ms=min_delta_ms,
+        )
+        baseline_ms = _median([block.baseline for block in blocks]) if blocks else 0.0
+        current_ms = _median([block.current for block in blocks]) if blocks else 0.0
+        raw_delta_ms = evidence.get("raw_effect_ms", current_ms - baseline_ms)
+        control_delta_ms = evidence.get("control_effect_ms", 0.0)
+        adjusted_delta_ms = evidence.get("adjusted_effect_ms", raw_delta_ms)
+        adjusted_delta_pct = evidence.get(
+            "adjusted_effect_pct",
+            (adjusted_delta_ms / baseline_ms) * 100.0 if baseline_ms > 0 else None,
+        )
+        signals.append(
+            {
+                "scope": scope,
+                "repo": repo,
+                "stage": stage,
+                "baseline_ms": baseline_ms,
+                "current_ms": current_ms,
+                "raw_delta_ms": raw_delta_ms,
+                "control_delta_ms": control_delta_ms,
+                "adjusted_delta_ms": adjusted_delta_ms,
+                "adjusted_delta_pct": adjusted_delta_pct,
+                "triggered": evidence["state"] == "triggered",
+                "inconclusive": evidence["state"] in ("inconclusive", "insufficient"),
+                "evidence": evidence,
+            }
+        )
+    return signals
+
+
+def run_self_test() -> None:
+    def blocks(deltas: list[float], baseline: float = 100.0) -> list[Block]:
+        return [
+            Block(index, ORDERS[(index - 1) % 2], baseline, baseline + delta)
+            for index, delta in enumerate(deltas, 1)
+        ]
+
+    stable = estimate_metric(
+        blocks([12.0] * 6), blocks([0.0] * 6), max_delta_pct=5.0, min_delta_ms=5.0
+    )
+    assert stable["state"] == "triggered" and stable["sign_test_p"] < 0.05
+    positive = estimate_metric(
+        blocks([12.0] * 6), blocks([3.0] * 6), max_delta_pct=5.0, min_delta_ms=5.0
+    )
+    assert positive["control_correction_ms"] == 3.0
+    negative = estimate_metric(
+        blocks([6.0] * 6), blocks([-3.0] * 6), max_delta_pct=5.0, min_delta_ms=5.0
+    )
+    assert negative["control_effect_ms"] == -3.0
+    assert negative["control_correction_ms"] == 0.0
+    order_bias = estimate_metric(
+        blocks([12.0, -12.0] * 3),
+        blocks([0.0] * 6),
+        max_delta_pct=5.0,
+        min_delta_ms=5.0,
+    )
+    assert order_bias["state"] == "inconclusive" and order_bias["order_conflict"]
+    noisy = estimate_metric(
+        blocks([20.0, 20.0, -5.0, 20.0, -5.0, 20.0]),
+        blocks([0.0] * 6),
+        max_delta_pct=5.0,
+        min_delta_ms=5.0,
+    )
+    assert noisy["state"] == "inconclusive" and not noisy["supported"]
+    missing = estimate_metric(
+        blocks([12.0] * 4), blocks([0.0] * 4), max_delta_pct=5.0, min_delta_ms=5.0
+    )
+    assert missing["state"] == "insufficient"
+
+    def run(iteration: int, label: str) -> dict[str, Any]:
+        return {
+            "iteration": iteration,
+            "label": label,
+            "pair_order": ORDERS[(iteration - 1) % 2],
+            "pair_position": 0 if (iteration % 2 == 1) == (label == "baseline") else 1,
+            "repo": "repo-a",
+        }
+
+    incomplete_report = {
+        "schema": "nose.query_regression_harness.v3",
+        "runs": [run(1, "baseline")],
+    }
+    try:
+        _paired_runs(incomplete_report, "repo-a")
+    except ControlEvidenceError as error:
+        assert "incomplete block" in str(error)
+    else:
+        raise AssertionError("an incomplete pair must not be inferred")
+    duplicate_report = {
+        "schema": "nose.query_regression_harness.v3",
+        "runs": [run(1, "baseline"), run(1, "baseline")],
+    }
+    try:
+        _paired_runs(duplicate_report, "repo-a")
+    except ControlEvidenceError as error:
+        assert "duplicate baseline" in str(error)
+    else:
+        raise AssertionError("duplicate rounds must not be silently dropped")

--- a/scripts/semantic-regression-smoke.sh
+++ b/scripts/semantic-regression-smoke.sh
@@ -67,7 +67,8 @@ is_relevant_path() {
     bench/semantic_regression_corpus.v1.json|bench/setup_repos.sh|\
     bench/prune_corpus.py|bench/corpus_prune/*|\
     .github/semantic-regression-expected-drift.json|.github/workflows/ci.yml|\
-    scripts/query-regression-harness.py|scripts/check-query-regression.py|\
+    scripts/query-regression-harness.py|scripts/query_regression_control.py|\
+    scripts/check-query-regression.py|\
     scripts/ruby-redefinition-scaling.py|scripts/semantic-regression-smoke.sh|\
     scripts/semantic-regression-summary.py)
       return 0
@@ -268,11 +269,11 @@ scaling_rc=$?
 set -e
 
 run_harness \
-  "$artifact_dir/primary.json" "$baseline_binary" "$current_binary" 2 0 \
+  "$artifact_dir/primary.json" "$baseline_binary" "$current_binary" 5 0 \
   "$base_ref" "$head_ref" "$base_sha" "$head_sha" \
   "${repo_args[@]}"
 run_harness \
-  "$artifact_dir/primary-control.json" "$baseline_binary" "$baseline_binary" 2 0 \
+  "$artifact_dir/primary-control.json" "$baseline_binary" "$baseline_binary" 5 0 \
   "$base_ref" "$base_ref" "$base_sha" "$base_sha" \
   "${repo_args[@]}"
 


### PR DESCRIPTION
## Summary

- preregister an order-aware paired runtime-control contract before applying it
- record pair order in schema v3 and estimate baseline/current deltas within each order
- prevent negative controls from inflating regressions while preserving the 5 ms / 5% gate
- fail closed on inconclusive order conflicts with one bounded focused rerun
- preserve schema-v2 legacy decisions and code-identical/output-drift behavior
- replay the frozen #892 r40 evidence into an exact decision ledger

## Frozen replay

- 226 runtime signals replayed
- 215 decisions unchanged
- 11 decisions changed
- legacy: 4 triggered / 222 clear
- order-aware: 0 triggered / 8 inconclusive / 218 clear
- the etcd lower and parse+lower false triggers become clear instead of being inflated by negative controls

## Validation

- `scripts/query_regression_control.py --self-test`
- `scripts/check-query-regression.py --self-test`
- Python compile and shell syntax checks
- checked schema-v2 regression artifacts regenerated byte-for-byte
- frozen #892 ledger regenerated and matched exactly
- prospective schema-v3 semantic smoke with 5 alternating blocks: 0 output drift, runtime within threshold
- docs and file-length checks

Closes #927