### PR TITLE
ci: pin and audit auxiliary development tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,12 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Resolve pinned shell tools
+        id: shell-tools
+        run: python3 scripts/aux_tools.py ci-spec shell-lint --github-output "$GITHUB_OUTPUT"
+      - uses: taiki-e/install-action@v2.85.4
+        with:
+          tool: ${{ steps.shell-tools.outputs.tools }}
       - name: gate · change-routing-selftest
         run: ./scripts/check-ci-local.sh --gate change-routing-selftest
       - name: gate · corpus-prune-selftest
@@ -100,13 +106,12 @@ jobs:
         run: ./scripts/check-ci-local.sh --gate accepted-pair-coverage
       - name: gate · cargo-target-prune-selftest
         run: ./scripts/check-ci-local.sh --gate cargo-target-prune-selftest
+      - name: gate · aux-tool-policy
+        run: ./scripts/check-ci-local.sh --gate aux-tool-policy
+      - name: Diagnose pinned shell tools
+        run: python3 scripts/aux_tools.py doctor --only shellcheck
       - name: gate · shell-lint
-        run: |
-          if ! command -v shellcheck >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y shellcheck
-          fi
-          ./scripts/check-ci-local.sh --gate shell-lint
+        run: ./scripts/check-ci-local.sh --gate shell-lint
       - name: gate · format
         run: ./scripts/check-ci-local.sh --gate format
       - name: gate · file-length
@@ -305,10 +310,15 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      # Prebuilt binary — no compile cost.
-      - uses: taiki-e/install-action@v2
+      - name: Resolve pinned coverage tools
+        id: coverage-tools
+        run: python3 scripts/aux_tools.py ci-spec coverage --github-output "$GITHUB_OUTPUT"
+      # Prebuilt, exact-version binary — no compile cost or moving setup state.
+      - uses: taiki-e/install-action@v2.85.4
         with:
-          tool: cargo-llvm-cov
+          tool: ${{ steps.coverage-tools.outputs.tools }}
+      - name: Diagnose pinned coverage tools
+        run: python3 scripts/aux_tools.py doctor --only cargo-llvm-cov
       # Line-coverage ratchet. The bar starts lenient; raise the shared
       # threshold over time as coverage improves.
       - name: gate · coverage
@@ -337,10 +347,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      # Prebuilt binaries — no compile cost.
-      - uses: taiki-e/install-action@v2
+      - name: Resolve pinned supply-chain tools
+        id: supply-chain-tools
+        run: python3 scripts/aux_tools.py ci-spec supply-chain --github-output "$GITHUB_OUTPUT"
+      # Prebuilt, exact-version binaries — no compile cost or moving setup state.
+      - uses: taiki-e/install-action@v2.85.4
         with:
-          tool: cargo-machete,cargo-deny
+          tool: ${{ steps.supply-chain-tools.outputs.tools }}
+      - name: Diagnose pinned supply-chain tools
+        run: python3 scripts/aux_tools.py doctor --only cargo-machete,cargo-deny
       - name: gate · supply-chain
         run: ./scripts/check-ci-local.sh --gate supply-chain
 
@@ -349,13 +364,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version: stable
-          cache: false
-      # awiki lints the docs/ wiki: fails on orphan pages or disconnected islands.
-      - name: install awiki
-        run: go install github.com/corca-ai/awiki/cmd/awiki@v0.1.4
+      - name: Install pinned awiki
+        run: |
+          ./scripts/bootstrap-tools.sh --only awiki --bin-dir "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Diagnose pinned awiki
+        run: python3 scripts/aux_tools.py doctor --only awiki
       - name: gate · docs
         run: ./scripts/check-ci-local.sh --gate docs
 
@@ -367,12 +381,14 @@ jobs:
       # The formal obligation registry maps proof-sensitive semantic surfaces to Lean
       # proof files and counterexamples. Shared Lean models are compiled under target/lean;
       # each proof must type-check with warnings promoted to errors. See formal/README.md.
-      - name: install elan (lean toolchain)
+      - name: Install pinned elan and Lean toolchain
         run: |
+          ./scripts/bootstrap-tools.sh --only elan --bin-dir "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           toolchain="$(cat lean-toolchain)"
-          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain "$toolchain"
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/elan" toolchain install "$toolchain"
+      - name: Diagnose pinned elan
+        run: python3 scripts/aux_tools.py doctor --only elan
       - name: gate · formal-obligations
         run: ./scripts/check-ci-local.sh --gate formal-obligations
       - name: gate · formal-lean

--- a/.github/workflows/corpus-verify.yml
+++ b/.github/workflows/corpus-verify.yml
@@ -25,10 +25,13 @@ on:
       - "scripts/check-formal-obligations.py"
       - "scripts/check-lean-proofs.sh"
       - "scripts/check-soundness-scorecard.py"
+      - "scripts/aux_tools.py"
+      - "scripts/bootstrap-tools.sh"
       - "scripts/corpus-verify-nightly.sh"
       - "scripts/formal_claim_schema.py"
       - "scripts/soundness-lab-gate.py"
       - "scripts/soundness_exclusions.py"
+      - "tools/auxiliary-tools.json"
   schedule:
     # Full pinned corpus every night; deeper independent campaigns every Sunday.
     - cron: "17 18 * * *"
@@ -77,14 +80,15 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: install Lean
+      - name: install pinned elan and Lean
         id: lean
         continue-on-error: true
         run: |
+          ./scripts/bootstrap-tools.sh --only elan --bin-dir "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           toolchain="$(cat lean-toolchain)"
-          curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain "$toolchain"
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/elan" toolchain install "$toolchain"
+          PATH="$HOME/.local/bin:$PATH" python3 scripts/aux_tools.py doctor --only elan
       - name: index touched claims
         id: plan
         if: ${{ failure() || success() }}

--- a/.github/workflows/tool-updates.yml
+++ b/.github/workflows/tool-updates.yml
@@ -1,0 +1,79 @@
+name: Auxiliary tool updates
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/tool-updates.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/corpus-verify.yml"
+      - "scripts/aux_tools.py"
+      - "scripts/bootstrap-tools.sh"
+      - "tools/auxiliary-tools.json"
+  schedule:
+    - cron: "31 16 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap-smoke:
+    name: bootstrap smoke · ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install and diagnose pinned release tools
+        run: |
+          bin_dir="$RUNNER_TEMP/nose-aux-bin"
+          ./scripts/bootstrap-tools.sh --only awiki,elan,shellcheck --bin-dir "$bin_dir"
+          PATH="$bin_dir:$PATH" \
+            python3 scripts/aux_tools.py doctor --only awiki,elan,shellcheck
+          ./scripts/bootstrap-tools.sh --only awiki,elan,shellcheck --bin-dir "$bin_dir"
+      - name: Exercise every supported asset plan
+        run: |
+          for target in \
+            darwin-aarch64 darwin-x86_64 linux-aarch64 linux-x86_64; do
+            ./scripts/bootstrap-tools.sh \
+              --only awiki,elan,shellcheck \
+              --dry-run \
+              --platform "$target" \
+              --bin-dir "$RUNNER_TEMP/dry-$target"
+          done
+
+  check:
+    name: compare checked auxiliary-tool pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Validate checked policy
+        run: |
+          python3 scripts/aux_tools.py selftest
+          python3 scripts/aux_tools.py check-policy
+      - name: Report upstream versions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p target/aux-tool-updates
+          update_status=0
+          python3 scripts/aux_tools.py check-updates \
+            --markdown \
+            --fail-on-update \
+            > target/aux-tool-updates/report.md || update_status=$?
+          cat target/aux-tool-updates/report.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$update_status"
+      - name: Upload update report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: auxiliary-tool-updates-${{ github.run_id }}
+          path: target/aux-tool-updates/report.md
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ break.
 ## [Unreleased]
 
 ### Changed
+- Centralized auxiliary development-tool versions and checksummed
+  macOS/Linux assets in one checked policy, with a read-only doctor, explicit
+  idempotent bootstrap, exact hosted CI consumption, drift self-tests, and
+  scheduled upstream-update reporting.
 - Added a checked documentation lifecycle catalog and freshness gate for every
   wiki page, with explicit current-guide, maintained-reference, decision,
   active-roadmap, and historical-record routing. Current guidance now stays on

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,7 +57,7 @@ a hand-maintained table here so the contributor guide cannot silently diverge
 from executable policy.
 
 The dev/CI Rust toolchain is pinned in `rust-toolchain.toml` (rustup installs it
-automatically). Repository evidence tools require Python 3.10 or newer; the
+automatically). Repository evidence tools require Python 3.10.0 or newer; the
 local gate checks this before dispatch because several validators rely on
 equal-length `zip(..., strict=True)` invariants. The **MSRV** (`rust-version`,
 currently 1.85) is deliberately older and checked by its own CI job. Bumping
@@ -107,20 +107,28 @@ can distinguish expected semantic expansion cost from accidental degradation.
 
 ### One-time tool install
 
