### PR TITLE
Parallelize default-head and opt-in local CI plans

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,6 +31,19 @@ Run everything CI runs, locally, with one command:
 ./scripts/check-ci-local.sh --full
 ```
 
+On a machine with spare CPU and memory, opt into the registry's bounded
+parallel planner:
+
+```sh
+./scripts/check-ci-local.sh --fast --jobs 2
+./scripts/check-ci-local.sh --full --jobs 2
+```
+
+The default remains one outer worker for predictable diagnostics and resource
+use. `NOSE_CI_JOBS=2` sets the same local default. Declared dependencies,
+parallel-safety, and resource groups keep binary consumers behind their build,
+stable Cargo work serial, and checked-output owners from colliding.
+
 `./scripts/check.sh` is kept as a backwards-compatible alias for `--full`. A
 green full run here is a green CI. The gate implementations live behind named
 `scripts/check-ci-local.sh --gate <name>` entries; GitHub Actions supplies

--- a/docs/pre-epic-readiness-948.md
+++ b/docs/pre-epic-readiness-948.md
@@ -160,6 +160,17 @@ warm isolated MSRV gate fell from 224.451 to 0.170 seconds, while a focused
 empty-cache MSRV run took 17.343 seconds. The next measured bottleneck is
 `default-head-evidence` at 214.754 seconds on clean fast.
 
+A parallel-planning follow-up at source commit `b8db7fda` moved the five
+independent default-head mutation self-tests behind a bounded three-worker pool.
+A focused run passed in 143.550 seconds, 71.204 seconds (33.2%) below the
+preceding 214.754-second serial result. Local fast/full plans remain sequential
+by default; `--jobs N` opts into the registry planner, whose declared
+dependencies, parallel-safety barriers, and resource groups prevent build
+consumers and shared-output owners from colliding. Aggregate local timing was
+not recorded because macOS policy inspection independently delayed locally
+built Rust test binaries during the measurement; hosted CI owns the complete
+gate qualification.
+
 The 599-line `crates/nose-cli/tests/cli/support.rs` test helper is now a
 13-line façade over focused `fixtures.rs` (210 lines), `process.rs` (149
 lines), and `query.rs` (245 lines). Existing `support::*` call sites remain

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -196,6 +196,21 @@ artifact validation, formatting, shell lint, and file-length policy remain
 sub-second or low-single-digit work, so removing them from fast feedback would
 save little while delaying actionable failures.
 
+### Recorded parallel-planning follow-up
+
+At source commit `b8db7fda`, a focused three-worker
+`default-head-evidence` run on the same arm64 macOS environment took 143.550
+seconds and passed without worktree drift. That is 71.204 seconds (33.2%) below
+the preceding receipt's 214.754-second serial result. The five independent
+mutation self-tests account for the change; all artifact validation remains
+serial and runs before the worker pool.
+
+No aggregate `--jobs 2` wall-time claim is recorded for this follow-up. During
+measurement, macOS policy inspection delayed each locally built Rust test
+binary independently of the planner, making the result non-representative.
+Planner behavior is covered by its scheduling and real-dispatch self-tests;
+the complete gate results are qualified by the hosted CI lanes.
+
 Use measurements to find duplicated setup or a gate assigned to the wrong lane.
 Do not remove validation or move release/soundness qualification to a faster
 lane merely to improve the aggregate time.

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -7,8 +7,9 @@ The repository's executable quality-policy boundary is:
 ```
 
 GitHub Actions supplies runner setup and calls that same boundary. Local plans,
-gate ownership, required tools, inputs, worktree effects, cache behavior, lane
-rationale, and focused commands are declared in the checked
+gate ownership, required tools, inputs, worktree effects, cache behavior,
+dependencies, parallel-safety, resource groups, lane rationale, and focused
+commands are declared in the checked
 [`scripts/ci/gates.json`](../scripts/ci/gates.json) registry.
 
 ## Discover and validate gates
@@ -37,6 +38,9 @@ runs. The validator fails if:
 - the Soundness Lab starts calling named gates without declaring the nightly
   lane;
 - a checked-output gate does not name the output it verifies.
+- a plan dependency is absent, ordered after its consumer, or names the
+  consumer itself;
+- a parallel-safety or resource-group declaration is malformed.
 
 The registry owns selection, ordering, and descriptive metadata. The shell
 dispatcher owns executable commands and diagnostics. The cross-check prevents
@@ -73,6 +77,32 @@ large evidence batch with a misleading error.
   is assigned to this lane. Its cheap runner mutation test is the separate
   `corpus-verify-selftest` pull-request gate.
 
+## Local execution
+
+Local plans remain sequential by default. Opt into bounded parallel execution
+when the machine has enough CPU and memory:
+
+```sh
+./scripts/check-ci-local.sh --fast --jobs 2
+./scripts/check-ci-local.sh --full --jobs 2
+```
+
+`NOSE_CI_JOBS` supplies the same default without changing the checked command.
+The planner starts only gates declared `parallel_safe`, waits for their
+mode-specific `depends_on` gates, and never overlaps members of one
+`resource_group`. A non-parallel-safe gate is an ordering barrier: earlier work
+must finish before it starts, and later work waits until it completes. Stable
+Cargo work shares `cargo-stable`; MSRV, coverage, checked label evidence, and
+checked Type-4 evidence use separate groups that match their isolated outputs.
+
+The `default-head-evidence` gate also runs its five independent mutation
+self-tests through a bounded worker pool after all checked artifacts validate.
+It fills each free slot immediately and defaults to three workers even when the
+outer plan is sequential. Set
+`NOSE_DEFAULT_HEAD_JOBS=1` to reproduce the former serial diagnostic order.
+Each worker writes only to its own temporary log or the self-test's own
+temporary directory; output is replayed in declaration order.
+
 ## Worktree effects
 
 Most gates are `read-only`: build/test output is confined to ignored caches such
@@ -94,6 +124,15 @@ Gate time depends on machine, compiler cache, and corpus state. The checked
 records its commit, environment, profile, mode, total time, per-gate time, exit
 status, and worktree-drift result instead of presenting one duration as a
 universal SLA.
+
+The checked per-gate receipt uses the default sequential outer plan so each
+gate retains an attributable duration. Measure the opt-in parallel plan
+separately:
+
+```sh
+/usr/bin/time -p ./scripts/check-ci-local.sh --fast --jobs 2
+/usr/bin/time -p ./scripts/check-ci-local.sh --full --jobs 2
+```
 
 Refresh it from a clean worktree with existing build caches:
 

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -14,10 +14,14 @@ mode="fast"
 gate_name=""
 gate_args=()
 list_format="text"
+parallel_jobs="${NOSE_CI_JOBS:-1}"
 case "${1:-}" in
