### PR TITLE
ci: split pull request test qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test:
-    name: build · test · lint · dup-gate
+    name: policy · lint · rustdoc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -78,6 +78,16 @@ jobs:
         run: ./scripts/check-ci-local.sh --gate clippy
       - name: gate · doc
         run: ./scripts/check-ci-local.sh --gate doc
+
+  release-product:
+    name: optimized product contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: gate · build-release
         run: ./scripts/check-ci-local.sh --gate build-release
       - name: gate · product-query-schema
@@ -97,10 +107,34 @@ jobs:
             ratchet_base="HEAD^"
           fi
           ./scripts/check-ci-local.sh --gate type4-axis-language target/release/nose "$ratchet_base"
-      - name: gate · test-release
-        run: ./scripts/check-ci-local.sh --gate test-release
       - name: gate · duplication
         run: ./scripts/check-ci-local.sh --gate duplication
+
+  workspace-tests-pr:
+    name: workspace tests · ci-test profile
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: gate · test-ci-compile
+        run: ./scripts/check-ci-local.sh --gate test-ci-compile
+      - name: gate · test-ci
+        run: ./scripts/check-ci-local.sh --gate test-ci
+
+  workspace-tests-protected:
+    name: workspace tests · release profile
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: gate · test-release-compile
+        run: ./scripts/check-ci-local.sh --gate test-release-compile
+      - name: gate · test-release
+        run: ./scripts/check-ci-local.sh --gate test-release
 
   default-head-evidence:
     name: default-head evidence
@@ -296,6 +330,9 @@ jobs:
     if: ${{ always() }}
     needs:
       - test
+      - release-product
+      - workspace-tests-pr
+      - workspace-tests-protected
       - default-head-evidence
       - divergence-evidence
       - surface-recall-evidence