-Python 3.10 or newer, `cargo-machete`, `cargo-deny`, `cargo-llvm-cov`, `shellcheck`,
+Python 3.10.0 or newer, Node.js, `cargo-machete`, `cargo-deny`,
+`cargo-llvm-cov`, `shellcheck`,
 [`awiki`](https://github.com/corca-ai/awiki), `elan`, and the MSRV Rust
 toolchain are required for `--full`. `--fast` requires the Rust toolchain plus
-Python 3.10 or newer, `awiki`, and `shellcheck`. Install the local CI tools with:
+Python 3.10.0 or newer, Node.js, `awiki`, and `shellcheck`.
+
+First diagnose the complete environment without changing it:
 
 ```sh
-cargo install cargo-machete cargo-deny cargo-llvm-cov
-rustup component add llvm-tools-preview   # cargo-llvm-cov needs this
-brew install python@3.14
-brew install shellcheck
-brew install corca-ai/tap/awiki   # or: go install github.com/corca-ai/awiki/cmd/awiki@latest
-curl -sSfL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh
-rustup toolchain install 1.85
+./scripts/aux_tools.py doctor
 ```
+
+Install only the checked versions with the explicit, idempotent bootstrap:
+
+```sh
+./scripts/bootstrap-tools.sh --with-toolchains
+```
+
+It never runs from an ordinary quality gate and never edits shell
+configuration. The checked pins, focused installs, dry runs, platform support,
+and update procedure are owned by the [auxiliary development tools
+guide](tooling.md).
 
 ### Git hooks
 

--- a/docs/development-and-evidence.md
+++ b/docs/development-and-evidence.md
@@ -18,6 +18,9 @@ classification, ownership, and freshness policy for every wiki page.
 - [normalization](normalization.md) — the passes that make behaviorally-equivalent code converge (the hard part).
 - [refactoring-ratchets](refactoring-ratchets.md) — repository quality ratchets for incremental design cleanup, including Rust file-length and the CLI prelude guard.
 - [repository gate inventory](repository-gates.md) — authoritative named-gate ownership, lane selection, worktree effects, and timing protocol.
+- [auxiliary development tools](tooling.md) — checked non-workspace tool pins,
+  read-only diagnosis, explicit bootstrap, hosted consumption, and update
+  procedure.
 - [evidence artifact lifecycle](evidence-artifact-lifecycle.md) — lifecycle classes, exact inventory drift checks, receipt/seal/baseline bindings, and conservative retention policy.
 - [semantic-regression-smoke](semantic-regression-smoke.md) — base/head semantic output and runtime tripwire, exact intentional-drift declarations, focused reruns, and pinned evidence.
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -67,6 +67,8 @@ Human-readable output is for interactive use. Integrations should inspect
 These pages are not required reading for users:
 
 - [Contributing](contributing.md) — development workflow and quality gates.
+- [Auxiliary development tools](tooling.md) — checked local/CI tool versions,
+  diagnostics, and explicit bootstrap.
 - [Architecture](architecture.md) — crates and the analysis pipeline.
 - [Design and direction](design.md) — product principles and roadmap decisions.
 - [Development and evidence index](development-and-evidence.md) — internal

--- a/docs/lifecycle.json
+++ b/docs/lifecycle.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "inventory": {
     "glob": "**/*.md",
-    "sha256": "1a54d4df4ae6e5db145cf33476bf9c9c3157af1513d97bc9dbb14b1fbacf4ba0"
+    "sha256": "e83e6c0dbac9b4f20cb86b7e79d126c37389cf1c079390a96102a4aedcd1093c"
   },
   "default": {
     "kind": "reference",
@@ -55,6 +55,7 @@
         "refactoring-ratchets.md",
         "repository-gates.md",
         "runtime-triage.md",
+        "tooling.md",
         "type4-semantic-pattern-loop.md"
       ]
     },

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,130 @@
+# Auxiliary development tools
+
+The checked [`tools/auxiliary-tools.json`](../tools/auxiliary-tools.json)
+manifest is the single policy authority for development tools that are not
+ordinary Cargo workspace dependencies. It owns the Python floor, exact `awiki`,
+ShellCheck, `cargo-deny`, `cargo-machete`, `cargo-llvm-cov`, and `elan` pins,
+the hosted prebuilt-binary installer ref, and checksummed macOS/Linux release
+assets. It also inventories unpinned host prerequisites such as Node.js; those
+must be present but are not installed or version-pinned by this repository.
+
+Rust development, MSRV, and Lean toolchain versions remain in their native
+owners: [`rust-toolchain.toml`](../rust-toolchain.toml),
+[`Cargo.toml`](../Cargo.toml), and [`lean-toolchain`](../lean-toolchain).
+The tooling commands read those files directly rather than copying their
+versions into another policy file.
+
+## Diagnose without changing the machine
+
+Run the fast, read-only doctor before a full local gate:
+
+```sh
+./scripts/aux_tools.py doctor
+./scripts/aux_tools.py doctor --json
+./scripts/aux_tools.py doctor --only awiki,shellcheck
+```
+
+The complete doctor checks command availability, exact auxiliary versions,
+Python's minimum version, and the presence of the checked Rust development,
+Rust MSRV, and Lean toolchains. A focused `--only` check probes just the named
+auxiliary binaries. It executes version/list queries with short timeouts; it
+does not access the network, install a package, edit a configuration file, or
+download a toolchain.
+
+To inspect the current pins without maintaining a second table:
+
+```sh
+./scripts/aux_tools.py list
+```
+
+`missing`, `too-old`, `mismatch`, `unrecognized`, and `probe-error` are
+diagnostic failures. Each failed auxiliary row points to the focused bootstrap
+command that repairs it.
+
+## Install only by explicit request
+
+The separate bootstrap command is the only repository-owned installation
+surface:
+
+```sh
+./scripts/bootstrap-tools.sh
+./scripts/bootstrap-tools.sh --only cargo-deny,awiki
+./scripts/bootstrap-tools.sh --with-toolchains
+./scripts/bootstrap-tools.sh --dry-run --platform linux-x86_64
+```
+
+It is idempotent: a binary at the checked version is skipped. Release binaries
+are selected by OS and architecture, downloaded from a version-bound HTTPS
+asset, verified against the checked SHA-256 digest, safely extracted, and
+atomically written. Cargo tools are built with the checked development Rust
+toolchain, `--locked`, and an exact package version. The default destination is
+`~/.local/bin`; use `--bin-dir` to choose another directory.
+
+Bootstrap never edits shell startup files, Cargo configuration, Git
+configuration, or unrelated files in the destination. If the destination is
+not already on `PATH`, it prints the required follow-up instead. On macOS or
+apt-based Linux, the shell wrapper can first obtain a supported Python when
+Python 3.10.0 or newer is absent; other hosts receive a prerequisite diagnostic.
+Node.js, `cargo`, `rustup`, and the host package manager remain explicit
+prerequisites when their corresponding path is needed.
+
+`--with-toolchains` additionally installs the versions named by the three
+native toolchain owners. Without that option, bootstrap changes auxiliary
+binaries only. The ordinary `--fast`, `--full`, and named gate commands never
+invoke bootstrap.
+
+## Hosted CI contract
+
+Hosted coverage, shell-lint, and supply-chain jobs ask
+`scripts/aux_tools.py ci-spec <group>` for their exact `tool@version` inputs.
+The action ref itself is exact and checked against the same manifest. Docs and
+formal jobs call the explicit bootstrap for their one release-archive tool,
+then run a focused doctor before the ordinary named gate. The Soundness Lab
+uses the same pinned `elan` path.
+
+`./scripts/check-ci-local.sh --gate aux-tool-policy` runs isolated
+missing/mismatch/acceptable-version tests, validates every supported
+macOS/Linux asset mapping, and rejects drift or moving setup references across
+the manifest, workflows, bootstrap, and contributor docs. It is a read-only
+fast/full/hosted gate.
+
+## Updating a pin
+
+The `Auxiliary tool updates` workflow runs Linux/macOS release-archive bootstrap
+smokes on relevant pull requests and every week. It also runs the
+network-read-only command:
+
+```sh
+./scripts/aux_tools.py check-updates
+```
+
+It reports upstream releases and fails visibly when a newer version is
+available; it does not modify the repository. Dependabot separately proposes
+GitHub Action ref updates. A maintainer reviews compatibility and makes the
+coherent policy change:
+
+1. Update the version once in `tools/auxiliary-tools.json`.
+2. For a release archive, replace every platform URL and SHA-256 digest with
+   the new official assets. For the hosted installer, update its exact
+   manifest ref and all three exact workflow refs together.
+3. Run the self-test, policy check, and all platform dry runs:
+
+   ```sh
+   ./scripts/aux_tools.py selftest
+   ./scripts/aux_tools.py check-policy
+   ./scripts/aux_tools.py bootstrap --dry-run --platform darwin-aarch64
+   ./scripts/aux_tools.py bootstrap --dry-run --platform darwin-x86_64
+   ./scripts/aux_tools.py bootstrap --dry-run --platform linux-aarch64
+   ./scripts/aux_tools.py bootstrap --dry-run --platform linux-x86_64
+   ```
+
+4. Bootstrap the changed tool on a supported host, run its focused doctor, and
+   run the gates that consume it before the full repository gate.
+
+Setup paths must not substitute a moving tag or an unversioned direct install.
+If an upstream no longer publishes one supported asset, keep the old checked
+pin until the platform policy is deliberately changed and reviewed.
+
+Return to the [contributor workflow](contributing.md) for the normal local
+sequence. The [repository gate inventory](repository-gates.md) explains how the
+policy check participates in every lane.

