### PR TITLE
Tests: move divergence policy below the CLI boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ break.
 ## [Unreleased]
 
 ### Changed
+- Moved divergent-edit tier, taxonomy, reason, and default-gate decisions into
+  a deterministic `nose-detect` policy boundary with focused owner tests, while
+  retaining CLI JSON/SARIF, Git, exit-status, and user-workflow contracts.
 - Added fail-closed, report-only pull-request change routing backed by the
   checked gate registry, historical/synthetic path matrices, auditable route
   receipts, and a stable aggregate qualification result. Main, release,

--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "ab781571dd0a1513e2a7e4239b606e9bd0d307af",
+  "product_crates_tree": "407ac2b25a737897409e0155d6c15b370cbbb07e",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-cli/src/divergence.rs
+++ b/crates/nose-cli/src/divergence.rs
@@ -25,13 +25,17 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use nose_detect::{EnclosingUnit, FragmentKind, Loc, RefactorFamily};
+#[cfg(test)]
+pub(crate) use nose_detect::DIVERGENT_EDIT_V2_POLICY;
+use nose_detect::{
+    divergence_policy, DivergencePolicyInput, DivergenceScope, EnclosingUnit, FragmentKind, Loc,
+    RefactorFamily, SharedLogicEvidence,
+};
+pub(crate) use nose_detect::{DivergenceLane, DivergencePolicyDecision, DivergenceTier};
 
 pub(crate) use detect::{detect_divergences, divergences_fire};
-pub(crate) use output::divergence_items_json;
+pub(crate) use output::{divergence_items_json, lane_value};
 
-pub(crate) const DIVERGENT_EDIT_V2_POLICY: &str = "divergent-edit-v2-strict";
-const ACTIVE_DIVERGENT_EDIT_POLICY: &str = DIVERGENT_EDIT_V2_POLICY;
 #[cfg(test)]
 pub(crate) const DIVERGENCE_LANE_VALUES: &[&str] = &["base-divergence", "new-copy"];
 #[cfg(test)]
