### PR TITLE
Speed up local CI with docs deduplication and MSRV cache isolation

### DIFF
--- a/docs/frontier-platform.md
+++ b/docs/frontier-platform.md
@@ -152,6 +152,11 @@ can be checked without rewriting them:
 python3 bench/type4/frontier_platform.py --check
 ```
 
+The repository policy owner for this check is the `type4-frontier` gate. The
+documentation gate validates the wiki, executable examples, and its other
+documentation-owned generated surfaces without repeating the corpus-backed
+frontier check.
+
 ## Proof-carrying admission
 
 Target packets are necessary but not sufficient to open exact semantic behavior.

--- a/docs/pre-epic-readiness-948.md
+++ b/docs/pre-epic-readiness-948.md
@@ -150,6 +150,16 @@ with zero failures and zero worktree drift. The four evidence gates total
 237.326 seconds in the clean local sequence, while their longest independent
 job is the 213.988-second default-head gate.
 
+A later cache-isolation follow-up at source commit `9481f3ec` removed the
+duplicate frontier-platform corpus check from the docs gate while retaining it
+under `type4-frontier`, and moved MSRV artifacts to `target/msrv/`. Its checked
+receipt records clean fast at 412.252 seconds, clean full at 382.548 seconds,
+and no-change fast at 364.204 seconds, again with complete gates, no failures,
+and no worktree drift. The docs gate fell from 45.948 to 0.583 seconds; the
+warm isolated MSRV gate fell from 224.451 to 0.170 seconds, while a focused
+empty-cache MSRV run took 17.343 seconds. The next measured bottleneck is
+`default-head-evidence` at 214.754 seconds on clean fast.
+
 The 599-line `crates/nose-cli/tests/cli/support.rs` test helper is now a
 13-line façade over focused `fixtures.rs` (210 lines), `process.rs` (149
 lines), and `query.rs` (245 lines). Existing `support::*` call sites remain

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -76,9 +76,12 @@ large evidence batch with a misleading error.
 ## Worktree effects
 
 Most gates are `read-only`: build/test output is confined to ignored caches such
-as `target/`. A `verify-checked-output` gate may deterministically regenerate a
-tracked receipt or evidence file, but it must compare that output and leave the
-worktree unchanged when the checked artifact is current.
+as `target/`. The MSRV gate uses `target/msrv/` so switching compilers does not
+invalidate the stable toolchain's incremental artifacts; set
+`NOSE_MSRV_TARGET_DIR` only when a different isolated cache location is needed.
+A `verify-checked-output` gate may deterministically regenerate a tracked receipt
+or evidence file, but it must compare that output and leave the worktree
+unchanged when the checked artifact is current.
 
 The timing harness fingerprints the complete tracked/untracked status before
 and after every gate. A successful gate that changes the worktree makes the

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -129,36 +129,38 @@ tracked path would make the later `evidence-artifacts` gate observe inventory
 drift. After installation, refresh that inventory digest and run the artifact
 lifecycle validator.
 
-### Recorded post-readiness follow-up
+### Recorded cache-isolation follow-up
 
-The receipt recorded at `1bfce491` uses arm64 macOS, Python 3.14.6, and
-Rust/Cargo 1.96.0. It covers all 33 registered gates:
+The current receipt records source commit `9481f3ec` on arm64 macOS with Python
+3.14.6 and Rust/Cargo 1.96.0. It covers all 33 registered gates:
 
 | Profile | Plan | Gates | Wall time | Failures | Worktree drift |
 |---|---|---:|---:|---:|---:|
-| clean-tree | fast | 23/23 | 458.469 s | 0 | 0 |
-| clean-tree | full | 31/31 | 621.739 s | 0 | 0 |
-| no-change | fast | 23/23 | 460.272 s | 0 | 0 |
+| clean-tree | fast | 23/23 | 412.252 s | 0 | 0 |
+| clean-tree | full | 31/31 | 382.548 s | 0 | 0 |
+| no-change | fast | 23/23 | 364.204 s | 0 | 0 |
 
-The former aggregate regression check is now four named gates. On the clean
-fast run, `default-head-evidence` took 213.988 seconds,
-`runtime-soundness-evidence` 18.042 seconds, `divergence-evidence` 3.230
-seconds, and `surface-recall-evidence` 2.066 seconds. Their local sequential
-sum is 237.326 seconds; dedicated hosted jobs can overlap them, with the
-213.988-second default-head job as the measured lower bound before runner setup
-and scheduling overhead. The full plan's leading costs are `msrv` (224.451
-seconds), `default-head-evidence` (213.403 seconds), `docs` (45.727 seconds),
-`type4-frontier` (44.923 seconds), and `coverage` (40.921 seconds).
+Compared with the preceding `1bfce491` receipt, clean fast is 46.217 seconds
+(10.1%) faster and clean full is 239.191 seconds (38.5%) faster. The docs gate
+no longer repeats the corpus-backed frontier-platform check owned by
+`type4-frontier`; its clean fast time fell from 45.948 to 0.583 seconds while
+`type4-frontier` still passed in 45.670 seconds. The MSRV gate now writes to the
+isolated `target/msrv/` cache. With that cache already warm, its clean full time
+fell from 224.451 to 0.170 seconds without invalidating stable-toolchain
+artifacts. A focused empty-cache MSRV run took 17.343 seconds; the warm result
+is not a cold-bootstrap claim.
 
-The timing does not identify a duplicated policy command that can be removed:
-the long gates qualify distinct product, regression, release, or compiler
-contracts. Registry validation, artifact validation, formatting, shell lint,
-and file-length policy are all sub-second on the recorded machine, so moving
-them out of fast feedback would save little while delaying actionable failures.
+The dominant remaining clean-fast costs are `default-head-evidence` (214.754
+seconds), `test-debug-cli` (96.670 seconds), `type4-frontier` (45.670 seconds),
+and `runtime-soundness-evidence` (18.058 seconds). Registry validation,
+artifact validation, formatting, shell lint, and file-length policy remain
+sub-second or low-single-digit work, so removing them from fast feedback would
+save little while delaying actionable failures.
 
 Use measurements to find duplicated setup or a gate assigned to the wrong lane.
 Do not remove validation or move release/soundness qualification to a faster
 lane merely to improve the aggregate time.
 
-The original 30-gate #949 measurement remains in the
+The preceding 33-gate `1bfce491` result and the original 30-gate #949
+measurement remain in the
 [pre-epic readiness record](pre-epic-readiness-948.md) as historical evidence.

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -200,13 +200,15 @@ run_shell_script_lint() {
 run_msrv_check() {
     need_cmd rustup
     local msrv
+    local msrv_target_dir="${NOSE_MSRV_TARGET_DIR:-target/msrv}"
     msrv="$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
     if ! rustup toolchain list 2>/dev/null | grep -q "^${msrv}"; then
         echo "missing Rust MSRV toolchain: ${msrv}" >&2
         echo "install it with: rustup toolchain install ${msrv}" >&2
         exit 127
     fi
-    cargo "+${msrv}" check --workspace --all-targets
+    CARGO_TARGET_DIR="$msrv_target_dir" \
+        cargo "+${msrv}" check --workspace --all-targets
 }
 
 run_semantic_pack_example_conformance() {

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -20,7 +20,6 @@ if command -v python3 >/dev/null 2>&1; then
     python3 scripts/check-semantic-pack-examples.py
     python3 scripts/check-ci-examples.py
     python3 scripts/check-divergent-history-artifacts.py
-    python3 bench/type4/frontier_platform.py --check
     python3 bench/type4/semantic_pattern_cards.py --check
     python3 bench/type4/open_surface_admission_audit.py --selftest
     python3 bench/type4/open_surface_admission_audit.py --check

--- a/scripts/ci/gate-timings.v1.json
+++ b/scripts/ci/gate-timings.v1.json
@@ -1,7 +1,7 @@
 {
   "schema": "nose.ci-gate-timings.v1",
-  "generated_at": "2026-07-29T09:36:16.261425+00:00",
-  "source_commit": "1bfce491e8c12eb3ae89810d9dfd5100412165d1",
+  "generated_at": "2026-07-29T11:17:15.758938+00:00",
+  "source_commit": "9481f3ec3955e0288ee25f50154ac17cabb8a349",
   "environment": {
     "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
     "machine": "arm64",
@@ -13,251 +13,71 @@
     {
       "profile": "clean-tree",
       "mode": "fast",
-      "started_at": "2026-07-29T09:18:01.217120+00:00",
-      "seconds": 459.629,
+      "started_at": "2026-07-29T11:03:55.465986+00:00",
+      "seconds": 412.252,
       "completed_gates": 23,
       "planned_gates": 23,
       "gates": [
         {
           "name": "corpus-prune-selftest",
           "args": [],
-          "seconds": 0.1,
+          "seconds": 0.101,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "corpus-verify-selftest",
           "args": [],
-          "seconds": 2.712,
+          "seconds": 2.678,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "semantic-pack-pricing",
           "args": [],
-          "seconds": 0.149,
+          "seconds": 0.147,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "type4-frontier",
           "args": [],
-          "seconds": 44.037,
+          "seconds": 45.67,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "default-head-evidence",
           "args": [],
-          "seconds": 213.988,
+          "seconds": 214.754,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "divergence-evidence",
           "args": [],
-          "seconds": 3.23,
+          "seconds": 3.284,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "surface-recall-evidence",
           "args": [],
-          "seconds": 2.066,
+          "seconds": 2.071,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "runtime-soundness-evidence",
           "args": [],
-          "seconds": 18.042,
+          "seconds": 18.058,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "evidence-artifacts",
           "args": [],
-          "seconds": 0.236,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "missed-worthy-frontier",
-          "args": [],
-          "seconds": 3.707,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "accepted-pair-coverage",
-          "args": [],
-          "seconds": 0.27,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "cargo-target-prune-selftest",
-          "args": [],
-          "seconds": 0.146,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "shell-lint",
-          "args": [],
-          "seconds": 0.41,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "format",
-          "args": [],
-          "seconds": 0.983,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "file-length",
-          "args": [
-            "origin/main"
-          ],
-          "seconds": 0.217,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "legacy-prelude",
-          "args": [],
-          "seconds": 0.127,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "clippy",
-          "args": [],
-          "seconds": 0.196,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "test-debug-cli",
-          "args": [],
-          "seconds": 109.038,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "build-debug-cli",
-          "args": [],
-          "seconds": 0.144,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "product-query-schema",
-          "args": [
-            "target/debug/nose"
-          ],
-          "seconds": 1.303,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "type4-executable",
-          "args": [
-            "target/debug/nose"
-          ],
-          "seconds": 2.183,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "type4-axis-language",
-          "args": [
-            "target/debug/nose",
-            "origin/main"
-          ],
-          "seconds": 9.237,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "docs",
-          "args": [],
-          "seconds": 45.948,
-          "exit_code": 0,
-          "worktree_changed": false
-        }
-      ]
-    },
-    {
-      "profile": "clean-tree",
-      "mode": "full",
-      "started_at": "2026-07-29T09:25:40.829246+00:00",
-      "seconds": 623.206,
-      "completed_gates": 31,
-      "planned_gates": 31,
-      "gates": [
-        {
-          "name": "corpus-prune-selftest",
-          "args": [],
-          "seconds": 0.099,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "corpus-verify-selftest",
-          "args": [],
-          "seconds": 2.738,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "semantic-pack-pricing",
-          "args": [],
-          "seconds": 0.144,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "type4-frontier",
-          "args": [],
-          "seconds": 44.923,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "default-head-evidence",
-          "args": [],
-          "seconds": 213.403,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "divergence-evidence",
-          "args": [],
-          "seconds": 3.234,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "surface-recall-evidence",
-          "args": [],
-          "seconds": 2.079,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "runtime-soundness-evidence",
-          "args": [],
-          "seconds": 17.97,
-          "exit_code": 0,
-          "worktree_changed": false
-        },
-        {
-          "name": "evidence-artifacts",
-          "args": [],
-          "seconds": 0.224,
+          "seconds": 0.226,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -271,28 +91,28 @@
         {
           "name": "accepted-pair-coverage",
           "args": [],
-          "seconds": 0.258,
+          "seconds": 0.243,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "cargo-target-prune-selftest",
           "args": [],
-          "seconds": 0.152,
+          "seconds": 0.154,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "shell-lint",
           "args": [],
-          "seconds": 0.421,
+          "seconds": 0.427,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "format",
           "args": [],
-          "seconds": 0.981,
+          "seconds": 0.991,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -301,35 +121,215 @@
           "args": [
             "origin/main"
           ],
-          "seconds": 0.187,
+          "seconds": 0.184,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "legacy-prelude",
           "args": [],
-          "seconds": 0.13,
+          "seconds": 0.112,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "clippy",
           "args": [],
-          "seconds": 0.206,
+          "seconds": 8.092,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "test-debug-cli",
+          "args": [],
+          "seconds": 96.67,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "build-debug-cli",
+          "args": [],
+          "seconds": 0.16,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "product-query-schema",
+          "args": [
+            "target/debug/nose"
+          ],
+          "seconds": 1.45,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "type4-executable",
+          "args": [
+            "target/debug/nose"
+          ],
+          "seconds": 2.149,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "type4-axis-language",
+          "args": [
+            "target/debug/nose",
+            "origin/main"
+          ],
+          "seconds": 9.149,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "docs",
+          "args": [],
+          "seconds": 0.583,
+          "exit_code": 0,
+          "worktree_changed": false
+        }
+      ]
+    },
+    {
+      "profile": "clean-tree",
+      "mode": "full",
+      "started_at": "2026-07-29T11:10:47.721331+00:00",
+      "seconds": 382.548,
+      "completed_gates": 31,
+      "planned_gates": 31,
+      "gates": [
+        {
+          "name": "corpus-prune-selftest",
+          "args": [],
+          "seconds": 0.097,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "corpus-verify-selftest",
+          "args": [],
+          "seconds": 2.616,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "semantic-pack-pricing",
+          "args": [],
+          "seconds": 0.145,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "type4-frontier",
+          "args": [],
+          "seconds": 45.98,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "default-head-evidence",
+          "args": [],
+          "seconds": 211.844,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "divergence-evidence",
+          "args": [],
+          "seconds": 3.237,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "surface-recall-evidence",
+          "args": [],
+          "seconds": 2.089,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "runtime-soundness-evidence",
+          "args": [],
+          "seconds": 18.026,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "evidence-artifacts",
+          "args": [],
+          "seconds": 0.241,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "missed-worthy-frontier",
+          "args": [],
+          "seconds": 3.705,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "accepted-pair-coverage",
+          "args": [],
+          "seconds": 0.276,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "cargo-target-prune-selftest",
+          "args": [],
+          "seconds": 0.143,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "shell-lint",
+          "args": [],
+          "seconds": 0.432,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "format",
+          "args": [],
+          "seconds": 0.976,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "file-length",
+          "args": [
+            "origin/main"
+          ],
+          "seconds": 0.196,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "legacy-prelude",
+          "args": [],
+          "seconds": 0.114,
+          "exit_code": 0,
+          "worktree_changed": false
+        },
+        {
+          "name": "clippy",
+          "args": [],
+          "seconds": 0.193,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "doc",
           "args": [],
-          "seconds": 0.161,
+          "seconds": 16.876,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "build-release",
           "args": [],
-          "seconds": 0.136,
+          "seconds": 0.157,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -338,7 +338,7 @@
           "args": [
             "target/release/nose"
           ],
-          "seconds": 0.853,
+          "seconds": 0.888,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -347,7 +347,7 @@
           "args": [
             "target/release/nose"
           ],
-          "seconds": 0.079,
+          "seconds": 0.078,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -356,7 +356,7 @@
           "args": [
             "target/release/nose"
           ],
-          "seconds": 1.353,
+          "seconds": 1.348,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -366,63 +366,63 @@
             "target/release/nose",
             "origin/main"
           ],
-          "seconds": 4.861,
+          "seconds": 4.88,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "test-release",
           "args": [],
-          "seconds": 4.383,
+          "seconds": 17.548,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "coverage",
           "args": [],
-          "seconds": 40.921,
+          "seconds": 40.569,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "duplication",
           "args": [],
-          "seconds": 0.466,
+          "seconds": 0.463,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "msrv",
           "args": [],
-          "seconds": 224.451,
+          "seconds": 0.17,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "supply-chain",
           "args": [],
-          "seconds": 1.128,
+          "seconds": 0.768,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "docs",
           "args": [],
-          "seconds": 45.727,
+          "seconds": 0.578,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "formal-obligations",
           "args": [],
-          "seconds": 0.396,
+          "seconds": 0.417,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "formal-lean",
           "args": [],
-          "seconds": 5.947,
+          "seconds": 5.988,
           "exit_code": 0,
           "worktree_changed": false
         }
@@ -431,106 +431,106 @@
     {
       "profile": "no-change",
       "mode": "fast",
-      "started_at": "2026-07-29T09:36:16.261575+00:00",
-      "seconds": 461.387,
+      "started_at": "2026-07-29T11:17:15.759049+00:00",
+      "seconds": 364.204,
       "completed_gates": 23,
       "planned_gates": 23,
       "gates": [
         {
           "name": "corpus-prune-selftest",
           "args": [],
-          "seconds": 0.104,
+          "seconds": 0.093,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "corpus-verify-selftest",
           "args": [],
-          "seconds": 2.729,
+          "seconds": 2.611,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "semantic-pack-pricing",
           "args": [],
-          "seconds": 0.154,
+          "seconds": 0.142,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "type4-frontier",
           "args": [],
-          "seconds": 45.382,
+          "seconds": 46.459,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "default-head-evidence",
           "args": [],
-          "seconds": 213.929,
+          "seconds": 210.612,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "divergence-evidence",
           "args": [],
-          "seconds": 3.225,
+          "seconds": 3.253,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "surface-recall-evidence",
           "args": [],
-          "seconds": 2.079,
+          "seconds": 2.057,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "runtime-soundness-evidence",
           "args": [],
-          "seconds": 18.038,
+          "seconds": 18.092,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "evidence-artifacts",
           "args": [],
-          "seconds": 0.232,
+          "seconds": 0.226,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "missed-worthy-frontier",
           "args": [],
-          "seconds": 3.763,
+          "seconds": 3.736,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "accepted-pair-coverage",
           "args": [],
-          "seconds": 0.248,
+          "seconds": 0.252,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "cargo-target-prune-selftest",
           "args": [],
-          "seconds": 0.136,
+          "seconds": 0.134,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "shell-lint",
           "args": [],
-          "seconds": 0.436,
+          "seconds": 0.444,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "format",
           "args": [],
-          "seconds": 0.987,
+          "seconds": 0.979,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -539,7 +539,7 @@
           "args": [
             "origin/main"
           ],
-          "seconds": 0.19,
+          "seconds": 0.195,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -553,21 +553,21 @@
         {
           "name": "clippy",
           "args": [],
-          "seconds": 0.193,
+          "seconds": 0.189,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "test-debug-cli",
           "args": [],
-          "seconds": 109.923,
+          "seconds": 60.054,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "build-debug-cli",
           "args": [],
-          "seconds": 0.158,
+          "seconds": 0.146,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -576,7 +576,7 @@
           "args": [
             "target/debug/nose"
           ],
-          "seconds": 1.322,
+          "seconds": 1.486,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -585,7 +585,7 @@
           "args": [
             "target/debug/nose"
           ],
-          "seconds": 2.157,
+          "seconds": 2.137,
           "exit_code": 0,
           "worktree_changed": false
         },
@@ -595,14 +595,14 @@
             "target/debug/nose",
             "origin/main"
           ],
-          "seconds": 9.044,
+          "seconds": 9.172,
           "exit_code": 0,
           "worktree_changed": false
         },
         {
           "name": "docs",
           "args": [],
-          "seconds": 45.733,
+          "seconds": 0.558,
           "exit_code": 0,
           "worktree_changed": false
         }

--- a/scripts/ci/gates.json
+++ b/scripts/ci/gates.json
@@ -483,10 +483,10 @@
       "tools": ["rustup", "cargo"],
       "inputs": ["Cargo.toml", "Cargo.lock", "crates/"],
       "worktree_effect": "read-only",
-      "outputs": ["target/"],
-      "cache": "cargo",
+      "outputs": ["target/msrv/"],
+      "cache": "cargo (isolated target/msrv)",
       "lanes": ["local-full", "pull-request", "release"],
-      "lane_reason": "Compatibility check is required before merge/release but uses a separate toolchain.",
+      "lane_reason": "Compatibility check is required before merge/release and keeps its separate compiler artifacts under target/msrv.",
       "focused_command": "./scripts/check-ci-local.sh --gate msrv",
       "plans": {
         "full": {"order": 230, "label": "MSRV (minimum supported rust version)", "args": []}

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -45,7 +45,7 @@
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
       "artifact_count": 6,
-      "inventory_sha256": "d7b728ee1baa5f553f431fcd7f2e4afab09da93009eaf218aa7f5a6460f99d93"
+      "inventory_sha256": "96ff5ad3db99bfe5d1df2b8be07117e38678b3ac4f3ca9d9df64532997b2c222"
     },
     {
       "id": "benchmark-root",

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -45,7 +45,7 @@
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
       "artifact_count": 6,
-      "inventory_sha256": "bbd71f90f226aeda667ba56686dadc2dd3754d85b440e7c9c6d3d39d01c23225"
+      "inventory_sha256": "d7b728ee1baa5f553f431fcd7f2e4afab09da93009eaf218aa7f5a6460f99d93"
     },
     {
       "id": "benchmark-root",


### PR DESCRIPTION
## Summary

- make `type4-frontier` the single owner of the corpus-backed frontier-platform check instead of repeating it in `docs`
- isolate MSRV compiler artifacts under `target/msrv/` so they do not invalidate the stable toolchain cache
- refresh the checked timing receipt and repository evidence catalog

## Measured result

- clean fast: 458.469s -> 412.252s (-10.1%)
- clean full: 621.739s -> 382.548s (-38.5%)
- docs: 45.948s -> 0.583s while type4-frontier still passes
- MSRV: 17.343s with an empty isolated cache, 0.170s warm

## Verification

- `./scripts/check-ci-local.sh --full`
- timing receipt validation
- gate registry validation
- evidence artifact lifecycle validation
- shell lint and docs gate
- zero worktree drift in all measured runs