--- a/scripts/aux_tools.py
+++ b/scripts/aux_tools.py
@@ -1,0 +1,1238 @@
+#!/usr/bin/env python3
+"""Pinned auxiliary-tool policy, diagnostics, bootstrap, and update checks."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, NoReturn
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "tools" / "auxiliary-tools.json"
+SCHEMA = "nose.auxiliary-tools.v1"
+SUPPORTED_PLATFORMS = {
+    ("darwin", "aarch64"): "darwin-aarch64",
+    ("darwin", "arm64"): "darwin-aarch64",
+    ("darwin", "x86_64"): "darwin-x86_64",
+    ("linux", "aarch64"): "linux-aarch64",
+    ("linux", "arm64"): "linux-aarch64",
+    ("linux", "x86_64"): "linux-x86_64",
+    ("linux", "amd64"): "linux-x86_64",
+}
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMAND_TIMEOUT_SECONDS = 5
+INSTALL_VERIFY_TIMEOUT_SECONDS = 30
+
+
+class PolicyError(ValueError):
+    """Raised when the checked auxiliary-tool policy is malformed or drifts."""
+
+
+def fail(message: str, status: int = 2) -> NoReturn:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(status)
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PolicyError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+        )
+    except (OSError, json.JSONDecodeError, PolicyError) as error:
+        raise PolicyError(f"cannot load {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise PolicyError(f"{path} root must be an object")
+    return value
+
+
+def require_object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PolicyError(f"{context} must be an object")
+    return value
+
+
+def require_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise PolicyError(f"{context} must be a non-empty string")
+    return value
+
+
+def require_string_list(value: Any, context: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise PolicyError(f"{context} must be a non-empty list")
+    for index, item in enumerate(value):
+        require_string(item, f"{context}[{index}]")
+    return value
+
+
+def require_keys(
+    value: dict[str, Any],
+    required: set[str],
+    allowed: set[str],
+    context: str,
+) -> None:
+    missing = sorted(required - value.keys())
+    unknown = sorted(value.keys() - allowed)
+    if missing:
+        raise PolicyError(f"{context} is missing fields: {', '.join(missing)}")
+    if unknown:
+        raise PolicyError(f"{context} has unknown fields: {', '.join(unknown)}")
+
+
+def version_tuple(value: str) -> tuple[int, int, int]:
+    if not VERSION_RE.fullmatch(value):
+        raise PolicyError(f"version must be X.Y.Z: {value!r}")
+    return tuple(int(part) for part in value.split("."))  # type: ignore[return-value]
+
+
+def validate_manifest(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    require_keys(
+        manifest,
+        {"schema", "python", "required_commands", "ci_installer", "ci_groups", "tools"},
+        {"schema", "python", "required_commands", "ci_installer", "ci_groups", "tools"},
+        "manifest",
+    )
+    if manifest["schema"] != SCHEMA:
+        raise PolicyError(f"manifest schema must be {SCHEMA!r}")
+
+    python_policy = require_object(manifest["python"], "python")
+    require_keys(
+        python_policy,
+        {"command", "minimum", "version_args", "version_pattern"},
+        {"command", "minimum", "version_args", "version_pattern"},
+        "python",
+    )
+    require_string(python_policy["command"], "python.command")
+    version_tuple(require_string(python_policy["minimum"], "python.minimum"))
+    require_string_list(python_policy["version_args"], "python.version_args")
+    try:
+        re.compile(require_string(python_policy["version_pattern"], "python.version_pattern"))
+    except re.error as error:
+        raise PolicyError(f"python.version_pattern is invalid: {error}") from error
+
+    required_commands = manifest["required_commands"]
+    if not isinstance(required_commands, list) or not required_commands:
+        raise PolicyError("required_commands must be a non-empty list")
+    required_names: set[str] = set()
+    for index, item in enumerate(required_commands):
+        command = require_object(item, f"required_commands[{index}]")
+        require_keys(
+            command,
+            {"command", "purpose"},
+            {"command", "purpose"},
+            f"required_commands[{index}]",
+        )
+        name = require_string(command["command"], f"required_commands[{index}].command")
+        require_string(command["purpose"], f"required_commands[{index}].purpose")
+        if name in required_names:
+            raise PolicyError(f"duplicate required command: {name}")
+        required_names.add(name)
+    expected_required_commands = {"cargo", "git", "node", "rustup"}
+    if required_names != expected_required_commands:
+        raise PolicyError(
+            "required_commands must cover exactly the external full-gate commands: "
+            + ", ".join(sorted(expected_required_commands))
+        )
+
+    installer = require_object(manifest["ci_installer"], "ci_installer")
+    require_keys(
+        installer,
+        {"repository", "version", "ref"},
+        {"repository", "version", "ref"},
+        "ci_installer",
+    )
+    repository = require_string(installer["repository"], "ci_installer.repository")
+    installer_version = require_string(installer["version"], "ci_installer.version")
+    version_tuple(installer_version)
+    if installer["ref"] != f"v{installer_version}":
+        raise PolicyError("ci_installer.ref must be v + ci_installer.version")
+    if repository != "taiki-e/install-action":
+        raise PolicyError("ci_installer.repository must remain taiki-e/install-action")
+
+    tools = manifest["tools"]
+    if not isinstance(tools, list) or not tools:
+        raise PolicyError("tools must be a non-empty list")
+    tools_by_id: dict[str, dict[str, Any]] = {}
+    commands: set[str] = set()
+    for index, value in enumerate(tools):
+        context = f"tools[{index}]"
+        tool = require_object(value, context)
+        require_keys(
+            tool,
+            {
+                "id",
+                "command",
+                "version",
+                "policy",
+                "version_args",
+                "version_pattern",
+                "install",
+                "update",
+            },
+            {
+                "id",
+                "command",
+                "version",
+                "policy",
+                "version_args",
+                "version_pattern",
+                "install",
+                "update",
+            },
+            context,
+        )
+        tool_id = require_string(tool["id"], f"{context}.id")
+        command = require_string(tool["command"], f"{context}.command")
+        version = require_string(tool["version"], f"{context}.version")
+        version_tuple(version)
+        if tool["policy"] != "exact":
+            raise PolicyError(f"{context}.policy must be 'exact'")
+        require_string_list(tool["version_args"], f"{context}.version_args")
+        try:
+            pattern = re.compile(
+                require_string(tool["version_pattern"], f"{context}.version_pattern")
+            )
+        except re.error as error:
+            raise PolicyError(f"{context}.version_pattern is invalid: {error}") from error
+        if pattern.groups != 1:
+            raise PolicyError(f"{context}.version_pattern must have exactly one capture")
+        if tool_id in tools_by_id:
+            raise PolicyError(f"duplicate tool id: {tool_id}")
+        if command in commands:
+            raise PolicyError(f"duplicate tool command: {command}")
+        tools_by_id[tool_id] = tool
+        commands.add(command)
+
+        install = require_object(tool["install"], f"{context}.install")
+        kind = install.get("kind")
+        if kind == "cargo":
+            require_keys(
+                install,
+                {"kind", "package", "ci_name"},
+                {"kind", "package", "ci_name", "rust_component"},
+                f"{context}.install",
+            )
+            require_string(install["package"], f"{context}.install.package")
+            require_string(install["ci_name"], f"{context}.install.ci_name")
+            if "rust_component" in install:
+                require_string(
+                    install["rust_component"],
+                    f"{context}.install.rust_component",
+                )
+        elif kind == "release-archive":
+            require_keys(
+                install,
+                {"kind", "archive_binary", "install_name", "assets"},
+                {"kind", "archive_binary", "install_name", "assets"},
+                f"{context}.install",
+            )
+            require_string(install["archive_binary"], f"{context}.install.archive_binary")
+            if install["install_name"] != command:
+                raise PolicyError(f"{context}.install_name must equal command")
+            assets = require_object(install["assets"], f"{context}.install.assets")
+            if set(assets) != set(SUPPORTED_PLATFORMS.values()):
+                raise PolicyError(
+                    f"{context}.install.assets must cover exactly "
+                    + ", ".join(sorted(set(SUPPORTED_PLATFORMS.values())))
+                )
+            for platform_id, asset_value in assets.items():
+                asset = require_object(asset_value, f"{context}.assets.{platform_id}")
+                require_keys(
+                    asset,
+                    {"url", "sha256"},
+                    {"url", "sha256"},
+                    f"{context}.assets.{platform_id}",
+                )
+                url = require_string(asset["url"], f"{context}.assets.{platform_id}.url")
+                checksum = require_string(
+                    asset["sha256"], f"{context}.assets.{platform_id}.sha256"
+                )
+                if not url.startswith("https://") or f"/v{version}/" not in url:
+                    raise PolicyError(
+                        f"{context}.assets.{platform_id}.url must be HTTPS and version-bound"
+                    )
+                if not SHA256_RE.fullmatch(checksum):
+                    raise PolicyError(
+                        f"{context}.assets.{platform_id}.sha256 must be lowercase SHA-256"
+                    )
+        else:
+            raise PolicyError(f"{context}.install.kind is unsupported: {kind!r}")
+
+        update = require_object(tool["update"], f"{context}.update")
+        update_kind = update.get("kind")
+        if update_kind == "crates-io":
+            require_keys(
+                update,
+                {"kind", "crate"},
+                {"kind", "crate"},
+                f"{context}.update",
+            )
+            require_string(update["crate"], f"{context}.update.crate")
+        elif update_kind == "github-release":
+            require_keys(
+                update,
+                {"kind", "repository"},
+                {"kind", "repository"},
+                f"{context}.update",
+            )
+            require_string(update["repository"], f"{context}.update.repository")
+        else:
+            raise PolicyError(f"{context}.update.kind is unsupported: {update_kind!r}")
+
+    groups = require_object(manifest["ci_groups"], "ci_groups")
+    expected_groups = {"coverage", "shell-lint", "supply-chain"}
+    if set(groups) != expected_groups:
+        raise PolicyError(
+            "ci_groups must define exactly: " + ", ".join(sorted(expected_groups))
+        )
+    grouped: set[str] = set()
+    for group, tool_ids_value in groups.items():
+        tool_ids = require_string_list(tool_ids_value, f"ci_groups.{group}")
+        for tool_id in tool_ids:
+            if tool_id not in tools_by_id:
+                raise PolicyError(f"ci_groups.{group} names unknown tool {tool_id!r}")
+            if tool_id in grouped:
+                raise PolicyError(f"CI tool {tool_id!r} appears in multiple groups")
+            grouped.add(tool_id)
+    if grouped != {"cargo-deny", "cargo-llvm-cov", "cargo-machete", "shellcheck"}:
+        raise PolicyError("CI groups must cover the hosted prebuilt tool set exactly")
+    return tools_by_id
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    manifest = read_json(path)
+    return manifest, validate_manifest(manifest)
+
+
+def parse_only(value: str | None, tools_by_id: dict[str, dict[str, Any]]) -> list[str]:
+    if value is None:
+        return sorted(tools_by_id)
+    selected = [item.strip() for item in value.split(",") if item.strip()]
+    if not selected:
+        raise PolicyError("--only must name at least one tool")
+    duplicates = sorted({item for item in selected if selected.count(item) > 1})
+    unknown = sorted(set(selected) - tools_by_id.keys())
+    if duplicates:
+        raise PolicyError("--only repeats tools: " + ", ".join(duplicates))
+    if unknown:
+        raise PolicyError("--only names unknown tools: " + ", ".join(unknown))
+    return selected
+
+
+def extract_version(output: str, pattern: str) -> str | None:
+    match = re.search(pattern, output)
+    return match.group(1) if match else None
+
+
+def evaluate_version(
+    *,
+    expected: str,
+    pattern: str,
+    output: str | None,
+    minimum: bool = False,
+) -> tuple[str, str | None]:
+    if output is None:
+        return "missing", None
+    observed = extract_version(output, pattern)
+    if observed is None:
+        return "unrecognized", None
+    try:
+        observed_tuple = version_tuple(observed)
+        expected_tuple = version_tuple(expected)
+    except PolicyError:
+        return "unrecognized", observed
+    if minimum:
+        return ("ok" if observed_tuple >= expected_tuple else "too-old"), observed
+    return ("ok" if observed_tuple == expected_tuple else "mismatch"), observed
+
+
+def probe(command: str, args: list[str]) -> tuple[str | None, str | None]:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return None, None
+    try:
+        completed = subprocess.run(
+            [resolved, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return "", str(error)
+    output = "\n".join(item for item in (completed.stdout, completed.stderr) if item)
+    return output.strip(), None
+
+
+def action_for(tool_id: str) -> str:
+    return f"./scripts/bootstrap-tools.sh --only {tool_id}"
+
+
+def tool_result(tool: dict[str, Any]) -> dict[str, Any]:
+    output, error = probe(tool["command"], tool["version_args"])
+    status, observed = evaluate_version(
+        expected=tool["version"],
+        pattern=tool["version_pattern"],
+        output=output,
+    )
+    return {
+        "id": tool["id"],
+        "command": tool["command"],
+        "status": status if error is None else "probe-error",
+        "expected": tool["version"],
+        "observed": observed,
+        "action": None if status == "ok" and error is None else action_for(tool["id"]),
+        "detail": error,
+    }
+
+
+def parse_rust_dev_pin() -> str:
+    text = (ROOT / "rust-toolchain.toml").read_text(encoding="utf-8")
+    match = re.search(r'^\s*channel\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if match is None:
+        raise PolicyError("rust-toolchain.toml has no channel")
+    return match.group(1)
+
+
+def parse_msrv_pin() -> str:
+    text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(r'^\s*rust-version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if match is None:
+        raise PolicyError("Cargo.toml has no rust-version")
+    value = match.group(1)
+    if value.count(".") == 1:
+        value += ".0"
+    version_tuple(value)
+    return value
+
+
+def required_rust_components(manifest: dict[str, Any]) -> list[str]:
+    text = (ROOT / "rust-toolchain.toml").read_text(encoding="utf-8")
+    match = re.search(r"^\s*components\s*=\s*\[([^\]]*)\]", text, re.MULTILINE)
+    if match is None:
+        raise PolicyError("rust-toolchain.toml has no components list")
+    components = re.findall(r'"([^"]+)"', match.group(1))
+    components.extend(
+        tool["install"]["rust_component"]
+        for tool in manifest["tools"]
+        if "rust_component" in tool["install"]
+    )
+    return sorted(set(components))
+
+
+def toolchain_present(command: str, args: list[str], expected: str) -> tuple[bool, str | None]:
+    output, error = probe(command, args)
+    if output is None:
+        return False, "command missing"
+    if error is not None:
+        return False, error
+    return any(
+        line == expected
+        or line.startswith(expected + " ")
+        or line.startswith(expected + "-")
+        for line in output.splitlines()
+    ), None
+
+
+def doctor_results(
+    manifest: dict[str, Any],
+    tools_by_id: dict[str, dict[str, Any]],
+    only: str | None,
+) -> list[dict[str, Any]]:
+    selected = parse_only(only, tools_by_id)
+    results = [tool_result(tools_by_id[tool_id]) for tool_id in selected]
+    if only is not None:
+        return results
+
+    python_policy = manifest["python"]
+    python_output = f"Python {platform.python_version()}"
+    status, observed = evaluate_version(
+        expected=python_policy["minimum"],
+        pattern=python_policy["version_pattern"],
+        output=python_output,
+        minimum=True,
+    )
+    results.insert(
+        0,
+        {
+            "id": "python",
+            "command": python_policy["command"],
+            "status": status,
+            "expected": f">={python_policy['minimum']}",
+            "observed": observed,
+            "action": None if status == "ok" else "./scripts/bootstrap-tools.sh",
+            "detail": None,
+        },
+    )
+    for item in manifest["required_commands"]:
+        present = shutil.which(item["command"]) is not None
+        results.append(
+            {
+                "id": item["command"],
+                "command": item["command"],
+                "status": "ok" if present else "missing",
+                "expected": "present",
+                "observed": "present" if present else None,
+                "action": None if present else f"install {item['command']} before bootstrap",
+                "detail": item["purpose"],
+            }
+        )
+
+    dev_pin = parse_rust_dev_pin()
+    msrv_pin = parse_msrv_pin()
+    for identifier, pin in (("rust-dev-toolchain", dev_pin), ("rust-msrv-toolchain", msrv_pin)):
+        present, detail = toolchain_present("rustup", ["toolchain", "list"], pin)
+        results.append(
+            {
+                "id": identifier,
+                "command": "rustup",
+                "status": "ok" if present else "missing",
+                "expected": pin,
+                "observed": pin if present else None,
+                "action": None if present else "./scripts/bootstrap-tools.sh --with-toolchains",
+                "detail": detail,
+            }
+        )
+
+    component_output, component_error = probe(
+        "rustup",
+        ["component", "list", "--toolchain", dev_pin, "--installed"],
+    )
+    component_lines = [] if component_output is None else component_output.splitlines()
+    for component in required_rust_components(manifest):
+        observed_component = component.removesuffix("-preview")
+        present = any(
+            line == observed_component
+            or line.startswith(observed_component + " ")
+            or line.startswith(observed_component + "-")
+            for line in component_lines
+        )
+        results.append(
+            {
+                "id": f"rust-component-{component}",
+                "command": "rustup",
+                "status": "ok" if present and component_error is None else "missing",
+                "expected": f"{component}@{dev_pin}",
+                "observed": observed_component if present else None,
+                "action": (
+                    None
+                    if present and component_error is None
+                    else "./scripts/bootstrap-tools.sh --with-toolchains"
+                ),
+                "detail": component_error,
+            }
+        )
+
+    lean_pin = (ROOT / "lean-toolchain").read_text(encoding="utf-8").strip()
+    present, detail = toolchain_present("elan", ["toolchain", "list"], lean_pin)
+    results.append(
+        {
+            "id": "lean-toolchain",
+            "command": "elan",
+            "status": "ok" if present else "missing",
+            "expected": lean_pin,
+            "observed": lean_pin if present else None,
+            "action": None if present else "./scripts/bootstrap-tools.sh --with-toolchains",
+            "detail": detail,
+        }
+    )
+    return results
+
+
+def print_doctor(results: list[dict[str, Any]], as_json: bool) -> int:
+    if as_json:
+        print(json.dumps({"results": results}, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            observed = result["observed"] or "-"
+            print(
+                f"{result['status']:>11}  {result['id']:<22} "
+                f"expected={result['expected']} observed={observed}"
+            )
+            if result["detail"] and result["status"] != "ok":
+                print(f"             detail: {result['detail']}")
+            if result["action"]:
+                print(f"             fix: {result['action']}")
+    return 0 if all(result["status"] == "ok" for result in results) else 1
+
+
+def ci_tool_spec(tool: dict[str, Any]) -> str:
+    install = tool["install"]
+    name = install["ci_name"] if install["kind"] == "cargo" else tool["id"]
+    return f"{name}@{tool['version']}"
+
+
+def append_github_output(path: Path, key: str, value: str) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def platform_id(override: str | None) -> str:
+    if override is not None:
+        if override not in set(SUPPORTED_PLATFORMS.values()):
+            raise PolicyError(f"unsupported platform: {override}")
+        return override
+    key = (platform.system().lower(), platform.machine().lower())
+    try:
+        return SUPPORTED_PLATFORMS[key]
+    except KeyError as error:
+        raise PolicyError(
+            f"unsupported host platform: {key[0]}-{key[1]}"
+        ) from error
+
+
+def verify_download(path: Path, expected: str) -> None:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    observed = digest.hexdigest()
+    if observed != expected:
+        raise PolicyError(
+            f"download checksum mismatch: expected {expected}, observed {observed}"
+        )
+
+
+def download(url: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "nose-auxiliary-tool-bootstrap/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            with destination.open("wb") as output:
+                shutil.copyfileobj(response, output)
+    except (OSError, urllib.error.URLError) as error:
+        raise PolicyError(f"cannot download {url}: {error}") from error
+
+
+def extract_named_binary(archive: Path, archive_binary: str, destination: Path) -> None:
+    try:
+        with tarfile.open(archive, mode="r:*") as bundle:
+            matches = []
+            for member in bundle.getmembers():
+                member_path = PurePosixPath(member.name)
+                if member_path.is_absolute() or ".." in member_path.parts:
+                    raise PolicyError(f"unsafe archive path: {member.name}")
+                if member.islnk() or member.issym() or member.isdev():
+                    raise PolicyError(f"unsafe archive member: {member.name}")
+                if member.isfile() and member_path.name == archive_binary:
+                    matches.append(member)
+            if len(matches) != 1:
+                raise PolicyError(
+                    f"archive must contain exactly one {archive_binary!r}; "
+                    f"found {len(matches)}"
+                )
+            source = bundle.extractfile(matches[0])
+            if source is None:
+                raise PolicyError(f"cannot read {matches[0].name} from archive")
+            with destination.open("wb") as output:
+                shutil.copyfileobj(source, output)
+    except (OSError, tarfile.TarError) as error:
+        raise PolicyError(f"cannot extract {archive}: {error}") from error
+
+
+def atomic_install(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        delete=False,
+    ) as output:
+        temporary = Path(output.name)
+        with source.open("rb") as input_handle:
+            shutil.copyfileobj(input_handle, output)
+    try:
+        temporary.chmod(
+            stat.S_IRUSR
+            | stat.S_IWUSR
+            | stat.S_IXUSR
+            | stat.S_IRGRP
+            | stat.S_IXGRP
+            | stat.S_IROTH
+            | stat.S_IXOTH
+        )
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def install_release_tool(tool: dict[str, Any], selected_platform: str, bin_dir: Path) -> None:
+    install = tool["install"]
+    asset = install["assets"][selected_platform]
+    suffix = ".tar.xz" if asset["url"].endswith(".tar.xz") else ".tar.gz"
+    with tempfile.TemporaryDirectory(prefix=f"nose-{tool['id']}-") as temp_name:
+        temp = Path(temp_name)
+        archive = temp / f"download{suffix}"
+        binary = temp / install["install_name"]
+        print(f"download  {tool['id']} {tool['version']} ({selected_platform})")
+        download(asset["url"], archive)
+        verify_download(archive, asset["sha256"])
+        extract_named_binary(archive, install["archive_binary"], binary)
+        atomic_install(binary, bin_dir / install["install_name"])
+
+
+def install_cargo_tool(tool: dict[str, Any], bin_dir: Path, dev_pin: str) -> None:
+    install = tool["install"]
+    if shutil.which("cargo") is None:
+        raise PolicyError("cargo is required to install cargo-based auxiliary tools")
+    if shutil.which("rustup") is None:
+        raise PolicyError("rustup is required to use the pinned development toolchain")
+    with tempfile.TemporaryDirectory(prefix=f"nose-{tool['id']}-") as temp_name:
+        install_root = Path(temp_name) / "cargo-root"
+        command = [
+            "cargo",
+            f"+{dev_pin}",
+            "install",
+            "--locked",
+            "--version",
+            tool["version"],
+            "--root",
+            str(install_root),
+            install["package"],
+        ]
+        print("run       " + " ".join(command))
+        subprocess.run(command, cwd=ROOT, check=True)
+        source = install_root / "bin" / tool["command"]
+        if not source.is_file():
+            raise PolicyError(f"cargo install did not produce {source}")
+        atomic_install(source, bin_dir / tool["command"])
+
+
+def bootstrap_toolchains(manifest: dict[str, Any], elan_path: Path) -> None:
+    if shutil.which("rustup") is None:
+        raise PolicyError("rustup is required before --with-toolchains")
+    dev_pin = parse_rust_dev_pin()
+    msrv_pin = parse_msrv_pin()
+    for pin in (dev_pin, msrv_pin):
+        print(f"toolchain rust {pin}")
+        subprocess.run(["rustup", "toolchain", "install", pin], check=True)
+    subprocess.run(
+        [
+            "rustup",
+            "component",
+            "add",
+            *required_rust_components(manifest),
+            "--toolchain",
+            dev_pin,
+        ],
+        check=True,
+    )
+    elan_tool = next(tool for tool in manifest["tools"] if tool["id"] == "elan")
+    elan_result = tool_result_with_path(elan_tool, elan_path)
+    if elan_result["status"] != "ok":
+        raise PolicyError(
+            "the exact pinned elan must be bootstrapped before Lean toolchain setup"
+        )
+    lean_pin = (ROOT / "lean-toolchain").read_text(encoding="utf-8").strip()
+    print(f"toolchain Lean {lean_pin}")
+    subprocess.run([str(elan_path), "toolchain", "install", lean_pin], check=True)
+
+
+def bootstrap(
+    manifest: dict[str, Any],
+    tools_by_id: dict[str, dict[str, Any]],
+    args: argparse.Namespace,
+) -> int:
+    selected = parse_only(args.only, tools_by_id)
+    selected_platform = platform_id(args.platform)
+    bin_dir = args.bin_dir.expanduser().resolve()
+    dev_pin = parse_rust_dev_pin()
+    for tool_id in selected:
+        tool = tools_by_id[tool_id]
+        destination = bin_dir / tool["command"]
+        result = (
+            tool_result_with_path(tool, destination)
+            if destination.is_file()
+            else {"status": "missing", "observed": None}
+        )
+        if result["status"] == "ok":
+            print(f"skip      {tool_id} {tool['version']} (already at {destination})")
+            continue
+        install = tool["install"]
+        if args.dry_run:
+            if install["kind"] == "cargo":
+                print(
+                    f"would run cargo +{dev_pin} install --locked --version "
+                    f"{tool['version']} {install['package']}"
+                )
+            else:
+                asset = install["assets"][selected_platform]
+                print(
+                    f"would install {tool_id} {tool['version']} from "
+                    f"{asset['url']} (sha256 {asset['sha256']})"
+                )
+            continue
+        if install["kind"] == "cargo":
+            install_cargo_tool(tool, bin_dir, dev_pin)
+        else:
+            install_release_tool(tool, selected_platform, bin_dir)
+        installed = tool_result_with_path(tool, bin_dir / tool["command"])
+        if installed["status"] != "ok":
+            raise PolicyError(
+                f"installed {tool_id} failed version verification: "
+                f"{installed['status']} ({installed['observed']})"
+            )
+        print(f"installed {tool_id} {tool['version']} -> {bin_dir / tool['command']}")
+    if args.with_toolchains:
+        if args.dry_run:
+            print(
+                f"would install Rust {dev_pin}, Rust {parse_msrv_pin()}, "
+                f"Rust components {','.join(required_rust_components(manifest))}, "
+                f"and Lean {(ROOT / 'lean-toolchain').read_text().strip()}"
+            )
+        else:
+            elan_path = bin_dir / tools_by_id["elan"]["command"]
+            if not elan_path.is_file():
+                resolved_elan = shutil.which(tools_by_id["elan"]["command"])
+                if resolved_elan is None:
+                    raise PolicyError(
+                        "--with-toolchains needs pinned elan; include elan in --only"
+                    )
+                elan_path = Path(resolved_elan)
+            bootstrap_toolchains(manifest, elan_path)
+    if not args.dry_run and str(bin_dir) not in os.environ.get("PATH", "").split(os.pathsep):
+        print(f"note: add {bin_dir} to PATH; bootstrap does not edit shell configuration")
+    return 0
+
+
+def tool_result_with_path(tool: dict[str, Any], command_path: Path) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            [str(command_path), *tool["version_args"]],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=INSTALL_VERIFY_TIMEOUT_SECONDS,
+        )
+        output = "\n".join(
+            item for item in (completed.stdout, completed.stderr) if item
+        ).strip()
+        error = None
+    except (OSError, subprocess.TimeoutExpired) as caught:
+        output = ""
+        error = str(caught)
+    status, observed = evaluate_version(
+        expected=tool["version"],
+        pattern=tool["version_pattern"],
+        output=output,
+    )
+    return {
+        "status": status if error is None else "probe-error",
+        "observed": observed,
+    }
+
+
+def policy_files() -> list[Path]:
+    return [
+        ROOT / ".github" / "workflows" / "ci.yml",
+        ROOT / ".github" / "workflows" / "corpus-verify.yml",
+        ROOT / "docs" / "contributing.md",
+        ROOT / "docs" / "tooling.md",
+        ROOT / "scripts" / "check-ci-local.sh",
+        ROOT / "scripts" / "check-docs.sh",
+        ROOT / "scripts" / "bootstrap-tools.sh",
+        ROOT / ".github" / "workflows" / "tool-updates.yml",
+    ]
+
+
+def check_repository_policy(manifest: dict[str, Any]) -> None:
+    installer = manifest["ci_installer"]
+    python_minimum = manifest["python"]["minimum"]
+    python_tuple = ", ".join(str(part) for part in version_tuple(python_minimum))
+    expected_action = f"{installer['repository']}@{installer['ref']}"
+    workflow_paths = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+    workflow_text = "\n".join(path.read_text(encoding="utf-8") for path in workflow_paths)
+    refs = set(re.findall(r"taiki-e/install-action@([^\s]+)", workflow_text))
+    if refs != {installer["ref"]}:
+        raise PolicyError(
+            f"install-action refs must be exactly {installer['ref']!r}; found {sorted(refs)}"
+        )
+    ci_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    if ci_text.count(f"uses: {expected_action}") != 3:
+        raise PolicyError("ci.yml must use the pinned installer exactly three times")
+
+    required_tokens = {
+        ROOT / ".github" / "workflows" / "ci.yml": [
+            "ci-spec shell-lint",
+            "ci-spec coverage",
+            "ci-spec supply-chain",
+            "bootstrap-tools.sh --only awiki",
+            "bootstrap-tools.sh --only elan",
+            "doctor --only awiki",
+            "doctor --only elan",
+            "gate · aux-tool-policy",
+        ],
+        ROOT / ".github" / "workflows" / "corpus-verify.yml": [
+            "bootstrap-tools.sh --only elan",
+            "doctor --only elan",
+        ],
+        ROOT / ".github" / "workflows" / "tool-updates.yml": [
+            "matrix:",
+            "ubuntu-latest",
+            "macos-latest",
+            "bootstrap-tools.sh --only awiki,elan,shellcheck",
+            "doctor --only awiki,elan,shellcheck",
+            "check-updates",
+            "darwin-aarch64",
+            "darwin-x86_64",
+            "linux-aarch64",
+            "linux-x86_64",
+        ],
+        ROOT / "docs" / "contributing.md": [
+            "./scripts/aux_tools.py doctor",
+            "./scripts/bootstrap-tools.sh",
+            "Node.js",
+            "tooling.md",
+        ],
+        ROOT / "docs" / "tooling.md": [
+            "tools/auxiliary-tools.json",
+            "./scripts/aux_tools.py check-updates",
+            "Node.js",
+        ],
+        ROOT / "scripts" / "check-ci-local.sh": [
+            "audit_aux_tools awiki",
+            "audit_aux_tools elan",
+            "audit_aux_tools shellcheck",
+            "audit_aux_tools cargo-llvm-cov",
+            "audit_aux_tools cargo-machete,cargo-deny",
+        ],
+    }
+    for path, tokens in required_tokens.items():
+        if not path.is_file():
+            raise PolicyError(f"required policy consumer is missing: {path.relative_to(ROOT)}")
+        text = path.read_text(encoding="utf-8")
+        missing = [token for token in tokens if token not in text]
+        if missing:
+            raise PolicyError(
+                f"{path.relative_to(ROOT)} does not consume policy tokens: {missing}"
+            )
+
+    for path in (
+        ROOT / "docs" / "contributing.md",
+        ROOT / "docs" / "tooling.md",
+    ):
+        if f"Python {python_minimum} or newer" not in path.read_text(encoding="utf-8"):
+            raise PolicyError(
+                f"{path.relative_to(ROOT)} does not name Python floor {python_minimum}"
+            )
+    for path in (
+        ROOT / "scripts" / "check-ci-local.sh",
+        ROOT / "scripts" / "bootstrap-tools.sh",
+    ):
+        text = path.read_text(encoding="utf-8")
+        if f"sys.version_info < ({python_tuple})" not in text:
+            raise PolicyError(
+                f"{path.relative_to(ROOT)} does not enforce Python floor {python_minimum}"
+            )
+    bootstrap_text = (ROOT / "scripts" / "bootstrap-tools.sh").read_text(
+        encoding="utf-8"
+    )
+    if 'if [[ "$dry_run" -eq 1 ]]' not in bootstrap_text:
+        raise PolicyError("bootstrap dry-run must not install a missing Python")
+
+    forbidden_patterns = {
+        r"leanprover/elan/master/elan-init\.sh": "moving elan installer",
+        r"awiki(?:/cmd/awiki)?@latest": "moving awiki version",
+        r"go install github\.com/corca-ai/awiki": "out-of-band awiki install",
+        r"brew install (?:shellcheck|corca-ai/tap/awiki)": "out-of-band tool install",
+        r"cargo install (?:cargo-deny|cargo-machete|cargo-llvm-cov)": (
+            "out-of-band cargo tool install"
+        ),
+        r"actions/setup-go@": "obsolete Go setup used only for awiki",
+        r"taiki-e/install-action@v2(?:\s|$)": "major-only installer ref",
+    }
+    for path in policy_files():
+        if not path.is_file():
+            raise PolicyError(f"policy file is missing: {path.relative_to(ROOT)}")
+        text = path.read_text(encoding="utf-8")
+        for pattern, reason in forbidden_patterns.items():
+            if re.search(pattern, text):
+                raise PolicyError(f"{path.relative_to(ROOT)} contains {reason}")
+
+
+def latest_version(tool: dict[str, Any]) -> str:
+    update = tool["update"]
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "nose-auxiliary-tool-update-check/1",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if update["kind"] == "github-release":
+        url = f"https://api.github.com/repos/{update['repository']}/releases/latest"
+        field = "tag_name"
+    else:
+        url = f"https://crates.io/api/v1/crates/{update['crate']}"
+        field = "crate.max_stable_version"
+        headers["User-Agent"] = "nose (https://github.com/corca-ai/nose)"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise PolicyError(f"cannot check updates for {tool['id']}: {error}") from error
+    if field == "tag_name":
+        value = payload.get("tag_name")
+    else:
+        value = payload.get("crate", {}).get("max_stable_version")
+    if not isinstance(value, str):
+        raise PolicyError(f"update response for {tool['id']} has no version")
+    value = value.removeprefix("v")
+    version_tuple(value)
+    return value
+
+
+def command_list(manifest: dict[str, Any], tools_by_id: dict[str, dict[str, Any]]) -> int:
+    print(
+        f"{'tool':<18} {'policy':<12} {'version':<10} {'installer':<16}"
+    )
+    python_policy = manifest["python"]
+    print(
+        f"{'python':<18} {'minimum':<12} {python_policy['minimum']:<10} {'platform':<16}"
+    )
+    for tool_id in sorted(tools_by_id):
+        tool = tools_by_id[tool_id]
+        print(
+            f"{tool_id:<18} {tool['policy']:<12} {tool['version']:<10} "
+            f"{tool['install']['kind']:<16}"
+        )
+    return 0
+
+
+def selftest(manifest: dict[str, Any], tools_by_id: dict[str, dict[str, Any]]) -> int:
+    cases = [
+        (
+            "missing",
+            evaluate_version(
+                expected="1.2.3", pattern=r"tool (\d+\.\d+\.\d+)", output=None
+            )[0],
+            "missing",
+        ),
+        (
+            "exact mismatch",
+            evaluate_version(
+                expected="1.2.3",
+                pattern=r"tool (\d+\.\d+\.\d+)",
+                output="tool 1.2.2",
+            )[0],
+            "mismatch",
+        ),
+        (
+            "exact acceptable",
+            evaluate_version(
+                expected="1.2.3",
+                pattern=r"tool (\d+\.\d+\.\d+)",
+                output="tool 1.2.3",
+            )[0],
+            "ok",
+        ),
+        (
+            "minimum old",
+            evaluate_version(
+                expected="3.10.0",
+                pattern=r"Python (\d+\.\d+\.\d+)",
+                output="Python 3.9.18",
+                minimum=True,
+            )[0],
+            "too-old",
+        ),
+        (
+            "minimum acceptable",
+            evaluate_version(
+                expected="3.10.0",
+                pattern=r"Python (\d+\.\d+\.\d+)",
+                output="Python 3.14.0",
+                minimum=True,
+            )[0],
+            "ok",
+        ),
+        (
+            "unrecognized",
+            evaluate_version(
+                expected="1.2.3", pattern=r"tool (\d+\.\d+\.\d+)", output="unknown"
+            )[0],
+            "unrecognized",
+        ),
+    ]
+    for name, observed, expected in cases:
+        if observed != expected:
+            raise PolicyError(
+                f"selftest {name!r}: expected {expected!r}, observed {observed!r}"
+            )
+    for target in sorted(set(SUPPORTED_PLATFORMS.values())):
+        if platform_id(target) != target:
+            raise PolicyError(f"selftest platform resolution failed for {target}")
+        for tool in tools_by_id.values():
+            if tool["install"]["kind"] == "release-archive":
+                _ = tool["install"]["assets"][target]
+
+    mutated = copy.deepcopy(manifest)
+    mutated["tools"][0]["version"] = "latest"
+    try:
+        validate_manifest(mutated)
+    except PolicyError:
+        pass
+    else:
+        raise PolicyError("selftest accepted a moving tool version")
+
+    with tempfile.TemporaryDirectory(prefix="nose-aux-policy-") as temp_name:
+        duplicate_path = Path(temp_name) / "duplicate.json"
+        duplicate_path.write_text('{"schema": 1, "schema": 2}', encoding="utf-8")
+        try:
+            read_json(duplicate_path)
+        except PolicyError:
+            pass
+        else:
+            raise PolicyError("selftest accepted a duplicate JSON key")
+    print("auxiliary-tool self-tests passed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help=argparse.SUPPRESS,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("selftest", help="run isolated policy and probe self-tests")
+    subparsers.add_parser(
+        "check-policy",
+        help="validate the manifest and repository consumers without network access",
+    )
+    subparsers.add_parser("list", help="render the checked versions")
+
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="read-only diagnosis of local auxiliary tools and toolchains",
+    )
+    doctor_parser.add_argument("--only", help="comma-separated tool ids")
+    doctor_parser.add_argument("--json", action="store_true", help="emit JSON")
+
+    spec_parser = subparsers.add_parser(
+        "ci-spec",
+        help="render exact tool@version specs for one hosted CI group",
+    )
+    spec_parser.add_argument("group")
+    spec_parser.add_argument("--github-output", type=Path)
+
+    bootstrap_parser = subparsers.add_parser(
+        "bootstrap",
+        help="explicitly install pinned tools without editing user configuration",
+    )
+    bootstrap_parser.add_argument("--only", help="comma-separated tool ids")
+    bootstrap_parser.add_argument(
+        "--bin-dir",
+        type=Path,
+        default=Path.home() / ".local" / "bin",
+    )
+    bootstrap_parser.add_argument("--dry-run", action="store_true")
+    bootstrap_parser.add_argument(
+        "--platform",
+        choices=sorted(set(SUPPORTED_PLATFORMS.values())),
+        help="override the host only for reproducible dry-run testing",
+    )
+    bootstrap_parser.add_argument("--with-toolchains", action="store_true")
+
+    update_parser = subparsers.add_parser(
+        "check-updates",
+        help="read release APIs and report newer compatible pins",
+    )
+    update_parser.add_argument("--fail-on-update", action="store_true")
+    update_parser.add_argument("--markdown", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        manifest, tools_by_id = load_manifest(args.manifest)
+        if args.command == "selftest":
+            return selftest(manifest, tools_by_id)
+        if args.command == "check-policy":
+            check_repository_policy(manifest)
+            print("auxiliary-tool policy is synchronized")
+            return 0
+        if args.command == "list":
+            return command_list(manifest, tools_by_id)
+        if args.command == "doctor":
+            return print_doctor(
+                doctor_results(manifest, tools_by_id, args.only),
+                args.json,
+            )
+        if args.command == "ci-spec":
+            groups = manifest["ci_groups"]
+            if args.group not in groups:
+                raise PolicyError(
+                    f"unknown CI group {args.group!r}; choose from "
+                    + ", ".join(sorted(groups))
+                )
+            value = ",".join(
+                ci_tool_spec(tools_by_id[tool_id]) for tool_id in groups[args.group]
+            )
+            print(value)
+            if args.github_output:
+                append_github_output(args.github_output, "tools", value)
+            return 0
+        if args.command == "bootstrap":
+            return bootstrap(manifest, tools_by_id, args)
+        if args.command == "check-updates":
+            rows = []
+            updates = 0
+            for tool_id in sorted(tools_by_id):
+                current = tools_by_id[tool_id]["version"]
+                latest = latest_version(tools_by_id[tool_id])
+                status = "update" if version_tuple(latest) > version_tuple(current) else "current"
+                updates += status == "update"
+                rows.append((tool_id, current, latest, status))
+            if args.markdown:
+                print("| Tool | Pinned | Latest | Status |")
+                print("|---|---:|---:|---|")
+                for row in rows:
+                    print(f"| {row[0]} | {row[1]} | {row[2]} | {row[3]} |")
+            else:
+                for row in rows:
+                    print(
+                        f"{row[3]:>7}  {row[0]:<18} pinned={row[1]} latest={row[2]}"
+                    )
+            if updates and args.fail_on_update:
+                return 3
+            return 0
+        raise AssertionError(f"unhandled command: {args.command}")
+    except (PolicyError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap-tools.sh
+++ b/scripts/bootstrap-tools.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Explicit, idempotent installer for the checked auxiliary-tool policy.
+# This command installs binaries only; it never edits shell or repository config.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+dry_run=0
+for argument in "$@"; do
+    if [[ "$argument" == "--dry-run" ]]; then
+        dry_run=1
+    fi
+done
+
+python_command=""
+if command -v python3 >/dev/null 2>&1 &&
+   python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10, 0))'; then
+    python_command="$(command -v python3)"
+fi
+
+if [[ -z "$python_command" ]]; then
+    if [[ "$dry_run" -eq 1 ]]; then
+        echo "Dry run requires Python 3.10.0+ and will not install it." >&2
+        echo "Install a supported Python explicitly, then rerun this command." >&2
+        exit 127
+    fi
+    case "$(uname -s)" in
+        Darwin)
+            if ! command -v brew >/dev/null 2>&1; then
+                echo "Python 3.10.0+ is missing and Homebrew is unavailable." >&2
+                echo "Install Python 3.10.0+ explicitly, then rerun this command." >&2
+                exit 127
+            fi
+            brew install python@3.14
+            python_command="$(brew --prefix python@3.14)/libexec/bin/python3"
+            ;;
+        Linux)
+            if ! command -v apt-get >/dev/null 2>&1; then
+                echo "Python 3.10.0+ is missing and this Linux host has no apt-get." >&2
+                echo "Install Python 3.10.0+ with the host package manager, then rerun." >&2
+                exit 127
+            fi
+            privilege=()
+            if [[ "$(id -u)" -ne 0 ]]; then
+                if ! command -v sudo >/dev/null 2>&1; then
+                    echo "Python bootstrap requires root or sudo on this host." >&2
+                    exit 127
+                fi
+                privilege=(sudo)
+            fi
+            "${privilege[@]}" apt-get update
+            "${privilege[@]}" apt-get install -y python3
+            python_command="$(command -v python3 || true)"
+            ;;
+        *)
+            echo "Automatic Python bootstrap supports macOS and apt-based Linux only." >&2
+            echo "Install Python 3.10.0+ explicitly, then rerun this command." >&2
+            exit 127
+            ;;
+    esac
+fi
+
+if [[ -z "$python_command" ]] ||
+   ! "$python_command" -c 'import sys; raise SystemExit(sys.version_info < (3, 10, 0))'; then
+    echo "Bootstrap requires Python 3.10.0 or newer." >&2
+    [[ -z "$python_command" ]] || "$python_command" --version >&2
+    exit 127
+fi
+
+exec "$python_command" scripts/aux_tools.py bootstrap "$@"

--- a/scripts/check-ci-local.sh
+++ b/scripts/check-ci-local.sh
@@ -60,7 +60,8 @@ usage: ./scripts/check-ci-local.sh [--fast|--full] [--jobs <count>]
        ./scripts/check-ci-local.sh --validate-gates
 
   --fast  corpus and semantic-pack self-tests, Type-4 packet/replay checks,
-          rustfmt, file-length ratchet, legacy-prelude guard, shellcheck,
+          auxiliary-tool policy, rustfmt, file-length ratchet,
+          legacy-prelude guard, shellcheck,
           clippy -D warnings, nose-cli tests, docs wiki lint
   --full  full local mirror of CI: format, clippy, docs, release build/tests,
           file-length ratchet, duplication, MSRV, supply-chain, docs wiki,
@@ -114,16 +115,15 @@ need_cmd() {
 
 need_python3() {
     need_cmd python3
-    if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
-        echo "Python 3.10 or newer is required for repository quality gates." >&2
+    if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10, 0))'; then
+        echo "Python 3.10.0 or newer is required for repository quality gates." >&2
         echo "observed: $(python3 --version 2>&1)" >&2
         exit 127
     fi
 }
 
 run_docs_wiki_lint() {
-    need_cmd awiki "install it with: brew install corca-ai/tap/awiki"
-    need_cmd python3
+    audit_aux_tools awiki
     ./scripts/check-docs.sh
 }
 
@@ -134,6 +134,7 @@ run_formal_obligations_lint() {
 }
 
 run_formal_lean() {
+    audit_aux_tools elan
     ./scripts/check-lean-proofs.sh
 }
 
@@ -217,8 +218,19 @@ run_product_query_schema_live_check() {
 }
 
 run_shell_script_lint() {
-    need_cmd shellcheck "install it with: brew install shellcheck"
+    audit_aux_tools shellcheck
     shellcheck -x .githooks/pre-commit .githooks/pre-push scripts/*.sh scripts/ci/*.sh
+}
+
+audit_aux_tools() {
+    need_python3
+    python3 scripts/aux_tools.py doctor --only "$1"
+}
+
+run_aux_tool_policy() {
+    need_python3
+    python3 scripts/aux_tools.py selftest
+    python3 scripts/aux_tools.py check-policy
 }
 
 run_msrv_check() {
@@ -248,7 +260,7 @@ run_semantic_pack_example_conformance() {
 
 run_coverage_gate() {
     need_cmd cargo
-    need_cmd cargo-llvm-cov "install it with: cargo install cargo-llvm-cov"
+    audit_aux_tools cargo-llvm-cov
     source scripts/coverage-threshold.env
     cargo llvm-cov \
         --workspace \
@@ -257,8 +269,7 @@ run_coverage_gate() {
 }
 
 run_supply_chain_checks() {
-    need_cmd cargo-machete "install it with: cargo install cargo-machete"
-    need_cmd cargo-deny "install it with: cargo install cargo-deny"
+    audit_aux_tools cargo-machete,cargo-deny
     cargo machete
     cargo deny check
 }
@@ -348,6 +359,9 @@ run_named_gate() {
             ;;
         cargo-target-prune-selftest)
             ./scripts/prune-cargo-target.sh --self-test
+            ;;
+        aux-tool-policy)
+            run_aux_tool_policy
             ;;
         shell-lint)
             run_shell_script_lint

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -10,9 +10,10 @@
 #   ./scripts/check-docs.sh
 #
 # awiki is optional locally (this skips with a notice if absent); CI always runs
-# it, so the gate is enforced there regardless. Install it with:
-#   brew install corca-ai/tap/awiki
-#   # or: go install github.com/corca-ai/awiki/cmd/awiki@latest
+# it, so the gate is enforced there regardless. Diagnose/install the checked
+# version with:
+#   ./scripts/aux_tools.py doctor --only awiki
+#   ./scripts/bootstrap-tools.sh --only awiki
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -48,7 +49,7 @@ else
 fi
 
 if ! command -v awiki >/dev/null 2>&1; then
-    echo "skipped — awiki not installed (brew install corca-ai/tap/awiki)"
+    echo "skipped — awiki not installed (run ./scripts/bootstrap-tools.sh --only awiki)"
     exit 0
 fi
 

--- a/scripts/ci/gates.json
+++ b/scripts/ci/gates.json
@@ -590,6 +590,25 @@
       }
     },
     {
+      "name": "aux-tool-policy",
+      "owner": "repository development environment policy",
+      "implementation": "run_aux_tool_policy",
+      "tools": ["python3 >= 3.10"],
+      "inputs": ["tools/auxiliary-tools.json", "scripts/aux_tools.py", "scripts/bootstrap-tools.sh", ".github/workflows/", "docs/tooling.md", "docs/contributing.md"],
+      "worktree_effect": "read-only",
+      "outputs": [],
+      "cache": "none",
+      "parallel_safe": true,
+      "resource_group": null,
+      "lanes": ["local-fast", "local-full", "pull-request", "release"],
+      "lane_reason": "Rejects moving setup dependencies and drift between the checked pins, hosted workflows, bootstrap, and contributor guidance.",
+      "focused_command": "./scripts/check-ci-local.sh --gate aux-tool-policy",
+      "plans": {
+        "fast": {"order": 85, "label": "auxiliary-tool policy and self-tests", "args": [], "depends_on": []},
+        "full": {"order": 85, "label": "auxiliary-tool policy and self-tests", "args": [], "depends_on": []}
+      }
+    },
+    {
       "name": "shell-lint",
       "owner": "repository shell tooling",
       "implementation": "run_shell_script_lint",

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -38,14 +38,14 @@
   "artifact_sets": [
     {
       "id": "repository-policy",
-      "globs": [".github/*.json", "scripts/*.json", "scripts/**/*.json"],
+      "globs": [".github/*.json", "scripts/*.json", "scripts/**/*.json", "tools/*.json"],
       "owner": "repository maintainers",
       "producer": "maintainer-authored policy or the command documented beside the receipt",
       "validator": "./scripts/check-ci-local.sh --gate evidence-artifacts",
       "consumers": ["local and hosted quality-gate orchestration"],
       "retention_policy": "Keep current policy plus any receipt required to interpret a checked release or gate result.",
-      "artifact_count": 6,
-      "inventory_sha256": "32e9a30bb60e4d5fdb07d3c1b66b213b816fdbef52b5073f0ef1f63aea58a764"
+      "artifact_count": 7,
+      "inventory_sha256": "181123568c50d3447eba9acb5e51be98e6bcc65d200a591bc1e20eaeb0e44694"
     },
     {
       "id": "benchmark-root",
@@ -199,7 +199,7 @@
       "consumers": ["documentation lifecycle and freshness gate"],
       "retention_policy": "Keep the current catalog synchronized with every Markdown page; retain supersession metadata while any historical record points to it.",
       "artifact_count": 1,
-      "inventory_sha256": "2ddc8b79bbf3b1a696ebe276ac7d9a256e5e0301e78a076d85c1eeebcecf7172"
+      "inventory_sha256": "005caffc0b018f7319077d461c662caa900631d9879c486db4fb8a4cfc9af166"
     },
     {
       "id": "documentation-examples",

--- a/tools/auxiliary-tools.json
+++ b/tools/auxiliary-tools.json
@@ -1,0 +1,196 @@
+{
+  "schema": "nose.auxiliary-tools.v1",
+  "python": {
+    "command": "python3",
+    "minimum": "3.10.0",
+    "version_args": ["--version"],
+    "version_pattern": "Python\\s+(\\d+\\.\\d+\\.\\d+)"
+  },
+  "required_commands": [
+    {
+      "command": "cargo",
+      "purpose": "Rust builds and cargo-installed auxiliary tools"
+    },
+    {
+      "command": "git",
+      "purpose": "repository gates and Lean dependencies"
+    },
+    {
+      "command": "node",
+      "purpose": "fast/full evidence artifact validation"
+    },
+    {
+      "command": "rustup",
+      "purpose": "pinned development and MSRV Rust toolchains"
+    }
+  ],
+  "ci_installer": {
+    "repository": "taiki-e/install-action",
+    "version": "2.85.4",
+    "ref": "v2.85.4"
+  },
+  "ci_groups": {
+    "coverage": ["cargo-llvm-cov"],
+    "shell-lint": ["shellcheck"],
+    "supply-chain": ["cargo-deny", "cargo-machete"]
+  },
+  "tools": [
+    {
+      "id": "awiki",
+      "command": "awiki",
+      "version": "0.5.0",
+      "policy": "exact",
+      "version_args": ["--version"],
+      "version_pattern": "(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "release-archive",
+        "archive_binary": "awiki",
+        "install_name": "awiki",
+        "assets": {
+          "darwin-aarch64": {
+            "url": "https://github.com/corca-ai/awiki/releases/download/v0.5.0/awiki-aarch64-apple-darwin.tar.xz",
+            "sha256": "8d2ad4bbb49c390ada2b2a1c882c4fd42475d1d242ee8d2f29ed47c33e7d6fa7"
+          },
+          "darwin-x86_64": {
+            "url": "https://github.com/corca-ai/awiki/releases/download/v0.5.0/awiki-x86_64-apple-darwin.tar.xz",
+            "sha256": "0e3f4a07291d6691667a07f79c889cf675178c5a01bd2bbc6fde3de9cf1e3a86"
+          },
+          "linux-aarch64": {
+            "url": "https://github.com/corca-ai/awiki/releases/download/v0.5.0/awiki-aarch64-unknown-linux-gnu.tar.xz",
+            "sha256": "bace1519f8afafb4172a28dc193d702390cab2f3263a2dc7d0b70cfcd63cc521"
+          },
+          "linux-x86_64": {
+            "url": "https://github.com/corca-ai/awiki/releases/download/v0.5.0/awiki-x86_64-unknown-linux-gnu.tar.xz",
+            "sha256": "c0b7ee22c089130c5ace0cd7201cf8c39a48afbfbc220463b03f5ba41fe8200e"
+          }
+        }
+      },
+      "update": {
+        "kind": "github-release",
+        "repository": "corca-ai/awiki"
+      }
+    },
+    {
+      "id": "cargo-deny",
+      "command": "cargo-deny",
+      "version": "0.20.2",
+      "policy": "exact",
+      "version_args": ["--version"],
+      "version_pattern": "cargo-deny\\s+(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "cargo",
+        "package": "cargo-deny",
+        "ci_name": "cargo-deny"
+      },
+      "update": {
+        "kind": "crates-io",
+        "crate": "cargo-deny"
+      }
+    },
+    {
+      "id": "cargo-llvm-cov",
+      "command": "cargo-llvm-cov",
+      "version": "0.8.7",
+      "policy": "exact",
+      "version_args": ["llvm-cov", "--version"],
+      "version_pattern": "cargo-llvm-cov\\s+(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "cargo",
+        "package": "cargo-llvm-cov",
+        "ci_name": "cargo-llvm-cov",
+        "rust_component": "llvm-tools-preview"
+      },
+      "update": {
+        "kind": "crates-io",
+        "crate": "cargo-llvm-cov"
+      }
+    },
+    {
+      "id": "cargo-machete",
+      "command": "cargo-machete",
+      "version": "0.9.2",
+      "policy": "exact",
+      "version_args": ["--version"],
+      "version_pattern": "(?:cargo-machete\\s+)?(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "cargo",
+        "package": "cargo-machete",
+        "ci_name": "cargo-machete"
+      },
+      "update": {
+        "kind": "crates-io",
+        "crate": "cargo-machete"
+      }
+    },
+    {
+      "id": "elan",
+      "command": "elan",
+      "version": "4.2.3",
+      "policy": "exact",
+      "version_args": ["--version"],
+      "version_pattern": "elan\\s+(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "release-archive",
+        "archive_binary": "elan-init",
+        "install_name": "elan",
+        "assets": {
+          "darwin-aarch64": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.2.3/elan-aarch64-apple-darwin.tar.gz",
+            "sha256": "7cae4c03b2f0de4053fb04a91359d5804551e6e37a6ddd1b2e0097dc561ae4a9"
+          },
+          "darwin-x86_64": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.2.3/elan-x86_64-apple-darwin.tar.gz",
+            "sha256": "10d037a69731c0593723e018130c5f54afde175796b4af8ba1317e561e55598c"
+          },
+          "linux-aarch64": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.2.3/elan-aarch64-unknown-linux-gnu.tar.gz",
+            "sha256": "cb69af0803b04157bc30201c29c12fca882bb3ad8b43476b8d2d3064810bc3ac"
+          },
+          "linux-x86_64": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.2.3/elan-x86_64-unknown-linux-gnu.tar.gz",
+            "sha256": "df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2"
+          }
+        }
+      },
+      "update": {
+        "kind": "github-release",
+        "repository": "leanprover/elan"
+      }
+    },
+    {
+      "id": "shellcheck",
+      "command": "shellcheck",
+      "version": "0.11.0",
+      "policy": "exact",
+      "version_args": ["--version"],
+      "version_pattern": "version:\\s+(\\d+\\.\\d+\\.\\d+)",
+      "install": {
+        "kind": "release-archive",
+        "archive_binary": "shellcheck",
+        "install_name": "shellcheck",
+        "assets": {
+          "darwin-aarch64": {
+            "url": "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz",
+            "sha256": "56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
+          },
+          "darwin-x86_64": {
+            "url": "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz",
+            "sha256": "3c89db4edcab7cf1c27bff178882e0f6f27f7afdf54e859fa041fca10febe4c6"
+          },
+          "linux-aarch64": {
+            "url": "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz",
+            "sha256": "12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588"
+          },
+          "linux-x86_64": {
+            "url": "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz",
+            "sha256": "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
+          }
+        }
+      },
+      "update": {
+        "kind": "github-release",
+        "repository": "koalaman/shellcheck"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add one checked auxiliary-tool policy with exact versions, checksummed macOS/Linux release assets, and hosted CI tool groups
- add a read-only doctor, explicit idempotent bootstrap, exact-version enforcement in local gates, and Linux/macOS bootstrap smoke coverage
- add checked update reporting, contributor/maintainer guidance, and lifecycle/evidence inventory integration

## Review

- completed exactly one parallel review round with two independent agents
- incorporated all valid findings: Node prerequisite audit, exact local-gate enforcement, custom-bin elan toolchain use, non-mutating dry-run without Python, longer post-install verification, and native Linux/macOS CI smoke tests

## Validation

- auxiliary policy self-tests and repository drift check
- missing/old/acceptable doctor cases plus complete doctor inventory
- dry-run asset plans for all four supported OS/architecture combinations
- checksummed macOS archive installs and idempotence for awiki, elan, and ShellCheck
- exact cargo-deny 0.20.2 and elan 4.2.3 temporary installs followed by supply-chain and Lean gates
- gate registry, ShellCheck, docs lifecycle/connectivity, evidence lifecycle, coverage, MSRV, rustfmt, clippy, and rustdoc gates
- nose-cli test suite
- upstream update check with every pin current

Closes #965