--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -52,6 +52,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  workspace-release-tests:
+    name: protected workspace tests · release profile
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: gate · test-release-compile
+        run: ./scripts/check-ci-local.sh --gate test-release-compile
+      - name: gate · test-release
+        run: ./scripts/check-ci-local.sh --gate test-release
+
   pr-claims:
     name: touched claims · batteries · proofs · scorecard
     if: ${{ github.event_name == 'pull_request' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ break.
 ## [Unreleased]
 
 ### Changed
+- Split hosted workspace test compilation from execution: pull requests use a
+  dev-semantic `ci-test` profile without unused debug data, while main,
+  nightly, local-full, and release qualification retain the full optimized
+  workspace suite. Optimized executable contracts now build in parallel.
 - Added job-scoped, read-only hosted CI timing receipts and summaries with job,
   named-gate, fan-in wall-time limiter, runner/toolchain, and recent p50/p95
   data. Superseded commits now cancel only within the same pull request; main,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,13 @@ opt-level = 3
 lto = "thin"
 codegen-units = 1
 
+# Pull-request workspace tests keep the built-in test profile's dev semantics
+# while omitting debug information that is not consumed on hosted runners.
+[profile.ci-test]
+inherits = "dev"
+debug = 0
+incremental = false
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -123,6 +123,19 @@ finished in about 5 seconds. The split spends additional runner startup and
 Cargo-cache storage to shorten the PR critical path; the hosted timing receipt
 is the authority for deciding whether that trade remains worthwhile.
 
+The after measurement is PR run
+[`30507374469`](https://github.com/corca-ai/nose/actions/runs/30507374469):
+the `ci-test` job took 95 seconds including setup, with 47 seconds in the
+compile-link gate and 23 seconds in the follow-on Cargo test gate. Their
+70-second combined gate time is 246 seconds (77.8%) below the old 316-second
+release-test step. The independent optimized-product job took 257 seconds,
+including a 215-second release build. Overall quality-job wall time was 546
+seconds versus 543 seconds before because the 539-second semantic regression
+job became the limiter; the PR test lane finished with 450 seconds of slack.
+This single run proves the test lane is no longer the limiter, but not an
+overall wall-time improvement. Repeated receipts, rather than this sample
+alone, should determine whether the extra runner and cache cost remains useful.
+
 ## Local execution
 
 Local plans remain sequential by default. Opt into bounded parallel execution

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -60,22 +60,68 @@ large evidence batch with a misleading error.
 
 `local-full`
 : Complete local mirror of repository quality policy. It adds release builds
-  and tests, coverage, duplication, MSRV, supply-chain, Rust documentation, and
-  formal proof gates.
+  and separately timed release-test compile-link/follow-on execution, coverage,
+  duplication, MSRV, supply-chain, Rust documentation, and formal proof gates.
 
 `pull-request`
-: Named gates invoked by `.github/workflows/ci.yml`, including gates split into
-  dedicated coverage, MSRV, supply-chain, documentation, and formal jobs.
+: Named gates selected by `.github/workflows/ci.yml` for pull requests. Every
+  workspace test runs under the `ci-test` profile, while optimized executable
+  product contracts retain the release profile.
 
 `release`
-: The same named quality policy, reused through the release workflow's
-  `quality-gate` call to `ci.yml`. Packaging remains owned by `cargo-dist`.
+: Protected non-PR gates selected by `ci.yml` for main pushes and for the
+  release workflow's `quality-gate` call. These lanes compile and execute every
+  workspace test under the full release profile. Packaging remains owned by
+  `cargo-dist`.
 
 `nightly`
-: Named gates invoked directly by the Soundness Lab workflow. The current
-  Soundness Lab owns its campaign commands directly, so no named repository gate
-  is assigned to this lane. Its cheap runner mutation test is the separate
-  `corpus-verify-selftest` pull-request gate.
+: Named gates invoked directly by the Soundness Lab workflow. Scheduled and
+  manually dispatched campaigns compile and execute every workspace test under
+  the full release profile in parallel with campaign work. The Soundness Lab
+  continues to own its other campaign commands directly.
+
+### Hosted test qualification
+
+The custom Cargo `ci-test` profile inherits `dev`, the same semantic base as the
+built-in `test` profile. It preserves debug assertions, overflow checks, panic
+behavior, zero optimization, and the full workspace target selection. It
+disables only debug information and incremental compilation, neither of which
+is consumed by a fresh hosted runner:
+
+```sh
+cargo test --workspace --profile ci-test --no-run
+cargo test --workspace --profile ci-test
+```
+
+PR CI runs those commands as separate named compile/link and follow-on Cargo
+test gates. Stable Cargo's `--no-run` compiles and links unit and integration
+test targets, but it does not precompile doctests. The second gate therefore
+runs the cached test binaries and also performs any doctest compilation and
+execution. The receipt reports those two stable-Cargo boundaries; it does not
+claim to split compiler time from linker time or doctest compilation from
+doctest execution. The current workspace has no executable doctest cases.
+
+The optimized product-contract job independently builds `target/release/nose`
+and runs query-schema, semantic-pack, Type-4, and duplication checks against it.
+Both jobs start with the other quality jobs instead of waiting behind policy,
+lint, and Rust documentation steps.
+
+Main, release, nightly, and local-full qualification use the corresponding
+full-release pair:
+
+```sh
+cargo test --workspace --release --no-run
+cargo test --workspace --release
+```
+
+The before measurement is PR run
+[`30503434259`](https://github.com/corca-ai/nose/actions/runs/30503434259):
+quality-job wall time was 543 seconds, optimized product build was 150 seconds,
+and the combined release-test step was 316 seconds. Cargo reported 309 seconds
+of compile/link work; the complete workspace test and doctest execution then
+finished in about 5 seconds. The split spends additional runner startup and
+Cargo-cache storage to shorten the PR critical path; the hosted timing receipt
+is the authority for deciding whether that trade remains worthwhile.
 
 ## Local execution
 
@@ -154,6 +200,14 @@ second gate-name map. The receipt also records the runner image, checked
 Rust/MSRV/Lean identities, and p50/p95 over the quality-job wall time of the
 latest 20 successful runs for the same event type. Percentiles use the
 deterministic nearest-rank method over those recorded samples.
+
+Each new receipt seals its creation-time lane and expected named-gate set.
+Offline validation uses that sealed contract rather than the current checkout's
+registry, so an older receipt remains verifiable after an intentional lane
+change. Legacy v1 receipts created before that field retain their recorded gate
+inventory as the historical contract. Event-inapplicable jobs remain visible
+as `skipped`, but their synthetic API timestamps are marked unavailable and do
+not influence wall time; GitHub may report those timestamps in reverse order.
 
 The reported critical path uses the workflow's fan-out/fan-in shape: the
 quality job that completes last is the current wall-time limiter. Its start

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -376,9 +376,21 @@ run_named_gate() {
             need_cmd cargo
             cargo test -p nose-cli
             ;;
+        test-ci-compile)
+            need_cmd cargo
+            cargo test --workspace --profile ci-test --no-run
+            ;;
+        test-ci)
+            need_cmd cargo
+            cargo test --workspace --profile ci-test
+            ;;
+        test-release-compile)
+            need_cmd cargo
+            cargo test --workspace --release --no-run
+            ;;
         test-release)
             need_cmd cargo
-            cargo test --release
+            cargo test --workspace --release
             ;;
         product-query-schema)
             run_product_query_schema_live_check "$1"