@@ -127,158 +131,37 @@ pub(crate) struct DirectPairWitness {
     pub(crate) similarity: f64,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum DivergenceLane {
-    BaseDivergence,
-    NewCopy,
-}
-
-impl DivergenceLane {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::BaseDivergence => "base-divergence",
-            Self::NewCopy => "new-copy",
-        }
-    }
-
-    pub(crate) fn base_family_id(self, family_id: &str) -> Option<&str> {
-        match self {
-            Self::BaseDivergence => Some(family_id),
-            Self::NewCopy => None,
-        }
-    }
-
-    pub(crate) fn site_tree(self) -> &'static str {
-        match self {
-            Self::BaseDivergence => "base",
-            Self::NewCopy => "current",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum DivergenceTier {
-    Strict,
-    Review,
-    ReportOnly,
-}
-
-/// The one active policy decision consumed by human, JSON, SARIF, and exit-status
-/// surfaces. Keeping the gate fields together prevents a renderer from silently
-/// re-deriving a different hard-block decision.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
-pub(crate) struct DivergenceGateDecision {
-    pub(crate) eligible: bool,
-    pub(crate) fail_default: bool,
-    pub(crate) policy: &'static str,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct DivergencePolicyDecision {
-    pub(crate) tier: DivergenceTier,
-    pub(crate) tier_reasons: Vec<&'static str>,
-    pub(crate) taxonomy_hint: &'static str,
-    pub(crate) gate: DivergenceGateDecision,
-}
-
-impl DivergenceTier {
-    pub(crate) fn sarif_rule_id(self) -> &'static str {
-        match self {
-            Self::Strict => "nose.divergent.strict",
-            Self::Review => "nose.divergent.review",
-            Self::ReportOnly => "nose.divergent.report-only",
-        }
-    }
-
-    pub(crate) fn sarif_rule_name(self) -> &'static str {
-        match self {
-            Self::Strict => "DivergentEditStrict",
-            Self::Review => "DivergentEditReview",
-            Self::ReportOnly => "DivergentEditReportOnly",
-        }
-    }
-
-    pub(crate) fn sarif_level(self) -> &'static str {
-        match self {
-            Self::Strict => "error",
-            Self::Review => "warning",
-            Self::ReportOnly => "note",
-        }
-    }
-
-    pub(crate) fn gate_eligible(self) -> bool {
-        matches!(self, Self::Strict | Self::Review)
-    }
-}
-
 impl Divergence {
     pub(crate) fn policy_decision(&self) -> DivergencePolicyDecision {
-        let tier = if self.lane == DivergenceLane::NewCopy || self.scope != "prod" {
-            DivergenceTier::ReportOnly
-        } else if self.fire_eligible {
-            DivergenceTier::Strict
+        let scope = if self.scope == "prod" {
+            DivergenceScope::Production
         } else {
-            DivergenceTier::Review
+            DivergenceScope::TestOrMixed
         };
-        let taxonomy_hint = if self.lane == DivergenceLane::NewCopy {
-            "unclear"
-        } else if self.scope != "prod" {
-            "test_scaffolding"
-        } else if self.fire_eligible {
-            "missed_propagation"
-        } else if self.changed.iter().any(|s| s.touches_shared == Some(false)) {
-            "no_propagation_needed"
+        let shared_logic = if self
+            .changed
+            .iter()
+            .any(|site| site.touches_shared == Some(true))
+        {
+            SharedLogicEvidence::Touched
+        } else if self
+            .changed
+            .iter()
+            .any(|site| site.touches_shared == Some(false))
+        {
+            SharedLogicEvidence::NotTouched
         } else {
-            "unclear"
+            SharedLogicEvidence::Unproven
         };
-        let mut reasons = Vec::with_capacity(3);
-        if self.lane == DivergenceLane::NewCopy {
-            reasons.push("new_copy_no_base_member");
-        } else {
-            if self.changed.iter().any(|s| s.touches_shared == Some(true)) {
-                reasons.push("shared_logic_touched");
-            } else if self.changed.iter().any(|s| s.touches_shared == Some(false)) {
-                reasons.push("shared_logic_not_touched");
-            } else {
-                reasons.push("shared_logic_unproven");
-            }
-        }
-        if self.scope == "prod" {
-            reasons.push("non_test_scope");
-        } else {
-            reasons.push("test_scope");
-            reasons.push("test_scaffolding");
-        }
-        DivergencePolicyDecision {
-            tier,
-            tier_reasons: reasons,
-            taxonomy_hint,
-            gate: DivergenceGateDecision {
-                eligible: tier.gate_eligible(),
-                fail_default: tier == DivergenceTier::Strict,
-                policy: ACTIVE_DIVERGENT_EDIT_POLICY,
-            },
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn tier(&self) -> DivergenceTier {
-        self.policy_decision().tier
+        divergence_policy(DivergencePolicyInput {
+            lane: self.lane,
+            scope,
+            shared_logic,
+        })
     }
 
     pub(crate) fn gate_fail_default(&self) -> bool {
         self.policy_decision().gate.fail_default
-    }
-
-    #[cfg(test)]
-    pub(crate) fn taxonomy_hint(&self) -> &'static str {
-        self.policy_decision().taxonomy_hint
-    }
-
-    #[cfg(test)]
-    pub(crate) fn tier_reasons(&self) -> Vec<&'static str> {
-        self.policy_decision().tier_reasons
     }
 }
 
@@ -302,7 +185,8 @@ pub(crate) struct Site {
     /// not-updated site.
     pub(crate) touches_shared: Option<bool>,
     /// Bounded base-to-current semantic change evidence (#849). This is deliberately
-    /// presentation-only in v2: neither `tier()` nor `gate_fail_default()` reads it.
+    /// presentation-only in v2: neither `policy_decision()` nor
+    /// `gate_fail_default()` reads it.
     pub(crate) semantic_change: Option<SemanticChangeWitness>,
 }
 

--- a/crates/nose-cli/src/divergence/output.rs
+++ b/crates/nose-cli/src/divergence/output.rs
@@ -1,5 +1,42 @@
 use super::*;
 
+pub(crate) fn lane_value(lane: DivergenceLane) -> &'static str {
+    match lane {
+        DivergenceLane::BaseDivergence => "base-divergence",
+        DivergenceLane::NewCopy => "new-copy",
+    }
+}
+
+fn base_family_id(lane: DivergenceLane, family_id: &str) -> Option<&str> {
+    match lane {
+        DivergenceLane::BaseDivergence => Some(family_id),
+        DivergenceLane::NewCopy => None,
+    }
+}
+
+fn site_tree(lane: DivergenceLane) -> &'static str {
+    match lane {
+        DivergenceLane::BaseDivergence => "base",
+        DivergenceLane::NewCopy => "current",
+    }
+}
+
+fn tier_value(tier: DivergenceTier) -> &'static str {
+    match tier {
+        DivergenceTier::Strict => "strict",
+        DivergenceTier::Review => "review",
+        DivergenceTier::ReportOnly => "report-only",
+    }
+}
+
+fn gate_json(gate: nose_detect::DivergenceGateDecision) -> serde_json::Value {
+    serde_json::json!({
+        "eligible": gate.eligible,
+        "fail_default": gate.fail_default,
+        "policy": gate.policy,
+    })
+}
+
 fn site_label(s: &Site) -> String {
     match &s.name {
         Some(n) if !n.is_empty() => format!("{} ({}:{}-{})", n, s.file, s.start_line, s.end_line),
@@ -77,17 +114,17 @@ pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::V
             let decision = d.policy_decision();
             let mut item = json!({
                 "family_id": d.family_id,
-                "lane": d.lane.as_str(),
-                "base_family_id": d.lane.base_family_id(&d.family_id),
+                "lane": lane_value(d.lane),
+                "base_family_id": base_family_id(d.lane, &d.family_id),
                 "similarity": d.similarity,
                 "complexity": d.complexity,
                 "scope": d.scope,
                 "witness_kind": d.witness_kind,
                 "fire_eligible": d.fire_eligible,
-                "tier": decision.tier,
+                "tier": tier_value(decision.tier),
                 "tier_reasons": decision.tier_reasons,
                 "taxonomy_hint": decision.taxonomy_hint,
-                "gate": decision.gate,
+                "gate": gate_json(decision.gate),
                 "suppression": null,
                 "graded": d.graded,
                 "targets": d.targets.iter().map(target_json).collect::<Vec<_>>(),
@@ -97,18 +134,18 @@ pub(crate) fn divergence_items_json(flagged: &[Divergence]) -> Vec<serde_json::V
                     item["changed"] = json!(d
                         .changed
                         .iter()
-                        .map(|s| site_json(s, d.lane.site_tree()))
+                        .map(|s| site_json(s, site_tree(d.lane)))
                         .collect::<Vec<_>>());
                     item["not_updated"] = json!(d
                         .not_updated
                         .iter()
-                        .map(|s| site_json(s, d.lane.site_tree()))
+                        .map(|s| site_json(s, site_tree(d.lane)))
                         .collect::<Vec<_>>());
                 }
                 DivergenceLane::NewCopy => {
                     let current_only = d.changed.iter().chain(&d.not_updated);
                     item["current_only"] = json!(current_only
-                        .map(|s| site_json(s, d.lane.site_tree()))
+                        .map(|s| site_json(s, site_tree(d.lane)))
                         .collect::<Vec<_>>());
                 }
             }
@@ -149,6 +186,30 @@ fn tier_label(tier: DivergenceTier) -> &'static str {
         DivergenceTier::Strict => "Strict",
         DivergenceTier::Review => "Review-only",
         DivergenceTier::ReportOnly => "Report-only",
+    }
+}
+
+fn sarif_rule_id(tier: DivergenceTier) -> &'static str {
+    match tier {
+        DivergenceTier::Strict => "nose.divergent.strict",
+        DivergenceTier::Review => "nose.divergent.review",
+        DivergenceTier::ReportOnly => "nose.divergent.report-only",
+    }
+}
+
+fn sarif_rule_name(tier: DivergenceTier) -> &'static str {
+    match tier {
+        DivergenceTier::Strict => "DivergentEditStrict",
+        DivergenceTier::Review => "DivergentEditReview",
+        DivergenceTier::ReportOnly => "DivergentEditReportOnly",
+    }
+}
+
+fn sarif_level(tier: DivergenceTier) -> &'static str {
+    match tier {
+        DivergenceTier::Strict => "error",
+        DivergenceTier::Review => "warning",
+        DivergenceTier::ReportOnly => "note",
     }
 }
 
