### PR TITLE
Fix frontend rustdoc link after corpus split

### DIFF
--- a/bench/type4/blind_attack.v1.json
+++ b/bench/type4/blind_attack.v1.json
@@ -17,7 +17,7 @@
     "path-bail": 0,
     "uninterpretable": 160
   },
-  "product_crates_tree": "c6b1d22a397c8a27ce3272c1fd16266ff7d01312",
+  "product_crates_tree": "160a0e30b5f6c515e0366b6dcd2ea0df39042cd9",
   "schema_version": 1,
   "summary": {
     "admission_rejections": 28,

--- a/crates/nose-frontend/src/lib.rs
+++ b/crates/nose-frontend/src/lib.rs
@@ -1,6 +1,6 @@
 //! Frontends: parse source with tree-sitter and lower each file's CST into raw
 //! IL. One [`Il`] per file; files are lowered in parallel and collected into a
-//! [`Corpus`] sharing a single interner.
+//! [`nose_il::Corpus`] sharing a single interner.
 
 mod c;
 mod corpus;

--- a/scripts/evidence/artifacts.json
+++ b/scripts/evidence/artifacts.json
@@ -188,7 +188,7 @@
       "consumers": ["Type-4 frontier, query-regression, and adversarial gates"],
       "retention_policy": "Preserve current gold/frontier inputs and any sealed or closeout evidence.",
       "artifact_count": 29,
-      "inventory_sha256": "ca09004a744517e72e4e20b6a3349333d86751a433130a86592d5d727146da80"
+      "inventory_sha256": "6e9080f742ebd9f62b9b615e518f6bde6594f0b9cd4b8227c6b841f27733e156"
     },
     {
       "id": "documentation-policy",


### PR DESCRIPTION
## Summary

- point the frontend crate documentation at `nose_il::Corpus` after the corpus orchestration split
- replay the Type-4 blind-attacker receipt for the resulting crates tree
- synchronize the Type-4 evidence inventory digest

Follow-up to #976, whose `policy · lint · rustdoc` job exposed the stale intra-doc link after merge.

## Validation

- `./scripts/check-ci-local.sh --gate doc`
- `./scripts/check-ci-local.sh --gate evidence-artifacts`
- `python3 scripts/soundness-lab-gate.py self-test`
- `python3 scripts/soundness-lab-gate.py check`
- Type-4 blind attacker: 54 exact groups, 0 false merges, 0 canon violations
