### PR TITLE
ci: add fail-closed change-aware routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,57 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  route:
+    name: change routing · report-only
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.route.outputs.mode }}
+      decision: ${{ steps.route.outputs.decision }}
+      proposed_jobs: ${{ steps.route.outputs.proposed_jobs }}
+      enforced_jobs: ${{ steps.route.outputs.enforced_jobs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute fail-closed proposed route
+        id: route
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p target/change-routing
+          route_args=()
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            route_head="${PR_HEAD_SHA:-HEAD}"
+            if git rev-parse --verify -q "${PR_BASE_SHA}^{commit}" >/dev/null &&
+               git rev-parse --verify -q "${route_head}^{commit}" >/dev/null &&
+               git diff --name-status -z --find-renames \
+                 "$PR_BASE_SHA" "$route_head" \
+                 > target/change-routing/changes.z; then
+              route_args+=(--changes-z target/change-routing/changes.z)
+            else
+              rm -f target/change-routing/changes.z
+            fi
+          fi
+          python3 scripts/ci/change_routing.py route \
+            --event "$GITHUB_EVENT_NAME" \
+            "${route_args[@]}" \
+            --output target/change-routing/route.json \
+            --summary target/change-routing/route.md \
+            --github-output "$GITHUB_OUTPUT"
+          cat target/change-routing/route.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload proposed routing evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: change-routing-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/change-routing
+          if-no-files-found: error
+          retention-days: 30
+
   test:
     name: policy · lint · rustdoc
     runs-on: ubuntu-latest
@@ -31,6 +82,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - name: gate · change-routing-selftest
+        run: ./scripts/check-ci-local.sh --gate change-routing-selftest
       - name: gate · corpus-prune-selftest
         run: ./scripts/check-ci-local.sh --gate corpus-prune-selftest
       - name: gate · corpus-verify-selftest
@@ -400,5 +453,58 @@ jobs:
         with:
           name: hosted-ci-timing-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/hosted-ci
+          if-no-files-found: error
+          retention-days: 30
+
+  qualification:
+    name: repository qualification
+    if: ${{ always() }}
+    needs:
+      - route
+      - test
+      - release-product
+      - workspace-tests-pr
+      - workspace-tests-protected
+      - default-head-evidence
+      - divergence-evidence
+      - surface-recall-evidence
+      - runtime-soundness-evidence
+      - semantic-regression
+      - coverage
+      - msrv
+      - supply-chain
+      - docs
+      - formal
+      - hosted-timing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Verify selected results and aggregate qualification
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          ROUTING_MODE: ${{ needs.route.outputs.mode }}
+          ENFORCED_JOBS_JSON: ${{ needs.route.outputs.enforced_jobs }}
+        run: |
+          mkdir -p target/change-routing
+          qualification_status=0
+          python3 scripts/ci/qualification.py \
+            --event "$GITHUB_EVENT_NAME" \
+            --mode "$ROUTING_MODE" \
+            --enforced-jobs "$ENFORCED_JOBS_JSON" \
+            --output target/change-routing/qualification.json \
+            --summary target/change-routing/qualification.md \
+            || qualification_status=$?
+          cat target/change-routing/qualification.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$qualification_status"
+
+      - name: Upload qualification evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: repository-qualification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/change-routing
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ break.
 ## [Unreleased]
 
 ### Changed
+- Added fail-closed, report-only pull-request change routing backed by the
+  checked gate registry, historical/synthetic path matrices, auditable route
+  receipts, and a stable aggregate qualification result. Main, release,
+  unknown, deleted, renamed, dependency/toolchain, CI-policy, and shared
+  semantic changes retain complete qualification; no gate skips are enabled.
 - Split hosted workspace test compilation from execution: pull requests use a
   dev-semantic `ci-test` profile without unused debug data, while main,
   nightly, local-full, and release qualification retain the full optimized

--- a/docs/repository-gates.md
+++ b/docs/repository-gates.md
@@ -46,6 +46,11 @@ The registry owns selection, ordering, and descriptive metadata. The shell
 dispatcher owns executable commands and diagnostics. The cross-check prevents
 either side from silently becoming an independent policy.
 
+The same registry owns change-aware routing under `change_routing`. Its
+validator binds every selected gate to the workflow job that invokes it and
+rejects unknown gates, jobs, path classes, conditions, or aggregate
+dependencies. Workflow YAML does not maintain a second path-to-gate map.
+
 Repository evidence validators require Python 3.10 or newer. The dispatcher
 checks the selected `python3` before any named gate runs and reports the
 observed version, so a system Python that is too old cannot fail later inside a
@@ -79,6 +84,73 @@ large evidence batch with a misleading error.
   manually dispatched campaigns compile and execute every workspace test under
   the full release profile in parallel with campaign work. The Soundness Lab
   continues to own its other campaign commands directly.
+
+## Change-aware pull-request routing
+
+Pull requests compute and publish a proposed route in parallel with the
+unchanged quality fan-out. The checked policy maps documentation, label
+evidence, Type-4 evidence, corpus evidence, semantic-pack evidence,
+runtime/soundness evidence, divergence evidence, formal models, product
+examples, and Rust product source to named gates. The router then derives
+workflow jobs from the actual `--gate` invocations in `ci.yml`; multi-step
+semantic regression is the only explicitly named extra job.
+
+The current mode is deliberately `report-only`. Every event-eligible quality
+job still runs, and `repository qualification` requires all of them to succeed.
+The route receipt nevertheless records the smaller proposed job set and is
+published as both a step summary and a 30-day artifact. Checked self-tests
+replay representative historical documentation, evidence, Rust product,
+dependency, CI-policy, deletion, and rename diffs.
+
+Routing fails closed to the complete PR gate set when:
+
+- a changed path is unclassified or malformed;
+- a file is deleted, renamed, copied, type-changed, conflicted, or carries an
+  unfamiliar change status;
+- Cargo manifests/lockfiles, workflows, scripts, toolchain/policy files, agent
+  instructions, or shared frontend/IL/normalization/semantic layers change;
+- comparison data is absent or malformed.
+
+Main pushes and reusable `workflow_call` qualification always select the
+complete release lane. Release tags reach `ci.yml` through the release
+workflow's reusable call, so they also remain complete. No workflow uses
+top-level `paths` filtering: the routing and stable aggregate checks therefore
+always exist, and branch protection cannot be left pending because a workflow
+was never created.
+
+The final `repository qualification` job runs with `always()` and consumes the
+complete `needs` result map. In report-only mode it rejects a missing, skipped,
+cancelled, failed, or malformed result for any event-eligible quality job, the
+route job, or hosted timing. The event-inapplicable workspace-test profile is
+the only expected skipped CI job and is not selected. The same aggregate logic
+can later accept unselected skips only after enforcing mode is deliberately
+enabled.
+
+### Rollout and rollback
+
+Do not enable skips from one successful sample. First retain report-only
+receipts across documentation-only, evidence-only, Rust/product, CI-policy,
+dependency/toolchain, mixed, and unknown changes. Audit every proposed route
+against the gates that actually ran, extend the checked historical matrix for
+any missed class, and require repeated evidence that no materially affected
+gate was omitted.
+
+An enforcing change must be a separate reviewed PR. It must:
+
+1. change the checked policy and validator together;
+2. make each conditional quality job depend on routing and use `always()` so it
+   runs when routing fails, the mode is `report-only`, or that job is selected,
+   without adding workflow-level `paths` filters;
+3. retain `repository qualification` as the stable branch-protection result
+   and keep unexpected selected skips fail-closed;
+4. demonstrate complete main, reusable release, and release-tag qualification;
+5. preserve the report artifact so skipped-job decisions remain auditable.
+
+Rollback does not require changing branch protection. Restore `report-only`
+mode (which makes every eligible job run), or revert the enforcing PR; the
+stable aggregate check remains present in either case. If the router itself
+cannot produce a valid decision, its failed result makes repository
+qualification fail while the independent quality jobs still run.
 
 ### Hosted test qualification
 
@@ -198,13 +270,14 @@ measurement fail, so artifact production cannot hide behind a green command.
 
 ### Hosted workflow timing
 
-The final `hosted CI timing` job depends on every quality job and runs with
-`always()`, so an earlier failure still produces timing evidence. It reads
-GitHub Actions job and step timestamps through a job-local, read-only Actions
-token, writes a `nose.hosted-ci-timings.v1` receipt, uploads the receipt and raw
-API inputs for 30 days, and adds the slowest jobs and named gates to the step
-summary. The timing checkout does not persist that token, and quality jobs never
-receive Actions API permission.
+The final `hosted CI timing` job depends on every timed quality job and runs
+with `always()`, so an earlier failure still produces timing evidence. Routing
+and aggregate-control jobs are excluded from the comparable quality timing
+window. It reads GitHub Actions job and step timestamps through a job-local,
+read-only Actions token, writes a `nose.hosted-ci-timings.v1` receipt, uploads
+the receipt and raw API inputs for 30 days, and adds the slowest jobs and named
+gates to the step summary. The timing checkout does not persist that token, and
+quality jobs never receive Actions API permission.
 
 Hosted gate steps use the checked `gate · <gate-name>` naming convention.
 Registry validation binds that structured step name to the gate invoked in the

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -266,6 +266,7 @@ run_supply_chain_checks() {
 run_gate_registry_validation() {
     need_python3
     python3 scripts/ci/gate_registry.py validate
+    python3 scripts/ci/change_routing.py validate
 }
 
 run_local_plan() {
@@ -306,6 +307,11 @@ run_named_gate() {
     local name="$1"
     shift
     case "$name" in
+        change-routing-selftest)
+            need_python3
+            python3 scripts/ci/change_routing.py validate --self-test
+            python3 scripts/ci/qualification.py --self-test
+            ;;
         corpus-prune-selftest)
             need_cmd python3
             python3 bench/prune_corpus.py --self-test

--- a/scripts/ci/change_routing.py
+++ b/scripts/ci/change_routing.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Compute and verify fail-closed, report-only CI change routing."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import gate_registry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "scripts/ci/gates.json"
+DEFAULT_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+ROUTING_SCHEMA = "nose.ci-change-routing.v1"
+RECEIPT_SCHEMA = "nose.ci-change-route-receipt.v1"
+CONTROL_JOBS = {"route", "hosted-timing", "qualification"}
+ALWAYS_REQUIRED_JOBS = {"route", "hosted-timing"}
+SAFE_CHANGE_STATUSES = {"A", "M"}
+
+
+class RoutingError(ValueError):
+    """Raised when routing policy or runtime evidence is invalid."""
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    path: str
+    previous_path: str | None = None
+
+
+def _text_list(value: Any, context: str, *, allow_empty: bool = False) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(item, str) or not item for item in value)
+        or len(value) != len(set(value))
+        or (not allow_empty and not value)
+    ):
+        qualifier = "unique non-empty strings"
+        if allow_empty:
+            qualifier = "unique strings"
+        raise RoutingError(f"{context} must contain {qualifier}")
+    return value
+
+
+def quality_jobs(workflow: Path = DEFAULT_WORKFLOW) -> dict[str, str]:
+    blocks = gate_registry.workflow_job_blocks(workflow)
+    missing_controls = CONTROL_JOBS - set(blocks)
+    if missing_controls:
+        raise RoutingError(
+            f"CI workflow misses routing control jobs: {sorted(missing_controls)}"
+        )
+    return {name: block for name, block in blocks.items() if name not in CONTROL_JOBS}
+
+
+def eligible_quality_jobs(
+    event: str, workflow: Path = DEFAULT_WORKFLOW
+) -> set[str]:
+    event_conditions = {
+        "workspace-tests-pr": "${{ github.event_name == 'pull_request' }}",
+        "workspace-tests-protected": "${{ github.event_name != 'pull_request' }}",
+    }
+    eligible: set[str] = set()
+    for name, block in quality_jobs(workflow).items():
+        condition_rows = re.findall(r"^ {4}if:\s*(.+)$", block, re.MULTILINE)
+        if len(condition_rows) > 1:
+            raise RoutingError(f"job {name} has multiple job-level conditions")
+        condition = condition_rows[0] if condition_rows else None
+        expected_condition = event_conditions.get(name)
+        if condition != expected_condition:
+            raise RoutingError(
+                f"job {name} condition must be {expected_condition!r}, got {condition!r}"
+            )
+        if condition is None or (
+            name == "workspace-tests-pr" and event == "pull_request"
+        ) or (
+            name == "workspace-tests-protected" and event != "pull_request"
+        ):
+            eligible.add(name)
+    return eligible
+
+
+def gate_jobs(workflow: Path = DEFAULT_WORKFLOW) -> dict[str, set[str]]:
+    jobs: dict[str, set[str]] = {}
+    for job, block in quality_jobs(workflow).items():
+        for name in re.findall(r"--gate\s+([a-z0-9-]+)", block):
+            jobs.setdefault(name, set()).add(job)
+    return jobs
+
+
+def load_policy(
+    manifest: Path = DEFAULT_MANIFEST,
+    workflow: Path = DEFAULT_WORKFLOW,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    registry = gate_registry.load_registry(manifest)
+    gates = gate_registry.validate_model(registry)
+    policy = registry.get("change_routing")
+    if not isinstance(policy, dict):
+        raise RoutingError("gate registry must define change_routing policy")
+    required_fields = {
+        "schema",
+        "mode",
+        "full_events",
+        "always_required_jobs",
+        "global_patterns",
+        "rules",
+        "historical_cases",
+    }
+    if set(policy) != required_fields:
+        raise RoutingError(
+            "change_routing fields drifted: "
+            f"missing={sorted(required_fields - set(policy))}, "
+            f"extra={sorted(set(policy) - required_fields)}"
+        )
+    if policy["schema"] != ROUTING_SCHEMA:
+        raise RoutingError(f"change_routing schema must be {ROUTING_SCHEMA!r}")
+    if policy["mode"] != "report-only":
+        raise RoutingError("change_routing must remain report-only until rollout")
+    full_events = set(_text_list(policy["full_events"], "full_events"))
+    if not {"push", "workflow_call"} <= full_events:
+        raise RoutingError("push and workflow_call must always qualify the full gate set")
+    always = set(
+        _text_list(policy["always_required_jobs"], "always_required_jobs")
+    )
+    if always != ALWAYS_REQUIRED_JOBS:
+        raise RoutingError(
+            f"always_required_jobs must be {sorted(ALWAYS_REQUIRED_JOBS)}"
+        )
+    global_patterns = _text_list(policy["global_patterns"], "global_patterns")
+    if any(pattern.startswith("/") or "\x00" in pattern for pattern in global_patterns):
+        raise RoutingError("global_patterns must be relative, NUL-free globs")
+
+    gates_by_name = {gate["name"]: gate for gate in gates}
+    mapped_jobs = gate_jobs(workflow)
+    available_jobs = set(quality_jobs(workflow))
+    pull_request_jobs = eligible_quality_jobs("pull_request", workflow)
+    release_jobs = eligible_quality_jobs("push", workflow)
+    for gate in gates:
+        jobs = mapped_jobs.get(gate["name"], set())
+        if "pull-request" in gate["lanes"] and not jobs & pull_request_jobs:
+            raise RoutingError(f"gate {gate['name']} has no pull-request eligible job")
+        if "release" in gate["lanes"] and not jobs & release_jobs:
+            raise RoutingError(f"gate {gate['name']} has no release eligible job")
+    seen_classes: set[str] = set()
+    for index, rule in enumerate(policy["rules"]):
+        if not isinstance(rule, dict) or set(rule) != {
+            "class",
+            "patterns",
+            "gates",
+            "jobs",
+        }:
+            raise RoutingError(
+                f"routing rule {index} must define class, patterns, gates, and jobs"
+            )
+        class_name = rule["class"]
+        if (
+            not isinstance(class_name, str)
+            or re.fullmatch(r"[a-z0-9-]+", class_name) is None
+            or class_name in seen_classes
+        ):
+            raise RoutingError(f"routing rule {index} has invalid/duplicate class")
+        seen_classes.add(class_name)
+        patterns = _text_list(rule["patterns"], f"rule {class_name}.patterns")
+        if any(pattern.startswith("/") or "\x00" in pattern for pattern in patterns):
+            raise RoutingError(f"rule {class_name} patterns must be relative globs")
+        rule_gates = _text_list(
+            rule["gates"], f"rule {class_name}.gates", allow_empty=True
+        )
+        rule_jobs = _text_list(
+            rule["jobs"], f"rule {class_name}.jobs", allow_empty=True
+        )
+        if not rule_gates and not rule_jobs:
+            raise RoutingError(f"rule {class_name} must select a gate or job")
+        unknown_gates = set(rule_gates) - set(gates_by_name)
+        if unknown_gates:
+            raise RoutingError(
+                f"rule {class_name} names unknown gates: {sorted(unknown_gates)}"
+            )
+        non_pr_gates = {
+            name
+            for name in rule_gates
+            if "pull-request" not in gates_by_name[name]["lanes"]
+        }
+        if non_pr_gates:
+            raise RoutingError(
+                f"rule {class_name} names non-PR gates: {sorted(non_pr_gates)}"
+            )
+        unmapped_gates = set(rule_gates) - set(mapped_jobs)
+        if unmapped_gates:
+            raise RoutingError(
+                f"rule {class_name} gates have no CI job: {sorted(unmapped_gates)}"
+            )
+        unknown_jobs = set(rule_jobs) - pull_request_jobs
+        if unknown_jobs:
+            raise RoutingError(
+                f"rule {class_name} names non-PR/unknown jobs: {sorted(unknown_jobs)}"
+            )
+
+    cases = policy["historical_cases"]
+    if not isinstance(cases, list) or not cases:
+        raise RoutingError("historical_cases must be a non-empty array")
+    seen_case_names: set[str] = set()
+    for index, case in enumerate(cases):
+        required = {
+            "name",
+            "commit",
+            "expected_full",
+            "required_classes",
+            "required_gates",
+            "required_jobs",
+        }
+        if not isinstance(case, dict) or set(case) != required:
+            raise RoutingError(f"historical case {index} fields drifted")
+        name = case["name"]
+        commit = case["commit"]
+        if (
+            not isinstance(name, str)
+            or not name
+            or name in seen_case_names
+            or not isinstance(commit, str)
+            or re.fullmatch(r"[0-9a-f]{40}", commit) is None
+            or not isinstance(case["expected_full"], bool)
+        ):
+            raise RoutingError(f"historical case {index} metadata is invalid")
+        seen_case_names.add(name)
+        _text_list(
+            case["required_classes"],
+            f"historical case {name}.required_classes",
+            allow_empty=True,
+        )
+        required_gates = set(
+            _text_list(
+                case["required_gates"],
+                f"historical case {name}.required_gates",
+                allow_empty=True,
+            )
+        )
+        required_jobs = set(
+            _text_list(
+                case["required_jobs"],
+                f"historical case {name}.required_jobs",
+                allow_empty=True,
+            )
+        )
+        if not required_gates <= set(gates_by_name):
+            raise RoutingError(f"historical case {name} names unknown gates")
+        if not required_jobs <= available_jobs:
+            raise RoutingError(f"historical case {name} names unknown jobs")
+    return registry, policy
+
+
+def parse_name_status_z(data: bytes) -> list[Change]:
+    if not data or not data.endswith(b"\0"):
+        raise RoutingError("name-status stream must be non-empty and NUL-terminated")
+    raw_tokens = data[:-1].split(b"\0")
+    try:
+        tokens = [token.decode("utf-8") for token in raw_tokens]
+    except UnicodeDecodeError as exc:
+        raise RoutingError("name-status stream is not UTF-8") from exc
+    changes: list[Change] = []
+    index = 0
+    while index < len(tokens):
+        status = tokens[index]
+        index += 1
+        if re.fullmatch(r"(?:[AMDTUXB]|[RC](?:100|0[0-9]{2}))", status) is None:
+            raise RoutingError(f"malformed change status: {status!r}")
+        if status[0] in {"R", "C"}:
+            if index + 1 >= len(tokens):
+                raise RoutingError(f"change status {status} misses two paths")
+            previous_path, path = tokens[index : index + 2]
+            index += 2
+            changes.append(Change(status=status, path=path, previous_path=previous_path))
+        else:
+            if index >= len(tokens):
+                raise RoutingError(f"change status {status} misses its path")
+            changes.append(Change(status=status, path=tokens[index]))
+            index += 1
+    return changes
+
+
+def _valid_path(path: str) -> bool:
+    parts = Path(path).parts
+    return (
+        bool(path)
+        and not path.startswith("/")
+        and "\\" not in path
+        and all(part not in {"", ".", ".."} for part in parts)
+        and not any(ord(character) < 32 for character in path)
+    )
+
+
+def _matches(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def compute_route(
+    registry: dict[str, Any],
+    policy: dict[str, Any],
+    *,
+    event: str,
+    changes: list[Change],
+    parse_error: str | None = None,
+    workflow: Path = DEFAULT_WORKFLOW,
+) -> dict[str, Any]:
+    eligible = eligible_quality_jobs(event, workflow)
+    mappings = gate_jobs(workflow)
+    gates = registry["gates"]
+    lane = "pull-request" if event == "pull_request" else "release"
+    full_gate_set = {gate["name"] for gate in gates if lane in gate["lanes"]}
+    selected_gates: set[str] = set()
+    selected_jobs: set[str] = set()
+    matched_classes: set[str] = set()
+    reasons: set[str] = set()
+
+    if event in set(policy["full_events"]):
+        reasons.add(f"full-qualification-event:{event}")
+    if parse_error is not None:
+        reasons.add(f"change-data-error:{parse_error}")
+    if not changes and not reasons:
+        reasons.add("empty-change-set")
+
+    for change in changes:
+        if change.status not in SAFE_CHANGE_STATUSES:
+            reasons.add(f"unsafe-change-status:{change.status}")
+        paths = [change.path]
+        if change.previous_path is not None:
+            paths.append(change.previous_path)
+        if any(not _valid_path(path) for path in paths):
+            reasons.add("malformed-path")
+            continue
+        if any(_matches(path, policy["global_patterns"]) for path in paths):
+            reasons.add("global-policy-path")
+            continue
+        path_matched = False
+        for rule in policy["rules"]:
+            if any(_matches(path, rule["patterns"]) for path in paths):
+                path_matched = True
+                matched_classes.add(rule["class"])
+                selected_gates.update(rule["gates"])
+                selected_jobs.update(rule["jobs"])
+        if not path_matched:
+            reasons.add("unclassified-path")
+
+    full = bool(reasons)
+    if full:
+        selected_gates = full_gate_set
+        proposed_jobs = eligible
+    else:
+        proposed_jobs = selected_jobs | {
+            job
+            for name in selected_gates
+            for job in mappings.get(name, set())
+        }
+        proposed_jobs &= eligible
+
+    enforced_quality = eligible if policy["mode"] == "report-only" else proposed_jobs
+    enforced_jobs = enforced_quality | set(policy["always_required_jobs"])
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "mode": policy["mode"],
+        "event": event,
+        "decision": "full" if full else "selective",
+        "full_reasons": sorted(reasons),
+        "changes": [
+            {
+                "status": change.status,
+                "path": change.path,
+                **(
+                    {"previous_path": change.previous_path}
+                    if change.previous_path is not None
+                    else {}
+                ),
+            }
+            for change in changes
+        ],
+        "matched_classes": sorted(matched_classes),
+        "selected_gates": sorted(selected_gates),
+        "proposed_jobs": sorted(proposed_jobs),
+        "enforced_jobs": sorted(enforced_jobs),
+    }
+
+
+def route_summary(receipt: dict[str, Any]) -> str:
+    proposed = ", ".join(f"`{name}`" for name in receipt["proposed_jobs"]) or "_none_"
+    classes = ", ".join(f"`{name}`" for name in receipt["matched_classes"]) or "_none_"
+    reasons = ", ".join(f"`{name}`" for name in receipt["full_reasons"]) or "_none_"
+    return (
+        "## Change-aware CI route\n\n"
+        f"- Mode: `{receipt['mode']}` (all eligible jobs remain enforced)\n"
+        f"- Decision: `{receipt['decision']}`\n"
+        f"- Matched classes: {classes}\n"
+        f"- Full-route reasons: {reasons}\n"
+        f"- Proposed quality jobs: {proposed}\n"
+        f"- Changed entries: `{len(receipt['changes'])}`\n"
+    )
+
+
+def validate_workflow(workflow: Path = DEFAULT_WORKFLOW) -> None:
+    text = workflow.read_text()
+    header = text.split("\njobs:", maxsplit=1)[0]
+    if re.search(r"^\s+paths(?:-ignore)?:", header, re.MULTILINE):
+        raise RoutingError("CI workflow must not use trigger-level path filtering")
+    blocks = gate_registry.workflow_job_blocks(workflow)
+    route = blocks.get("route", "")
+    qualification = blocks.get("qualification", "")
+    for job, expected_name in gate_registry.UNTIMED_HOSTED_JOB_NAMES.items():
+        if f"    name: {expected_name}\n" not in blocks.get(job, ""):
+            raise RoutingError(f"control job {job} display name drifted")
+    if "    outputs:\n" not in route:
+        raise RoutingError("route job must publish routing outputs")
+    if "    if: ${{ always() }}" not in qualification:
+        raise RoutingError("qualification job must run with always()")
+    match = re.search(
+        r"^ {4}needs:\n(?P<rows>(?:^ {6}- [a-z0-9-]+\n?)+)",
+        qualification,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise RoutingError("qualification job must list every dependency")
+    actual = set(re.findall(r"^ {6}- ([a-z0-9-]+)$", match.group("rows"), re.MULTILINE))
+    expected = set(blocks) - {"qualification"}
+    if actual != expected:
+        raise RoutingError(
+            "qualification needs mismatch: "
+            f"missing={sorted(expected - actual)}, extra={sorted(actual - expected)}"
+        )
+    if "toJSON(needs)" not in qualification:
+        raise RoutingError("qualification must consume the complete needs result map")
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def _write_summary(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--self-test", action="store_true")
+    route = subparsers.add_parser("route")
+    route.add_argument("--event", required=True)
+    route.add_argument("--changes-z", type=Path)
+    route.add_argument("--output", type=Path, required=True)
+    route.add_argument("--summary", type=Path, required=True)
+    route.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        registry, policy = load_policy(args.manifest, args.workflow)
+        validate_workflow(args.workflow)
+        if args.command == "validate":
+            if args.self_test:
+                import change_routing_selftest
+
+                change_routing_selftest.self_test(registry, policy)
+            print("change-aware CI routing policy OK")
+            return 0
+        changes: list[Change] = []
+        parse_error: str | None = None
+        if args.changes_z is None:
+            if args.event == "pull_request":
+                parse_error = "missing-change-data"
+        else:
+            try:
+                changes = parse_name_status_z(args.changes_z.read_bytes())
+            except (OSError, RoutingError) as exc:
+                parse_error = str(exc)
+        receipt = compute_route(
+            registry,
+            policy,
+            event=args.event,
+            changes=changes,
+            parse_error=parse_error,
+            workflow=args.workflow,
+        )
+        _write_json(args.output, receipt)
+        _write_summary(args.summary, route_summary(receipt))
+        if args.github_output is not None:
+            with args.github_output.open("a") as output:
+                for key in ("mode", "decision"):
+                    output.write(f"{key}={receipt[key]}\n")
+                for key in ("proposed_jobs", "enforced_jobs"):
+                    value = json.dumps(receipt[key], separators=(",", ":"))
+                    output.write(f"{key}={value}\n")
+        return 0
+    except (OSError, RoutingError, subprocess.CalledProcessError) as exc:
+        print(f"change-aware CI routing error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.modules.setdefault("change_routing", sys.modules[__name__])
+    raise SystemExit(main())

--- a/scripts/ci/change_routing_selftest.py
+++ b/scripts/ci/change_routing_selftest.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Focused mutation and historical-diff tests for change routing."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import change_routing as routing
+
+
+def _git_changes(commit: str) -> list[routing.Change]:
+    process = subprocess.run(
+        [
+            "git",
+            "show",
+            "--format=",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            commit,
+        ],
+        cwd=routing.ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return routing.parse_name_status_z(process.stdout)
+
+
+def _malformed_stream_fails_closed(
+    registry: dict[str, Any],
+    policy: dict[str, Any],
+    data: bytes,
+) -> None:
+    try:
+        routing.parse_name_status_z(data)
+    except routing.RoutingError as exc:
+        receipt = routing.compute_route(
+            registry,
+            policy,
+            event="pull_request",
+            changes=[],
+            parse_error=str(exc),
+        )
+        assert receipt["decision"] == "full"
+        assert receipt["full_reasons"][0].startswith("change-data-error:")
+    else:
+        raise AssertionError(f"malformed change stream passed: {data!r}")
+
+
+def self_test(registry: dict[str, Any], policy: dict[str, Any]) -> None:
+    docs = routing.compute_route(
+        registry,
+        policy,
+        event="pull_request",
+        changes=[routing.Change("M", "docs/repository-gates.md")],
+    )
+    assert docs["decision"] == "selective"
+    assert docs["proposed_jobs"] == ["docs"]
+
+    proof_sensitive = routing.compute_route(
+        registry,
+        policy,
+        event="pull_request",
+        changes=[routing.Change("M", "crates/nose-detect/src/witness.rs")],
+    )
+    assert "formal-obligations" in proof_sensitive["selected_gates"]
+    assert "formal" in proof_sensitive["proposed_jobs"]
+
+    for change, reason in (
+        (routing.Change("M", "unowned/new-area.txt"), "unclassified-path"),
+        (routing.Change("D", "docs/retired.md"), "unsafe-change-status:D"),
+        (
+            routing.Change("R100", "docs/new.md", "docs/old.md"),
+            "unsafe-change-status:R100",
+        ),
+        (routing.Change("M", "Cargo.lock"), "global-policy-path"),
+    ):
+        receipt = routing.compute_route(
+            registry,
+            policy,
+            event="pull_request",
+            changes=[change],
+        )
+        assert receipt["decision"] == "full"
+        assert reason in receipt["full_reasons"]
+
+    for malformed in (
+        b"M\0unterminated",
+        b"M42\0docs/novel.md\0",
+        b"A100\0docs/novel.md\0",
+        b"R101\0docs/old.md\0docs/new.md\0",
+    ):
+        _malformed_stream_fails_closed(registry, policy, malformed)
+
+    workflow_text = routing.DEFAULT_WORKFLOW.read_text()
+    marker = "  docs:\n    name: docs wiki connectivity (awiki)\n"
+    assert marker in workflow_text
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        mutated_workflow = Path(temporary_directory) / "ci.yml"
+        mutated_workflow.write_text(
+            workflow_text.replace(
+                marker,
+                "  docs:\n"
+                "    name: docs wiki connectivity (awiki)\n"
+                "    if: ${{ false }}\n",
+                1,
+            )
+        )
+        try:
+            routing.load_policy(workflow=mutated_workflow)
+        except routing.RoutingError as exc:
+            assert "job docs condition must be None" in str(exc)
+        else:
+            raise AssertionError("unexpected quality-job condition passed validation")
+
+    for case in policy["historical_cases"]:
+        receipt = routing.compute_route(
+            registry,
+            policy,
+            event="pull_request",
+            changes=_git_changes(case["commit"]),
+        )
+        assert (receipt["decision"] == "full") == case["expected_full"], case["name"]
+        assert set(case["required_classes"]) <= set(receipt["matched_classes"]), case[
+            "name"
+        ]
+        assert set(case["required_gates"]) <= set(receipt["selected_gates"]), case[
+            "name"
+        ]
+        assert set(case["required_jobs"]) <= set(receipt["proposed_jobs"]), case["name"]
+
+    print("change-aware CI routing self-test passed")

--- a/scripts/ci/gate_registry.py
+++ b/scripts/ci/gate_registry.py
@@ -26,6 +26,11 @@ WORKTREE_EFFECTS = {"read-only", "verify-checked-output"}
 LOCAL_PLAN_LANES = {"fast": "local-fast", "full": "local-full"}
 LIFECYCLE_GATE = "evidence-artifacts"
 HOSTED_GATE_PREFIX = "gate · "
+HOSTED_TIMING_EXCLUDED_JOBS = {"route", "qualification"}
+UNTIMED_HOSTED_JOB_NAMES = {
+    "route": "change routing · report-only",
+    "qualification": "repository qualification",
+}
 PR_TEST_GATES = {"test-ci-compile", "test-ci"}
 PROTECTED_TEST_GATES = {"test-release-compile", "test-release"}
 TEST_GATE_COMMANDS = {
@@ -172,7 +177,7 @@ def validate_hosted_timing_policy(path: Path) -> None:
     if needs_match is None:
         raise RegistryError("hosted-timing must list every quality job in needs")
     needs = set(re.findall(r"^ {6}- ([a-z0-9-]+)$", needs_match.group("rows"), re.MULTILINE))
-    expected = set(blocks) - {"hosted-timing"}
+    expected = set(blocks) - {"hosted-timing"} - HOSTED_TIMING_EXCLUDED_JOBS
     if needs != expected:
         raise RegistryError(
             "hosted-timing needs mismatch: "

--- a/scripts/ci/gates.json
+++ b/scripts/ci/gates.json
@@ -7,7 +7,336 @@
     "release": "Protected non-PR gates selected for main and reusable release qualification.",
     "nightly": "Named gates called by the scheduled Soundness Lab workflow."
   },
+  "change_routing": {
+    "schema": "nose.ci-change-routing.v1",
+    "mode": "report-only",
+    "full_events": [
+      "push",
+      "workflow_call"
+    ],
+    "always_required_jobs": [
+      "route",
+      "hosted-timing"
+    ],
+    "global_patterns": [
+      ".github/**",
+      ".githooks/**",
+      ".coderabbit.yaml",
+      ".gitignore",
+      "AGENTS.md",
+      "CLAUDE.md",
+      "Cargo.lock",
+      "Cargo.toml",
+      "clippy.toml",
+      "deny.toml",
+      "dist-workspace.toml",
+      "lean-toolchain",
+      "rust-toolchain.toml",
+      "scripts/**",
+      "crates/nose-frontend/**",
+      "crates/nose-il/**",
+      "crates/nose-normalize/**",
+      "crates/nose-semantics/**"
+    ],
+    "rules": [
+      {
+        "class": "documentation",
+        "patterns": [
+          "CHANGELOG.md",
+          "CONTRIBUTING.md",
+          "LICENSE",
+          "README.md",
+          "docs/**"
+        ],
+        "gates": [
+          "docs"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "semantic-pack-examples",
+        "patterns": [
+          "docs/examples/semantic-pack-lock-v1.json",
+          "docs/examples/semantic-packs/**"
+        ],
+        "gates": [
+          "semantic-pack-examples"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "label-evidence",
+        "patterns": [
+          "bench/labels/**"
+        ],
+        "gates": [
+          "default-head-evidence",
+          "surface-recall-evidence",
+          "evidence-artifacts",
+          "missed-worthy-frontier",
+          "accepted-pair-coverage",
+          "product-query-schema"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "type4-evidence",
+        "patterns": [
+          "bench/type4/**"
+        ],
+        "gates": [
+          "type4-frontier",
+          "type4-executable",
+          "type4-axis-language",
+          "evidence-artifacts"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "corpus-evidence",
+        "patterns": [
+          "bench/corpus_prune/**",
+          "bench/goldens/**",
+          "bench/prune_corpus.py",
+          "bench/semantic_regression_corpus.v1.json",
+          "bench/setup_repos.sh"
+        ],
+        "gates": [
+          "corpus-prune-selftest",
+          "corpus-verify-selftest",
+          "evidence-artifacts"
+        ],
+        "jobs": [
+          "semantic-regression"
+        ]
+      },
+      {
+        "class": "semantic-pack-evidence",
+        "patterns": [
+          "bench/semantic_pack/**"
+        ],
+        "gates": [
+          "semantic-pack-pricing",
+          "semantic-pack-examples",
+          "evidence-artifacts"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "runtime-soundness-evidence",
+        "patterns": [
+          "bench/cache/**",
+          "bench/release/**",
+          "bench/soundness/**"
+        ],
+        "gates": [
+          "runtime-soundness-evidence",
+          "evidence-artifacts"
+        ],
+        "jobs": [
+          "semantic-regression"
+        ]
+      },
+      {
+        "class": "divergence-evidence",
+        "patterns": [
+          "eval/divergence_fire/**"
+        ],
+        "gates": [
+          "divergence-evidence",
+          "evidence-artifacts"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "formal-model",
+        "patterns": [
+          "formal/**"
+        ],
+        "gates": [
+          "formal-obligations",
+          "formal-lean",
+          "type4-axis-language"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "product-examples",
+        "patterns": [
+          "examples/**"
+        ],
+        "gates": [
+          "product-query-schema"
+        ],
+        "jobs": []
+      },
+      {
+        "class": "product-source",
+        "patterns": [
+          "crates/**"
+        ],
+        "gates": [
+          "format",
+          "file-length",
+          "legacy-prelude",
+          "clippy",
+          "doc",
+          "build-release",
+          "test-ci-compile",
+          "test-ci",
+          "product-query-schema",
+          "semantic-pack-examples",
+          "type4-executable",
+          "type4-axis-language",
+          "formal-obligations",
+          "coverage",
+          "duplication",
+          "msrv",
+          "supply-chain"
+        ],
+        "jobs": [
+          "semantic-regression"
+        ]
+      }
+    ],
+    "historical_cases": [
+      {
+        "name": "docs-only-result-note",
+        "commit": "de873534c361cd08e03ee838bf0e589d85f4ff7c",
+        "expected_full": false,
+        "required_classes": [
+          "documentation"
+        ],
+        "required_gates": [
+          "docs"
+        ],
+        "required_jobs": [
+          "docs"
+        ]
+      },
+      {
+        "name": "evidence-domain-optimization",
+        "commit": "afcf8b8a763fcf7affd496d5d13e5b889dba9e4c",
+        "expected_full": false,
+        "required_classes": [
+          "documentation",
+          "label-evidence",
+          "type4-evidence"
+        ],
+        "required_gates": [
+          "docs",
+          "default-head-evidence",
+          "type4-frontier",
+          "evidence-artifacts"
+        ],
+        "required_jobs": [
+          "docs",
+          "test",
+          "default-head-evidence",
+          "surface-recall-evidence",
+          "release-product"
+        ]
+      },
+      {
+        "name": "product-source-optimization",
+        "commit": "f6f7b2ed8e120c9e25baf398f31a75df8b97b30b",
+        "expected_full": false,
+        "required_classes": [
+          "product-source"
+        ],
+        "required_gates": [
+          "format",
+          "clippy",
+          "build-release",
+          "test-ci",
+          "formal-obligations",
+          "coverage",
+          "duplication"
+        ],
+        "required_jobs": [
+          "test",
+          "release-product",
+          "workspace-tests-pr",
+          "semantic-regression",
+          "formal",
+          "coverage",
+          "msrv",
+          "supply-chain"
+        ]
+      },
+      {
+        "name": "dependency-security-update",
+        "commit": "99fe1d2a6896c10d739be09777e5dcfab7721c3d",
+        "expected_full": true,
+        "required_classes": [],
+        "required_gates": [
+          "test-ci",
+          "supply-chain"
+        ],
+        "required_jobs": [
+          "workspace-tests-pr",
+          "supply-chain"
+        ]
+      },
+      {
+        "name": "ci-policy-update",
+        "commit": "964bcb75b8d20a5916a67f34258b50eedc99c5d2",
+        "expected_full": true,
+        "required_classes": [],
+        "required_gates": [
+          "change-routing-selftest"
+        ],
+        "required_jobs": [
+          "test",
+          "workspace-tests-pr"
+        ]
+      },
+      {
+        "name": "deleted-test-support",
+        "commit": "38087d9db9ebdc36eda7e3235fbb3c0c8c66af90",
+        "expected_full": true,
+        "required_classes": [],
+        "required_gates": [
+          "test-ci"
+        ],
+        "required_jobs": [
+          "workspace-tests-pr"
+        ]
+      },
+      {
+        "name": "renamed-evidence-records",
+        "commit": "aed5ed58ec51ac4490063957a031b130ba8e46c8",
+        "expected_full": true,
+        "required_classes": [],
+        "required_gates": [
+          "evidence-artifacts"
+        ],
+        "required_jobs": [
+          "test"
+        ]
+      }
+    ]
+  },
   "gates": [
+    {
+      "name": "change-routing-selftest",
+      "owner": "change-aware CI routing",
+      "implementation": "scripts/ci/change_routing.py validate --self-test && scripts/ci/qualification.py --self-test",
+      "tools": ["python3 >= 3.10", "git"],
+      "inputs": ["scripts/ci/gates.json", "scripts/ci/change_routing.py", "scripts/ci/change_routing_selftest.py", "scripts/ci/qualification.py", ".github/workflows/ci.yml"],
+      "worktree_effect": "read-only",
+      "outputs": [],
+      "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
+      "lanes": ["local-fast", "local-full", "pull-request", "release"],
+      "lane_reason": "Mutation-tests fail-closed path selection and the stable aggregate result.",
+      "focused_command": "./scripts/check-ci-local.sh --gate change-routing-selftest",
+      "plans": {
+        "fast": {"order": 5, "label": "change-aware CI routing self-test", "args": [], "depends_on": []},
+        "full": {"order": 5, "label": "change-aware CI routing self-test", "args": [], "depends_on": []}
+      }
+    },
     {
       "name": "corpus-prune-selftest",
       "owner": "benchmark corpus pruning",

--- a/scripts/ci/hosted_timing.py
+++ b/scripts/ci/hosted_timing.py
@@ -20,6 +20,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SCHEMA = "nose.hosted-ci-timings.v1"
 MINIMUM_PYTHON = (3, 10)
 TIMING_JOB_NAME = "hosted CI timing"
+UNTIMED_CONTROL_JOB_NAMES = set(gate_registry.UNTIMED_HOSTED_JOB_NAMES.values())
 
 
 class TimingError(ValueError):
@@ -98,6 +99,7 @@ def scoped_quality_jobs(
         if job is not timing_jobs[0]
         and isinstance(job.get("name"), str)
         and job["name"].startswith(prefix)
+        and job["name"][len(prefix) :] not in UNTIMED_CONTROL_JOB_NAMES
     ]
 
 
@@ -770,6 +772,17 @@ def sample_inputs() -> tuple[dict[str, Any], dict[str, Any]]:
     jobs = {
         "jobs": [
             {
+                "id": 5,
+                "name": "change routing · report-only",
+                "conclusion": "success",
+                "started_at": "2025-12-31T23:59:50Z",
+                "completed_at": "2026-01-01T00:00:08Z",
+                "runner_name": "runner",
+                "runner_group_name": "GitHub Actions",
+                "labels": ["ubuntu-latest"],
+                "steps": [],
+            },
+            {
                 "id": 1,
                 "name": "build and test",
                 "conclusion": "success",
@@ -818,6 +831,17 @@ def sample_inputs() -> tuple[dict[str, Any], dict[str, Any]]:
                 "completed_at": None,
                 "runner_name": "runner",
                 "runner_group_name": "GitHub Actions",
+                "labels": ["ubuntu-latest"],
+                "steps": [],
+            },
+            {
+                "id": 6,
+                "name": "repository qualification",
+                "conclusion": None,
+                "started_at": None,
+                "completed_at": None,
+                "runner_name": None,
+                "runner_group_name": None,
                 "labels": ["ubuntu-latest"],
                 "steps": [],
             },
@@ -893,6 +917,10 @@ def self_test() -> None:
     )
     assert receipt["history"]["sample_count"] == 1
     assert receipt["history"]["p50_seconds"] == 120.0
+    assert {
+        "change routing · report-only",
+        "repository qualification",
+    }.isdisjoint(job["name"] for job in receipt["jobs"])
     skipped = next(
         job for job in receipt["jobs"] if job["conclusion"] == "skipped"
     )

--- a/scripts/ci/qualification.py
+++ b/scripts/ci/qualification.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Verify the stable aggregate result for routed repository qualification."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import change_routing
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+SCHEMA = "nose.ci-qualification-receipt.v1"
+KNOWN_RESULTS = {"success", "failure", "cancelled", "skipped"}
+
+
+def aggregate_results(
+    *,
+    mode: str,
+    event: str,
+    enforced_jobs: list[Any],
+    needs: dict[str, Any],
+    workflow: Path = DEFAULT_WORKFLOW,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if not isinstance(needs, dict):
+        raise change_routing.RoutingError("needs evidence must be an object")
+    malformed_jobs = any(
+        not isinstance(job, str) or not job for job in enforced_jobs
+    )
+    valid_jobs = [
+        job for job in enforced_jobs if isinstance(job, str) and job
+    ]
+    if malformed_jobs or len(valid_jobs) != len(set(valid_jobs)):
+        errors.append("enforced job list is malformed or contains duplicates")
+    enforced = set(valid_jobs)
+    missing_controls = change_routing.ALWAYS_REQUIRED_JOBS - enforced
+    if missing_controls:
+        errors.append(
+            f"always-required jobs are absent: {sorted(missing_controls)}"
+        )
+    if mode == "report-only":
+        expected = (
+            change_routing.eligible_quality_jobs(event, workflow)
+            | change_routing.ALWAYS_REQUIRED_JOBS
+        )
+        if enforced != expected:
+            errors.append(
+                "report-only enforced job set drifted: "
+                f"missing={sorted(expected - enforced)}, "
+                f"extra={sorted(enforced - expected)}"
+            )
+    elif mode != "enforce":
+        errors.append(f"unknown routing mode: {mode!r}")
+
+    observed: dict[str, str | None] = {}
+    for job, evidence in needs.items():
+        result = evidence.get("result") if isinstance(evidence, dict) else None
+        observed[job] = result
+        if result not in KNOWN_RESULTS:
+            errors.append(f"job {job} has invalid/absent result: {result!r}")
+    missing = enforced - set(needs)
+    if missing:
+        errors.append(f"required selected jobs are absent: {sorted(missing)}")
+    for job in sorted(enforced & set(needs)):
+        if observed[job] != "success":
+            errors.append(f"required selected job {job} concluded {observed[job]!r}")
+    return {
+        "schema": SCHEMA,
+        "mode": mode,
+        "event": event,
+        "conclusion": "success" if not errors else "failure",
+        "enforced_jobs": sorted(enforced),
+        "observed_results": dict(sorted(observed.items())),
+        "errors": errors,
+    }
+
+
+def summary(receipt: dict[str, Any]) -> str:
+    errors = "\n".join(f"- {error}" for error in receipt["errors"]) or "- none"
+    return (
+        "## Repository qualification\n\n"
+        f"- Conclusion: `{receipt['conclusion']}`\n"
+        f"- Routing mode: `{receipt['mode']}`\n"
+        f"- Enforced jobs: `{len(receipt['enforced_jobs'])}`\n"
+        "- Errors:\n"
+        f"{errors}\n"
+    )
+
+
+def self_test() -> None:
+    eligible = change_routing.eligible_quality_jobs("pull_request")
+    enforced = sorted(eligible | change_routing.ALWAYS_REQUIRED_JOBS)
+    passing_needs = {job: {"result": "success"} for job in enforced}
+    passing_needs["workspace-tests-protected"] = {"result": "skipped"}
+    passed = aggregate_results(
+        mode="report-only",
+        event="pull_request",
+        enforced_jobs=enforced,
+        needs=passing_needs,
+    )
+    assert passed["conclusion"] == "success"
+    selected = next(iter(eligible))
+    for label, mutation in (
+        ("failure", {**passing_needs, selected: {"result": "failure"}}),
+        (
+            "missing",
+            {job: value for job, value in passing_needs.items() if job != "route"},
+        ),
+        ("selected skip", {**passing_needs, selected: {"result": "skipped"}}),
+    ):
+        failed = aggregate_results(
+            mode="report-only",
+            event="pull_request",
+            enforced_jobs=enforced,
+            needs=mutation,
+        )
+        assert failed["conclusion"] == "failure", label
+    malformed = aggregate_results(
+        mode="report-only",
+        event="pull_request",
+        enforced_jobs=[*enforced, ["nested-list"]],
+        needs=passing_needs,
+    )
+    assert malformed["conclusion"] == "failure"
+    assert "enforced job list is malformed or contains duplicates" in malformed["errors"]
+    print("repository qualification aggregate self-test passed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--event")
+    parser.add_argument("--mode")
+    parser.add_argument("--enforced-jobs")
+    parser.add_argument("--needs-env", default="NEEDS_JSON")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--summary", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        if args.event is None:
+            return 0
+    required = {
+        "--event": args.event,
+        "--mode": args.mode,
+        "--enforced-jobs": args.enforced_jobs,
+        "--output": args.output,
+        "--summary": args.summary,
+    }
+    missing = [name for name, value in required.items() if value is None]
+    if missing:
+        print(f"qualification error: missing {', '.join(missing)}", file=sys.stderr)
+        return 2
+
+    parse_errors: list[str] = []
+    try:
+        enforced_jobs = json.loads(args.enforced_jobs)
+    except json.JSONDecodeError as exc:
+        enforced_jobs = []
+        parse_errors.append(f"cannot parse enforced jobs: {exc}")
+    if not isinstance(enforced_jobs, list):
+        enforced_jobs = []
+        parse_errors.append("enforced jobs output is not an array")
+    try:
+        needs = json.loads(os.environ.get(args.needs_env, ""))
+    except json.JSONDecodeError as exc:
+        needs = {}
+        parse_errors.append(f"cannot parse needs evidence: {exc}")
+    try:
+        receipt = aggregate_results(
+            mode=args.mode,
+            event=args.event,
+            enforced_jobs=enforced_jobs,
+            needs=needs,
+            workflow=args.workflow,
+        )
+    except (OSError, change_routing.RoutingError) as exc:
+        receipt = {
+            "schema": SCHEMA,
+            "mode": args.mode,
+            "event": args.event,
+            "conclusion": "failure",
+            "enforced_jobs": enforced_jobs,
+            "observed_results": {},
+            "errors": [str(exc)],
+        }
+    receipt["errors"] = parse_errors + receipt["errors"]
+    if parse_errors:
+        receipt["conclusion"] = "failure"
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    args.summary.write_text(summary(receipt))
+    return 0 if receipt["conclusion"] == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -45,7 +45,7 @@
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
       "artifact_count": 6,
-      "inventory_sha256": "4db34269df672543c590aefb61cfaa8fdba4cb3b00650ac0b6104cb0010a6c41"
+      "inventory_sha256": "32e9a30bb60e4d5fdb07d3c1b66b213b816fdbef52b5073f0ef1f63aea58a764"
     },
     {
       "id": "benchmark-root",


### PR DESCRIPTION
## Summary

- add one checked changed-path routing policy derived from the existing gate registry and actual workflow gate calls
- publish report-only route receipts while retaining every current event-eligible quality job
- add a stable fail-closed `repository qualification` aggregate result and preserve complete main/release qualification
- cover malformed, unknown, deleted, renamed, global-policy, proof-sensitive, and historical diff cases
- document enforcement rollout and rollback before any skip can be enabled

## Validation

- `./scripts/check-ci-local.sh --fast --jobs 2`
- `./scripts/check-ci-local.sh --full --jobs 2`
- `./scripts/check-ci-local.sh --gate change-routing-selftest`
- `./scripts/check-ci-local.sh --gate evidence-artifacts`
- `./scripts/check-ci-local.sh --gate docs`
- `./scripts/check-ci-local.sh --gate shell-lint`
- `./scripts/check-ci-local.sh --gate file-length`
- `python scripts/ci/hosted_timing.py --self-test`
- `actionlint .github/workflows/ci.yml`

## Review

Completed the requested one parallel review round with two independent agents. Incorporated all findings: exact event-condition validation, canonical rename/copy status parsing, proof-sensitive formal routing, robust malformed aggregate handling, and explicit fail-open-to-full rollout guidance.

Closes #962