-    "" | --fast)
+    "")
         mode="fast"
-        shift $#
+        ;;
+    --fast)
+        mode="fast"
+        shift
         ;;
     --full)
         mode="full"
@@ -50,7 +54,7 @@ case "${1:-}" in
         ;;
     -h | --help)
         cat <<'EOF'
-usage: ./scripts/check-ci-local.sh [--fast|--full]
+usage: ./scripts/check-ci-local.sh [--fast|--full] [--jobs <count>]
        ./scripts/check-ci-local.sh --gate <name> [gate arguments...]
        ./scripts/check-ci-local.sh --list-gates [--format text|json]
        ./scripts/check-ci-local.sh --validate-gates
@@ -61,6 +65,7 @@ usage: ./scripts/check-ci-local.sh [--fast|--full]
   --full  full local mirror of CI: format, clippy, docs, release build/tests,
           file-length ratchet, duplication, MSRV, supply-chain, docs wiki,
           formal obligation lint, and Lean proofs
+  --jobs  opt into bounded parallel local-plan execution; default: 1
   --gate  internal named-gate surface shared with GitHub Actions
   --list-gates
           authoritative owner, lane, effect, cache, and focused-command inventory
@@ -75,6 +80,25 @@ EOF
         exit 2
         ;;
 esac
