### PR TITLE
test(dogfood): review watch-session family drift

### DIFF
--- a/docs/dogfooding-history.md
+++ b/docs/dogfooding-history.md
@@ -1364,3 +1364,14 @@ the self-query fingerprints enough for the long-standing
 `aa2b95cf822a1cd2` to fall below value 40; neither numeric policy was changed.
 No replacement family appears, so the stale ID is removed without accepting
 new duplication.
+
+The #878 watch-session integration moves the reviewed count from 27 to 28. The
+new session and incremental-orchestration modules shift nose's self-query
+fingerprints enough for the same long-standing `interp/ops.rs::int_bin` /
+`float_bin` dispatcher representative `aa2b95cf822a1cd2` to cross value 40
+again; neither function was changed. The family shares ten dispatch lines, but
+integer wrapping, floor/modulo, bitwise, and unsupported-operation policy must
+remain separate from float IEEE arithmetic. Extracting a common dispatcher
+would couple those soundness boundaries for incidental structure, so the
+already reviewed family is restored to the baseline. No new avoidable
+duplication is accepted.

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -280,6 +280,11 @@ set -euo pipefail
 # `aa2b95cf822a1cd2` to cross value 40 again; neither member changed. Integer wrapping/floor/bitwise
 # and float IEEE policies remain deliberately separate, so no shared numeric dispatcher is accepted.
 # See docs/dogfooding-history.md.
+# 27 -> 28 (#878 watch-session integration): the session and incremental-orchestration source
+# layout shifts the self-query fingerprints enough for the same long-reviewed `int_bin` /
+# `float_bin` dispatcher family `aa2b95cf822a1cd2` to cross value 40 again. Neither numeric policy
+# changed; integer wrapping/floor/bitwise behavior remains intentionally separate from float IEEE
+# behavior, so no common dispatcher or new avoidable duplication is accepted.
 BIN="${NOSE_BIN:-./target/release/nose}"
 BASELINE="${NOSE_DUP_BASELINE:-scripts/duplication-baseline.json}"
 

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -14,6 +14,7 @@
     "95e83331abfa623f",
     "2bca2e8582b7d7a7",
     "a679fd9cdbda1be2",
+    "aa2b95cf822a1cd2",
     "b59e5826da2acff8",
     "c8961b547fcb59c7",
     "cf7e3e2870c92ccb",
@@ -28,7 +29,7 @@
     "f6d422cfc56ae976",
     "f918559454acf9c4"
   ],
-  "budget": 27,
+  "budget": 28,
   "generated_by": "target/release/nose query crates all top=0 --mode near --min-value 40 --format json",
   "min_value": 40,
   "mode": "near",


### PR DESCRIPTION
## Summary

- record the returning, previously reviewed `int_bin` / `float_bin` self-query family after #878 source-layout changes
- raise the dogfood budget from 27 to 28 without changing either numeric implementation
- retain separate integer wrapping/floor/bitwise and float IEEE soundness policies

## Evidence

- family `aa2b95cf822a1cd2` is the same numeric dispatcher pair reviewed repeatedly in earlier milestones
- neither member changed in #878
- `./scripts/check-duplication.sh` passes with exactly 28 accepted default-surface families

Follow-up to #941.