### PR TITLE
chore(dogfood): refresh duplication baseline

### DIFF
--- a/docs/dogfooding-history.md
+++ b/docs/dogfooding-history.md
@@ -1423,3 +1423,15 @@ matcher family moves from `95e83331abfa623f` to `6f76ca34bf54735e` with the
 same two functions and 18 shared lines, while the typed request refactor
 reduces its reported duplicate span from 81 to 66 lines. No new family or
 avoidable duplication is accepted, so the budget remains 29.
+
+The final post-v0.20 quality follow-up also keeps the reviewed count at 29.
+Collapsing Java type resolution to the single policy supported by library API
+contracts moves the same three representatives again. The method-receiver
+policy-table family moves from `0b51b6310b2f7504` to `faaaa56b67e0870a`, and
+the four-member Java map factory projection family moves from
+`9cc68991edd9e364` to `8d25d95857065748`; both retain identical members and
+metrics. The callee-dependency matcher family moves from `6f76ca34bf54735e` to
+`6ea43f3112542ece` with the same two functions, 66 duplicate lines, 18 shared
+lines, and value 48.114. Removing the unused policy branches reduces only its
+mean semantic size from 89 to 85. No new family or avoidable duplication is
+accepted, so the budget remains 29.

--- a/scripts/duplication-baseline.json
+++ b/scripts/duplication-baseline.json
@@ -8,10 +8,10 @@
     "90373a49a4b8174d",
     "3cdf8f9a869d1932",
     "5ad08a3c9ab9f5c3",
-    "0b51b6310b2f7504",
+    "faaaa56b67e0870a",
     "0fba8db9b311bd86",
     "8d3e36bdd11cf2c0",
-    "6f76ca34bf54735e",
+    "6ea43f3112542ece",
     "2bca2e8582b7d7a7",
     "a679fd9cdbda1be2",
     "aa2b95cf822a1cd2",
@@ -28,7 +28,7 @@
     "f6a2c8af9c3fd791",
     "3157af5787fd407a",
     "c2698e293c4c4d57",
-    "9cc68991edd9e364"
+    "8d25d95857065748"
   ],
   "budget": 29,
   "generated_by": "target/release/nose query crates all top=0 --mode near --min-value 40 --format json",


### PR DESCRIPTION
## Summary

- review the three substantial duplication-family deltas as representative-ID churn
- record the unchanged members/metrics and the callee semantic-size shift in dogfooding history
- replace the three stale accepted IDs while keeping the reviewed budget at 29

## Validation

- `scripts/check-duplication.sh`
- `scripts/check-docs.sh`
- `PATH="/opt/homebrew/bin:$PATH" ./scripts/check-ci-local.sh --fast`