+
+if [[ "$mode" == "fast" || "$mode" == "full" ]]; then
+    if [[ "${1:-}" == "--jobs" ]]; then
+        if [[ -z "${2:-}" ]]; then
+            echo "--jobs requires a positive integer" >&2
+            exit 2
+        fi
+        parallel_jobs="$2"
+        shift 2
+    fi
+    if [[ "$#" -ne 0 ]]; then
+        echo "unknown local-plan argument: $1" >&2
+        exit 2
+    fi
+    if [[ ! "$parallel_jobs" =~ ^[1-9][0-9]*$ ]]; then
+        echo "--jobs must be a positive integer: $parallel_jobs" >&2
+        exit 2
+    fi
+fi
 
 step() { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
 
@@ -271,6 +295,13 @@ run_local_plan() {
     done < <(python3 scripts/ci/gate_registry.py plan --mode "$plan_mode")
 }
 
+run_parallel_local_plan() {
+    local plan_mode="$1"
+    local jobs="$2"
+    need_python3
+    python3 scripts/ci/run_plan.py --mode "$plan_mode" --jobs "$jobs"
+}
+
 run_named_gate() {
     local name="$1"
     shift
@@ -408,11 +439,16 @@ fi
 if [[ "$mode" == "validate" ]]; then
     run_gate_registry_validation
     python3 scripts/ci/gate_registry.py validate --self-test
+    python3 scripts/ci/run_plan.py --self-test
     exit 0
 fi
 
 run_gate_registry_validation
-run_local_plan "$mode"
+if [[ "$parallel_jobs" -eq 1 ]]; then
+    run_local_plan "$mode"
+else
+    run_parallel_local_plan "$mode" "$parallel_jobs"
+fi
 if [[ "$mode" == "fast" ]]; then
     printf '\n\033[1;32mFast local CI gates passed.\033[0m\n'
 else

--- a/scripts/ci/evidence-gates.sh
+++ b/scripts/ci/evidence-gates.sh
@@ -1,6 +1,103 @@
 #!/usr/bin/env bash
 # Domain-owned command batches behind check-ci-local.sh named evidence gates.
 
+run_default_head_residual_ranking_selftest() {
+    python3 bench/labels/residual_ranking.py self-test
+}
+
+run_default_head_residual_topup_selftest() {
+    python3 bench/labels/residual_ranking_topup.py self-test
+}
+
+run_default_head_residual_panel_selftest() {
+    python3 bench/labels/residual_ranking_panel.py self-test
+}
+
+run_default_head_residual_closeout_selftest() {
+    python3 bench/labels/residual_ranking_closeout.py self-test
+}
+
+run_default_head_closeout_selftest() {
+    python3 bench/labels/default_head_closeout.py --self-test
+}
+
+run_bounded_evidence_checks() {
+    local max_jobs="$1"
+    shift
+    if [[ ! "$max_jobs" =~ ^[1-9][0-9]*$ ]]; then
+        echo "evidence worker count must be a positive integer: $max_jobs" >&2
+        return 2
+    fi
+
+    local log_dir
+    log_dir="$(mktemp -d "${TMPDIR:-/tmp}/nose-evidence.XXXXXX")"
+    local -a checks=("$@")
+    local check_count="${#checks[@]}"
+    local -a pids=()
+    local -a logs=()
+    local -a status_files=()
+    local next_index=0
+    local active_count=0
+    local completed_count=0
+    local first_status=0
+
+    while [[ "$completed_count" -lt "$check_count" ]]; do
+        while [[ "$active_count" -lt "$max_jobs" && "$next_index" -lt "$check_count" ]]; do
+            local check_name="${checks[$next_index]}"
+            local log_file="$log_dir/$next_index.log"
+            local status_file="$log_dir/$next_index.status"
+            (
+                local status=0
+                if "$check_name"; then
+                    status=0
+                else
+                    status=$?
+                fi
+                printf '%s\n' "$status" >"$status_file"
+            ) >"$log_file" 2>&1 &
+            pids[next_index]="$!"
+            logs[next_index]="$log_file"
+            status_files[next_index]="$status_file"
+            next_index=$((next_index + 1))
+            active_count=$((active_count + 1))
+        done
+
+        local made_progress=0
+        local running_index
+        for ((running_index = 0; running_index < next_index; running_index++)); do
+            if [[ -z "${pids[$running_index]:-}" || ! -s "${status_files[$running_index]}" ]]; then
+                continue
+            fi
+
+            wait "${pids[$running_index]}"
+            pids[running_index]=""
+            active_count=$((active_count - 1))
+            completed_count=$((completed_count + 1))
+            made_progress=1
+        done
+        if [[ "$made_progress" -eq 0 ]]; then
+            sleep 0.05
+        fi
+    done
+
+    local result_index
+    for ((result_index = 0; result_index < check_count; result_index++)); do
+        local status
+        status="$(<"${status_files[$result_index]}")"
+        cat "${logs[$result_index]}"
+        if [[ "$status" -ne 0 ]]; then
+            echo "parallel evidence check failed: ${checks[$result_index]}" >&2
+            if [[ "$first_status" -eq 0 ]]; then
+                first_status="$status"
+            fi
+        fi
+        rm -f -- "${logs[$result_index]}" "${status_files[$result_index]}"
+    done
+
+    rmdir -- "$log_dir"
+    return "$first_status"
+}
+
 run_default_head_evidence_checks() {
     need_cmd python3
     need_cmd node
@@ -52,21 +149,22 @@ run_default_head_evidence_checks() {
     fi
     python3 bench/labels/proof_actionability_no_go.py --self-test
     python3 bench/labels/residual_ranking.py validate
-    python3 bench/labels/residual_ranking.py self-test
     python3 bench/labels/residual_ranking_topup.py validate
-    python3 bench/labels/residual_ranking_topup.py self-test
     python3 bench/labels/residual_ranking_panel.py validate-arbitration
     python3 bench/labels/residual_ranking_panel.py validate-decisions
     python3 bench/labels/residual_ranking_panel.py validate-component
-    python3 bench/labels/residual_ranking_panel.py self-test
     python3 bench/labels/residual_ranking_closeout.py validate
-    python3 bench/labels/residual_ranking_closeout.py self-test
     python3 bench/labels/default_head_fresh_repository_audit.py
     python3 bench/labels/default_head_fresh_repository_audit.py --self-test
     python3 bench/labels/default_head_measurement_replay.py validate
     python3 bench/labels/default_head_measurement_replay.py self-test
     python3 bench/labels/default_head_closeout.py
-    python3 bench/labels/default_head_closeout.py --self-test
+    run_bounded_evidence_checks "${NOSE_DEFAULT_HEAD_JOBS:-3}" \
+        run_default_head_residual_ranking_selftest \
+        run_default_head_residual_topup_selftest \
+        run_default_head_residual_panel_selftest \
+        run_default_head_residual_closeout_selftest \
+        run_default_head_closeout_selftest
 }
 
 run_divergence_evidence_checks() {

--- a/scripts/ci/gate_registry.py
+++ b/scripts/ci/gate_registry.py
@@ -19,7 +19,7 @@ DEFAULT_CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 DEFAULT_NIGHTLY_WORKFLOW = ROOT / ".github/workflows/corpus-verify.yml"
 DEFAULT_RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
 
-SCHEMA = "nose.ci-gates.v1"
+SCHEMA = "nose.ci-gates.v2"
 WORKTREE_EFFECTS = {"read-only", "verify-checked-output"}
 LOCAL_PLAN_LANES = {"fast": "local-fast", "full": "local-full"}
 REQUIRED_GATE_FIELDS = {
@@ -31,6 +31,8 @@ REQUIRED_GATE_FIELDS = {
     "worktree_effect",
     "outputs",
     "cache",
+    "parallel_safe",
+    "resource_group",
     "lanes",
     "lane_reason",
     "focused_command",
@@ -86,6 +88,12 @@ def validate_model(registry: dict[str, Any]) -> list[dict[str, Any]]:
 
     seen_names: set[str] = set()
     plan_orders: dict[str, set[int]] = {mode: set() for mode in LOCAL_PLAN_LANES}
+    plan_order_by_name: dict[str, dict[str, int]] = {
+        mode: {} for mode in LOCAL_PLAN_LANES
+    }
+    plan_dependencies: dict[str, dict[str, list[str]]] = {
+        mode: {} for mode in LOCAL_PLAN_LANES
+    }
     for index, gate in enumerate(gates):
         if not isinstance(gate, dict):
             raise RegistryError(f"gate at index {index} must be an object")
@@ -124,6 +132,16 @@ def validate_model(registry: dict[str, Any]) -> list[dict[str, Any]]:
             )
         if gate["worktree_effect"] == "verify-checked-output" and not gate["outputs"]:
             raise RegistryError(f"gate {name}: checked-output gate must name its outputs")
+        if not isinstance(gate["parallel_safe"], bool):
+            raise RegistryError(f"gate {name}: parallel_safe must be boolean")
+        resource_group = gate["resource_group"]
+        if resource_group is not None and (
+            not isinstance(resource_group, str)
+            or re.fullmatch(r"[a-z0-9-]+", resource_group) is None
+        ):
+            raise RegistryError(
+                f"gate {name}: resource_group must be null or a kebab-case name"
+            )
         focused_prefix = f"./scripts/check-ci-local.sh --gate {name}"
         if not gate["focused_command"].startswith(focused_prefix):
             raise RegistryError(
@@ -142,9 +160,14 @@ def validate_model(registry: dict[str, Any]) -> list[dict[str, Any]]:
             if not planned:
                 continue
             plan = plans[mode]
-            if not isinstance(plan, dict) or set(plan) != {"order", "label", "args"}:
+            if not isinstance(plan, dict) or set(plan) != {
+                "order",
+                "label",
+                "args",
+                "depends_on",
+            }:
                 raise RegistryError(
-                    f"gate {name}: {mode} plan needs order, label, and args"
+                    f"gate {name}: {mode} plan needs order, label, args, and depends_on"
                 )
             order = plan["order"]
             if not isinstance(order, int) or order <= 0:
@@ -152,6 +175,7 @@ def validate_model(registry: dict[str, Any]) -> list[dict[str, Any]]:
             if order in plan_orders[mode]:
                 raise RegistryError(f"{mode} plan reuses order {order}")
             plan_orders[mode].add(order)
+            plan_order_by_name[mode][name] = order
             if not isinstance(plan["label"], str) or not plan["label"]:
                 raise RegistryError(f"gate {name}: {mode} label must be non-empty")
             args = plan["args"]
@@ -162,6 +186,40 @@ def validate_model(registry: dict[str, Any]) -> list[dict[str, Any]]:
             ):
                 raise RegistryError(
                     f"gate {name}: {mode} args must contain at most two strings"
+                )
+            dependencies = plan["depends_on"]
+            if (
+                not isinstance(dependencies, list)
+                or any(
+                    not isinstance(dependency, str)
+                    or re.fullmatch(r"[a-z0-9-]+", dependency) is None
+                    for dependency in dependencies
+                )
+                or len(dependencies) != len(set(dependencies))
+            ):
+                raise RegistryError(
+                    f"gate {name}: {mode} depends_on must contain unique gate names"
+                )
+            if name in dependencies:
+                raise RegistryError(f"gate {name}: {mode} cannot depend on itself")
+            plan_dependencies[mode][name] = dependencies
+
+    for mode in LOCAL_PLAN_LANES:
+        planned_names = set(plan_order_by_name[mode])
+        for name, dependencies in plan_dependencies[mode].items():
+            unknown = set(dependencies) - planned_names
+            if unknown:
+                raise RegistryError(
+                    f"gate {name}: {mode} depends on unplanned gates {sorted(unknown)}"
+                )
+            late = [
+                dependency
+                for dependency in dependencies
+                if plan_order_by_name[mode][dependency] >= plan_order_by_name[mode][name]
+            ]
+            if late:
+                raise RegistryError(
+                    f"gate {name}: {mode} dependencies must have lower order: {sorted(late)}"
                 )
 
     return gates
@@ -219,7 +277,12 @@ def validate_live_registry(
 def plan_rows(gates: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:
     return sorted(
         (
-            {"name": gate["name"], **gate["plans"][mode]}
+            {
+                "name": gate["name"],
+                "parallel_safe": gate["parallel_safe"],
+                "resource_group": gate["resource_group"],
+                **gate["plans"][mode],
+            }
             for gate in gates
             if mode in gate["plans"]
         ),
@@ -244,7 +307,9 @@ def print_list(gates: list[dict[str, Any]], output_format: str) -> None:
         json.dump(gates, sys.stdout, indent=2)
         print()
         return
-    print("gate\tlanes\tworktree\tcache\towner\tfocused command")
+    print(
+        "gate\tlanes\tworktree\tparallel\tresource group\tcache\towner\tfocused command"
+    )
     for gate in gates:
         print(
             "\t".join(
@@ -252,6 +317,8 @@ def print_list(gates: list[dict[str, Any]], output_format: str) -> None:
                     gate["name"],
                     ",".join(gate["lanes"]),
                     gate["worktree_effect"],
+                    str(gate["parallel_safe"]).lower(),
+                    gate["resource_group"] or "-",
                     gate["cache"],
                     gate["owner"],
                     gate["focused_command"],
@@ -280,11 +347,18 @@ def self_test() -> None:
                 "worktree_effect": "read-only",
                 "outputs": [],
                 "cache": "none",
+                "parallel_safe": True,
+                "resource_group": None,
                 "lanes": ["local-fast"],
                 "lane_reason": "sample rationale",
                 "focused_command": "./scripts/check-ci-local.sh --gate sample",
                 "plans": {
-                    "fast": {"order": 10, "label": "sample", "args": []}
+                    "fast": {
+                        "order": 10,
+                        "label": "sample",
+                        "args": [],
+                        "depends_on": [],
+                    }
                 },
             }
         ],
@@ -319,6 +393,24 @@ def self_test() -> None:
         assert "must agree" in str(exc)
     else:
         raise AssertionError("plan/lane drift passed")
+
+    bad_dependency = copy.deepcopy(sample)
+    bad_dependency["gates"][0]["plans"]["fast"]["depends_on"] = ["missing"]
+    try:
+        validate_model(bad_dependency)
+    except RegistryError as exc:
+        assert "unplanned gates" in str(exc)
+    else:
+        raise AssertionError("unknown plan dependency passed")
+
+    bad_group = copy.deepcopy(sample)
+    bad_group["gates"][0]["resource_group"] = "not_a_group"
+    try:
+        validate_model(bad_group)
+    except RegistryError as exc:
+        assert "resource_group" in str(exc)
+    else:
+        raise AssertionError("invalid resource group passed")
 
     print("CI gate registry self-test passed")
 

--- a/scripts/ci/gates.json
+++ b/scripts/ci/gates.json
@@ -1,5 +1,5 @@
 {
-  "schema": "nose.ci-gates.v1",
+  "schema": "nose.ci-gates.v2",
   "lanes": {
     "local-fast": "Common pre-push feedback with debug product-contract checks.",
     "local-full": "Complete local mirror of repository quality policy.",
@@ -17,12 +17,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Cheap mutation self-test for the pinned-corpus selection boundary.",
       "focused_command": "./scripts/check-ci-local.sh --gate corpus-prune-selftest",
       "plans": {
-        "fast": {"order": 10, "label": "corpus prune self-test", "args": []},
-        "full": {"order": 10, "label": "corpus prune self-test", "args": []}
+        "fast": {"order": 10, "label": "corpus prune self-test", "args": [], "depends_on": []},
+        "full": {"order": 10, "label": "corpus prune self-test", "args": [], "depends_on": []}
       }
     },
     {
@@ -34,12 +36,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Tests nightly orchestration without checking out or executing the corpus.",
       "focused_command": "./scripts/check-ci-local.sh --gate corpus-verify-selftest",
       "plans": {
-        "fast": {"order": 20, "label": "corpus verify runner self-test", "args": []},
-        "full": {"order": 20, "label": "corpus verify runner self-test", "args": []}
+        "fast": {"order": 20, "label": "corpus verify runner self-test", "args": [], "depends_on": []},
+        "full": {"order": 20, "label": "corpus verify runner self-test", "args": [], "depends_on": []}
       }
     },
     {
@@ -51,12 +55,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Keeps checked semantic-pack pricing evidence reproducible on every change.",
       "focused_command": "./scripts/check-ci-local.sh --gate semantic-pack-pricing",
       "plans": {
-        "fast": {"order": 30, "label": "semantic-pack pricing self-test", "args": []},
-        "full": {"order": 30, "label": "semantic-pack pricing self-test", "args": []}
+        "fast": {"order": 30, "label": "semantic-pack pricing self-test", "args": [], "depends_on": []},
+        "full": {"order": 30, "label": "semantic-pack pricing self-test", "args": [], "depends_on": []}
       }
     },
     {
@@ -68,12 +74,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "type4-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Validates proof-carrying frontier packets and generators before product tests.",
       "focused_command": "./scripts/check-ci-local.sh --gate type4-frontier",
       "plans": {
-        "fast": {"order": 40, "label": "Type-4 frontier evidence checks", "args": []},
-        "full": {"order": 40, "label": "Type-4 frontier evidence checks", "args": []}
+        "fast": {"order": 40, "label": "Type-4 frontier evidence checks", "args": [], "depends_on": []},
+        "full": {"order": 40, "label": "Type-4 frontier evidence checks", "args": [], "depends_on": []}
       }
     },
     {
@@ -85,12 +93,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["bench/labels/"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "labels-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Mutation-tests and validates the checked default-head label, reveal, calibration, and closeout chain.",
       "focused_command": "./scripts/check-ci-local.sh --gate default-head-evidence",
       "plans": {
-        "fast": {"order": 50, "label": "default-head evidence checks", "args": []},
-        "full": {"order": 50, "label": "default-head evidence checks", "args": []}
+        "fast": {"order": 50, "label": "default-head evidence checks", "args": [], "depends_on": []},
+        "full": {"order": 50, "label": "default-head evidence checks", "args": [], "depends_on": []}
       }
     },
     {
@@ -102,12 +112,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["eval/divergence_fire/"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Replays and validates the checked divergence-fire precision protocol and receipt.",
       "focused_command": "./scripts/check-ci-local.sh --gate divergence-evidence",
       "plans": {
-        "fast": {"order": 51, "label": "divergence evidence checks", "args": []},
-        "full": {"order": 51, "label": "divergence evidence checks", "args": []}
+        "fast": {"order": 51, "label": "divergence evidence checks", "args": [], "depends_on": []},
+        "full": {"order": 51, "label": "divergence evidence checks", "args": [], "depends_on": []}
       }
     },
     {
@@ -119,12 +131,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["bench/labels/"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "labels-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Mutation-tests generated-surface contracts and the recall-frontier evidence helpers.",
       "focused_command": "./scripts/check-ci-local.sh --gate surface-recall-evidence",
       "plans": {
-        "fast": {"order": 52, "label": "generated surface and recall evidence checks", "args": []},
-        "full": {"order": 52, "label": "generated surface and recall evidence checks", "args": []}
+        "fast": {"order": 52, "label": "generated surface and recall evidence checks", "args": [], "depends_on": []},
+        "full": {"order": 52, "label": "generated surface and recall evidence checks", "args": [], "depends_on": []}
       }
     },
     {
@@ -136,12 +150,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["bench/cache/", "bench/release/", "bench/soundness/"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Mutation-tests and validates checked runtime, cache, release, and soundness receipts.",
       "focused_command": "./scripts/check-ci-local.sh --gate runtime-soundness-evidence",
       "plans": {
-        "fast": {"order": 53, "label": "runtime and soundness evidence checks", "args": []},
-        "full": {"order": 53, "label": "runtime and soundness evidence checks", "args": []}
+        "fast": {"order": 53, "label": "runtime and soundness evidence checks", "args": [], "depends_on": []},
+        "full": {"order": 53, "label": "runtime and soundness evidence checks", "args": [], "depends_on": []}
       }
     },
     {
@@ -153,12 +169,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": false,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Fail-closes ownership coverage, large-file identity, retention, and receipt/seal/baseline bindings.",
       "focused_command": "./scripts/check-ci-local.sh --gate evidence-artifacts",
       "plans": {
-        "fast": {"order": 55, "label": "evidence artifact lifecycle", "args": []},
-        "full": {"order": 55, "label": "evidence artifact lifecycle", "args": []}
+        "fast": {"order": 55, "label": "evidence artifact lifecycle", "args": [], "depends_on": []},
+        "full": {"order": 55, "label": "evidence artifact lifecycle", "args": [], "depends_on": []}
       }
     },
     {
@@ -170,12 +188,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "labels-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Fail-closes the checked recall-frontier decision chain.",
       "focused_command": "./scripts/check-ci-local.sh --gate missed-worthy-frontier",
       "plans": {
-        "fast": {"order": 60, "label": "current missed-worthy frontier artifacts", "args": []},
-        "full": {"order": 60, "label": "current missed-worthy frontier artifacts", "args": []}
+        "fast": {"order": 60, "label": "current missed-worthy frontier artifacts", "args": [], "depends_on": []},
+        "full": {"order": 60, "label": "current missed-worthy frontier artifacts", "args": [], "depends_on": []}
       }
     },
     {
@@ -187,12 +207,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "labels-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Validates accepted-edge coverage and its runtime/output price.",
       "focused_command": "./scripts/check-ci-local.sh --gate accepted-pair-coverage",
       "plans": {
-        "fast": {"order": 70, "label": "current accepted-pair coverage artifacts", "args": []},
-        "full": {"order": 70, "label": "current accepted-pair coverage artifacts", "args": []}
+        "fast": {"order": 70, "label": "current accepted-pair coverage artifacts", "args": [], "depends_on": []},
+        "full": {"order": 70, "label": "current accepted-pair coverage artifacts", "args": [], "depends_on": []}
       }
     },
     {
@@ -204,12 +226,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "temporary-directory",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Protects the pre-push target-pruning helper with a cheap isolated self-test.",
       "focused_command": "./scripts/check-ci-local.sh --gate cargo-target-prune-selftest",
       "plans": {
-        "fast": {"order": 80, "label": "Cargo target prune self-test", "args": []},
-        "full": {"order": 80, "label": "Cargo target prune self-test", "args": []}
+        "fast": {"order": 80, "label": "Cargo target prune self-test", "args": [], "depends_on": []},
+        "full": {"order": 80, "label": "Cargo target prune self-test", "args": [], "depends_on": []}
       }
     },
     {
@@ -221,12 +245,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Cheap syntax and portability feedback for executable repository tooling.",
       "focused_command": "./scripts/check-ci-local.sh --gate shell-lint",
       "plans": {
-        "fast": {"order": 90, "label": "shell scripts (shellcheck)", "args": []},
-        "full": {"order": 90, "label": "shell scripts (shellcheck)", "args": []}
+        "fast": {"order": 90, "label": "shell scripts (shellcheck)", "args": [], "depends_on": []},
+        "full": {"order": 90, "label": "shell scripts (shellcheck)", "args": [], "depends_on": []}
       }
     },
     {
@@ -238,12 +264,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Fast canonical formatting check.",
       "focused_command": "./scripts/check-ci-local.sh --gate format",
       "plans": {
-        "fast": {"order": 100, "label": "rustfmt (formatting)", "args": []},
-        "full": {"order": 100, "label": "rustfmt (formatting)", "args": []}
+        "fast": {"order": 100, "label": "rustfmt (formatting)", "args": [], "depends_on": []},
+        "full": {"order": 100, "label": "rustfmt (formatting)", "args": [], "depends_on": []}
       }
     },
     {
@@ -255,12 +283,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Cheap no-loosening check for module ownership pressure.",
       "focused_command": "./scripts/check-ci-local.sh --gate file-length <base-ref>",
       "plans": {
-        "fast": {"order": 110, "label": "Rust file-length ratchet", "args": ["origin/main"]},
-        "full": {"order": 110, "label": "Rust file-length ratchet", "args": ["origin/main"]}
+        "fast": {"order": 110, "label": "Rust file-length ratchet", "args": ["origin/main"], "depends_on": []},
+        "full": {"order": 110, "label": "Rust file-length ratchet", "args": ["origin/main"], "depends_on": []}
       }
     },
     {
@@ -272,12 +302,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Prevents reintroduction of the retired ambient CLI prelude.",
       "focused_command": "./scripts/check-ci-local.sh --gate legacy-prelude",
       "plans": {
-        "fast": {"order": 120, "label": "CLI legacy-prelude guard", "args": []},
-        "full": {"order": 120, "label": "CLI legacy-prelude guard", "args": []}
+        "fast": {"order": 120, "label": "CLI legacy-prelude guard", "args": [], "depends_on": []},
+        "full": {"order": 120, "label": "CLI legacy-prelude guard", "args": [], "depends_on": []}
       }
     },
     {
@@ -289,12 +321,14 @@
       "worktree_effect": "read-only",
       "outputs": ["target/"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "High-value compiler feedback required before push and merge.",
       "focused_command": "./scripts/check-ci-local.sh --gate clippy",
       "plans": {
-        "fast": {"order": 130, "label": "clippy (lints, -D warnings)", "args": []},
-        "full": {"order": 130, "label": "clippy (lints, -D warnings)", "args": []}
+        "fast": {"order": 130, "label": "clippy (lints, -D warnings)", "args": [], "depends_on": []},
+        "full": {"order": 130, "label": "clippy (lints, -D warnings)", "args": [], "depends_on": []}
       }
     },
     {
@@ -306,11 +340,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/doc/"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Full/merge gate for Rust documentation links and warnings.",
       "focused_command": "./scripts/check-ci-local.sh --gate doc",
       "plans": {
-        "full": {"order": 140, "label": "doc (rustdoc warnings)", "args": []}
+        "full": {"order": 140, "label": "doc (rustdoc warnings)", "args": [], "depends_on": []}
       }
     },
     {
@@ -322,11 +358,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/debug/nose"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-fast"],
       "lane_reason": "Builds the debug binary used by fast live product-contract checks.",
       "focused_command": "./scripts/check-ci-local.sh --gate build-debug-cli",
       "plans": {
-        "fast": {"order": 150, "label": "build debug CLI", "args": []}
+        "fast": {"order": 150, "label": "build debug CLI", "args": [], "depends_on": []}
       }
     },
     {
@@ -338,11 +376,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/release/nose"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Produces the optimized binary used by full product-contract gates.",
       "focused_command": "./scripts/check-ci-local.sh --gate build-release",
       "plans": {
-        "full": {"order": 150, "label": "build (release)", "args": []}
+        "full": {"order": 150, "label": "build (release)", "args": [], "depends_on": []}
       }
     },
     {
@@ -354,11 +394,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/debug/"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-fast"],
       "lane_reason": "Representative no-optimization test feedback for pre-push use.",
       "focused_command": "./scripts/check-ci-local.sh --gate test-debug-cli",
       "plans": {
-        "fast": {"order": 140, "label": "nose-cli tests", "args": []}
+        "fast": {"order": 140, "label": "nose-cli tests", "args": [], "depends_on": []}
       }
     },
     {
@@ -370,11 +412,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/release/"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Complete optimized workspace test suite before merge and release.",
       "focused_command": "./scripts/check-ci-local.sh --gate test-release",
       "plans": {
-        "full": {"order": 200, "label": "test (release)", "args": []}
+        "full": {"order": 200, "label": "test (release)", "args": [], "depends_on": ["build-release"]}
       }
     },
     {
@@ -386,12 +430,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Executes the versioned machine contract against the just-built binary.",
       "focused_command": "./scripts/check-ci-local.sh --gate product-query-schema <nose-bin>",
       "plans": {
-        "fast": {"order": 160, "label": "product query JSON schema", "args": ["target/debug/nose"]},
-        "full": {"order": 160, "label": "product query JSON schema", "args": ["target/release/nose"]}
+        "fast": {"order": 160, "label": "product query JSON schema", "args": ["target/debug/nose"], "depends_on": ["build-debug-cli"]},
+        "full": {"order": 160, "label": "product query JSON schema", "args": ["target/release/nose"], "depends_on": ["build-release"]}
       }
     },
     {
@@ -403,11 +449,13 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Full/merge executable check for published semantic-pack examples.",
       "focused_command": "./scripts/check-ci-local.sh --gate semantic-pack-examples <nose-bin>",
       "plans": {
-        "full": {"order": 170, "label": "semantic-pack example conformance", "args": ["target/release/nose"]}
+        "full": {"order": 170, "label": "semantic-pack example conformance", "args": ["target/release/nose"], "depends_on": ["build-release"]}
       }
     },
     {
@@ -419,12 +467,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["bench/type4/executable_expectations.v1.json"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "type4-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Runs focused executable convergence checks and verifies the checked receipt.",
       "focused_command": "./scripts/check-ci-local.sh --gate type4-executable <nose-bin>",
       "plans": {
-        "fast": {"order": 170, "label": "Type-4 executable focused expectations", "args": ["target/debug/nose"]},
-        "full": {"order": 180, "label": "Type-4 executable focused expectations", "args": ["target/release/nose"]}
+        "fast": {"order": 170, "label": "Type-4 executable focused expectations", "args": ["target/debug/nose"], "depends_on": ["build-debug-cli"]},
+        "full": {"order": 180, "label": "Type-4 executable focused expectations", "args": ["target/release/nose"], "depends_on": ["build-release"]}
       }
     },
     {
@@ -436,12 +486,14 @@
       "worktree_effect": "verify-checked-output",
       "outputs": ["bench/type4/coverage_evidence.v1.json", "bench/type4/coverage_matrix.v1.json", "bench/type4/blind_attack.v1.json"],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": "type4-evidence",
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Regenerates and compares the checked claim perimeter against a ratchet base.",
       "focused_command": "./scripts/check-ci-local.sh --gate type4-axis-language <nose-bin> <base-ref>",
       "plans": {
-        "fast": {"order": 180, "label": "Type-4 axis-language claim perimeter", "args": ["target/debug/nose", "origin/main"]},
-        "full": {"order": 190, "label": "Type-4 axis-language claim perimeter", "args": ["target/release/nose", "origin/main"]}
+        "fast": {"order": 180, "label": "Type-4 axis-language claim perimeter", "args": ["target/debug/nose", "origin/main"], "depends_on": ["type4-executable"]},
+        "full": {"order": 190, "label": "Type-4 axis-language claim perimeter", "args": ["target/release/nose", "origin/main"], "depends_on": ["type4-executable"]}
       }
     },
     {
@@ -453,11 +505,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/llvm-cov-target/"],
       "cache": "cargo-llvm-cov",
+      "parallel_safe": true,
+      "resource_group": "cargo-coverage",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Slower quality ratchet required before merge and release, not pre-push.",
       "focused_command": "./scripts/check-ci-local.sh --gate coverage",
       "plans": {
-        "full": {"order": 210, "label": "coverage gate", "args": []}
+        "full": {"order": 210, "label": "coverage gate", "args": [], "depends_on": []}
       }
     },
     {
@@ -469,11 +523,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/duplication-gate/"],
       "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Full/merge review ratchet; changes require explicit family-level judgment.",
       "focused_command": "./scripts/check-ci-local.sh --gate duplication",
       "plans": {
-        "full": {"order": 220, "label": "duplication gate (nose on itself)", "args": []}
+        "full": {"order": 220, "label": "duplication gate (nose on itself)", "args": [], "depends_on": ["build-release"]}
       }
     },
     {
@@ -485,11 +541,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/msrv/"],
       "cache": "cargo (isolated target/msrv)",
+      "parallel_safe": true,
+      "resource_group": "cargo-msrv",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Compatibility check is required before merge/release and keeps its separate compiler artifacts under target/msrv.",
       "focused_command": "./scripts/check-ci-local.sh --gate msrv",
       "plans": {
-        "full": {"order": 230, "label": "MSRV (minimum supported rust version)", "args": []}
+        "full": {"order": 230, "label": "MSRV (minimum supported rust version)", "args": [], "depends_on": []}
       }
     },
     {
@@ -501,11 +559,13 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "cargo-index",
+      "parallel_safe": true,
+      "resource_group": "cargo-metadata",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Network/index-sensitive dependency policy runs before merge and release.",
       "focused_command": "./scripts/check-ci-local.sh --gate supply-chain",
       "plans": {
-        "full": {"order": 240, "label": "supply chain (unused dependencies / advisories / licenses)", "args": []}
+        "full": {"order": 240, "label": "supply chain (unused dependencies / advisories / licenses)", "args": [], "depends_on": []}
       }
     },
     {
@@ -517,12 +577,14 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-fast", "local-full", "pull-request", "release"],
       "lane_reason": "Contributor-facing docs and executable examples must stay connected on every change.",
       "focused_command": "./scripts/check-ci-local.sh --gate docs",
       "plans": {
-        "fast": {"order": 190, "label": "docs wiki connectivity (awiki)", "args": []},
-        "full": {"order": 250, "label": "docs wiki connectivity (awiki)", "args": []}
+        "fast": {"order": 190, "label": "docs wiki connectivity (awiki)", "args": [], "depends_on": []},
+        "full": {"order": 250, "label": "docs wiki connectivity (awiki)", "args": [], "depends_on": []}
       }
     },
     {
@@ -534,11 +596,13 @@
       "worktree_effect": "read-only",
       "outputs": [],
       "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Proof-sensitive markers and counterexamples must be registered before merge.",
       "focused_command": "./scripts/check-ci-local.sh --gate formal-obligations",
       "plans": {
-        "full": {"order": 260, "label": "formal obligation registry", "args": []}
+        "full": {"order": 260, "label": "formal obligation registry", "args": [], "depends_on": []}
       }
     },
     {
@@ -550,11 +614,13 @@
       "worktree_effect": "read-only",
       "outputs": ["target/lean/"],
       "cache": "lean",
+      "parallel_safe": true,
+      "resource_group": "formal-lean",
       "lanes": ["local-full", "pull-request", "release"],
       "lane_reason": "Proof compilation is required before merge/release but is not a pre-push default.",
       "focused_command": "./scripts/check-ci-local.sh --gate formal-lean",
       "plans": {
-        "full": {"order": 270, "label": "Lean proofs (formal soundness)", "args": []}
+        "full": {"order": 270, "label": "Lean proofs (formal soundness)", "args": [], "depends_on": ["formal-obligations"]}
       }
     }
   ]

--- a/scripts/ci/run_plan.py
+++ b/scripts/ci/run_plan.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Run a registry-defined local CI plan with bounded parallelism."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import gate_registry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECK_SCRIPT = ROOT / "scripts/check-ci-local.sh"
+MINIMUM_PYTHON = (3, 10)
+
+
+@dataclass
+class RunningGate:
+    index: int
+    row: dict[str, Any]
+    process: subprocess.Popen[bytes]
+    log_path: Path
+    log_stream: BinaryIO
+    started: float
+
+
+@dataclass(frozen=True)
+class GateResult:
+    status: int
+    seconds: float
+    log_path: Path
+
+
+def worktree_fingerprint() -> str:
+    fingerprint = hashlib.sha256()
+    for command in (
+        ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        ["git", "diff", "--no-ext-diff", "--binary", "--"],
+        ["git", "diff", "--cached", "--no-ext-diff", "--binary", "--"],
+    ):
+        output = subprocess.run(
+            command,
+            cwd=ROOT,
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        fingerprint.update(len(output).to_bytes(8, "big"))
+        fingerprint.update(output)
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    for raw_path in untracked.split(b"\0"):
+        if not raw_path:
+            continue
+        fingerprint.update(raw_path)
+        fingerprint.update((ROOT / os.fsdecode(raw_path)).read_bytes())
+    return fingerprint.hexdigest()
+
+
+def can_start(
+    row: dict[str, Any],
+    active_rows: list[dict[str, Any]],
+    completed: dict[str, int],
+) -> bool:
+    if any(completed.get(dependency) != 0 for dependency in row["depends_on"]):
+        return False
+    if not row["parallel_safe"]:
+        return not active_rows
+    if any(not active["parallel_safe"] for active in active_rows):
+        return False
+    resource_group = row["resource_group"]
+    return resource_group is None or all(
+        active["resource_group"] != resource_group for active in active_rows
+    )
+
+
+def next_startable_position(
+    pending: list[tuple[int, dict[str, Any]]],
+    active_rows: list[dict[str, Any]],
+    completed: dict[str, int],
+) -> int | None:
+    for position, (_, row) in enumerate(pending):
+        if can_start(row, active_rows, completed):
+            return position
+        if not row["parallel_safe"]:
+            return None
+    return None
+
+
+def emit_result(row: dict[str, Any], result: GateResult) -> None:
+    verdict = "passed" if result.status == 0 else f"failed ({result.status})"
+    print(
+        f"\n\033[1m== {row['label']}: {verdict} in {result.seconds:.1f}s ==\033[0m",
+        flush=True,
+    )
+    with result.log_path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            sys.stdout.buffer.write(chunk)
+    sys.stdout.buffer.flush()
+
+
+def run_plan(
+    rows: list[dict[str, Any]],
+    jobs: int,
+    *,
+    check_script: Path = CHECK_SCRIPT,
+) -> int:
+    before = worktree_fingerprint()
+    completed: dict[str, int] = {}
+    results: dict[int, GateResult] = {}
+    pending = list(enumerate(rows))
+    running: dict[int, RunningGate] = {}
+    next_to_emit = 0
+    first_failure = 0
+
+    with tempfile.TemporaryDirectory(prefix="nose-ci-plan-") as directory:
+        log_dir = Path(directory)
+        try:
+            while pending or running:
+                if first_failure == 0:
+                    while len(running) < jobs:
+                        active_rows = [gate.row for gate in running.values()]
+                        candidate = next_startable_position(
+                            pending,
+                            active_rows,
+                            completed,
+                        )
+                        if candidate is None:
+                            break
+                        index, row = pending.pop(candidate)
+                        log_path = log_dir / f"{index:03d}-{row['name']}.log"
+                        log_stream = log_path.open("wb")
+                        command = [
+                            str(check_script),
+                            "--gate",
+                            row["name"],
+                            *row["args"],
+                        ]
+                        process = subprocess.Popen(
+                            command,
+                            cwd=ROOT,
+                            stdout=log_stream,
+                            stderr=subprocess.STDOUT,
+                            start_new_session=True,
+                        )
+                        running[index] = RunningGate(
+                            index=index,
+                            row=row,
+                            process=process,
+                            log_path=log_path,
+                            log_stream=log_stream,
+                            started=time.perf_counter(),
+                        )
+                        print(
+                            f"\033[1m== started: {row['label']} ==\033[0m",
+                            flush=True,
+                        )
+
+                if not running:
+                    if pending:
+                        if first_failure == 0:
+                            blocked = ", ".join(row["name"] for _, row in pending)
+                            print(
+                                f"local CI plan could not schedule: {blocked}",
+                                file=sys.stderr,
+                            )
+                            first_failure = 1
+                        else:
+                            skipped = ", ".join(row["name"] for _, row in pending)
+                            print(
+                                f"local CI gates not run after failure: {skipped}",
+                                file=sys.stderr,
+                            )
+                    break
+
+                while True:
+                    finished: list[int] = []
+                    for index, gate in running.items():
+                        status = gate.process.poll()
+                        if status is None:
+                            continue
+                        gate.log_stream.close()
+                        results[index] = GateResult(
+                            status=status,
+                            seconds=time.perf_counter() - gate.started,
+                            log_path=gate.log_path,
+                        )
+                        completed[gate.row["name"]] = status
+                        if status != 0 and first_failure == 0:
+                            first_failure = status
+                        finished.append(index)
+                    for index in finished:
+                        del running[index]
+                    if finished:
+                        break
+                    time.sleep(0.05)
+
+                while next_to_emit in results:
+                    emit_result(rows[next_to_emit], results[next_to_emit])
+                    next_to_emit += 1
+        except KeyboardInterrupt:
+            for gate in running.values():
+                try:
+                    os.killpg(gate.process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            for gate in running.values():
+                gate.process.wait()
+                gate.log_stream.close()
+            print("local CI plan interrupted", file=sys.stderr)
+            return 130
+
+        for index in sorted(results):
+            if index >= next_to_emit:
+                emit_result(rows[index], results[index])
+
+    after = worktree_fingerprint()
+    if before != after:
+        print("local CI plan changed the worktree", file=sys.stderr)
+        if first_failure == 0:
+            first_failure = 1
+    return first_failure
+
+
+def self_test() -> None:
+    base = {
+        "depends_on": [],
+        "parallel_safe": True,
+        "resource_group": None,
+    }
+    first = {**base, "name": "first", "resource_group": "shared"}
+    same_group = {**base, "name": "same-group", "resource_group": "shared"}
+    independent = {**base, "name": "independent"}
+    dependent = {**base, "name": "dependent", "depends_on": ["first"]}
+    exclusive = {**base, "name": "exclusive", "parallel_safe": False}
+
+    assert can_start(first, [], {})
+    assert not can_start(same_group, [first], {})
+    assert can_start(independent, [first], {})
+    assert not can_start(dependent, [], {})
+    assert can_start(dependent, [], {"first": 0})
+    assert not can_start(dependent, [], {"first": 1})
+    assert not can_start(exclusive, [first], {})
+    assert not can_start(first, [exclusive], {})
+    pending = [(0, exclusive), (1, independent)]
+    assert next_startable_position(pending, [first], {}) is None
+    with tempfile.TemporaryDirectory(prefix="nose-ci-plan-selftest-") as directory:
+        dispatcher = Path(directory) / "gate"
+        dispatcher.write_text(
+            "#!/usr/bin/env bash\n"
+            "if [[ \"$2\" == \"fail\" ]]; then exit 7; fi\n"
+            "printf 'fake gate passed: %s\\n' \"$2\"\n"
+        )
+        dispatcher.chmod(0o755)
+        row = {
+            **base,
+            "name": "pass",
+            "label": "passing fake gate",
+            "args": [],
+        }
+        assert run_plan([row], 2, check_script=dispatcher) == 0
+        failed = {
+            **exclusive,
+            "name": "fail",
+            "label": "failing fake gate",
+            "args": [],
+        }
+        assert run_plan([failed], 2, check_script=dispatcher) == 7
+    print("local CI parallel planner self-test passed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("fast", "full"))
+    parser.add_argument("--jobs", type=int, default=1)
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.version_info < MINIMUM_PYTHON:
+        observed = ".".join(str(part) for part in sys.version_info[:3])
+        print(
+            "local CI parallel planner requires Python 3.10 or newer "
+            f"(observed {observed})",
+            file=sys.stderr,
+        )
+        return 127
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.mode is None:
+        print("--mode is required", file=sys.stderr)
+        return 2
+    if args.jobs <= 0:
+        print("--jobs must be a positive integer", file=sys.stderr)
+        return 2
+    try:
+        gates = gate_registry.validate_live_registry(gate_registry.load_registry())
+        rows = gate_registry.plan_rows(gates, args.mode)
+    except (OSError, gate_registry.RegistryError) as exc:
+        print(f"local CI plan error: {exc}", file=sys.stderr)
+        return 1
+    return run_plan(rows, args.jobs)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -45,7 +45,7 @@
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
       "artifact_count": 6,
-      "inventory_sha256": "96ff5ad3db99bfe5d1df2b8be07117e38678b3ac4f3ca9d9df64532997b2c222"
+      "inventory_sha256": "906ca71fa00eeacab7e0113d734e4ebd8a02c69c60a1e8d956c402feadbf5426"
     },
     {
       "id": "benchmark-root",


### PR DESCRIPTION
## Summary

- run the five independent default-head mutation self-tests through a bounded three-worker pool with deterministic output
- add an opt-in registry-driven local planner via `--jobs N`, including dependencies, parallel-safety barriers, resource groups, deterministic logs, and worktree-drift detection
- document the execution contract and focused 33.2% default-head improvement

## Measurements

- previous checked serial `default-head-evidence`: 214.754 s
- focused three-worker run at `b8db7fda`: 143.550 s
- savings: 71.204 s (33.2%)

No aggregate local `--jobs 2` claim is made: macOS policy inspection delayed each locally built Rust test binary during measurement, independently of the planner.

## Verification

- `NOSE_DEFAULT_HEAD_JOBS=3 ./scripts/check-ci-local.sh --gate default-head-evidence`
- `./scripts/check-ci-local.sh --validate-gates`
- `python3 scripts/ci/run_plan.py --self-test`
- `shellcheck -x scripts/check-ci-local.sh scripts/ci/evidence-gates.sh`
- `./scripts/check-ci-local.sh --gate evidence-artifacts`
- `./scripts/check-ci-local.sh --gate docs`
- `git diff --check`