@@ -214,19 +275,19 @@ fn divergence_sarif_result(d: &Divergence) -> serde_json::Value {
         ),
     };
     json!({
-        "ruleId": tier.sarif_rule_id(),
-        "level": tier.sarif_level(),
+        "ruleId": sarif_rule_id(tier),
+        "level": sarif_level(tier),
         "message": { "text": message },
         "locations": locations,
         "relatedLocations": related_locations,
         "properties": {
             "family_id": d.family_id,
-            "base_family_id": d.lane.base_family_id(&d.family_id),
-            "lane": d.lane.as_str(),
-            "tier": decision.tier,
+            "base_family_id": base_family_id(d.lane, &d.family_id),
+            "lane": lane_value(d.lane),
+            "tier": tier_value(decision.tier),
             "tier_reasons": decision.tier_reasons,
             "taxonomy_hint": decision.taxonomy_hint,
-            "gate": decision.gate,
+            "gate": gate_json(decision.gate),
             "policy": decision.gate.policy,
             "fire_eligible": d.fire_eligible,
             "targets": d.targets.iter().map(target_json).collect::<Vec<_>>(),
@@ -247,8 +308,8 @@ fn divergence_sarif_rules() -> Vec<serde_json::Value> {
     .into_iter()
     .map(|tier| {
         json!({
-            "id": tier.sarif_rule_id(),
-            "name": tier.sarif_rule_name(),
+            "id": sarif_rule_id(tier),
+            "name": sarif_rule_name(tier),
             "shortDescription": { "text": match tier {
                 DivergenceTier::Strict => "A likely missed clone-sibling edit",
                 DivergenceTier::Review => "A divergent clone edit needing review",

--- a/crates/nose-cli/src/divergence/tests.rs
+++ b/crates/nose-cli/src/divergence/tests.rs
@@ -7,9 +7,7 @@ use super::git::{
 };
 use super::output::{divergence_items_json, divergence_sarif, fragment_context};
 use super::{
-    Divergence, DivergenceLane, DivergenceTier, SemanticAlignment, SemanticChangeKind,
-    SemanticChangeWitness, SemanticProjectionStatus, SemanticWitnessCaps, SemanticWitnessCaveat,
-    SemanticWitnessCoverage, SemanticWitnessStatus, Site, DIVERGENCE_LANE_VALUES,
+    Divergence, DivergenceLane, DivergenceTier, Site, DIVERGENCE_LANE_VALUES,
     DIVERGENCE_SUPPRESSION_KIND_VALUES, DIVERGENCE_TAXONOMY_HINT_VALUES,
     DIVERGENCE_TIER_REASON_VALUES, DIVERGENCE_TIER_VALUES, DIVERGENT_EDIT_V2_POLICY,
 };
@@ -304,68 +302,49 @@ fn tier_divergence(scope: &'static str, fire_eligible: bool, touch: Option<bool>
 }
 
 #[test]
-fn v2_tier_routes_new_copy_lane_to_report_only() {
-    let mut d = tier_divergence("prod", false, None);
-    d.lane = DivergenceLane::NewCopy;
-    assert_eq!(d.tier(), DivergenceTier::ReportOnly);
-    assert!(!d.gate_fail_default(), "new-copy lane is advisory");
-    assert_eq!(d.taxonomy_hint(), "unclear");
-    assert_eq!(
-        d.tier_reasons(),
-        vec!["new_copy_no_base_member", "non_test_scope"]
-    );
-}
+fn policy_adapter_normalizes_cli_scope_and_site_evidence() {
+    let unproven = tier_divergence("prod", false, None);
+    let not_touched = tier_divergence("prod", false, Some(false));
+    let mut touched = tier_divergence("prod", true, Some(false));
+    touched.changed.push(tier_site("c.py", Some(true)));
+    let mixed = tier_divergence("mixed", true, Some(true));
 
-#[test]
-fn v2_tier_routes_unknown_shared_evidence_to_review() {
-    let mut d = tier_divergence("prod", false, None);
-    d.changed[0].semantic_change = Some(SemanticChangeWitness {
-        status: SemanticWitnessStatus::Unavailable,
-        change_kind: SemanticChangeKind::Unknown,
-        facets: Vec::new(),
-        alignment: SemanticAlignment::None,
-        base_projection: SemanticProjectionStatus::Ok,
-        current_projection: SemanticProjectionStatus::UnitMissing,
-        coverage: SemanticWitnessCoverage {
-            base_affected_nodes: 0,
-            current_affected_nodes: 0,
-            mapped_shared_nodes: 0,
-            sibling_units_checked: 0,
-        },
-        sink_deltas: Vec::new(),
-        caveats: vec![SemanticWitnessCaveat::MissingCurrentUnit],
-        caps: SemanticWitnessCaps {
-            max_files: 64,
-            max_file_bytes: 2 * 1024 * 1024,
-            max_changed_sites_per_family: 16,
-            max_siblings_per_family: 16,
-            max_targets_per_family: 64,
-            max_units_per_file: 512,
-            max_nodes_per_unit: 2_048,
-        },
-    });
-    assert_eq!(d.tier(), DivergenceTier::Review);
-    assert!(
-        !d.gate_fail_default(),
-        "an unavailable semantic witness cannot promote the v2 gate"
-    );
-    assert_eq!(d.taxonomy_hint(), "unclear");
-    assert_eq!(
-        d.tier_reasons(),
-        vec!["shared_logic_unproven", "non_test_scope"]
-    );
-}
-
-#[test]
-fn v2_tier_routes_mixed_scope_to_report_only_even_when_legacy_fire_eligible() {
-    let d = tier_divergence("mixed", true, Some(true));
-    assert_eq!(d.tier(), DivergenceTier::ReportOnly);
-    assert!(!d.gate_fail_default(), "report-only never fails default CI");
-    assert_eq!(d.taxonomy_hint(), "test_scaffolding");
-    assert_eq!(
-        d.tier_reasons(),
-        vec!["shared_logic_touched", "test_scope", "test_scaffolding"]
-    );
+    for (divergence, tier, taxonomy, reasons, fail_default) in [
+        (
+            unproven,
+            DivergenceTier::Review,
+            "unclear",
+            vec!["shared_logic_unproven", "non_test_scope"],
+            false,
+        ),
+        (
+            not_touched,
+            DivergenceTier::Review,
+            "no_propagation_needed",
+            vec!["shared_logic_not_touched", "non_test_scope"],
+            false,
+        ),
+        (
+            touched,
+            DivergenceTier::Strict,
+            "missed_propagation",
+            vec!["shared_logic_touched", "non_test_scope"],
+            true,
+        ),
+        (
+            mixed,
+            DivergenceTier::ReportOnly,
+            "test_scaffolding",
+            vec!["shared_logic_touched", "test_scope", "test_scaffolding"],
+            false,
+        ),
+    ] {
+        let decision = divergence.policy_decision();
+        assert_eq!(decision.tier, tier);
+        assert_eq!(decision.taxonomy_hint, taxonomy);
+        assert_eq!(decision.tier_reasons, reasons);
+        assert_eq!(decision.gate.fail_default, fail_default);
+    }
 }
 
 #[test]
@@ -468,22 +447,5 @@ fn v8_json_and_sarif_share_policy_fields() {
             item["suppression"].is_null(),
             "active v8 output omits suppressed rows by default: {item}"
         );
-    }
-}
-
-#[test]
-fn active_policy_decision_is_the_single_gate_authority() {
-    for divergence in [
-        tier_divergence("prod", true, Some(true)),
-        tier_divergence("prod", false, Some(false)),
-        tier_divergence("mixed", true, Some(true)),
-    ] {
-        let decision = divergence.policy_decision();
-        assert_eq!(divergence.tier(), decision.tier);
-        assert_eq!(divergence.tier_reasons(), decision.tier_reasons);
-        assert_eq!(divergence.taxonomy_hint(), decision.taxonomy_hint);
-        assert_eq!(divergence.gate_fail_default(), decision.gate.fail_default);
-        assert_eq!(decision.gate.eligible, decision.tier.gate_eligible());
-        assert_eq!(decision.gate.policy, DIVERGENT_EDIT_V2_POLICY);
     }
 }

--- a/crates/nose-cli/src/query_views.rs
+++ b/crates/nose-cli/src/query_views.rs
@@ -141,7 +141,7 @@ pub(super) fn render_query_base(
             (_, _, "test_scaffolding") => "report-only (test/mixed scope)",
             _ => "report-only (advisory)",
         };
-        let lane = d.lane.as_str();
+        let lane = divergence::lane_value(d.lane);
         println!(
             "  {}  {} · {} · {lane} · {propagation}",
             short_id(&d.family_id),

--- a/crates/nose-detect/src/divergence_policy.rs
+++ b/crates/nose-detect/src/divergence_policy.rs
@@ -1,0 +1,210 @@
+//! Pure product policy for divergent-edit findings.
+//!
+//! The CLI adapter provides normalized detection evidence through
+//! [`DivergencePolicyInput`]. This module owns only the deterministic tier,
+//! taxonomy, reason, and gate decision; rendering and process behavior remain
+//! at the CLI boundary.
+
+pub const DIVERGENT_EDIT_V2_POLICY: &str = "divergent-edit-v2-strict";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DivergenceLane {
+    BaseDivergence,
+    NewCopy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DivergenceScope {
+    Production,
+    TestOrMixed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SharedLogicEvidence {
+    Touched,
+    NotTouched,
+    Unproven,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DivergencePolicyInput {
+    pub lane: DivergenceLane,
+    pub scope: DivergenceScope,
+    pub shared_logic: SharedLogicEvidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DivergenceTier {
+    Strict,
+    Review,
+    ReportOnly,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DivergenceGateDecision {
+    pub eligible: bool,
+    pub fail_default: bool,
+    pub policy: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DivergencePolicyDecision {
+    pub tier: DivergenceTier,
+    pub tier_reasons: Vec<&'static str>,
+    pub taxonomy_hint: &'static str,
+    pub gate: DivergenceGateDecision,
+}
+
+pub fn divergence_policy(input: DivergencePolicyInput) -> DivergencePolicyDecision {
+    let production = input.scope == DivergenceScope::Production;
+    let tier = if input.lane == DivergenceLane::NewCopy || !production {
+        DivergenceTier::ReportOnly
+    } else if input.shared_logic == SharedLogicEvidence::Touched {
+        DivergenceTier::Strict
+    } else {
+        DivergenceTier::Review
+    };
+    let taxonomy_hint = if input.lane == DivergenceLane::NewCopy {
+        "unclear"
+    } else if !production {
+        "test_scaffolding"
+    } else {
+        match input.shared_logic {
+            SharedLogicEvidence::Touched => "missed_propagation",
+            SharedLogicEvidence::NotTouched => "no_propagation_needed",
+            SharedLogicEvidence::Unproven => "unclear",
+        }
+    };
+    let mut tier_reasons = Vec::with_capacity(3);
+    if input.lane == DivergenceLane::NewCopy {
+        tier_reasons.push("new_copy_no_base_member");
+    } else {
+        tier_reasons.push(match input.shared_logic {
+            SharedLogicEvidence::Touched => "shared_logic_touched",
+            SharedLogicEvidence::NotTouched => "shared_logic_not_touched",
+            SharedLogicEvidence::Unproven => "shared_logic_unproven",
+        });
+    }
+    if production {
+        tier_reasons.push("non_test_scope");
+    } else {
+        tier_reasons.push("test_scope");
+        tier_reasons.push("test_scaffolding");
+    }
+    DivergencePolicyDecision {
+        tier,
+        tier_reasons,
+        taxonomy_hint,
+        gate: DivergenceGateDecision {
+            eligible: matches!(tier, DivergenceTier::Strict | DivergenceTier::Review),
+            fail_default: tier == DivergenceTier::Strict,
+            policy: DIVERGENT_EDIT_V2_POLICY,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decide(
+        lane: DivergenceLane,
+        scope: DivergenceScope,
+        shared_logic: SharedLogicEvidence,
+    ) -> DivergencePolicyDecision {
+        divergence_policy(DivergencePolicyInput {
+            lane,
+            scope,
+            shared_logic,
+        })
+    }
+
+    #[test]
+    fn new_copy_is_advisory_without_base_members() {
+        let decision = decide(
+            DivergenceLane::NewCopy,
+            DivergenceScope::Production,
+            SharedLogicEvidence::Unproven,
+        );
+        assert_eq!(decision.tier, DivergenceTier::ReportOnly);
+        assert_eq!(decision.taxonomy_hint, "unclear");
+        assert_eq!(
+            decision.tier_reasons,
+            ["new_copy_no_base_member", "non_test_scope"]
+        );
+        assert!(!decision.gate.eligible);
+        assert!(!decision.gate.fail_default);
+    }
+
+    #[test]
+    fn unproven_product_change_requires_review_but_does_not_fail() {
+        let decision = decide(
+            DivergenceLane::BaseDivergence,
+            DivergenceScope::Production,
+            SharedLogicEvidence::Unproven,
+        );
+        assert_eq!(decision.tier, DivergenceTier::Review);
+        assert_eq!(decision.taxonomy_hint, "unclear");
+        assert_eq!(
+            decision.tier_reasons,
+            ["shared_logic_unproven", "non_test_scope"]
+        );
+        assert!(decision.gate.eligible);
+        assert!(!decision.gate.fail_default);
+    }
+
+    #[test]
+    fn test_or_mixed_scope_stays_report_only_with_shared_logic_evidence() {
+        let decision = decide(
+            DivergenceLane::BaseDivergence,
+            DivergenceScope::TestOrMixed,
+            SharedLogicEvidence::Touched,
+        );
+        assert_eq!(decision.tier, DivergenceTier::ReportOnly);
+        assert_eq!(decision.taxonomy_hint, "test_scaffolding");
+        assert_eq!(
+            decision.tier_reasons,
+            ["shared_logic_touched", "test_scope", "test_scaffolding"]
+        );
+        assert!(!decision.gate.eligible);
+        assert!(!decision.gate.fail_default);
+    }
+
+    #[test]
+    fn product_gate_distinguishes_shared_logic_evidence() {
+        for (evidence, tier, taxonomy, eligible, fail_default) in [
+            (
+                SharedLogicEvidence::Touched,
+                DivergenceTier::Strict,
+                "missed_propagation",
+                true,
+                true,
+            ),
+            (
+                SharedLogicEvidence::NotTouched,
+                DivergenceTier::Review,
+                "no_propagation_needed",
+                true,
+                false,
+            ),
+            (
+                SharedLogicEvidence::Unproven,
+                DivergenceTier::Review,
+                "unclear",
+                true,
+                false,
+            ),
+        ] {
+            let decision = decide(
+                DivergenceLane::BaseDivergence,
+                DivergenceScope::Production,
+                evidence,
+            );
+            assert_eq!(decision.tier, tier);
+            assert_eq!(decision.taxonomy_hint, taxonomy);
+            assert_eq!(decision.gate.eligible, eligible);
+            assert_eq!(decision.gate.fail_default, fail_default);
+            assert_eq!(decision.gate.policy, DIVERGENT_EDIT_V2_POLICY);
+        }
+    }
+}

--- a/crates/nose-detect/src/lib.rs
+++ b/crates/nose-detect/src/lib.rs
@@ -13,6 +13,7 @@ mod cluster;
 mod connected;
 mod contiguous;
 mod detectors;
+mod divergence_policy;
 mod exact_policy;
 mod fragment;
 mod il_utils;
@@ -36,6 +37,11 @@ pub(crate) use detectors::env_or;
 pub use detectors::{
     exact_safe_roots_by_span, CopyPasteDetector, Detector, ExactBehaviorDetector,
     StructuralDetector,
+};
+pub use divergence_policy::{
+    divergence_policy, DivergenceGateDecision, DivergenceLane, DivergencePolicyDecision,
+    DivergencePolicyInput, DivergenceScope, DivergenceTier, SharedLogicEvidence,
+    DIVERGENT_EDIT_V2_POLICY,
 };
 pub use exact_policy::{exact_claim_eligible, exact_claim_eligible_parts};
 pub use fragment::{

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ A Cargo workspace; data flows left-to-right through them.
 | `nose-semantics` | builtin semantic facade: language profiles, evidence/source-fact helpers, type-domain contracts, effect/operator/module/stdlib predicates, API contracts, and exact-channel proof obligations |
 | `nose-frontend` | tree-sitter parse + per-language CST→IL lowering and builtin evidence emission (one module tree per language, incl. declarative CSS/HTML; `<script>`/`<style>`/markup region extraction for Vue/Svelte/HTML) |
 | `nose-normalize` | the normalization passes, inferred immutable binding-domain evidence, and the value graph (GVN) |
-| `nose-detect` | unit/feature extraction, exact-fragment extraction, strict exact-safety gates, MinHash/LSH, scoring, clustering, test/generated scope tagging, refactor ranking, and query-surface policy |
+| `nose-detect` | unit/feature extraction, exact-fragment extraction, strict exact-safety gates, MinHash/LSH, scoring, clustering, test/generated scope tagging, refactor ranking, and query-surface policy, including the divergent-edit decision policy |
 | `nose-eval` | benchmark scoring (precision/recall, pooled, stratified) — see [benchmark](benchmark.md) |
 | `nose-markdown` | self-contained same-language Markdown prose near-duplicate domain (char-n-gram MinHash-LSH + winnowing + containment → TF-IDF rank → span witness), distinct from the value-graph code engine — see [markdown-duplication](markdown-duplication.md) |
 | `nose-cli` | the `nose` binary and process boundary: argument models, command dispatch, config/cache/baseline plumbing, query dashboard/JSON/open views, verify/oracle reporting, recall-loss reports, and local diagnostics |

--- a/docs/development-and-evidence.md
+++ b/docs/development-and-evidence.md
@@ -17,6 +17,7 @@ specific decision or measurement, not a user-facing feature contract.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [refactoring-ratchets](refactoring-ratchets.md) — repository quality ratchets for incremental design cleanup, including Rust file-length and the CLI prelude guard.
 - [repository gate inventory](repository-gates.md) — authoritative named-gate ownership, lane selection, worktree effects, and timing protocol.
+- [test ownership: divergent-edit policy](test-ownership-963.md) — #963's CLI test inventory, bounded pure-policy move, preserved process/output contracts, and honest compile/link timing.
 - [evidence artifact lifecycle](evidence-artifact-lifecycle.md) — lifecycle classes, exact inventory drift checks, receipt/seal/baseline bindings, and conservative retention policy.
 - [semantic-regression-smoke](semantic-regression-smoke.md) — base/head semantic output and runtime tripwire, exact intentional-drift declarations, focused reruns, and pinned evidence.
 

--- a/docs/refactoring-ratchets.md
+++ b/docs/refactoring-ratchets.md
@@ -75,8 +75,10 @@ and behavior easier to reason about:
 - keep the `nose-cli` crate root free of ambient helper imports. The legacy
   compatibility prelude has been retired; new module dependencies should name
   their actual owner with `crate::<module>::...`;
-- keep divergent-edit review split by adapter boundary; detection policy,
-  git/worktree diff plumbing, output formats, and tests now live under
+- keep divergent-edit review split by adapter boundary: normalized
+  evidence-to-tier/taxonomy/gate policy lives in
+  `nose-detect/src/divergence_policy.rs`; finding projection, Git/worktree diff
+  plumbing, output formats, and public-contract tests stay under
   `nose-cli/src/divergence/`, with the `base=<ref>` query adapter in
   `nose-cli/src/{query_commands,query_views}.rs`;
 - keep `nose-il` roots as API indexes; units/domains/evidence facets, the arena

--- a/docs/test-ownership-963.md
+++ b/docs/test-ownership-963.md
@@ -1,0 +1,73 @@
+# Test ownership: divergent-edit policy
+
+Issue [#963](https://github.com/corca-ai/nose/issues/963) uses one bounded
+tranche to establish the test-ownership rule without turning test count into a
+target. The selected cohort is divergent-edit tiering: given normalized lane,
+scope, and shared-logic evidence, decide the tier, taxonomy, reason codes, and
+default CI gate behavior.
+
+## Inventory
+
+The issue-opening Cargo inventory reported 2,208 Rust tests, 996 under
+`nose-cli`. A whitespace-aware static `#[test]` scan at the start of this
+tranche found 272 inline tests under `nose-cli/src` and 724 integration-test
+declarations under `nose-cli/tests`. The static counts are an ownership aid
+rather than an alternative test-count metric.
+
+| Responsibility | Representative current locations | Owner and intended layer |
+|---|---|---|
+| pure policy | query option/settings decisions, cache invalidation decisions, divergent-edit tiering | the smallest deterministic module that owns the vocabulary; no filesystem, process, renderer, or broad mock setup |
+| analysis integration | `tests/equivalence/`, `tests/detection.rs`, `tests/connected_witness.rs`, inline query/detection tests | the crate that composes the real frontend, normalization, detection, and query collaborators |
+| filesystem/process boundary | `tests/cli/cache/`, `tests/cli/watch.rs`, `tests/robustness.rs`, command/config fixtures | `nose-cli` integration tests using temporary repositories and the real binary |
+| public output contract | query JSON/SARIF/baseline tests, mode/config precedence, representative user workflows | a bounded `nose-cli` unit or process test that observes exit status and versioned output rather than private calls |
+
+The divergent-edit cohort now has these explicit owners:
+
+| Surface | Owner | Preserved evidence |
+|---|---|---|
+| lane/scope/shared-evidence → tier, taxonomy, reasons, and gate | `nose-detect::divergence_policy` | four deterministic owner tests cover new-copy, unproven product evidence, test/mixed scope, and all product gate outcomes |
+| detection/CLI evidence projection | `nose-cli::divergence::Divergence::policy_decision` | a focused adapter test fixes scope normalization and `Touched > NotTouched > Unproven`; the real adapter has no I/O or second policy table |
+| closed schema and JSON/SARIF agreement | `nose-cli::divergence::tests` | the closed v8 enums and shared JSON/SARIF policy fields remain checked |
+| binary, Git, exit, and output behavior | `nose-cli/tests/cli/query_base/tier_policy.rs` | mixed/test report-only, exact strict, semantic witness, varying-spot review, shared-logic strict, SARIF, and `--fail` behavior remain end to end |
+
+No production input, schema field, reason string, tier, taxonomy, or gate rule
+changed. The former CLI policy examples moved to the owner tests; the broad
+adapter-call equivalence test was removed because the JSON/SARIF and process
+contracts observe the same behavior without asserting private delegation.
+
+## Local timing and diagnostics
+
+Measurements used the repository debug profile on the same Apple Silicon host
+with dependencies already present. Immediately before each focused command,
+the owning production source file was touched so Cargo had to rebuild and link
+the affected test target. Test bodies themselves completed in `0.00s`.
+
+| Layout | Focused command | Cargo compile/link | Wall | Test executable |
+|---|---|---:|---:|---:|
+| before: policy inside the CLI finding model | `cargo test -p nose-cli --lib divergence::tests::v2_ -- --nocapture` | 16.39s | 121.09s | 56 MiB |
+| rejected candidate: isolated `nose-eval` policy target | `cargo test -p nose-eval --test divergence_policy -- --nocapture` | 60.00s | 130.05s | 1 MiB |
+| selected: cohesive `nose-detect` owner target | `cargo test -p nose-detect divergence_policy -- --nocapture` | 47.12s | 144.88s | 33 MiB |
+
+The local wall-time objective did not improve: this host spent most of each run
+before the new test executable entered `main`, and the smaller target did not
+offset that launch cost. This tranche therefore makes no local-speed claim.
+What improved is failure ownership and target scope: a policy regression now
+names one of four evidence-to-decision behaviors in the cohesive detector owner
+instead of starting from the 272-test pre-move CLI unit binary. The smaller
+`nose-eval` candidate was rejected because benchmark evaluation does not own
+query-surface product policy. Hosted workspace compile/test timings are recorded
+on the pull request and must remain green; a future tranche should be accepted
+for speed only with a repeatable hosted or local win.
+
+## Rules for later tranches
+
+- Move a cohort only when its input and observable result can be named without
+  CLI argument, filesystem, process, or renderer state.
+- Keep at least one real-binary test for every touched precedence, exit-status,
+  JSON, SARIF, baseline, or cache-correctness contract.
+- Prefer an existing cohesive owner. Do not create a crate merely to obtain a
+  smaller test binary.
+- Record compile/link and execution evidence before and after. A test-count
+  decrease is neither required nor sufficient.
+- Treat cache, determinism, soundness, and schema changes as product changes;
+  they do not belong in a relocation-only tranche.

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -188,7 +188,7 @@
       "consumers": ["Type-4 frontier, query-regression, and adversarial gates"],
       "retention_policy": "Preserve current gold/frontier inputs and any sealed or closeout evidence.",
       "artifact_count": 29,
-      "inventory_sha256": "f077ca1074ba0acde3568c4fc934130503bfa0a8f9a15993fdd25554305d6db9"
+      "inventory_sha256": "e0d4fe960a83e79215bb96d35be4ce99fea27032a1b95a1b3427713b59294f7d"
     },
     {
       "id": "documentation-examples",


### PR DESCRIPTION
## Summary
- move divergent-edit tier, taxonomy, reason, and gate decisions into a pure `nose-detect` policy owner
- keep raw finding projection plus JSON/SARIF/Git/process behavior in `nose-cli`
- replace duplicated CLI policy examples with four owner tests and one focused adapter-normalization contract
- document the CLI test inventory, ownership rule, and measured local compile/link results without claiming a speedup

## Independent review round
Two parallel reviewers examined the completed tranche once. Incorporated findings:
- selected `nose-detect`, the existing query-surface policy owner, instead of broadening benchmark-only `nose-eval`
- kept lane/SARIF wire mappings in the CLI output adapter
- removed contradictory independent `fire_eligible` and shared-logic policy inputs
- added the CLI scope/site-evidence normalization matrix and corrected the inventory to 272 inline + 724 integration tests

## Measurements
| layout | compile/link | wall | executable |
|---|---:|---:|---:|
| before CLI owner | 16.39s | 121.09s | 56 MiB |
| rejected `nose-eval` candidate | 60.00s | 130.05s | 1 MiB |
| selected `nose-detect` owner | 47.12s | 144.88s | 33 MiB |

The local wall objective did not improve because executable startup dominated on this host. The gain is cohesive ownership and a narrower failure target; hosted timing will be recorded after CI.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nose-detect divergence_policy -- --nocapture`
- `cargo test -p nose-cli --lib divergence::tests:: -- --nocapture`
- `cargo test -p nose-cli --test cli query_base::tier_policy -- --nocapture`
- `cargo clippy -p nose-detect -p nose-cli --all-targets -- -D warnings`
- docs, file-length, duplication, and coverage gates
- release build, product query schema, semantic-pack examples, Type-4 executable, and axis-language gates

Closes #963