--- a/scripts/ci/gate_registry.py
+++ b/scripts/ci/gate_registry.py
@@ -19,12 +19,21 @@ DEFAULT_DISPATCHER = ROOT / "scripts/check-ci-local.sh"
 DEFAULT_CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 DEFAULT_NIGHTLY_WORKFLOW = ROOT / ".github/workflows/corpus-verify.yml"
 DEFAULT_RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+DEFAULT_CARGO_MANIFEST = ROOT / "Cargo.toml"
 
 SCHEMA = "nose.ci-gates.v2"
 WORKTREE_EFFECTS = {"read-only", "verify-checked-output"}
 LOCAL_PLAN_LANES = {"fast": "local-fast", "full": "local-full"}
 LIFECYCLE_GATE = "evidence-artifacts"
 HOSTED_GATE_PREFIX = "gate · "
+PR_TEST_GATES = {"test-ci-compile", "test-ci"}
+PROTECTED_TEST_GATES = {"test-release-compile", "test-release"}
+TEST_GATE_COMMANDS = {
+    "test-ci-compile": "cargo test --workspace --profile ci-test --no-run",
+    "test-ci": "cargo test --workspace --profile ci-test",
+    "test-release-compile": "cargo test --workspace --release --no-run",
+    "test-release": "cargo test --workspace --release",
+}
 REQUIRED_GATE_FIELDS = {
     "name",
     "owner",
@@ -67,6 +76,23 @@ def gate_names_from_dispatcher(path: Path = DEFAULT_DISPATCHER) -> set[str]:
     if match is None:
         raise RegistryError(f"cannot locate run_named_gate dispatcher in {path}")
     return set(re.findall(r"^ {8}([a-z0-9-]+)\)$", match.group("body"), re.MULTILINE))
+
+
+def dispatcher_gate_commands(path: Path, name: str) -> list[str]:
+    match = re.search(
+        rf"^ {{8}}{re.escape(name)}\)\n"
+        r"(?P<body>.*?)"
+        r"(?=^ {8}[a-z0-9-]+\)\n|^ {4}esac$)",
+        path.read_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise RegistryError(f"cannot locate dispatcher branch for gate {name}")
+    return [
+        line.strip()
+        for line in match.group("body").splitlines()
+        if line.strip() and line.strip() != ";;"
+    ]
 
 
 def gate_names_from_workflow(path: Path) -> set[str]:
@@ -174,6 +200,100 @@ def validate_hosted_timing_policy(path: Path) -> None:
     if missing_tokens:
         raise RegistryError(
             f"hosted PR-only concurrency policy drifted: missing {missing_tokens}"
+        )
+
+
+def validate_test_qualification_policy(
+    gates: list[dict[str, Any]],
+    ci_workflow: Path,
+    cargo_manifest: Path,
+    dispatcher: Path,
+) -> None:
+    gates_by_name = {gate["name"]: gate for gate in gates}
+    for name in PR_TEST_GATES | PROTECTED_TEST_GATES:
+        if name not in gates_by_name:
+            raise RegistryError(f"test qualification gate is missing: {name}")
+        command = TEST_GATE_COMMANDS[name]
+        if gates_by_name[name].get("implementation") != command:
+            raise RegistryError(f"gate {name} must declare exact command: {command}")
+        if dispatcher_gate_commands(dispatcher, name) != ["need_cmd cargo", command]:
+            raise RegistryError(f"dispatcher gate {name} must run exact command: {command}")
+    for name in PR_TEST_GATES:
+        if set(gates_by_name[name]["lanes"]) != {"pull-request"}:
+            raise RegistryError(f"gate {name} must be pull-request-only")
+    for name in PROTECTED_TEST_GATES:
+        if set(gates_by_name[name]["lanes"]) != {
+            "local-full",
+            "release",
+            "nightly",
+        }:
+            raise RegistryError(
+                f"gate {name} must remain on local-full, release, and nightly"
+            )
+
+    blocks = workflow_job_blocks(ci_workflow)
+    expected_jobs = {
+        "workspace-tests-pr": (
+            "    if: ${{ github.event_name == 'pull_request' }}",
+            PR_TEST_GATES,
+        ),
+        "workspace-tests-protected": (
+            "    if: ${{ github.event_name != 'pull_request' }}",
+            PROTECTED_TEST_GATES,
+        ),
+    }
+    for job_name, (condition, expected_gates) in expected_jobs.items():
+        block = blocks.get(job_name)
+        if block is None or condition not in block:
+            raise RegistryError(f"{job_name} must keep its event selection condition")
+        actual_gates = set(re.findall(r"--gate\s+([a-z0-9-]+)", block))
+        if actual_gates != expected_gates:
+            raise RegistryError(
+                f"{job_name} gate mismatch: "
+                f"missing={sorted(expected_gates - actual_gates)}, "
+                f"extra={sorted(actual_gates - expected_gates)}"
+            )
+
+    product = blocks.get("release-product")
+    product_gates = {
+        "build-release",
+        "product-query-schema",
+        "semantic-pack-examples",
+        "type4-executable",
+        "type4-axis-language",
+        "duplication",
+    }
+    if product is None or set(
+        re.findall(r"--gate\s+([a-z0-9-]+)", product)
+    ) != product_gates:
+        raise RegistryError(
+            "release-product must own the optimized executable contract gates"
+        )
+
+    profile_match = re.search(
+        r"^\[profile\.ci-test\]\n(?P<body>(?:^(?!\[).*(?:\n|$))*)",
+        cargo_manifest.read_text(),
+        re.MULTILINE,
+    )
+    required_profile_rows = {
+        'inherits = "dev"',
+        "debug = 0",
+        "incremental = false",
+    }
+    profile_rows = (
+        []
+        if profile_match is None
+        else [
+            line.strip()
+            for line in profile_match.group("body").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+    )
+    if len(profile_rows) != len(required_profile_rows) or set(
+        profile_rows
+    ) != required_profile_rows:
+        raise RegistryError(
+            "ci-test profile must contain only the reviewed dev-semantic overrides"
         )
 
 
@@ -367,6 +487,7 @@ def validate_live_registry(
     ci_workflow: Path = DEFAULT_CI_WORKFLOW,
     nightly_workflow: Path = DEFAULT_NIGHTLY_WORKFLOW,
     release_workflow: Path = DEFAULT_RELEASE_WORKFLOW,
+    cargo_manifest: Path = DEFAULT_CARGO_MANIFEST,
 ) -> list[dict[str, Any]]:
     gates = validate_model(registry)
     registry_names = {gate["name"] for gate in gates}
@@ -381,21 +502,29 @@ def validate_live_registry(
     pull_request_names = {
         gate["name"] for gate in gates if "pull-request" in gate["lanes"]
     }
+    release_names = {gate["name"] for gate in gates if "release" in gate["lanes"]}
+    hosted_names = pull_request_names | release_names
     workflow_names = gate_names_from_workflow(ci_workflow)
-    if pull_request_names != workflow_names:
+    if hosted_names != workflow_names:
         raise RegistryError(
-            "pull-request lane/.github workflow mismatch: "
-            f"registry-only={sorted(pull_request_names - workflow_names)}, "
-            f"workflow-only={sorted(workflow_names - pull_request_names)}"
+            "hosted lanes/.github workflow mismatch: "
+            f"registry-only={sorted(hosted_names - workflow_names)}, "
+            f"workflow-only={sorted(workflow_names - hosted_names)}"
         )
     hosted_workflow_names = hosted_gate_names_from_workflow(ci_workflow)
-    if hosted_workflow_names != pull_request_names:
+    if hosted_workflow_names != hosted_names:
         raise RegistryError(
-            "hosted timing step names/pull-request lane mismatch: "
-            f"registry-only={sorted(pull_request_names - hosted_workflow_names)}, "
-            f"workflow-only={sorted(hosted_workflow_names - pull_request_names)}"
+            "hosted timing step names/lane mismatch: "
+            f"registry-only={sorted(hosted_names - hosted_workflow_names)}, "
+            f"workflow-only={sorted(hosted_workflow_names - hosted_names)}"
         )
     validate_hosted_timing_policy(ci_workflow)
+    validate_test_qualification_policy(
+        gates,
+        ci_workflow,
+        cargo_manifest,
+        dispatcher,
+    )
 
     nightly_names = {gate["name"] for gate in gates if "nightly" in gate["lanes"]}
     nightly_workflow_names = gate_names_from_workflow(nightly_workflow)
@@ -406,11 +535,6 @@ def validate_live_registry(
             f"workflow-only={sorted(nightly_workflow_names - nightly_names)}"
         )
 
-    release_names = {gate["name"] for gate in gates if "release" in gate["lanes"]}
-    if release_names != pull_request_names:
-        raise RegistryError(
-            "release lane must equal pull-request lane while release reuses ci.yml"
-        )
     release_text = release_workflow.read_text()
     if "uses: ./.github/workflows/ci.yml" not in release_text:
         raise RegistryError("release workflow no longer reuses .github/workflows/ci.yml")
@@ -657,6 +781,154 @@ def self_test() -> None:
                 assert expected in str(exc), (name, exc)
             else:
                 raise AssertionError(f"{name} passed")
+
+        test_workflow = (
+            "jobs:\n"
+            "  release-product:\n"
+            "    steps:\n"
+            "      - run: ./scripts/check-ci-local.sh --gate build-release\n"
+            "      - run: ./scripts/check-ci-local.sh --gate product-query-schema\n"
+            "      - run: ./scripts/check-ci-local.sh --gate semantic-pack-examples\n"
+            "      - run: ./scripts/check-ci-local.sh --gate type4-executable\n"
+            "      - run: ./scripts/check-ci-local.sh --gate type4-axis-language\n"
+            "      - run: ./scripts/check-ci-local.sh --gate duplication\n"
+            "  workspace-tests-pr:\n"
+            "    if: ${{ github.event_name == 'pull_request' }}\n"
+            "    steps:\n"
+            "      - run: ./scripts/check-ci-local.sh --gate test-ci-compile\n"
+            "      - run: ./scripts/check-ci-local.sh --gate test-ci\n"
+            "  workspace-tests-protected:\n"
+            "    if: ${{ github.event_name != 'pull_request' }}\n"
+            "    steps:\n"
+            "      - run: ./scripts/check-ci-local.sh --gate test-release-compile\n"
+            "      - run: ./scripts/check-ci-local.sh --gate test-release\n"
+        )
+        cargo_manifest = Path(directory) / "Cargo.toml"
+        cargo_profile = (
+            "[profile.ci-test]\n"
+            'inherits = "dev"\n'
+            "debug = 0\n"
+            "incremental = false\n"
+        )
+        test_dispatcher = Path(directory) / "check-ci-local.sh"
+        test_dispatcher_text = "run_named_gate() {\n    case \"$1\" in\n"
+        for gate_name, command in TEST_GATE_COMMANDS.items():
+            test_dispatcher_text += (
+                f"        {gate_name})\n"
+                "            need_cmd cargo\n"
+                f"            {command}\n"
+                "            ;;\n"
+            )
+        test_dispatcher_text += "    esac\n}\n"
+        test_gates = [
+            {
+                "name": "test-ci-compile",
+                "implementation": TEST_GATE_COMMANDS["test-ci-compile"],
+                "lanes": ["pull-request"],
+            },
+            {
+                "name": "test-ci",
+                "implementation": TEST_GATE_COMMANDS["test-ci"],
+                "lanes": ["pull-request"],
+            },
+            {
+                "name": "test-release-compile",
+                "implementation": TEST_GATE_COMMANDS["test-release-compile"],
+                "lanes": ["local-full", "release", "nightly"],
+            },
+            {
+                "name": "test-release",
+                "implementation": TEST_GATE_COMMANDS["test-release"],
+                "lanes": ["local-full", "release", "nightly"],
+            },
+        ]
+        workflow.write_text(test_workflow)
+        cargo_manifest.write_text(cargo_profile)
+        test_dispatcher.write_text(test_dispatcher_text)
+        validate_test_qualification_policy(
+            test_gates,
+            workflow,
+            cargo_manifest,
+            test_dispatcher,
+        )
+        test_policy_mutations = [
+            (
+                "PR test condition",
+                test_workflow.replace(
+                    "github.event_name == 'pull_request'",
+                    "github.event_name != 'pull_request'",
+                    1,
+                ),
+                cargo_profile,
+                test_gates,
+                "event selection condition",
+            ),
+            (
+                "ci-test profile",
+                test_workflow,
+                cargo_profile.replace("debug = 0", "debug = 1"),
+                test_gates,
+                "ci-test profile",
+            ),
+            (
+                "ci-test semantic override",
+                test_workflow,
+                cargo_profile + "debug-assertions = false\n",
+                test_gates,
+                "ci-test profile",
+            ),
+            (
+                "PR test lane",
+                test_workflow,
+                cargo_profile,
+                [
+                    (
+                        dict(gate, lanes=["pull-request", "release"])
+                        if gate["name"] == "test-ci"
+                        else gate
+                    )
+                    for gate in test_gates
+                ],
+                "pull-request-only",
+            ),
+        ]
+        for name, workflow_text, profile_text, gates_value, expected in (
+            test_policy_mutations
+        ):
+            workflow.write_text(workflow_text)
+            cargo_manifest.write_text(profile_text)
+            try:
+                validate_test_qualification_policy(
+                    gates_value,
+                    workflow,
+                    cargo_manifest,
+                    test_dispatcher,
+                )
+            except RegistryError as exc:
+                assert expected in str(exc), (name, exc)
+            else:
+                raise AssertionError(f"{name} mutation passed")
+
+        workflow.write_text(test_workflow)
+        cargo_manifest.write_text(cargo_profile)
+        test_dispatcher.write_text(
+            test_dispatcher_text.replace(
+                TEST_GATE_COMMANDS["test-ci-compile"],
+                "cargo test --profile ci-test --no-run",
+                1,
+            )
+        )
+        try:
+            validate_test_qualification_policy(
+                test_gates,
+                workflow,
+                cargo_manifest,
+                test_dispatcher,
+            )
+        except RegistryError as exc:
+            assert "must run exact command" in str(exc), exc
+        else:
+            raise AssertionError("test dispatcher command mutation passed")
 
     lifecycle_join = copy.deepcopy(sample)
     producer = lifecycle_join["gates"][0]

--- a/scripts/ci/gates.json
+++ b/scripts/ci/gates.json
@@ -3,9 +3,9 @@
   "lanes": {
     "local-fast": "Common pre-push feedback with debug product-contract checks.",
     "local-full": "Complete local mirror of repository quality policy.",
-    "pull-request": "Named gates invoked by .github/workflows/ci.yml.",
-    "release": "The pull-request policy reused by the release quality-gate job.",
-    "nightly": "Reserved for named gates called by the Soundness Lab workflow."
+    "pull-request": "Named gates selected for pull requests by .github/workflows/ci.yml.",
+    "release": "Protected non-PR gates selected for main and reusable release qualification.",
+    "nightly": "Named gates called by the scheduled Soundness Lab workflow."
   },
   "gates": [
     {
@@ -428,21 +428,71 @@
       }
     },
     {
-      "name": "test-release",
-      "owner": "workspace release tests",
-      "implementation": "cargo test --release",
+      "name": "test-ci-compile",
+      "owner": "pull-request workspace test compilation",
+      "implementation": "cargo test --workspace --profile ci-test --no-run",
       "tools": ["cargo"],
-      "inputs": ["crates/"],
+      "inputs": ["Cargo.toml", "Cargo.lock", "crates/"],
+      "worktree_effect": "read-only",
+      "outputs": ["target/ci-test/"],
+      "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
+      "lanes": ["pull-request"],
+      "lane_reason": "Compiles and links every non-doctest workspace test target with dev/test semantics and without unused hosted debug information.",
+      "focused_command": "./scripts/check-ci-local.sh --gate test-ci-compile",
+      "plans": {}
+    },
+    {
+      "name": "test-ci",
+      "owner": "pull-request workspace test execution",
+      "implementation": "cargo test --workspace --profile ci-test",
+      "tools": ["cargo"],
+      "inputs": ["Cargo.toml", "Cargo.lock", "crates/", "target/ci-test/"],
+      "worktree_effect": "read-only",
+      "outputs": ["target/ci-test/"],
+      "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
+      "lanes": ["pull-request"],
+      "lane_reason": "Runs the full workspace suite after the separately timed unit/integration compile-link gate; Cargo also compiles and runs doctests here.",
+      "focused_command": "./scripts/check-ci-local.sh --gate test-ci",
+      "plans": {}
+    },
+    {
+      "name": "test-release-compile",
+      "owner": "protected workspace release-test compilation",
+      "implementation": "cargo test --workspace --release --no-run",
+      "tools": ["cargo"],
+      "inputs": ["Cargo.toml", "Cargo.lock", "crates/"],
       "worktree_effect": "read-only",
       "outputs": ["target/release/"],
       "cache": "cargo",
       "parallel_safe": true,
       "resource_group": "cargo-stable",
-      "lanes": ["local-full", "pull-request", "release"],
-      "lane_reason": "Complete optimized workspace test suite before merge and release.",
+      "lanes": ["local-full", "release", "nightly"],
+      "lane_reason": "Compiles and links every optimized non-doctest workspace test target on each protected qualification lane.",
+      "focused_command": "./scripts/check-ci-local.sh --gate test-release-compile",
+      "plans": {
+        "full": {"order": 195, "label": "compile tests (release)", "args": [], "depends_on": ["build-release"]}
+      }
+    },
+    {
+      "name": "test-release",
+      "owner": "workspace release tests",
+      "implementation": "cargo test --workspace --release",
+      "tools": ["cargo"],
+      "inputs": ["Cargo.toml", "Cargo.lock", "crates/", "target/release/"],
+      "worktree_effect": "read-only",
+      "outputs": ["target/release/"],
+      "cache": "cargo",
+      "parallel_safe": true,
+      "resource_group": "cargo-stable",
+      "lanes": ["local-full", "release", "nightly"],
+      "lane_reason": "Runs the full optimized workspace suite on main, nightly, local-full, and release; Cargo also compiles and runs doctests here.",
       "focused_command": "./scripts/check-ci-local.sh --gate test-release",
       "plans": {
-        "full": {"order": 200, "label": "test (release)", "args": [], "depends_on": ["build-release"]}
+        "full": {"order": 200, "label": "execute tests (release)", "args": [], "depends_on": ["test-release-compile"]}
       }
     },
     {

--- a/scripts/ci/hosted_timing.py
+++ b/scripts/ci/hosted_timing.py
@@ -118,6 +118,7 @@ def quality_job_seconds(
             parse_timestamp(job["completed_at"], f"{context}.{index}.completed_at"),
         )
         for index, job in enumerate(raw_jobs)
+        if job.get("conclusion") != "skipped"
         if job.get("started_at") is not None
         and job.get("completed_at") is not None
     ]
@@ -209,10 +210,18 @@ def normalized_job(raw: dict[str, Any], index: int) -> dict[str, Any]:
     name = raw.get("name")
     if not isinstance(name, str) or not name:
         raise TimingError(f"jobs[{index}] must have a name")
-    seconds = elapsed_seconds(
-        raw.get("started_at"),
-        raw.get("completed_at"),
-        f"job {name}",
+    conclusion = raw.get("conclusion")
+    # GitHub may give skipped jobs synthetic timestamps with completion before
+    # start. Preserve those API values for auditability, but do not present
+    # them as elapsed timing data.
+    seconds = (
+        None
+        if conclusion == "skipped"
+        else elapsed_seconds(
+            raw.get("started_at"),
+            raw.get("completed_at"),
+            f"job {name}",
+        )
     )
     raw_steps = raw.get("steps")
     if not isinstance(raw_steps, list):
@@ -225,7 +234,7 @@ def normalized_job(raw: dict[str, Any], index: int) -> dict[str, Any]:
     return {
         "id": raw.get("id"),
         "name": name,
-        "conclusion": raw.get("conclusion"),
+        "conclusion": conclusion,
         "started_at": raw.get("started_at"),
         "completed_at": raw.get("completed_at"),
         "seconds": seconds,
@@ -369,6 +378,11 @@ def collect_receipt(
     return {
         "schema": SCHEMA,
         "generated_at": metadata["generated_at"],
+        "gate_contract": {
+            "source": "scripts/ci/gates.json",
+            "lane": hosted_lane(metadata["event"]),
+            "expected_gates": sorted(expected_gates),
+        },
         "run": {
             "repository": metadata["repository"],
             "workflow": metadata["workflow"],
@@ -431,7 +445,10 @@ def require_text(value: Any, context: str, *, allow_empty: bool = False) -> None
         raise TimingError(f"{context} must be {qualifier}")
 
 
-def validate_receipt(receipt: dict[str, Any], expected_gates: set[str]) -> None:
+def validate_receipt(
+    receipt: dict[str, Any],
+    expected_gates: set[str] | None = None,
+) -> None:
     if receipt.get("schema") != SCHEMA:
         raise TimingError(f"timing receipt schema must be {SCHEMA}")
     parse_timestamp(receipt.get("generated_at"), "generated_at")
@@ -502,6 +519,17 @@ def validate_receipt(receipt: dict[str, Any], expected_gates: set[str]) -> None:
                 round((completed - job_completed).total_seconds(), 3),
                 f"job {job['name']}.completion_slack_seconds",
             )
+        else:
+            for field in (
+                "seconds",
+                "start_offset_seconds",
+                "completion_offset_seconds",
+                "completion_slack_seconds",
+            ):
+                if job.get(field) is not None:
+                    raise TimingError(
+                        f"job {job['name']}.{field} must be null without timing"
+                    )
     if run.get("observed_conclusion") != observed_conclusion(jobs):
         raise TimingError("run.observed_conclusion does not match recorded jobs")
 
@@ -539,6 +567,31 @@ def validate_receipt(receipt: dict[str, Any], expected_gates: set[str]) -> None:
     actual_gates = set(gate_names)
     if len(gate_names) != len(actual_gates):
         raise TimingError("timing receipt contains duplicate hosted gates")
+    gate_contract = receipt.get("gate_contract")
+    contract_gates: set[str] | None = None
+    if gate_contract is not None:
+        if not isinstance(gate_contract, dict):
+            raise TimingError("timing receipt gate_contract must be an object")
+        if gate_contract.get("source") != "scripts/ci/gates.json":
+            raise TimingError("gate_contract.source is unsupported")
+        if gate_contract.get("lane") != hosted_lane(run["event"]):
+            raise TimingError("gate_contract.lane does not match run.event")
+        sealed_gates = gate_contract.get("expected_gates")
+        if (
+            not isinstance(sealed_gates, list)
+            or any(not isinstance(name, str) or not name for name in sealed_gates)
+            or sealed_gates != sorted(set(sealed_gates))
+        ):
+            raise TimingError(
+                "gate_contract.expected_gates must be sorted unique gate names"
+            )
+        contract_gates = set(sealed_gates)
+    if expected_gates is None:
+        # Receipts created before gate_contract was added remain independently
+        # verifiable from their recorded, creation-time gate inventory.
+        expected_gates = contract_gates or actual_gates
+    elif contract_gates is not None and contract_gates != expected_gates:
+        raise TimingError("gate_contract does not match the expected hosted gates")
     if actual_gates != expected_gates:
         raise TimingError(
             "timing receipt gate coverage mismatch: "
@@ -747,6 +800,17 @@ def sample_inputs() -> tuple[dict[str, Any], dict[str, Any]]:
                 "steps": [],
             },
             {
+                "id": 4,
+                "name": "event-inapplicable tests",
+                "conclusion": "skipped",
+                "started_at": "2026-01-01T00:02:00Z",
+                "completed_at": "2026-01-01T00:01:59Z",
+                "runner_name": None,
+                "runner_group_name": None,
+                "labels": ["ubuntu-latest"],
+                "steps": [],
+            },
+            {
                 "id": 3,
                 "name": TIMING_JOB_NAME,
                 "conclusion": None,
@@ -829,7 +893,15 @@ def self_test() -> None:
     )
     assert receipt["history"]["sample_count"] == 1
     assert receipt["history"]["p50_seconds"] == 120.0
+    skipped = next(
+        job for job in receipt["jobs"] if job["conclusion"] == "skipped"
+    )
+    assert skipped["timing_available"] is False
+    assert skipped["seconds"] is None
     assert "sample" in render_summary(receipt)
+    historical_receipt = json.loads(json.dumps(receipt))
+    historical_receipt.pop("gate_contract")
+    validate_receipt(historical_receipt)
 
     reusable_jobs = json.loads(json.dumps(jobs))
     reusable_jobs["jobs"].insert(
@@ -932,9 +1004,14 @@ def self_test() -> None:
     print("hosted CI timing self-test passed")
 
 
-def expected_pull_request_gates() -> set[str]:
+def hosted_lane(event: str) -> str:
+    return "pull-request" if event == "pull_request" else "release"
+
+
+def expected_hosted_gates(event: str) -> set[str]:
     gates = gate_registry.validate_live_registry(gate_registry.load_registry())
-    return {gate["name"] for gate in gates if "pull-request" in gate["lanes"]}
+    lane = hosted_lane(event)
+    return {gate["name"] for gate in gates if lane in gate["lanes"]}
 
 
 def load_history_jobs(path: Path) -> dict[int, dict[str, Any]]:
@@ -981,9 +1058,9 @@ def main() -> int:
         if args.self_test:
             self_test()
             return 0
-        expected_gates = expected_pull_request_gates()
         if args.validate is not None:
-            validate_receipt(load_object(args.validate, "timing receipt"), expected_gates)
+            receipt = load_object(args.validate, "timing receipt")
+            validate_receipt(receipt)
             print(f"hosted CI timing receipt OK: {args.validate}")
             return 0
         required = {
@@ -1004,6 +1081,7 @@ def main() -> int:
         missing = [name for name, value in required.items() if value is None]
         if missing:
             raise TimingError(f"missing required arguments: {', '.join(missing)}")
+        expected_gates = expected_hosted_gates(args.event)
         metadata = {
             "generated_at": datetime.now().astimezone().isoformat(),
             "repository": args.repository,
@@ -1025,7 +1103,7 @@ def main() -> int:
             expected_gates=expected_gates,
             toolchains=read_checked_toolchains(ROOT),
         )
-        validate_receipt(receipt, expected_gates)
+        validate_receipt(receipt)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(receipt, indent=2) + "\n")
         args.summary.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -45,7 +45,7 @@
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
       "artifact_count": 6,
-      "inventory_sha256": "119d8a57c1e298c78c9ed3c9c16cb8054829431ab54b67cb48a7b1e007b4292f"
+      "inventory_sha256": "4db34269df672543c590aefb61cfaa8fdba4cb3b00650ac0b6104cb0010a6c41"
     },
     {
       "id": "benchmark-root",


### PR DESCRIPTION
## Summary

- add a dev-semantic `ci-test` Cargo profile and separate PR compile-link/execution gates
- keep optimized product contracts independent and retain full release workspace tests on main, nightly, and release lanes
- fail-close lane, command, profile, timing, skipped-job, and historical receipt drift
- document the before baseline, stable Cargo/doctest timing boundary, and runner/cache cost trade-off

## Review

Completed one requested parallel review round with two independent reviewers. Incorporated skipped-job timestamp handling, creation-time receipt gate contracts, exact dispatcher/profile mutation checks, and explicit doctest measurement limits.

## Validation

- `./scripts/check-ci-local.sh --fast --jobs 2`
- `./scripts/check-ci-local.sh --full --jobs 2`
- `./scripts/check-ci-local.sh --validate-gates`
- `python3 scripts/ci/hosted_timing.py --self-test`
- baseline hosted receipt `30503434259` offline validation
- `actionlint .github/workflows/ci.yml .github/workflows/corpus-verify.yml`

Closes #960
Part of #959