### PR TITLE
Avoid repeated default-head residual validation

### DIFF
--- a/docs/pre-epic-readiness-948.md
+++ b/docs/pre-epic-readiness-948.md
@@ -171,6 +171,13 @@ not recorded because macOS policy inspection independently delayed locally
 built Rust test binaries during the measurement; hosted CI owns the complete
 gate qualification.
 
+A subsequent serial-path cleanup at source commit `9d5be0b7` removed six
+standalone residual-chain validations already owned transitively by the
+aggregate default-head closeout. The same focused gate passed in 98.060 seconds,
+45.490 seconds (31.7%) below the three-worker result and 116.694 seconds (54.3%)
+below the original serial result. No artifact validator or mutation self-test
+was removed.
+
 The 599-line `crates/nose-cli/tests/cli/support.rs` test helper is now a
 13-line façade over focused `fixtures.rs` (210 lines), `process.rs` (149
 lines), and `query.rs` (245 lines). Existing `support::*` call sites remain

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -103,6 +103,12 @@ outer plan is sequential. Set
 Each worker writes only to its own temporary log or the self-test's own
 temporary directory; output is replayed in declaration order.
 
+The serial phase validates the residual-ranking artifact chain once through the
+aggregate default-head closeout. That closeout rebuilds the calibration, top-up
+selection, blind panel, arbitration, decisions, label component, and residual
+closeout, so the local plan does not repeat their focused validation commands
+before running the same aggregate check.
+
 ## Worktree effects
 
 Most gates are `read-only`: build/test output is confined to ignored caches such

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -211,6 +211,13 @@ the preceding receipt's 214.754-second serial result. The five independent
 mutation self-tests account for the change; all artifact validation remains
 serial and runs before the worker pool.
 
+At source commit `9d5be0b7`, the serial phase stopped invoking six focused
+residual-chain validators that the aggregate default-head closeout already
+rebuilds and validates. The same focused gate passed in 98.060 seconds: 45.490
+seconds (31.7%) below the three-worker result and 116.694 seconds (54.3%) below
+the original 214.754-second result. The aggregate artifact validation and all
+five mutation self-tests remain in the gate.
+
 No aggregate `--jobs 2` wall-time claim is recorded for this follow-up. During
 measurement, macOS policy inspection delayed each locally built Rust test
 binary independently of the planner, making the result non-representative.

--- a/scripts/ci/evidence-gates.sh
+++ b/scripts/ci/evidence-gates.sh
@@ -148,16 +148,12 @@ run_default_head_evidence_checks() {
         python3 bench/labels/default_head_heldout_reveal_receipt.py self-test
     fi
     python3 bench/labels/proof_actionability_no_go.py --self-test
-    python3 bench/labels/residual_ranking.py validate
-    python3 bench/labels/residual_ranking_topup.py validate
-    python3 bench/labels/residual_ranking_panel.py validate-arbitration
-    python3 bench/labels/residual_ranking_panel.py validate-decisions
-    python3 bench/labels/residual_ranking_panel.py validate-component
-    python3 bench/labels/residual_ranking_closeout.py validate
     python3 bench/labels/default_head_fresh_repository_audit.py
     python3 bench/labels/default_head_fresh_repository_audit.py --self-test
     python3 bench/labels/default_head_measurement_replay.py validate
     python3 bench/labels/default_head_measurement_replay.py self-test
+    # This aggregate rebuilds and validates the complete residual ranking,
+    # top-up selection, panel, arbitration, decision, component, and closeout chain.
     python3 bench/labels/default_head_closeout.py
     run_bounded_evidence_checks "${NOSE_DEFAULT_HEAD_JOBS:-3}" \
         run_default_head_residual_ranking_selftest \


### PR DESCRIPTION
## Summary

- remove six focused residual-chain validation invocations already rebuilt and validated by the aggregate default-head closeout
- retain the aggregate artifact validation and all five mutation self-tests
- document the single-owner validation path and focused timing evidence

## Measurement

- original serial gate: 214.754 s
- three-worker gate after #955: 143.550 s
- this change: 98.060 s
- additional savings: 45.490 s (31.7%); total savings from the original: 116.694 s (54.3%)

## Verification

- `NOSE_DEFAULT_HEAD_JOBS=3 ./scripts/check-ci-local.sh --gate default-head-evidence`
- `./scripts/check-ci-local.sh --validate-gates`
- `shellcheck -x scripts/check-ci-local.sh scripts/ci/evidence-gates.sh`
- `./scripts/check-ci-local.sh --gate docs`
- `./scripts/check-ci-local.sh --gate evidence-artifacts`
- `git diff --check`
